### PR TITLE
Allow leading underscore for var names and remove tslint warnings

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -46,8 +46,9 @@ export class JsonForms {
   }
   public static get schemaService(): SchemaService  {
     if (this._schemaService === undefined) {
-      console.error("Schema service has not been initialized");
+      console.error('Schema service has not been initialized');
     }
+
     return this._schemaService;
   }
 }

--- a/test/renderers/date.control.test.ts
+++ b/test/renderers/date.control.test.ts
@@ -164,7 +164,6 @@ test('DateControl static no label', t => {
   renderer.setDataSchema(t.context.schema);
   renderer.setUiSchema(uiSchema);
   const result = renderer.render();
-  const className = result.className;
   t.true(result.className.indexOf('control') !== -1);
   t.is(result.childNodes.length, 3);
   const label = result.children[0] as HTMLLabelElement;

--- a/test/renderers/treemasterdetail.control.test.ts
+++ b/test/renderers/treemasterdetail.control.test.ts
@@ -10,11 +10,9 @@ import {
   treeMasterDetailTester,
 } from '../../src/renderers/additional/tree-renderer';
 import {
-  testDisable,
-  testEnable,
   testNotifyAboutVisibiltyWhenDisconnected,
 } from './base.control.tests';
-import {JsonForms} from "../../src/core";
+import { JsonForms } from '../../src/core';
 
 test.beforeEach(t => {
   t.context.data = {};

--- a/test/schema.service.test.ts
+++ b/test/schema.service.test.ts
@@ -330,13 +330,10 @@ test('support for array references', t => {
   const selfContainedClassSchema = JSON.parse(
     JSON.stringify(schema.definitions.class as JsonSchema)
   );
-  const items: JsonSchema = selfContainedClassSchema.properties.associations.items;
-  // tslint:disable:no-string-literal
-  // items['links'][0].targetSchema = {$ref: '#'};
-  // tslint:enable:no-string-literal
   selfContainedClassSchema.id = '#' + (schema.properties.classes.items as JsonSchema).$ref;
   t.deepEqual(properties[0].targetSchema, selfContainedClassSchema);
 });
+
 test('support for object references', t => {
   // tslint:disable:no-object-literal-type-assertion
   const schema: JsonSchema = {
@@ -385,9 +382,6 @@ test('support for object references', t => {
   t.is(properties[0].label, 'id');
 
   const selfContainedClassSchema = JSON.parse(JSON.stringify(schema.definitions.class));
-  // tslint:disable:no-string-literal
-  // selfContainedClassSchema.properties.association['links'][0].targetSchema = {$ref: '#'};
-  // tslint:enable:no-string-literal
   selfContainedClassSchema.id = '#' + (schema.properties.classes.items as JsonSchema).$ref;
   t.deepEqual(properties[0].targetSchema, selfContainedClassSchema);
 });

--- a/tslint.json
+++ b/tslint.json
@@ -165,7 +165,7 @@
             true,
             "always"
         ],
-        "variable-name": true,
+        "variable-name": [true, "allow-leading-underscore"],
         "whitespace": [
             true,
             "check-branch",


### PR DESCRIPTION
Allow leading underscore for (preferably private) variables.