### PR TITLE
Enum Renderer - Set values as options' innerText

### DIFF
--- a/src/renderers/controls/enum.control.ts
+++ b/src/renderers/controls/enum.control.ts
@@ -35,6 +35,7 @@ export class EnumControl extends BaseControl<HTMLSelectElement> {
       const option = document.createElement('option');
       option.value = optionValue;
       option.label = optionValue;
+      option.innerText = optionValue;
       input.appendChild(option);
     });
   }

--- a/test/renderers/enum.control.test.ts
+++ b/test/renderers/enum.control.test.ts
@@ -169,7 +169,9 @@ test('EnumControl static', t => {
   t.is(input.value, 'a');
   t.is(input.options.length, 2);
   t.is(input.options.item(0).value, 'a');
+  t.is(input.options.item(0).innerText, 'a');
   t.is(input.options.item(1).value, 'b');
+  t.is(input.options.item(1).innerText, 'b');
   const validation = result.children[2];
   t.is(validation.tagName, 'DIV');
   t.is(validation.children.length, 0);
@@ -200,7 +202,9 @@ test('EnumControl static no label', t => {
   t.is(input.value, 'b');
   t.is(input.options.length, 2);
   t.is(input.options.item(0).value, 'a');
+  t.is(input.options.item(0).innerText, 'a');
   t.is(input.options.item(1).value, 'b');
+  t.is(input.options.item(1).innerText, 'b');
   const validation = result.children[2];
   t.is(validation.tagName, 'DIV');
   t.is(validation.children.length, 0);


### PR DESCRIPTION
For every option created in the enum control, the enum literal's label is now also set as the option element's `innerText`. This allows proper display of the enum for stylings that rely on the `innerText` instead of the label of an option element.