### PR TITLE
Refactor reference property, allow ref. property to handle multi references

### DIFF
--- a/src/core/schema.service.ts
+++ b/src/core/schema.service.ts
@@ -1,6 +1,5 @@
 import * as _ from 'lodash';
 import { JsonSchema } from '../models/jsonSchema';
-import { JsonForms } from '../core';
 /**
  * A Property wraps a JsonSchema and provides additional information
  * like a label and the property key.
@@ -66,10 +65,13 @@ export interface ReferenceProperty extends Property {
    */
   addToData(root: Object, data: Object, valueToAdd: object): void;
   /**
-   * This allows to retrieve the data of the reference.
-   * @param root The root object, needed for finding the value to retrieve
-   * @param data The object the reference is in
-   * @return The referenced value
+   * This allows to retrieve the refernced data object(s) of the reference.
+   *
+   * @param root The root object, The root data object needed for finding the referenced value(s).
+   * @param data The object that contains the reference
+   * @return The referenced value(s). If no referenced value was found and the reference property
+   *         defines a single reference, null is returned. If the property defines a multi
+   *         reference, in this case an empty array is returned.
    */
   getData(root: Object, data: Object): Object;
 
@@ -81,16 +83,6 @@ export interface ReferenceProperty extends Property {
    *         for this reference property.
    */
   findReferenceTargets(rootData: Object): Object[];
-
-  /**
-   * Resolves a reference value for this Reference by using the given porpertyValue to
-   * identify the referenced Object.
-   *
-   * @param rootData The root data object needed for finding the referenced value.
-   * @param propertyValue The property value identifying the referenced data object.
-   * @return The resolved data object or null if it coiuld not be resolved.
-   */
-  resolveReference(rootData: Object, propertyValue: string): Object;
 }
 
 export class ContainmentPropertyImpl implements ContainmentProperty {
@@ -136,8 +128,7 @@ export class ReferencePropertyImpl implements ReferenceProperty {
     private innerTargetSchema: JsonSchema,
     private key: string,
     private name: string,
-    private pathToContainment: string,
-    private identifyingProperty: string,
+    private findFunction: (rootObject: Object) => Object[],
     private addFunction: (root: object, data: object, valueToAdd: object) => void,
     private getFunction: (root: object, data: object) => Object
   ) {}
@@ -168,44 +159,7 @@ export class ReferencePropertyImpl implements ReferenceProperty {
     return this.getFunction(root, data);
   }
   findReferenceTargets(rootData: Object): Object[] {
-    const candidates = this.pathToContainment
-      .split('/')
-      .reduce(
-        (prev, cur) => {
-          if (cur === '#') {
-            return prev;
-          }
-
-          return prev[cur];
-        },
-        rootData) as Object[];
-    if (!_.isEmpty(candidates)) {
-      return JsonForms.filterObjectsByType(candidates, this.targetSchema.id);
-    }
-
-    return [];
-  }
-
-  resolveReference(rootData: Object, propertyValue: string): Object {
-    if (_.isEmpty(propertyValue) || _.isEmpty(this.identifyingProperty)) {
-      return null;
-    }
-    // get all objects that could be referenced.
-    const candidates = this.findReferenceTargets(rootData);
-    // use identifying property to identify the referenced property by the given propertyValue
-    const resultList = candidates.filter(value => {
-      return value[this.identifyingProperty] === propertyValue;
-    });
-
-    if (_.isEmpty(resultList)) {
-      return null;
-    }
-    if (resultList.length > 1) {
-      throw Error('There was more than one possible reference target with value \'' + propertyValue
-                  + '\' in the identifying property \'' + this.identifyingProperty + '\'.');
-    }
-
-    return _.first(resultList);
+    return this.findFunction(rootData);
   }
 }
 

--- a/test/schema.service.test.ts
+++ b/test/schema.service.test.ts
@@ -24,6 +24,113 @@ test.beforeEach(t => {
       }
     }
   };
