### PR TITLE
Update Typings and Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,16 @@ For documentation, examples and more information, please see [jsonforms.org](htt
 
 ## First time setup
 * Install [node.js](https://nodejs.org/)(version > 4.x.x)
-* Install [typings](https://github.com/typings/typings): `npm install -g typings` 
-* Install [tslint](https://palantir.github.io/tslint/): `npm install -g tslint`
-* Install [webpack](https://github.com/webpack/webpack): `npm install -g webpack`
 * Clone this repository
 * Install dependencies: `npm install`
+* Generate typings: `npm run typings-install`
 
 ## Build & Testing
 * Normal Build: `npm run build` (runs `tslint` as well)
 * Bootstrap Build: `npm run build-bootstrap`
+* Material Build: `npm run build-material`
 * Test: `npm run test`
-* Watch: `npm run dev`, point your browser to `http://localhost:8080/webpack-dev-server/`
+* Watch: `npm run dev` (or `dev-bootstrap`, `dev-material`), point your browser to `http://localhost:8080/webpack-dev-server/`
 
 ## How to run the examples 
 JSONForms ships with a couple of examples. The examples' dependencies are managed

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build-bootstrap": "webpack --config webpack/webpack.build-bootstrap.js --NODE_ENV=production --display-error-details",
     "build-material": "webpack --config webpack/webpack.build-material.js --NODE_ENV=production --display-error-details",
     "build-all": "npm run tsc && npm run tsc-bootstrap && npm run tsc-material && npm run build && npm run build-bootstrap && npm run build-material",
-    "postinstall": "node_modules/.bin/typings install",
+    "typings-install": "node_modules/.bin/typings install",
     "publish-patch": "npm run build-all && npm run test && npm -no-git-tag-version version patch && npm run commit-local && npm run push-tag && npm publish",
     "publish-minor": "npm run build-all && npm run test && npm -no-git-tag-version version minor && npm run commit-local && npm run push-tag && npm publish",
     "publish-major": "npm run build-all && npm run test && npm -no-git-tag-version version major && npm run commit-local && npm run push-tag && npm publish",


### PR DESCRIPTION
* Fixes #470 by removing Typings from Postinstall Trigger (see https://github.com/npm/npm/issues/8263)
* Update README.md for Typings
* Remove unnecessary First-Time Setup instructions
