### PR TITLE
fix datetime sync

### DIFF
--- a/src/components/renderers/controls/datetime/datetime-directive.ts
+++ b/src/components/renderers/controls/datetime/datetime-directive.ts
@@ -40,6 +40,7 @@ class DateTimeController extends AbstractControl {
         if (value) {
             this.dt = new Date(value);
         }
+        scope.$watch('vm.modelValue[vm.fragment]', (newValue) => {this.updateDateObject(); });
     }
     public openDate() {
         this.isOpen = true;
@@ -52,6 +53,9 @@ class DateTimeController extends AbstractControl {
             this.modelValue[this.fragment] = null;
         }
         super.modelChanged();
+    }
+    private updateDateObject() {
+        this.dt = new Date(this.modelValue[this.fragment]);
     }
 }
 const DateTimeControlRendererTester: RendererTester = function(element: IUISchemaElement,


### PR DESCRIPTION
As the datetime renderer has to use a date object instead of the string value in the model, there is an issue, that the shown date between multiple renderers bound to the same modelvalue is not synced.
This patch fixes this issue by adding a watch to the model value and trigger an update of the date obejct.