+
+  // For reference properties tests
+  JsonForms.config.setIdentifyingProp('id');
+  t.context.referenceObjectSchema = {
+    definitions: {
+      class: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string'
+          },
+          association: {
+            type: 'string'
+          }
+        },
+        links: [{
+          rel: 'full',
+          href: '#/classes/{association}',
+          targetSchema: {$ref: '#/definitions/class'}
+        }]
+      }
+    },
+    type: 'object',
+    properties: {
+      classes: {
+        type: 'array',
+        items: {
+          $ref: '#/definitions/class'
+        }
+      }
+    }
+  };
+  t.context.referenceArraySchema = {
+    definitions: {
+      class: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string'
+          },
+          associations: {
+            type: 'array',
+            items: {
+              type: 'string'
+            }
+          }
+        },
+        links: [{
+          rel: 'full',
+          href: '#/classes/{associations}',
+          targetSchema: {$ref: '#/definitions/class'}
+        }]
+      }
+    },
+    type: 'object',
+    properties: {
+      classes: {
+        type: 'array',
+        items: {
+          $ref: '#/definitions/class'
+        }
+      }
+    }
+  };
+  t.context.referenceFindSchema = {
+    definitions: {
+      class: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string'
+          },
+          association: {
+            type: 'string'
+          }
+        },
+        links: [{
+          rel: 'full',
+          href: '#/classes/{association}',
+          targetSchema: {$ref: '#/definitions/class'}
+        }]
+      },
+      element : {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string'
+          }
+        }
+      }
+    },
+    type: 'object',
+    properties: {
+      classes: {
+        type: 'array',
+        items: {
+          $ref: '#/definitions/class'
+        }
+      },
+      elements: {
+        type: 'array',
+        items: {
+          $ref: '#/definitions/element'
+        }
+      }
+    }
+  };
 });
 test.failing('array with array ', t => {
   const schema: JsonSchema = {
@@ -618,222 +725,99 @@ test('containment properties delete when array defined', t => {
   t.is(data.foo.length, 1);
   t.is(data.foo[0].bar, 'stay');
 });
+
 test('reference object properties add', t => {
-  // tslint:disable:no-object-literal-type-assertion
-  const schema: JsonSchema = {
-    definitions: {
-      class: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'string'
-          },
-          association: {
-            type: 'integer',
-            minimum: 0
-          }
-        },
-        links: [{
-          rel: 'full',
-          href: '#/classes/{association}',
-          targetSchema: {$ref: '#/definitions/class'}
-        }]
-      }
-    },
-    type: 'object',
-    properties: {
-      classes: {
-        type: 'array',
-        items: {
-          $ref: '#/definitions/class'
-        }
-      }
-    }
-  } as JsonSchema;
-  // tslint:enable:no-object-literal-type-assertion
+  const schema: JsonSchema = t.context.referenceObjectSchema;
   const service: SchemaService = new SchemaServiceImpl(schema);
   const property = service.getReferenceProperties(schema.definitions.class)[0];
-  const data = {classes: [{id: 1}, {id: 2}]};
+  const data = {classes: [{id: 'c1'}, {id: 'c2'}]};
   property.addToData(data, data.classes[1], data.classes[0]);
   // tslint:disable:no-string-literal
-  t.is(data.classes[1]['association'], 0);
+  t.is(data.classes[1]['association'], 'c1');
   // tslint:enable:no-string-literal
 });
 test('reference object properties get', t => {
-  // tslint:disable:no-object-literal-type-assertion
-  const schema: JsonSchema = {
-    definitions: {
-      class: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'string'
-          },
-          association: {
-            type: 'integer',
-            minimum: 0
-          }
-        },
-        links: [{
-          rel: 'full',
-          href: '#/classes/{association}',
-          targetSchema: {$ref: '#/definitions/class'}
-        }]
-      }
-    },
-    type: 'object',
-    properties: {
-      classes: {
-        type: 'array',
-        items: {
-          $ref: '#/definitions/class'
-        }
-      }
-    }
-  } as JsonSchema;
-  // tslint:enable:no-object-literal-type-assertion
+  const schema: JsonSchema = t.context.referenceObjectSchema;
   const service: SchemaService = new SchemaServiceImpl(schema);
   const property = service.getReferenceProperties(schema.properties.classes.items as JsonSchema)[0];
-  const data = {classes: [{id: 1}, {id: 2, association: 0}]};
+  const data = {classes: [{id: 'c1'}, {id: 'c2', association: 'c1'}]};
   const getData = property.getData(data, data.classes[1]);
   t.is(getData, data.classes[0]);
 });
+
 test('reference array properties add to undefined', t => {
-  // tslint:disable:no-object-literal-type-assertion
-  const schema: JsonSchema = {
-    definitions: {
-      class: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'string'
-          },
-          associations: {
-            type: 'array',
-            items: {
-              type: 'integer',
-              minimum: 0
-            }
-          }
-        },
-        links: [{
-          rel: 'full',
-          href: '#/classes/{associations}',
-          targetSchema: {$ref: '#/definitions/class'}
-        }]
-      }
-    },
-    type: 'object',
-    properties: {
-      classes: {
-        type: 'array',
-        items: {
-          $ref: '#/definitions/class'
-        }
-      }
-    }
-  } as JsonSchema;
-  // tslint:enable:no-object-literal-type-assertion
+  const schema: JsonSchema = t.context.referenceArraySchema;
   const service: SchemaService = new SchemaServiceImpl(schema);
   const property =
     service.getReferenceProperties(schema.definitions.class)[0];
-  const data = {classes: [{id: 1}, {id: 2}]};
+  const data = {classes: [{id: 'c1'}, {id: 'c2'}]};
   property.addToData(data, data.classes[1], data.classes[0]);
   // tslint:disable:no-string-literal
   const associations = data.classes[1]['associations'];
   // tslint:enable:no-string-literal
   t.is(associations.length, 1);
