### PR TITLE
Add buttons for trying the example in the editor

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -352,6 +352,17 @@ angular.module('jsonforms-website', [
             return false;
         };
 
+        vm.openEditorInNewTab = function () {
+            vm.reparseStatic();
+            var tab = window.open('http://jsonformseditor.herokuapp.com/#/demo');
+            setTimeout(function() {
+                tab.postMessage({
+                    dataSchema: vm.localStaticModelObject,
+                    uiSchema: vm.localStaticViewObject
+                }, '*');
+            }, 14000); // heroku needs 12 secs. aprox. to build the editor
+        };
+
         vm.staticDataProvider = StaticData;
         vm.dynamicDataProvider = DynamicData;
 

--- a/partials/examples.html
+++ b/partials/examples.html
@@ -22,5 +22,10 @@
                 </jsonforms>
             </div>
         </div>
+        <div layout="column" layout-align="center center">
+            <md-button style="background-color: #d9534f"
+                       class="md-raised md-primary"
+                       ng-click="vm.openEditorInNewTab()">Try in the Editor</md-button>
+        </div>
     </div>
 </article>

--- a/partials/landing.html
+++ b/partials/landing.html
@@ -76,9 +76,14 @@
             </div>
         </div>
         <div layout="column" layout-align="center center">
-            <md-button style="background-color: #d9534f"
-                       class="md-raised md-primary"
-                       ui-sref="examples">More examples</md-button>
+            <div layout="row">
+                <md-button style="background-color: #d9534f"
+                           class="md-raised md-primary"
+                           ui-sref="examples">More examples</md-button>
+                <md-button style="background-color: #d9534f"
+                           class="md-raised md-primary"
+                           ng-click="vm.openEditorInNewTab()">Try in the Editor</md-button>
+            </div>
         </div>
     </div>
 </article>


### PR DESCRIPTION
The button "Try in the Editor" opens the JSON Forms Editor in a new tab, with the actual data and ui schemas.

Note that for this to work, the pull request of JSON Forms Editor (https://github.com/eclipsesource/JsonFormsEditor/pull/71) has to be merged. And after that, it has to be deployed to heroku.

I have set a timeout of 14 seconds because sometimes heroku needs some time to build the editor. If a plan which allowed the app to run continuously was purchased in heroku, this time could be decreased.
