### PR TITLE
Jsonforms2 refernence resolvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "es6-shim": "^0.35.3",
     "json-refs": "^2.1.6",
     "lodash": "^4.17.4",
-    "sortablejs": "^1.6.0"
+    "sortablejs": "^1.6.0",
+    "uuid": "^3.1.0"
   },
   "devDependencies": {
     "ava": "^0.18.1",

--- a/src/core.ts
+++ b/src/core.ts
@@ -19,6 +19,23 @@ export interface JsonFormService {
   dispose(): void;
 }
 
+export class JsonFormsConfig {
+
+  private _identifyingProp;
+
+  setIdentifyingProp(propName: string) {
+    this._identifyingProp = propName;
+  }
+
+  getIdentifyingProp() {
+    return this._identifyingProp;
+  }
+
+  shouldGenerateIdentifier() {
+    return this._identifyingProp !== undefined;
+  }
+}
+
 /**
  * Encapsulates instantiation logic of a JSONForms service.
  */
@@ -37,6 +54,7 @@ export interface JsonFormsServiceConstructable {
  * Global JSONForms object that holds services and registries.
  */
 export class JsonForms {
+  private static _config = new JsonFormsConfig();
   private static _schemaService;
   public static rendererService = new RendererService();
   public static jsonFormsServices: JsonFormsServiceConstructable[] = [];
@@ -52,6 +70,10 @@ export class JsonForms {
     }
 
     return this._schemaService;
+  }
+
+  public static get config(): JsonFormsConfig {
+    return this._config;
   }
 
   /**

--- a/src/core/schema.service.impl.ts
+++ b/src/core/schema.service.impl.ts
@@ -55,7 +55,7 @@ const addToArray =
     data[key] = [];
   }
   if (!_.isEmpty(identifyingProperty)) {
-    data[identifyingProperty] = uuid.v4();
+    valueToAdd[identifyingProperty] = uuid.v4();
   }
   const childArray = data[key];
   if (neighbourValue !== undefined && neighbourValue !== null) {

--- a/src/core/schema.service.impl.ts
+++ b/src/core/schema.service.impl.ts
@@ -187,6 +187,7 @@ export class SchemaServiceImpl implements SchemaService {
             variable,
             variable,
             pathToContainment.substring(0, pathToContainment.length - 1),
+            this._identifyingProp,
             addReference(schema, variable, pathToContainment),
             getReference(href, variable, variableWrapped)
           )

--- a/src/core/schema.service.impl.ts
+++ b/src/core/schema.service.impl.ts
@@ -8,6 +8,7 @@ import {
   ReferencePropertyImpl,
   SchemaService
 } from './schema.service';
+import * as uuid from 'uuid';
 
 interface ReferenceSchemaMap {
   [ref: string]: JsonSchema;
@@ -46,10 +47,15 @@ const findAllRefs = (schema: JsonSchema, result: ReferenceSchemaMap = {}): Refer
 
   return result;
 };
-const addToArray = (key: string) => (data: Object) => (valueToAdd: object, neighbourValue?: object,
-                                                       insertAfter = true) => {
+const addToArray =
+    (key: string, identifyingProperty?: string) =>
+    (data: Object) =>
+    (valueToAdd: object, neighbourValue?: object, insertAfter = true) => {
   if (data[key] === undefined) {
     data[key] = [];
+  }
+  if (!_.isEmpty(identifyingProperty)) {
+    data[identifyingProperty] = uuid.v4();
   }
   const childArray = data[key];
   if (neighbourValue !== undefined && neighbourValue !== null) {
@@ -270,7 +276,7 @@ export class SchemaServiceImpl implements SchemaService {
         schema.items,
         rootSchema,
         true,
-        addToArray(key),
+        addToArray(key, this._identifyingProp),
         deleteFromArray(key),
         getArray(key)
       );

--- a/src/core/schema.service.impl.ts
+++ b/src/core/schema.service.impl.ts
@@ -133,6 +133,7 @@ const getReference = (href: string, variable: string, variableWrapped: string) =
   };
 
 export class SchemaServiceImpl implements SchemaService {
+  private _identifyingProp;
   private selfContainedSchemas: {[id: string]: JsonSchema} = {};
   constructor(private rootSchema: JsonSchema) {
     if (_.isEmpty(rootSchema.id)) {
@@ -202,6 +203,26 @@ export class SchemaServiceImpl implements SchemaService {
 
     return [];
   }
+
+  /**
+   * @inheritDoc
+   */
+  setIdentifyingProp(propName: string): SchemaService {
+    this._identifyingProp = propName;
+
+    return this;
+  }
+
+  /**
+   * Determines whether the identifigenerer value should be generated
+   * @returns {boolean} true, if the the identifying value should be generated
+   *
+   * @see setIdentifyingProp
+   */
+  shouldGenerateIdentifier() {
+    return this._identifyingProp !== undefined;
+  }
+
   private getContainment(key: string, name: string, schema: JsonSchema, rootSchema: JsonSchema,
                          isInContainment: boolean,
                          addFunction: (data: object) => (valueToAdd: object,

--- a/src/core/schema.service.impl.ts
+++ b/src/core/schema.service.impl.ts
@@ -9,6 +9,7 @@ import {
   SchemaService
 } from './schema.service';
 import * as uuid from 'uuid';
+import { JsonForms } from '../core';
 
 interface ReferenceSchemaMap {
   [ref: string]: JsonSchema;
@@ -139,7 +140,6 @@ const getReference = (href: string, variable: string, variableWrapped: string) =
   };
 
 export class SchemaServiceImpl implements SchemaService {
-  private _identifyingProp;
   private selfContainedSchemas: {[id: string]: JsonSchema} = {};
   constructor(private rootSchema: JsonSchema) {
     if (_.isEmpty(rootSchema.id)) {
@@ -194,7 +194,7 @@ export class SchemaServiceImpl implements SchemaService {
             variable,
             variable,
             pathToContainment.substring(0, pathToContainment.length - 1),
-            this._identifyingProp,
+            JsonForms.config.getIdentifyingProp(),
             addReference(schema, variable, pathToContainment),
             getReference(href, variable, variableWrapped)
           )
@@ -208,25 +208,6 @@ export class SchemaServiceImpl implements SchemaService {
     }
 
     return [];
-  }
-
-  /**
-   * @inheritDoc
-   */
-  setIdentifyingProp(propName: string): SchemaService {
-    this._identifyingProp = propName;
-
-    return this;
-  }
-
-  /**
-   * Determines whether the identifigenerer value should be generated
-   * @returns {boolean} true, if the the identifying value should be generated
-   *
-   * @see setIdentifyingProp
-   */
-  shouldGenerateIdentifier() {
-    return this._identifyingProp !== undefined;
   }
 
   private getContainment(key: string, name: string, schema: JsonSchema, rootSchema: JsonSchema,
@@ -276,7 +257,7 @@ export class SchemaServiceImpl implements SchemaService {
         schema.items,
         rootSchema,
         true,
-        addToArray(key, this._identifyingProp),
+        addToArray(key, JsonForms.config.getIdentifyingProp()),
         deleteFromArray(key),
         getArray(key)
       );

--- a/src/core/schema.service.ts
+++ b/src/core/schema.service.ts
@@ -245,4 +245,12 @@ export interface SchemaService {
    * @see ReferenceProperty
    */
   getReferenceProperties(schema: JsonSchema): ReferenceProperty[];
+
+  /**
+   * Set the name of the property that uniquely identifies any given schema element.
+   *
+   * @param propName the name of the identifying property
+   * @return the schema service itself for convenience reasons
+   */
+  setIdentifyingProp(propName: string): SchemaService;
 }

--- a/src/core/schema.service.ts
+++ b/src/core/schema.service.ts
@@ -245,12 +245,4 @@ export interface SchemaService {
    * @see ReferenceProperty
    */
   getReferenceProperties(schema: JsonSchema): ReferenceProperty[];
-
-  /**
-   * Set the name of the property that uniquely identifies any given schema element.
-   *
-   * @param propName the name of the identifying property
-   * @return the schema service itself for convenience reasons
-   */
-  setIdentifyingProp(propName: string): SchemaService;
 }

--- a/src/core/schema.service.ts
+++ b/src/core/schema.service.ts
@@ -179,8 +179,11 @@ export class ReferencePropertyImpl implements ReferenceProperty {
           return prev[cur];
         },
         rootData) as Object[];
+    if (!_.isEmpty(candidates)) {
+      return JsonForms.filterObjectsByType(candidates, this.targetSchema.id);
+    }
 
-    return JsonForms.filterObjectsByType(candidates, this.targetSchema.id);
+    return [];
   }
 
   resolveReference(rootData: Object, propertyValue: string): Object {

--- a/test/data/modelreference.data.ts
+++ b/test/data/modelreference.data.ts
@@ -1,235 +1,235 @@
 export const testDataSchema = {
-  "definitions": {
-    "eClassifier": {
-      "anyOf":[
-        {"$ref":"#/definitions/eclass"},
-        {"$ref":"#/definitions/enum"},
-        {"$ref":"#/definitions/datatype"}
+  'definitions': {
+    'eClassifier': {
+      'anyOf': [
+        {'$ref': '#/definitions/eclass'},
+        {'$ref': '#/definitions/enum'},
+        {'$ref': '#/definitions/datatype'}
       ]
     },
-    "type": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "integer",
-          "minimum": 0
+    'type': {
+      'type': 'object',
+      'properties': {
+        'id': {
+          'type': 'integer',
+          'minimum': 0
         }
       },
-      "links": [{
-        "rel": "full",
-        "href": "#/eClassifiers/{id}",
-        "targetSchema": {
-          $ref: "#/definitions/eClassifier"
+      'links': [{
+        'rel': 'full',
+        'href': '#/eClassifiers/{id}',
+        'targetSchema': {
+          $ref: '#/definitions/eClassifier'
         }
       }],
-      "additionalProperties": false
+      'additionalProperties': false
     },
-    "enum": {
-      "id":"#enum",
-      "type": "object",
-      "properties": {
-        "eClass": {
-          "type": "string",
-          "default": "http://www.eclipse.org/emf/2002/Ecore#//EEnum"
+    'enum': {
+      'id': '#enum',
+      'type': 'object',
+      'properties': {
+        'eClass': {
+          'type': 'string',
+          'default': 'http://www.eclipse.org/emf/2002/Ecore#//EEnum'
         },
-        "_id": {
-          "type": "string"
+        '_id': {
+          'type': 'string'
         },
-        "name": {
-          "type": "string"
+        'name': {
+          'type': 'string'
         },
-        "instanceClassName": {
-          "type": "string"
+        'instanceClassName': {
+          'type': 'string'
         },
-        "instanceTypeName": {
-          "type": "string"
+        'instanceTypeName': {
+          'type': 'string'
         },
-        "serializable": {
-          "type": "boolean"
+        'serializable': {
+          'type': 'boolean'
         },
-        "eLiterals": {
-          "type": "array",
-          "items": {
-            "type": "string"
+        'eLiterals': {
+          'type': 'array',
+          'items': {
+            'type': 'string'
           }
         },
       },
-      "additionalProperties": false
+      'additionalProperties': false
     },
-    "datatype": {
-      "id":"#datatype",
-      "type": "object",
-      "properties": {
-        "eClass": {
-          "type": "string",
-          "default": "http://www.eclipse.org/emf/2002/Ecore#//EDataType"
+    'datatype': {
+      'id': '#datatype',
+      'type': 'object',
+      'properties': {
+        'eClass': {
+          'type': 'string',
+          'default': 'http://www.eclipse.org/emf/2002/Ecore#//EDataType'
         },
-        "_id": {
-          "type": "string"
+        '_id': {
+          'type': 'string'
         },
-        "name": {
-          "type": "string"
+        'name': {
+          'type': 'string'
         },
-        "instanceClassName": {
-          "type": "string"
+        'instanceClassName': {
+          'type': 'string'
         },
-        "instanceTypeName": {
-          "type": "string"
+        'instanceTypeName': {
+          'type': 'string'
         },
       },
-      "additionalProperties": true
+      'additionalProperties': true
     },
-    "eclass": {
-      "type": "object",
-      "id":"#class",
-      "properties": {
-        "eClass": {
-          "type": "string",
-          "default": "http://www.eclipse.org/emf/2002/Ecore#//EClass"
+    'eclass': {
+      'type': 'object',
+      'id': '#class',
+      'properties': {
+        'eClass': {
+          'type': 'string',
+          'default': 'http://www.eclipse.org/emf/2002/Ecore#//EClass'
         },
-        "_id": {
-          "type": "string"
+        '_id': {
+          'type': 'string'
         },
-        "name": {
-          "type": "string"
+        'name': {
+          'type': 'string'
         },
-        "secondName": {
-          "type": "string"
+        'secondName': {
+          'type': 'string'
         },
-        "instanceClassName": {
-          "type": "string"
+        'instanceClassName': {
+          'type': 'string'
         },
-        "instanceTypeName": {
-          "type": "string"
+        'instanceTypeName': {
+          'type': 'string'
         },
-        "interface": {
-          "type": "boolean"
+        'interface': {
+          'type': 'boolean'
         },
-        "eStructuralFeatures": {
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {"$ref": "#/definitions/attribute"},
-              {"$ref": "#/definitions/reference"}
+        'eStructuralFeatures': {
+          'type': 'array',
+          'items': {
+            'anyOf': [
+              {'$ref': '#/definitions/attribute'},
+              {'$ref': '#/definitions/reference'}
             ]
           }
         }
       },
-      "additionalProperties": true
+      'additionalProperties': true
     },
-    "attribute": {
-      "id":"#attribute",
-      "type": "object",
-      "properties": {
-        "eClass": {
-          "type": "string",
-          "default": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute"
+    'attribute': {
+      'id': '#attribute',
+      'type': 'object',
+      'properties': {
+        'eClass': {
+          'type': 'string',
+          'default': 'http://www.eclipse.org/emf/2002/Ecore#//EAttribute'
         },
-        "_id": {
-          "type": "string"
+        '_id': {
+          'type': 'string'
         },
-        "name": {
-          "type": "string"
+        'name': {
+          'type': 'string'
         },
-        "containment": {
-          "type": "boolean"
+        'containment': {
+          'type': 'boolean'
         },
-        "eType": {
-          "type": "object",
-          "properties": {
-            "$ref": {
-              "type": "string",
-              "enum": [
-                "http://www.eclipse.org/emf/2002/Ecore#//EBoolean",
-                "http://www.eclipse.org/emf/2002/Ecore#//EString",
-                "http://www.eclipse.org/emf/2002/Ecore#//EDate",
-                "http://www.eclipse.org/emf/2002/Ecore#//EInt",
-                "http://www.eclipse.org/emf/2002/Ecore#//EDouble",
+        'eType': {
+          'type': 'object',
+          'properties': {
+            '$ref': {
+              'type': 'string',
+              'enum': [
+                'http://www.eclipse.org/emf/2002/Ecore#//EBoolean',
+                'http://www.eclipse.org/emf/2002/Ecore#//EString',
+                'http://www.eclipse.org/emf/2002/Ecore#//EDate',
+                'http://www.eclipse.org/emf/2002/Ecore#//EInt',
+                'http://www.eclipse.org/emf/2002/Ecore#//EDouble',
               ]
             }
           }
         }
       },
-      "additionalProperties": true
+      'additionalProperties': true
     },
-    "reference": {
-      "id": "#reference",
-      "type": "object",
-      "properties": {
-        "eClass": {
-          "type": "string",
-          "default": "http://www.eclipse.org/emf/2002/Ecore#//EReference"
+    'reference': {
+      'id': '#reference',
+      'type': 'object',
+      'properties': {
+        'eClass': {
+          'type': 'string',
+          'default': 'http://www.eclipse.org/emf/2002/Ecore#//EReference'
         },
-        "_id": {
-          "type": "string"
+        '_id': {
+          'type': 'string'
         },
-        "name": {
-          "type": "string"
+        'name': {
+          'type': 'string'
         },
-        "lowerBound": {
-          "type": "integer"
+        'lowerBound': {
+          'type': 'integer'
         },
-        "upperBound": {
-          "type": "integer"
+        'upperBound': {
+          'type': 'integer'
         },
-        "many": {
-          "type": "boolean"
+        'many': {
+          'type': 'boolean'
         },
-        "containment": {
-          "type": "boolean"
+        'containment': {
+          'type': 'boolean'
         },
-        "eOpposite": {
-          "type": "object",
-          "properties": {
-            "$ref": {
-              "type": "string"
+        'eOpposite': {
+          'type': 'object',
+          'properties': {
+            '$ref': {
+              'type': 'string'
             }
           },
-          "additionalProperties": false
+          'additionalProperties': false
         },
-        "eType": {
-          "type": "string",
+        'eType': {
+          'type': 'string',
         }
       },
-      "links": [{
-        "rel": "full",
-        "href": "#/eClassifiers/{eType}",
-        "targetSchema": {
-          $ref: "#/definitions/eclass"
+      'links': [{
+        'rel': 'full',
+        'href': '#/eClassifiers/{eType}',
+        'targetSchema': {
+          $ref: '#/definitions/eclass'
         }
       }],
-      "additionalProperties": true
+      'additionalProperties': true
     }
   },
-  "type": "object",
-  "id":"#package",
-  "properties": {
-    "eClass": {
-      "type": "string",
-      "default": "http://www.eclipse.org/emf/2002/Ecore#//EPackage"
+  'type': 'object',
+  'id': '#package',
+  'properties': {
+    'eClass': {
+      'type': 'string',
+      'default': 'http://www.eclipse.org/emf/2002/Ecore#//EPackage'
     },
-    "_id": {
-      "type": "string"
+    '_id': {
+      'type': 'string'
     },
-    "name": {
-      "type": "string"
+    'name': {
+      'type': 'string'
     },
-    "nsURI": {
-      "type": "string"
+    'nsURI': {
+      'type': 'string'
     },
-    "nsPrefix": {
-      "type": "string"
+    'nsPrefix': {
+      'type': 'string'
     },
-    "eClassifiers": {
-      "type": "array",
-      "items": {
-        "anyOf": [
-            {"$ref": "#/definitions/eclass"},
-            {"$ref": "#/definitions/enum"},
-            {"$ref": "#/definitions/datatype"}
+    'eClassifiers': {
+      'type': 'array',
+      'items': {
+        'anyOf': [
+            {'$ref': '#/definitions/eclass'},
+            {'$ref': '#/definitions/enum'},
+            {'$ref': '#/definitions/datatype'}
         ]
       }
     }
   },
-  "additionalProperties": false
-}
+  'additionalProperties': false
+};

--- a/test/modelmapping.test.ts
+++ b/test/modelmapping.test.ts
@@ -7,57 +7,57 @@ import { SchemaServiceImpl } from '../src/core/schema.service.impl';
 test.beforeEach(t => {
 
   const classA = {
-    "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
-    "name": "classA",
-    "_id" : "id-class-a",
-    "eStructuralFeatures": [
+    'eClass': 'http://www.eclipse.org/emf/2002/Ecore#//EClass',
+    'name': 'classA',
+    '_id' : 'id-class-a',
+    'eStructuralFeatures': [
       {
-        "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
-        "eType": {},
-        "name": "attributeOne"
+        'eClass': 'http://www.eclipse.org/emf/2002/Ecore#//EAttribute',
+        'eType': {},
+        'name': 'attributeOne'
       },
       {
-        "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
-        "eType": {},
-        "name": "attributeTwo"
+        'eClass': 'http://www.eclipse.org/emf/2002/Ecore#//EAttribute',
+        'eType': {},
+        'name': 'attributeTwo'
       },
       {
-        "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EReference",
-        "name": "referenceOne",
-        "eType": "id-class-b"
+        'eClass': 'http://www.eclipse.org/emf/2002/Ecore#//EReference',
+        'name': 'referenceOne',
+        'eType': 'id-class-b'
       }
     ]
   };
 
   const classB = {
-    "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EClass",
-      "name": "classB",
-      "_id": "id-class-b",
-      "eStructuralFeatures": [
+    'eClass': 'http://www.eclipse.org/emf/2002/Ecore#//EClass',
+      'name': 'classB',
+      '_id': 'id-class-b',
+      'eStructuralFeatures': [
         {
-          "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EAttribute",
-          "eType": {},
-          "name": "attributeOne"
+          'eClass': 'http://www.eclipse.org/emf/2002/Ecore#//EAttribute',
+          'eType': {},
+          'name': 'attributeOne'
         },
       ]
-  }
+  };
 
   const enumOne = {
-     "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EEnum",
-      "name": "enumOne",
-      "_id": "id-enum-one",
-      "eLiterals": [
-          "enumLiteralOne", "enumLiteralTwo", "enumLiteralThree"
+     'eClass': 'http://www.eclipse.org/emf/2002/Ecore#//EEnum',
+      'name': 'enumOne',
+      '_id': 'id-enum-one',
+      'eLiterals': [
+          'enumLiteralOne', 'enumLiteralTwo', 'enumLiteralThree'
       ]
-  }
+  };
 
   const dataTypeOne = {
-    "eClass": "http://www.eclipse.org/emf/2002/Ecore#//EDataType",
-     "name": "dataTypeOne",
-     "_id": "id-datatype-one",
-     "instanceClassName" : "dataTypeOne",
-     "instanceTypeName" : "java.lang.String"
-  }
+    'eClass': 'http://www.eclipse.org/emf/2002/Ecore#//EDataType',
+     'name': 'dataTypeOne',
+     '_id': 'id-datatype-one',
+     'instanceClassName' : 'dataTypeOne',
+     'instanceTypeName' : 'java.lang.String'
+  };
 
   t.context.candidates = [
       classA,
@@ -69,9 +69,9 @@ test.beforeEach(t => {
   // data has to consist of a bunch of eClassifiers
   // so we can verify whether the filtering works
   t.context.data = {
-    "name": "packageOne",
-    "eClassifiers": t.context.candidates
-  }
+    'name': 'packageOne',
+    'eClassifiers': t.context.candidates
+  };
 
   t.context.modelMapping = {
     'attribute': 'eClass',
@@ -89,9 +89,9 @@ test.beforeEach(t => {
 
 test('available options filtering for reference attribute candidates', t => {
 
-  const matchingOptions = JsonForms.filterObjectsByType(t.context.candidates, "#class");
+  const matchingOptions = JsonForms.filterObjectsByType(t.context.candidates, '#class');
 
-  t.is(Object.keys(matchingOptions).length, 2, "array of length two expected");
+  t.is(Object.keys(matchingOptions).length, 2, 'array of length two expected');
 
 });
 
@@ -101,6 +101,6 @@ test('available options filtering for reference attribute', t => {
   const reference = service.getReferenceProperties(testDataSchema.definitions.reference)[0];
   const availableOptions = reference.findReferenceTargets(t.context.data);
 
-  t.is(Object.keys(availableOptions).length, 2, "array of length two expected");
+  t.is(Object.keys(availableOptions).length, 2, 'array of length two expected');
 
 });

--- a/test/schema.service.test.ts
+++ b/test/schema.service.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../src/core/schema.service';
 import { SchemaServiceImpl } from '../src/core/schema.service.impl';
 import { JsonSchema } from '../src/models/jsonSchema';
+import { JsonForms } from '../src/core';
 
 test.beforeEach(t => {
   t.context.fooBarArraySchema = {
@@ -443,8 +444,9 @@ test('containment properties add when array not defined and generate ID', t => {
     }
   };
 
-  const service: SchemaService = new SchemaServiceImpl(schema)
-    .setIdentifyingProp('_id');
+  JsonForms.config.setIdentifyingProp('_id');
+  const service: SchemaService = new SchemaServiceImpl(schema);
+
   const property = service.getContainmentProperties(schema)[0];
   const data = {
     foo: undefined

--- a/test/schema.service.test.ts
+++ b/test/schema.service.test.ts
@@ -411,6 +411,7 @@ test('support object with array $ref', t => {
   t.is(properties[0].label, 'root');
   t.deepEqual(properties[0].schema, schema.definitions.root.items as JsonSchema);
 });
+
 test('containment properties add when array not defined', t => {
   const schema = t.context.fooBarArraySchema;
   const service: SchemaService = new SchemaServiceImpl(schema);
@@ -424,6 +425,38 @@ test('containment properties add when array not defined', t => {
   t.is(data.foo.length, 1);
   t.is(data.foo[0], valueToAdd);
 });
+
+test('containment properties add when array not defined and generate ID', t => {
+  const schema = {
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            _id: { type: 'string' },
+            bar: { type: 'string' }
+          }
+        }
+      }
+    }
+  };
+
+  const service: SchemaService = new SchemaServiceImpl(schema)
+    .setIdentifyingProp('_id');
+  const property = service.getContainmentProperties(schema)[0];
+  const data = {
+    foo: undefined
+  };
+  const valueToAdd = { bar: `Hey Mum, look, it's an idea` };
+  property.addToData(data)(valueToAdd);
+
+  t.true(data.foo !== undefined);
+  t.is(data.foo.length, 1);
+  t.true(data.foo[0]._id !== undefined);
+});
+
 test('containment properties add when array defined', t => {
   const schema = t.context.fooBarArraySchema;
   const service: SchemaService = new SchemaServiceImpl(schema);
@@ -435,6 +468,7 @@ test('containment properties add when array defined', t => {
   t.is(data.foo.length, 2);
   t.is(data.foo[1], valueToAdd);
 });
+
 test('containment properties add default with existing neighbour', t => {
   // expectation default === add after neighbour
   const schema = t.context.fooBarArraySchema;
@@ -451,6 +485,7 @@ test('containment properties add default with existing neighbour', t => {
   t.is(data.foo[1], valueToAdd);
   t.is(data.foo[2], lastValue);
 });
+
 test('containment properties add after existing neighbour(not last in array)', t => {
   const schema = t.context.fooBarArraySchema;
   const service: SchemaService = new SchemaServiceImpl(schema);


### PR DESCRIPTION
Added reference resolvement and resolving of possible reference targets to reference properties in schema service.
Now findAllRefs is only defined in path.util. Furthermore, it now can deal with already resolved targetSchemas in link blocks.
The schema service now can be configure with an identifier property: this property is used to identify referenced objects. The schema service generates uuids for newly created objects in containment properties.