### PR TITLE
Clean-up of PathUtil 

### DIFF
--- a/src/components/generators/uischema.spec.ts
+++ b/src/components/generators/uischema.spec.ts
@@ -224,7 +224,7 @@ describe('UISchemaGenerator', () => {
                 },
                 {
                     "type": "Control",
-                    "label": "Last name",
+                    "label": "Last Name",
                     "scope": {
                         "$ref": "#/properties/lastName"
                     }
@@ -238,7 +238,7 @@ describe('UISchemaGenerator', () => {
                 },
                 {
                     "type": "Control",
-                    "label": "First name",
+                    "label": "First Name",
                     "scope": {
                         "$ref": "#/properties/firstName"
                     }
@@ -259,7 +259,7 @@ describe('UISchemaGenerator', () => {
                 },
                 {
                     "type": "Control",
-                    "label": "Registration time",
+                    "label": "Registration Time",
                     "scope": {
                         "$ref": "#/properties/registrationTime"
                     }
@@ -287,7 +287,7 @@ describe('UISchemaGenerator', () => {
                 },
                 {
                     "type": "Control",
-                    "label": "Birth date",
+                    "label": "Birth Date",
                     "scope": {
                         "$ref": "#/properties/birthDate"
                     }

--- a/src/components/renderers/controls/abstract-control.ts
+++ b/src/components/renderers/controls/abstract-control.ts
@@ -13,7 +13,7 @@ export abstract class AbstractControl implements IRuleServiceCallBack{
     protected fragment:string;
     protected uiSchema:IControlObject;
     protected schema:SchemaElement;
-    protected data:any
+    protected data:any;
     private services:Services;
     private alerts=[];
     //IRuleServiceCallBack
@@ -35,7 +35,7 @@ export abstract class AbstractControl implements IRuleServiceCallBack{
             // instead try to iterate over all services and call some sort of notifier
             this.validate();
             this.services.get<IRuleService>(ServiceId.RuleService).reevaluateRules(this.schemaPath);
-        })
+        });
 
         //IRuleServiceCallBack
         this.instance=this.data;
@@ -86,12 +86,12 @@ export abstract class AbstractControl implements IRuleServiceCallBack{
     }
 
     private isRequired(schemaPath: string): boolean {
-        var path = PathUtil.inits(schemaPath);
+        var path = PathUtil.init(schemaPath);
         var lastFragment = PathUtil.lastFragment(path);
 
         // if last fragment points to properties, we need to move one level higher
         if (lastFragment === "properties") {
-            path = PathUtil.inits(path);
+            path = PathUtil.init(path);
         }
 
         // FIXME: we want resolveSchema to actually return an array here

--- a/src/components/renderers/controls/reference/reference-directive.ts
+++ b/src/components/renderers/controls/reference/reference-directive.ts
@@ -21,7 +21,7 @@ class ReferenceController extends AbstractControl {
         return "#"+this.uiSchema['href']['url']+"/"+this.data[normalizedPath];
     };
     private get linkText(){
-        return this.uiSchema['href']['label'] ? this.uiSchema['href']['label'] : this.label;;
+        return this.uiSchema['href']['label'] ? this.uiSchema['href']['label'] : this.label;
     }
     private get prefix(){
         return this.uiSchema.label ? this.uiSchema.label : "Go to ";

--- a/src/components/renderers/controls/reference/reference.spec.ts
+++ b/src/components/renderers/controls/reference/reference.spec.ts
@@ -31,7 +31,7 @@ describe('Reference control', () => {
         scope.$digest();
         let a = el.find('a');
         expect(a.attr('href')).toBe('#/fake/3');
-        expect(a.text()).toBe('Some id');
+        expect(a.text()).toBe('Some Id');
     }));
 
     it("should support customizable via a label properties",

--- a/src/components/services/pathutil.spec.ts
+++ b/src/components/services/pathutil.spec.ts
@@ -10,6 +10,10 @@ describe("PathUtil", () => {
       expect(() => PathUtil.toPropertyAccessString(null)).toThrowError();
    });
 
+    it("should return an empty array when converting a path to fragments", () => {
+        expect(PathUtil.toPropertyFragments(undefined)).toEqual([]);
+    });
+
     it("should return the last fragment", () => {
         expect(PathUtil.lastFragment("foo/bar")).toBe("bar")
     });

--- a/src/components/services/pathutil.spec.ts
+++ b/src/components/services/pathutil.spec.ts
@@ -3,12 +3,24 @@ import "angular-mocks"
 
 import {PathUtil} from "./pathutil";
 
-describe("Path-Util", () => {
+describe("PathUtil", () => {
 
    it("should throw error if passed undefined or null in toPropertyAccessString", () => {
       expect(() => PathUtil.toPropertyAccessString(undefined)).toThrowError();
       expect(() => PathUtil.toPropertyAccessString(null)).toThrowError();
    });
+
+    it("should return the last fragment", () => {
+        expect(PathUtil.lastFragment("foo/bar")).toBe("bar")
+    });
+
+    it("should beautify the last fragment", () => {
+        expect(PathUtil.beautifiedLastFragment("foo/bar")).toBe("Bar")
+    });
+
+    it("should filter indices from a path", () => {
+        expect(PathUtil.filterIndexes("foo/items/1/bar")).toBe("foo/items/bar")
+    });
    
    it("should return a proper property access path for paths of length 2 in toPropertyAccessString", () => {
       expect(PathUtil.toPropertyAccessString("/property1/property1a")).toBe("['property1']['property1a']");

--- a/src/components/services/pathutil.spec.ts
+++ b/src/components/services/pathutil.spec.ts
@@ -14,6 +14,10 @@ describe("PathUtil", () => {
         expect(PathUtil.toPropertyFragments(undefined)).toEqual([]);
     });
 
+    it("should convert a string to start case when beautifying it", () => {
+        expect(PathUtil.beautify("first name")).toBe("First Name");
+    });
+
     it("should return the last fragment", () => {
         expect(PathUtil.lastFragment("foo/bar")).toBe("bar")
     });

--- a/src/components/services/pathutil.ts
+++ b/src/components/services/pathutil.ts
@@ -87,7 +87,7 @@ export class PathUtil {
      * @returns {any} the last fragment in a beautified manner
      */
     static beautifiedLastFragment(schemaPath: string): string  {
-        return _.flow(PathUtil.lastFragment, _.upperFirst, PathUtil.beautify)(schemaPath);
+        return _.flow(PathUtil.lastFragment, PathUtil.beautify)(schemaPath);
     }
 
     /**

--- a/src/components/services/pathutil.ts
+++ b/src/components/services/pathutil.ts
@@ -1,80 +1,110 @@
+import "lodash"
 
 export class PathUtil {
 
     private static Keywords:string[] = ["items", "properties", "#"];
 
-    static normalize = (path:string):string => {
-        return PathUtil.filterNonKeywords(PathUtil.toPropertyFragments(path)).join("/");
-    };
+    private static joinWithSlash: (string) => string = _.partialRight(_.join, "/");
+    private static numberRegex = /^\d+$/;
 
-    static toPropertyFragments = (path:string):string[] => {
+    /**
+     * Converts a given schema path to its instance representation
+     *
+     * @param schemaPath a schema path
+     * @returns {string} the instance path
+     */
+    static normalize(schemaPath: string):string {
+        return _.flow(PathUtil.toPropertyFragments, PathUtil.filterNonKeywords, PathUtil.joinWithSlash)(schemaPath);
+    }
+
+    /**
+     * Splits the given path, which is expected to be separated by slashes.
+     *
+     * @param path the path to be splitted
+     * @returns {string[]} an array of fragments
+     */
+    static toPropertyFragments(path:string): string[] {
         if (path === undefined) {
             return [];
         }
-        return path.split('/').filter(function (fragment) {
-            return fragment.length > 0;
-        })
-    };
+        return  path.split('/').filter(fragment => fragment.length > 0);
+    }
 
     /**
-     * Creates a string with single quotes on properties for accessing a property based on path fragments
-     * @param propertyPathFragments the
+     * Creates a string with single quotes on properties for accessing a property based on path fragments.
+     *
+     * @param propertyPath the path to
+     * @return {string} the property access path
      */
-
-    static toPropertyAccessString = (propertyPath: string):string => {
-        if (propertyPath === undefined || propertyPath === null) {
-            throw new Error("property path is not defined!");
+    static toPropertyAccessString(propertyPath: string):string {
+        if (propertyPath === null || propertyPath === undefined) {
+            throw new Error("Property path must not be undefined.")
         }
-        var fragments = PathUtil.toPropertyFragments(propertyPath);
-        return fragments.reduce((propertyAccessString, fragment)=>{
-            return `${propertyAccessString}['${fragment}']`;
-        },"");
-    };
+        let fragments = PathUtil.toPropertyFragments(propertyPath);
+        return fragments.reduce((propertyAccessString, fragment) =>
+            `${propertyAccessString}['${fragment}']`
+            , "");
+    }
 
-    static inits(schemaPath: string): string {
-        var fragments = PathUtil.toPropertyFragments(schemaPath);
-        return '/' + fragments.slice(0, fragments.length - 1).join('/');
-    };
 
+    /**
+     * Gets all but the last fragments of the given path as a string.
+     *
+     * @param schemaPath the path from which to retrieve all but the last fragment
+     * @returns {string} the path without the last fragment
+     */
+    static init(schemaPath: string): string {
+        return '/' + _.flow(PathUtil.toPropertyFragments, _.initial, PathUtil.joinWithSlash)(schemaPath);
+    }
+
+    /**
+     * Removes all array indices from an instance path
+     *
+     * @param path the instance path from which to remove indices
+     * @returns {string} the filtered path without indices
+     */
     static filterIndexes(path:string):string {
-        return PathUtil.toPropertyFragments(path).filter(function (fragment, index, fragments) {
-            return !(fragment.match("^[0-9]+$") && fragments[index - 1] == "items");
-        }).join("/");
+        return PathUtil.toPropertyFragments(path)
+            .filter((fragment, index, fragments) =>
+                !(fragment.match(PathUtil.numberRegex) && fragments[index - 1] == "items")
+            ).join("/");
     }
-
-    static filterNonKeywords = (fragments:string[]):string[] => {
-        return fragments.filter(function (fragment) {
-            return !(PathUtil.Keywords.indexOf(fragment) !== -1);
-        });
-    };
-
-    static beautifiedLastFragment(schemaPath: string): string  {
-        return PathUtil.beautify(PathUtil.capitalizeFirstLetter(PathUtil.lastFragment(schemaPath)));
-    }
-
-    static lastFragment(schemaPath: string): string {
-        return schemaPath.substr(schemaPath.lastIndexOf('/') + 1, schemaPath.length)
-    }
-
-    private static capitalizeFirstLetter(string): string {
-        return string.charAt(0).toUpperCase() + string.slice(1);
-    }
-
 
     /**
-     * Beautifies by performing the following steps (if applicable)
-     * 1. split on uppercase letters
-     * 2. transform uppercase letters to lowercase
-     * 3. transform first letter uppercase
+     * Removes all schema-specific fragments from the given path.
+     *
+     * @param fragments the path from which to filter out the schema specific fragment
+     * @returns {string[]} a path without schema specific fragments
      */
-    static beautify = (text: string): string => {
-        if(text && text.length > 0){
-            var textArray = text.split(/(?=[A-Z])/).map((x)=>{return x.toLowerCase()});
-            textArray[0] = textArray[0].charAt(0).toUpperCase() + textArray[0].slice(1);
-            return textArray.join(' ');
-        }
-        return text;
-    };
+    static filterNonKeywords(fragments:string[]):string[] {
+        return fragments.filter(fragment => !_.includes(PathUtil.Keywords, fragment))
+    }
 
+    /**
+     * Returns the last fragment of the given path in a beautified manner.
+     *
+     * @param schemaPath the path from which to extract the beautified fragment
+     * @returns {any} the last fragment in a beautified manner
+     */
+    static beautifiedLastFragment(schemaPath: string): string  {
+        return _.flow(PathUtil.lastFragment, _.upperFirst, PathUtil.beautify)(schemaPath);
+    }
+
+    /**
+     * Returns the last fragment of the given path which is expected to be separated
+     * by slashes.
+     *
+     * @param path the slash separated path
+     * @returns {string} the last fragment of the path
+     */
+    static lastFragment(path: string): string {
+        return path.substr(path.lastIndexOf('/') + 1)
+    }
+
+    /**
+     * Beautifies given string by performing conversion to start case.
+     * @param text the text to be beautified
+     */
+    static beautify(text: string): string { return _.startCase(text) };
 }
 


### PR DESCRIPTION
Small refactoring of PathUtil + JSDoc, also fixed some minor warnings.
Usage of [start case](https://en.wikipedia.org/wiki/Letter_case#Stylistic_or_specialised_usage) when beautifying labels.
Fixed name of inits function, which actually should be named init (as e.g. [here](http://www.scala-lang.org/api/2.7.7/scala/List.html#init)).