### PR TITLE
Abstract Reference Renderer

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -61,6 +61,7 @@ export class JsonForms {
   public static uischemaRegistry: UISchemaRegistry = new UISchemaRegistryImpl();
   public static stylingRegistry: StylingRegistry = new StylingRegistryImpl();
   public static modelMapping;
+  public static rootData: Object;
   public static set schema(schema: JsonSchema) {
     JsonForms._schemaService = new SchemaServiceImpl(schema);
   }

--- a/src/renderers/controls/reference.control.ts
+++ b/src/renderers/controls/reference.control.ts
@@ -33,11 +33,15 @@ export abstract class ReferenceControl extends BaseControl<HTMLSelectElement> {
   }
 
   /**
-   * Overwrite to provide the root data object which contains the possible reference targets.
+   * Returns the root data object that contains the possible reference targets.
+   * Might be overwritten to provide the root data object in another way
+   * than from the static JsonForms object.
    *
    * @return The root data object containing the possible reference targets.
    */
-  protected abstract getRootData(): Object;
+  protected getRootData(): Object {
+    return JsonForms.rootData;
+  }
 
   /**
    * Overwrite to provide the property that contains the label to display for
@@ -55,6 +59,16 @@ export abstract class ReferenceControl extends BaseControl<HTMLSelectElement> {
   }
 
   /**
+   * Returns the label of the default option.
+   * Might be overwritten by implementing classes to change the label.
+   *
+   * @return the label of the default option.
+   */
+  protected getDefaultOptionLabel(): string {
+    return 'Choose Reference Target...';
+  }
+
+  /**
    * Adds all possible reference targets as options to the control's combo box.
    */
   protected addOptions(input) {
@@ -63,6 +77,13 @@ export abstract class ReferenceControl extends BaseControl<HTMLSelectElement> {
       _.head(JsonForms.schemaService.getReferenceProperties(eReferenceSchema));
 
     const referencees = eTypeRefProp.findReferenceTargets(this.getRootData());
+
+    const defaultOption = document.createElement('option');
+    defaultOption.selected = true;
+    defaultOption.disabled = true;
+    defaultOption.hidden = true;
+    defaultOption.innerText = this.getDefaultOptionLabel();
+    input.appendChild(defaultOption);
 
     referencees.forEach((referencee, index) => {
       const option = document.createElement('option');

--- a/src/renderers/controls/reference.control.ts
+++ b/src/renderers/controls/reference.control.ts
@@ -1,0 +1,77 @@
+import * as _ from 'lodash';
+
+import { JsonForms } from '../../core';
+import { BaseControl } from './base.control';
+import { ReferenceProperty } from '../../core/schema.service';
+
+/**
+ * Abstract class that can be extended to get a single reference renderer.
+ * Thereby the implementing client needs to provide the root data object
+ * and the name of the property containing the label of possible
+ * reference targets.
+ */
+export abstract class ReferenceControl extends BaseControl<HTMLSelectElement> {
+
+  protected configureInput(input: HTMLSelectElement): void {
+    this.addOptions(input);
+  }
+
+  protected get valueProperty(): string {
+    return 'value';
+  }
+
+  protected get inputChangeProperty(): string {
+    return 'onchange';
+  }
+
+  protected createInputElement(): HTMLSelectElement {
+    return document.createElement('select');
+  }
+
+  protected convertModelValue(value: any): any {
+    return (value === undefined || value === null) ? undefined : value.toString();
+  }
+
+  /**
+   * Overwrite to provide the root data object which contains the possible reference targets.
+   *
+   * @return The root data object containing the possible reference targets.
+   */
+  protected abstract getRootData(): Object;
+
+  /**
+   * Overwrite to provide the property that contains the label to display for
+   * possible reference targets.
+   *
+   * @return The name of the label property
+   */
+  protected abstract getLabelProperty(): string;
+
+  /**
+   * @return The name of the property that identifies a referencable data object.
+   */
+  protected getIdentifyingProperty(): string {
+    return JsonForms.config.getIdentifyingProp();
+  }
+
+  /**
+   * Adds all possible reference targets as options to the control's combo box.
+   */
+  protected addOptions(input) {
+    const eReferenceSchema = this.dataSchema;
+    const eTypeRefProp: ReferenceProperty =
+      _.head(JsonForms.schemaService.getReferenceProperties(eReferenceSchema));
+
+    const referencees = eTypeRefProp.findReferenceTargets(this.getRootData());
+
+    referencees.forEach((referencee, index) => {
+      const option = document.createElement('option');
+      option.value = referencee[this.getIdentifyingProperty()];
+      option.label = referencee[this.getLabelProperty()];
+      option.innerText = referencee[this.getLabelProperty()];
+      input.appendChild(option);
+    });
+
+    input.classList.add('form-control');
+  }
+}

--- a/src/renderers/renderers.ts
+++ b/src/renderers/renderers.ts
@@ -8,6 +8,7 @@ export * from './controls/integer.control';
 export * from './controls/number.control';
 export * from './controls/date.control';
 export * from './controls/enum.control';
+export * from './controls/reference.control';
 export * from './controls/textarea.control';
 export * from './layouts/vertical.layout';
 export * from './layouts/horizontal.layout';

--- a/test/renderers/reference.control.test.ts
+++ b/test/renderers/reference.control.test.ts
@@ -1,0 +1,120 @@
+import test from 'ava';
+import * as installCE from 'document-register-element/pony';
+// inject window, document etc.
+import 'jsdom-global/register';
+declare let global;
+installCE(global, 'force');
+import { JsonForms } from '../../src/core';
+import { DataService } from '../../src/core/data.service';
+import { SchemaService } from '../../src/core/schema.service';
+import { SchemaServiceImpl } from '../../src/core/schema.service.impl';
+import { JsonSchema } from '../../src/models/jsonSchema';
+import { ReferenceControl } from '../../src/renderers/controls/reference.control';
+import { ReferenceControlTestImpl } from './reference.control.testimpl';
+
+test.before(t => {
+  JsonForms.stylingRegistry.registerMany([
+    {
+      name: 'control',
+      classNames: ['control-TEST']
+    },
+    {
+      name: 'control.label',
+      classNames: ['label-TEST']
+    },
+    {
+      name: 'control.input',
+      classNames: ['input-TEST']
+    },
+    {
+      name: 'control.validation',
+      classNames: ['validation-TEST']
+    }
+  ]);
+});
+
+test.beforeEach(t => {
+  t.context.schema = {
+    definitions: {
+      class: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string'
+          },
+          name: {
+            type: 'string'
+          },
+          association: {
+            type: 'string'
+          }
+        },
+        links: [{
+          rel: 'full',
+          href: '#/classes/{association}',
+          targetSchema: {$ref: '#/definitions/class'}
+        }]
+      }
+    },
+    type: 'object',
+    properties: {
+      classes: {
+        type: 'array',
+        items: {
+          $ref: '#/definitions/class'
+        }
+      }
+    }
+  };
+
+  JsonForms.config.setIdentifyingProp('id');
+  JsonForms.schema = t.context.schema;
+  t.context.uiSchema = {
+    type: 'Control',
+    scope: {
+      $ref: '#/properties/association'
+    }
+  };
+});
+
+test('Abstract Reference Control - render all options', t => {
+  customElements.define('test-renderer', ReferenceControlTestImpl);
+  const schema: JsonSchema = t.context.schema;
+  const data = {classes: [{id: 'c1', name: 'CL1'}, {id: 'c2', name: 'CL2', association: 'c1'}]};
+  const renderer: ReferenceControl = new ReferenceControlTestImpl(data, 'name');
+  renderer.setDataSchema(schema.definitions.class);
+  renderer.setUiSchema(t.context.uiSchema);
+  renderer.setDataService(new DataService(data.classes[1]));
+  const result = renderer.render();
+
+  const className = result.className;
+  t.true(className.indexOf('root_properties_association') !== -1);
+  t.true(className.indexOf('control-TEST') !== -1);
+  t.is(result.childNodes.length, 3);
+  const label = result.children[0] as HTMLLabelElement;
+  t.true(label.className.indexOf('label-TEST') !== -1);
+  t.is(label.tagName, 'LABEL');
+  t.is(label.textContent, 'Association');
+  const input = result.children[1] as HTMLInputElement;
+
+  // Check combo box
+  t.true(input.className.indexOf('input-TEST') !== -1);
+  t.is(input.tagName, 'SELECT');
+  t.is(input.children.length, 2);
+  const option1 = input.children[0] as HTMLOptionElement;
+  const option2 = input.children[1] as HTMLOptionElement;
+  t.is(option1.tagName, 'OPTION');
+  t.is(option2.tagName, 'OPTION');
+  t.is(option1.value, 'c1');
+  t.is(option2.value, 'c2');
+  t.is(option1.innerText, 'CL1');
+  t.is(option2.innerText, 'CL2');
+  // commented out because JsDom does not properly support the option's label property
+  // t.is(option1.label, 'CL1');
+  // t.is(option2.label, 'CL2');
+
+  const validation = result.children[2];
+  t.true(validation.className.indexOf('validation-TEST') !== -1);
+  t.is(validation.tagName, 'DIV');
+  t.is(validation.children.length, 0);
+});

--- a/test/renderers/reference.control.test.ts
+++ b/test/renderers/reference.control.test.ts
@@ -6,8 +6,6 @@ declare let global;
 installCE(global, 'force');
 import { JsonForms } from '../../src/core';
 import { DataService } from '../../src/core/data.service';
-import { SchemaService } from '../../src/core/schema.service';
-import { SchemaServiceImpl } from '../../src/core/schema.service.impl';
 import { JsonSchema } from '../../src/models/jsonSchema';
 import { ReferenceControl } from '../../src/renderers/controls/reference.control';
 import { ReferenceControlTestImpl } from './reference.control.testimpl';
@@ -31,6 +29,8 @@ test.before(t => {
       classNames: ['validation-TEST']
     }
   ]);
+
+  customElements.define('test-renderer', ReferenceControlTestImpl);
 });
 
 test.beforeEach(t => {
@@ -77,10 +77,10 @@ test.beforeEach(t => {
   };
 });
 
-test('Abstract Reference Control - render all options', t => {
-  customElements.define('test-renderer', ReferenceControlTestImpl);
+test('Abstract Reference Control - no pre-selection', t => {
   const schema: JsonSchema = t.context.schema;
-  const data = {classes: [{id: 'c1', name: 'CL1'}, {id: 'c2', name: 'CL2', association: 'c1'}]};
+  const data = {classes: [{id: 'c1', name: 'CL1'}, {id: 'c2', name: 'CL2'}]};
+  JsonForms.rootData = data;
   const renderer: ReferenceControl = new ReferenceControlTestImpl(data, 'name');
   renderer.setDataSchema(schema.definitions.class);
   renderer.setUiSchema(t.context.uiSchema);
@@ -95,20 +95,25 @@ test('Abstract Reference Control - render all options', t => {
   t.true(label.className.indexOf('label-TEST') !== -1);
   t.is(label.tagName, 'LABEL');
   t.is(label.textContent, 'Association');
-  const input = result.children[1] as HTMLInputElement;
+  const input = result.children[1] as HTMLSelectElement;
 
   // Check combo box
   t.true(input.className.indexOf('input-TEST') !== -1);
   t.is(input.tagName, 'SELECT');
-  t.is(input.children.length, 2);
-  const option1 = input.children[0] as HTMLOptionElement;
-  const option2 = input.children[1] as HTMLOptionElement;
+  t.is(input.children.length, 3);
+  const defaultOption = input.children[0] as HTMLOptionElement;
+  const option1 = input.children[1] as HTMLOptionElement;
+  const option2 = input.children[2] as HTMLOptionElement;
+  t.is(defaultOption.tagName, 'OPTION');
   t.is(option1.tagName, 'OPTION');
   t.is(option2.tagName, 'OPTION');
   t.is(option1.value, 'c1');
   t.is(option2.value, 'c2');
+  t.is(defaultOption.innerText, 'Choose Reference Target...');
   t.is(option1.innerText, 'CL1');
   t.is(option2.innerText, 'CL2');
+  t.true(defaultOption.disabled);
+  t.true(defaultOption.hidden);
   // commented out because JsDom does not properly support the option's label property
   // t.is(option1.label, 'CL1');
   // t.is(option2.label, 'CL2');
@@ -117,4 +122,60 @@ test('Abstract Reference Control - render all options', t => {
   t.true(validation.className.indexOf('validation-TEST') !== -1);
   t.is(validation.tagName, 'DIV');
   t.is(validation.children.length, 0);
+
+  /* tslint:disable:no-string-literal */
+  t.is(data.classes[1]['association'], undefined);
+  /* tslint:enable:no-string-literal */
+});
+
+test('Abstract Reference Control - pre-selection', t => {
+  const schema: JsonSchema = t.context.schema;
+  const data = {classes: [{id: 'c1', name: 'CL1'}, {id: 'c2', name: 'CL2', association: 'c2'}]};
+  JsonForms.rootData = data;
+  const renderer: ReferenceControl = new ReferenceControlTestImpl(data, 'name');
+  renderer.setDataSchema(schema.definitions.class);
+  renderer.setUiSchema(t.context.uiSchema);
+  renderer.setDataService(new DataService(data.classes[1]));
+  const result = renderer.render();
+
+  const className = result.className;
+  t.true(className.indexOf('root_properties_association') !== -1);
+  t.true(className.indexOf('control-TEST') !== -1);
+  t.is(result.childNodes.length, 3);
+  const label = result.children[0] as HTMLLabelElement;
+  t.true(label.className.indexOf('label-TEST') !== -1);
+  t.is(label.tagName, 'LABEL');
+  t.is(label.textContent, 'Association');
+  const input = result.children[1] as HTMLSelectElement;
+
+  // Check combo box
+  t.true(input.className.indexOf('input-TEST') !== -1);
+  t.is(input.tagName, 'SELECT');
+  t.is(input.children.length, 3);
+  t.is(input.selectedIndex, 2);
+  const defaultOption = input.children[0] as HTMLOptionElement;
+  const option1 = input.children[1] as HTMLOptionElement;
+  const option2 = input.children[2] as HTMLOptionElement;
+  t.is(defaultOption.tagName, 'OPTION');
+  t.is(option1.tagName, 'OPTION');
+  t.is(option2.tagName, 'OPTION');
+  t.is(option1.value, 'c1');
+  t.is(option2.value, 'c2');
+  t.is(defaultOption.innerText, 'Choose Reference Target...');
+  t.is(option1.innerText, 'CL1');
+  t.is(option2.innerText, 'CL2');
+  t.true(defaultOption.disabled);
+  t.true(defaultOption.hidden);
+  // commented out because JsDom does not properly support the option's label property
+  // t.is(option1.label, 'CL1');
+  // t.is(option2.label, 'CL2');
+
+  const validation = result.children[2];
+  t.true(validation.className.indexOf('validation-TEST') !== -1);
+  t.is(validation.tagName, 'DIV');
+  t.is(validation.children.length, 0);
+
+  /* tslint:disable:no-string-literal */
+  t.is(data.classes[1]['association'], 'c2');
+  /* tslint:enable:no-string-literal */
 });

--- a/test/renderers/reference.control.testimpl.ts
+++ b/test/renderers/reference.control.testimpl.ts
@@ -24,10 +24,6 @@ export class ReferenceControlTestImpl extends ReferenceControl {
     this.labelProperty = labelProperty;
   }
 
-  protected getRootData(): Object {
-    return this.rootData;
-  }
-
   protected getLabelProperty(): string {
     return this.labelProperty;
   }

--- a/test/renderers/reference.control.testimpl.ts
+++ b/test/renderers/reference.control.testimpl.ts
@@ -1,19 +1,5 @@
 import { ReferenceControl } from '../../src/renderers/controls/reference.control';
-// import { and, RankedTester, rankWith, schemaTypeIs, uiTypeIs } from '../../src/core/testers';
-// import { JsonFormsRenderer } from '../../src/renderers/renderer.util';
 
-// export const booleanControlTester: RankedTester = rankWith(2, and(
-//     uiTypeIs('Control'),
-//     schemaTypeIs('boolean')
-//   ));
-//
-// /**
-//  * Default boolean control.
-//  */
-// @JsonFormsRenderer({
-//   selector: 'jsonforms-boolean',
-//   tester: booleanControlTester
-// })
 export class ReferenceControlTestImpl extends ReferenceControl {
   private rootData: Object;
   private labelProperty: string;

--- a/test/renderers/reference.control.testimpl.ts
+++ b/test/renderers/reference.control.testimpl.ts
@@ -1,0 +1,34 @@
+import { ReferenceControl } from '../../src/renderers/controls/reference.control';
+// import { and, RankedTester, rankWith, schemaTypeIs, uiTypeIs } from '../../src/core/testers';
+// import { JsonFormsRenderer } from '../../src/renderers/renderer.util';
+
+// export const booleanControlTester: RankedTester = rankWith(2, and(
+//     uiTypeIs('Control'),
+//     schemaTypeIs('boolean')
+//   ));
+//
+// /**
+//  * Default boolean control.
+//  */
+// @JsonFormsRenderer({
+//   selector: 'jsonforms-boolean',
+//   tester: booleanControlTester
+// })
+export class ReferenceControlTestImpl extends ReferenceControl {
+  private rootData: Object;
+  private labelProperty: string;
+
+  constructor(rootData: Object, labelProperty: string) {
+    super();
+    this.rootData = rootData;
+    this.labelProperty = labelProperty;
+  }
+
+  protected getRootData(): Object {
+    return this.rootData;
+  }
+
+  protected getLabelProperty(): string {
+    return this.labelProperty;
+  }
+}


### PR DESCRIPTION
Implemented an abstract reference renderer that can be implemented by clients to renderer references to other objects in the same root data object.

- implemented abstract renderer
- the abstract renderer provides various overwritable methods to customize its behavior, e.g. like defining the label of the default option
- added global rootData variable to the JsonForms class
- implemented test cases for the abstract renderer
