### PR TITLE
Only generate an id if the identifying property is empty

### DIFF
--- a/src/core/schema.service.impl.ts
+++ b/src/core/schema.service.impl.ts
@@ -29,7 +29,7 @@ const addToArray =
   if (data[key] === undefined) {
     data[key] = [];
   }
-  if (!_.isEmpty(identifyingProperty)) {
+  if (!_.isEmpty(identifyingProperty) && _.isEmpty(valueToAdd[identifyingProperty])) {
     valueToAdd[identifyingProperty] = uuid.v4();
   }
   const childArray = data[key];

--- a/test/schema.service.test.ts
+++ b/test/schema.service.test.ts
@@ -566,6 +566,39 @@ test('containment properties add when array not defined and generate ID', t => {
   t.true(data.foo[0]._id !== undefined);
 });
 
+test('containment properties add when array not defined and do not overwrite existing ID', t => {
+  const schema = {
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            _id: { type: 'string' },
+            bar: { type: 'string' }
+          }
+        }
+      }
+    }
+  };
+
+  JsonForms.config.setIdentifyingProp('_id');
+  const service: SchemaService = new SchemaServiceImpl(schema);
+
+  const property = service.getContainmentProperties(schema)[0];
+  const data = {
+    foo: undefined
+  };
+  const valueToAdd = { bar: `Hey Mum, look, it's an idea`, _id: 'TEST-ID' };
+  property.addToData(data)(valueToAdd);
+
+  t.true(data.foo !== undefined);
+  t.is(data.foo.length, 1);
+  t.is(data.foo[0].bar, `Hey Mum, look, it's an idea`);
+  t.is(data.foo[0]._id, 'TEST-ID');
+});
+
 test('containment properties add when array defined', t => {
   const schema = t.context.fooBarArraySchema;
   const service: SchemaService = new SchemaServiceImpl(schema);


### PR DESCRIPTION
ID was always regenerated on add. This regenerated the id after drag and drop even if it was already present.