-  t.is(associations[0], 0);
+  t.is(associations[0], 'c1');
 });
 test('reference array properties add to defined', t => {
-  // tslint:disable:no-object-literal-type-assertion
-  const schema: JsonSchema = {
-    definitions: {
-      class: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'string'
-          },
-          associations: {
-            type: 'array',
-            items: {
-              type: 'integer',
-              minimum: 0
-            }
-          }
-        },
-        links: [{
-          rel: 'full',
-          href: '#/classes/{associations}',
-          targetSchema: {$ref: '#/definitions/class'}
-        }]
-      }
-    },
-    type: 'object',
-    properties: {
-      classes: {
-        type: 'array',
-        items: {
-          $ref: '#/definitions/class'
-        }
-      }
-    }
-  } as JsonSchema;
-  // tslint:enable:no-object-literal-type-assertion
+  const schema: JsonSchema = t.context.referenceArraySchema;
   const service: SchemaService = new SchemaServiceImpl(schema);
   const property =
     service.getReferenceProperties(schema.definitions.class)[0];
-  const data = {classes: [{id: 1}, {id: 2, associations: []}]};
+  const data = {classes: [{id: 'c1'}, {id: 'c2', associations: []}]};
   property.addToData(data, data.classes[1], data.classes[0]);
   // tslint:disable:no-string-literal
   const associations = data.classes[1]['associations'];
   // tslint:enable:no-string-literal
   t.is(associations.length, 1);
-  t.is(associations[0], 0);
+  t.is(associations[0], 'c1');
 });
 test('reference array properties get', t => {
-  // tslint:disable:no-object-literal-type-assertion
-  const schema: JsonSchema = {
-    definitions: {
-      class: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'string'
-          },
-          associations: {
-            type: 'array',
-            items: {
-              type: 'integer',
-              minimum: 0
-            }
-          }
-        },
-        links: [{
-          rel: 'full',
-          href: '#/classes/{associations}',
-          targetSchema: {$ref: '#/definitions/class'}
-        }]
-      }
-    },
-    type: 'object',
-    properties: {
-      classes: {
-        type: 'array',
-        items: {
-          $ref: '#/definitions/class'
-        }
-      }
-    }
-  } as JsonSchema;
-  // tslint:enable:no-object-literal-type-assertion
+  const schema: JsonSchema = t.context.referenceArraySchema;
   const service: SchemaService = new SchemaServiceImpl(schema);
   const property =
     service.getReferenceProperties(schema.definitions.class)[0];
-  const data = {classes: [{id: 1}, {id: 2, associations: [0]}]};
+  const data = {classes: [{id: 'c1'}, {id: 'c2', associations: ['c1']}]};
   const getData = property.getData(data, data.classes[1]);
-  t.is(getData, data.classes[0]);
+  t.true(Array.isArray(getData));
+  t.deepEqual(getData, [data.classes[0]]);
+});
+test('reference array properties get multiple', t => {
+  const schema: JsonSchema = t.context.referenceArraySchema;
+  const service: SchemaService = new SchemaServiceImpl(schema);
+  const property =
+    service.getReferenceProperties(schema.definitions.class)[0];
+  const data = {classes: [{id: 'c1'}, {id: 'c2', associations: ['c1', 'c3']}, {id: 'c3'},
+                          {id: 'c4'}]};
+  const getData = property.getData(data, data.classes[1]);
+  t.true(Array.isArray(getData));
+  const getDataArray = getData as Object[];
+  t.is(getDataArray.length, 2);
+  t.is(getDataArray[0], data.classes[0]);
+  t.is(getDataArray[1], data.classes[2]);
+});
+
+test('reference property find reference targets', t => {
+  const schema = t.context.referenceFindSchema;
+  const service: SchemaService = new SchemaServiceImpl(schema);
+  const property = service.getReferenceProperties(schema.properties.classes.items as JsonSchema)[0];
+  const data = {
+    classes: [{id: 'c1'}, {id: 'c2', association: 'c1'}],
+    elements: [{id: 'e1'}]
+  };
+  const targets = property.findReferenceTargets(data);
+  t.is(targets.length, 2);
+  t.is(targets[0], data.classes[0]);
+  t.is(targets[1], data.classes[1]);
+});
+test('reference property find reference targets - target container undefined', t => {
+  const schema = t.context.referenceFindSchema;
+  const service: SchemaService = new SchemaServiceImpl(schema);
+  const property = service.getReferenceProperties(schema.properties.classes.items as JsonSchema)[0];
+  const data = {
+    elements: [{id: 'e1'}]
+  };
+  const targets = property.findReferenceTargets(data);
+  t.deepEqual(targets, []);
 });
 
 test('property type check', t => {


### PR DESCRIPTION
This PR refactors the ReferenceProperty implementation of the schema service to make the implementation locations more consistent and allow the reference property implementation to properly handle multi references using ids to identify referenced objects.

- Adapted reference properties get and add functions to properly handle
ids and multi refs.
- Added constructor parameter to ReferencePropertyImpl for find
reference target function
- Implemented function in schema.service.impl and provide it to created
reference properties
- Removed obsolete resolveReference function (same purpose as getData)
from ReferenceProperty
- Removed obsolete constructor parameters from ReferencePropertyImpl
- Added and adapted reference property test cases