### PR TITLE
Path-based Referencing, Resource Set, and Minor Improvements

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -63,7 +63,7 @@ export class JsonForms {
   public static stylingRegistry: StylingRegistry = new StylingRegistryImpl();
   public static modelMapping;
   public static rootData: Object;
-  public static resources: ResourceSet = new ResourceSetImpl();
+  private static _resources: ResourceSet = new ResourceSetImpl();
   public static set schema(schema: JsonSchema) {
     JsonForms._schemaService = new SchemaServiceImpl(schema);
   }
@@ -77,6 +77,13 @@ export class JsonForms {
 
   public static get config(): JsonFormsConfig {
     return this._config;
+  }
+
+  /**
+   * Returns the {ResourceSet} containing all registered resources.
+   */
+  public static get resources(): ResourceSet {
+    return this._resources;
   }
 
   /**

--- a/src/core.ts
+++ b/src/core.ts
@@ -7,6 +7,7 @@ import { RendererService } from './core/renderer.service';
 import { StylingRegistry, StylingRegistryImpl } from './core/styling.registry';
 import { SchemaService } from './core/schema.service';
 import { SchemaServiceImpl } from './core/schema.service.impl';
+import { ResourceSet, ResourceSetImpl } from './core/resource-set';
 
 /**
  * Represents a JSONForms service.
@@ -62,6 +63,7 @@ export class JsonForms {
   public static stylingRegistry: StylingRegistry = new StylingRegistryImpl();
   public static modelMapping;
   public static rootData: Object;
+  public static resources: ResourceSet = new ResourceSetImpl();
   public static set schema(schema: JsonSchema) {
     JsonForms._schemaService = new SchemaServiceImpl(schema);
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -22,7 +22,7 @@ export interface JsonFormService {
 
 export class JsonFormsConfig {
 
-  private _identifyingProp;
+  private _identifyingProp: string;
 
   setIdentifyingProp(propName: string) {
     this._identifyingProp = propName;

--- a/src/core/resource-set.ts
+++ b/src/core/resource-set.ts
@@ -29,6 +29,11 @@ export interface ResourceSet {
    * @return The old resource if one was already registered for the given name, undefined otherwise
    */
   registerResource(name: string, resource: Object, resolveReferences: boolean): Object;
+
+  /**
+   * Remove all registered resources from the ResourceSet.
+   */
+  clear();
 }
 
 export class ResourceSetImpl implements ResourceSet {
@@ -58,5 +63,9 @@ export class ResourceSetImpl implements ResourceSet {
     }
 
     return oldResource;
+  }
+
+  clear() {
+    this.resourceMap = {};
   }
 }

--- a/src/core/resource-set.ts
+++ b/src/core/resource-set.ts
@@ -56,7 +56,7 @@ export class ResourceSetImpl implements ResourceSet {
     if (resolveReferences) {
       const resourcePromise = JsonRefs.resolveRefs(resource, {includeInvalid: true});
       resourcePromise.then(result => {
-        this.resourceMap[name] = result;
+        this.resourceMap[name] = result.resolved;
       });
     } else {
       this.resourceMap[name] = resource;

--- a/src/core/resource-set.ts
+++ b/src/core/resource-set.ts
@@ -1,0 +1,62 @@
+import * as JsonRefs from 'json-refs';
+
+export const RS_PROTOCOL = 'rs://';
+
+/**
+ * A ResourceSet contains an arbitrary number of data objects, each registered under a unique name.
+ */
+export interface ResourceSet {
+  /**
+   * Get the resource registered for the given name.
+   * @param name The name of the resource to retrieve.
+   * @return The resource if it is present; undefined otherwise.
+   */
+  getResource(name: string): Object;
+
+  /**
+   * Returns whether the resource set contains a data resource for the given name.
+   * @param name the name identifying the resource
+   * @return whether the resource is present in the resource set
+   */
+  hasResource(name: string): Object;
+
+  /**
+   * Register the given resource under the given name.
+   * @param name The name to register the resource for.
+   *             It can later be retrieved by calling getResource() for the same name.
+   * @param resource The resource Object
+   * @param resolveReferenecs If true, JSON References in the resource are resolved
+   * @return The old resource if one was already registered for the given name, undefined otherwise
+   */
+  registerResource(name: string, resource: Object, resolveReferences: boolean): Object;
+}
+
+export class ResourceSetImpl implements ResourceSet {
+  private resourceMap: { [name: string]: Object};
+
+  constructor() {
+    this.resourceMap = {};
+  }
+
+  getResource(name: string) {
+    return this.resourceMap[name];
+  }
+
+  hasResource(name: string) {
+    return this.resourceMap[name] !== undefined;
+  }
+
+  registerResource(name: string, resource: Object, resolveReferences = false): Object {
+    const oldResource = this.resourceMap[name];
+    if (resolveReferences) {
+      const resourcePromise = JsonRefs.resolveRefs(resource, {includeInvalid: true});
+      resourcePromise.then(result => {
+        this.resourceMap[name] = result;
+      });
+    } else {
+      this.resourceMap[name] = resource;
+    }
+
+    return oldResource;
+  }
+}

--- a/src/core/schema.service.impl.ts
+++ b/src/core/schema.service.impl.ts
@@ -338,6 +338,15 @@ export class SchemaServiceImpl implements SchemaService {
         // TODO Special case: JSON Schema 04 for UI Schema editor
         if (link.targetSchema.$ref !== undefined) {
           targetSchema = this.getSelfContainedSchema(this.rootSchema, link.targetSchema.$ref);
+        } else if (link.targetSchema.resource !== undefined) {
+          const resSchema = JsonForms.resources.getResource(link.targetSchema.resource);
+          if (resSchema === undefined) {
+            console.error(`Could not find target schema: There is no resource with name:` +
+                          `${link.targetSchema.resource}`);
+
+            return [];
+          }
+          targetSchema = resSchema;
         } else {
           targetSchema = link.targetSchema;
         }

--- a/src/core/schema.service.impl.ts
+++ b/src/core/schema.service.impl.ts
@@ -133,7 +133,7 @@ const getFindReferenceTargetsFunction = (href: string, schemaId: string, idProp:
     const candidates = getReferenceTargetData(href) as Object[];
     if (!_.isEmpty(candidates)) {
       const result = {};
-      for (const candidate in JsonForms.filterObjectsByType(candidates, schemaId)) {
+      for (const candidate of JsonForms.filterObjectsByType(candidates, schemaId)) {
         const id = candidate[idProp];
         result[id] = candidate;
       }
@@ -155,10 +155,10 @@ const getFindReferenceTargetsFunction = (href: string, schemaId: string, idProp:
  */
 const getReferenceTargetData = (href: string): Object => {
   let rootData: Object;
-  let localPath: string;
+  let localTemplatePath: string;
   if (_.startsWith(href, RS_PROTOCOL)) {
     const resourceName = href.substring(RS_PROTOCOL.length).split('/')[0];
-    localPath = href.substring(RS_PROTOCOL.length + resourceName.length + 1);
+    localTemplatePath = href.substring(RS_PROTOCOL.length + resourceName.length + 1);
     rootData = JsonForms.resources.getResource(resourceName);
     // reference to data in resource set
   } else if (_.startsWith(href, 'http://')) {
@@ -169,13 +169,14 @@ const getReferenceTargetData = (href: string): Object => {
   } else if (_.startsWith(href, '#')) {
     // local data
     rootData = JsonForms.rootData;
-    localPath = href;
+    localTemplatePath = href;
   } else {
     console.error(`'${href}' is not a supported URI to specify reference targets in a link block.`);
 
-    return null;
+    return {};
   }
 
+  const localPath = localTemplatePath.split(/\/\{.*\}/)[0]
   return resolveLocalData(rootData, localPath);
 };
 

--- a/src/core/schema.service.impl.ts
+++ b/src/core/schema.service.impl.ts
@@ -204,7 +204,7 @@ const getFindReferenceTargetsFunction = (href: string, schemaId: string, idProp:
  * The result is an object mapping from the found paths to the target data object
  * found at the path.
  */
-const collectionHelperMap = (currentPath: string, data: Object, targetSchema: JsonSchema)
+export const collectionHelperMap = (currentPath: string, data: Object, targetSchema: JsonSchema)
     : { [key: string]: Object } => {
   const result = {};
   if (checkData(data, targetSchema)) {

--- a/src/core/schema.service.impl.ts
+++ b/src/core/schema.service.impl.ts
@@ -15,7 +15,6 @@ import { JsonForms } from '../core';
 import { findAllRefs, resolveLocalData } from '../path.util';
 import { RS_PROTOCOL } from './resource-set';
 
-// TODO configure ajv for json schema 04
 const ajv = new AJV({jsonPointers: true});
 
 const isObject = (schema: JsonSchema): boolean => {
@@ -56,7 +55,6 @@ const addToArray =
 
         return;
       }
-      // TODO proper logging
       console.warn('Could not add the new value after the given neighbour value. ' +
                   'The new value was added at the end.');
     } else {
@@ -65,7 +63,6 @@ const addToArray =
 
         return;
       }
-      // TODO proper logging
       console.warn('The given neighbour value could not be found. ' +
                   'The new value was added at the end.');
     }
@@ -194,9 +191,6 @@ const getFindReferenceTargetsFunction = (href: string, schemaId: string, idProp:
 
     return {};
   };
-
-// NOTE Json Schema 04 allows additional properties by default. probably needs to be
-// restricted to work for finding valid UI Schema targets
 
 /**
  * Recursive method to find all paths to valid reference targets based on the
@@ -328,12 +322,13 @@ export class SchemaServiceImpl implements SchemaService {
       const result: ReferenceProperty[] = [];
       links.forEach(link => {
         if (_.isEmpty(link.targetSchema) || _.isEmpty(link.href)) {
-          // FIXME log
+          console.warn(`Could not create link property because the configuration was invalid`,
+                       link);
+
           return;
         }
         let targetSchema;
         // TODO what if schema is url but not resolved?
-        // TODO Special case: JSON Schema 04 for UI Schema editor
         if (link.targetSchema.$ref !== undefined) {
           targetSchema = this.getSelfContainedSchema(this.rootSchema, link.targetSchema.$ref);
         } else if (link.targetSchema.resource !== undefined) {
@@ -408,7 +403,6 @@ export class SchemaServiceImpl implements SchemaService {
                                                          insertAfter?: boolean) => void,
                          deleteFunction: (data: object) => (valueToDelete: object) => void,
                          getFunction: (data: object) => Object,
-                         // TODO rename
                          internal = false
                        ): ContainmentProperty[] {
     if (schema.$ref !== undefined) {

--- a/src/core/schema.service.impl.ts
+++ b/src/core/schema.service.impl.ts
@@ -144,7 +144,7 @@ const getReferenceTargetData = (href: string): Object => {
 
 // reference resolvement for id based references
 const resolveRef = (schema: JsonSchema, findTargets: () => { [key: string]: Object },
-                    propName: string) => (data: Object) => {
+                    propName: string) => (data: Object): { [key: string]: Object } => {
     if (_.isEmpty(data)) {
       return {};
     }
@@ -182,7 +182,7 @@ const resolveRef = (schema: JsonSchema, findTargets: () => { [key: string]: Obje
   };
 
 const getFindReferenceTargetsFunction = (href: string, schemaId: string, idProp: string) =>
-  () => {
+  (): { [key: string]: Object } => {
     const candidates = getReferenceTargetData(href) as Object[];
     if (!_.isEmpty(candidates)) {
       const result = {};

--- a/src/core/schema.service.impl.ts
+++ b/src/core/schema.service.impl.ts
@@ -114,9 +114,7 @@ const getReferenceTargetData = (href: string): Object => {
   let localTemplatePath: string;
   if (_.startsWith(href, RS_PROTOCOL)) {
     const resourceName = href.substring(RS_PROTOCOL.length).split('/')[0];
-    console.log('resource name', resourceName);
     localTemplatePath = href.substring(RS_PROTOCOL.length + resourceName.length + 1);
-    console.log('local template path', localTemplatePath);
     rootData = JsonForms.resources.getResource(resourceName);
     // reference to data in resource set
   } else if (_.startsWith(href, 'http://')) {

--- a/src/core/schema.service.ts
+++ b/src/core/schema.service.ts
@@ -71,7 +71,8 @@ export interface ReferenceProperty extends Property {
    * and the data object as value.
    *
    * @param data The object that contains the reference
-   * @return The referenced value(s). If no referenced value(s) are found an empty object is returned.
+   * @return The referenced value(s).
+   *         If no referenced value(s) are found an empty object is returned.
    */
   getData(data: Object): { [key: string]: Object };
 
@@ -86,8 +87,8 @@ export interface ReferenceProperty extends Property {
    * and the referencable data object as value
    *
    * @return The object containing possible reference targets. Keys are identifiers of the targets
-             and values are the actual data objects. If there are no available reference targets,
-             an empty object is returned.
+   *         and values are the actual data objects. If there are no available reference targets,
+   *         an empty object is returned.
    */
   findReferenceTargets(): { [key: string]: Object };
 }

--- a/src/core/schema.service.ts
+++ b/src/core/schema.service.ts
@@ -59,30 +59,37 @@ export interface ReferenceProperty extends Property {
   readonly targetSchema: JsonSchema;
   /**
    * This allows to set the reference.
-   * @param root The root object, needed for matching the valueToAdd
+   *
    * @param data The object to add to
-   * @param valueToAdd The object to add
+   * @param valueToAdd For id based referencing: The object referenced by the id.
+   *                   For path based referencing: the path itself
    */
-  addToData(root: Object, data: Object, valueToAdd: object): void;
+  addToData(data: Object, valueToAdd: object): void;
   /**
    * This allows to retrieve the refernced data object(s) of the reference.
+   * The result object contains the data objects' identifier (its ID or path) as key
+   * and the data object as value.
    *
-   * @param root The root object, The root data object needed for finding the referenced value(s).
    * @param data The object that contains the reference
-   * @return The referenced value(s). If no referenced value was found and the reference property
-   *         defines a single reference, null is returned. If the property defines a multi
-   *         reference, in this case an empty array is returned.
+   * @return The referenced value(s). If no referenced value(s) are found an empty object is returned.
    */
-  getData(root: Object, data: Object): Object;
+  getData(data: Object): { [key: string]: Object };
+
+  /**
+   * Returns true if the references use ids to identify targets and false if they use paths.
+   */
+  isIdBased(): boolean;
 
   /**
    * Returns all possible objects which can be referenced by this property.
+   * The result object contains targets' identifier (its ID or path) as key
+   * and the referencable data object as value
    *
-   * @param root The root data object needed for finding the values
-   * @return The array of data objects which are possible reference targets
-   *         for this reference property.
+   * @return The object containing possible reference targets. Keys are identifiers of the targets
+             and values are the actual data objects. If there are no available reference targets,
+             an empty object is returned.
    */
-  findReferenceTargets(rootData: Object): Object[];
+  findReferenceTargets(): { [key: string]: Object };
 }
 
 export class ContainmentPropertyImpl implements ContainmentProperty {
@@ -128,9 +135,10 @@ export class ReferencePropertyImpl implements ReferenceProperty {
     private innerTargetSchema: JsonSchema,
     private key: string,
     private name: string,
-    private findFunction: (rootObject: Object) => Object[],
-    private addFunction: (root: object, data: object, valueToAdd: object) => void,
-    private getFunction: (root: object, data: object) => Object
+    private idBased: boolean,
+    private findFunction: () => { [key: string]: Object },
+    private addFunction: (data: object, valueToAdd: object) => void,
+    private getFunction: (data: object) => { [key: string]: Object }
   ) {}
   get label(): string {
     return _.find(
@@ -152,14 +160,17 @@ export class ReferencePropertyImpl implements ReferenceProperty {
   get targetSchema(): JsonSchema {
     return this.innerTargetSchema;
   }
-  addToData(root: object, data: object, valueToAdd: object): void {
-    this.addFunction(root, data, valueToAdd);
+  addToData(data: object, valueToAdd: object): void {
+    this.addFunction(data, valueToAdd);
   }
-  getData(root: object, data: object): Object {
-    return this.getFunction(root, data);
+  getData(data: object): { [key: string]: Object } {
+    return this.getFunction(data);
   }
-  findReferenceTargets(rootData: Object): Object[] {
-    return this.findFunction(rootData);
+  isIdBased(): boolean {
+    return this.idBased;
+  }
+  findReferenceTargets(): {[key: string]: Object} {
+    return this.findFunction();
   }
 }
 

--- a/src/core/schema.service.ts
+++ b/src/core/schema.service.ts
@@ -64,7 +64,7 @@ export interface ReferenceProperty extends Property {
    * @param valueToAdd For id based referencing: The object referenced by the id.
    *                   For path based referencing: the path itself
    */
-  addToData(data: Object, valueToAdd: object): void;
+  addToData(data: Object, valueToAdd: Object): void;
   /**
    * This allows to retrieve the refernced data object(s) of the reference.
    * The result object contains the data objects' identifier (its ID or path) as key
@@ -161,7 +161,7 @@ export class ReferencePropertyImpl implements ReferenceProperty {
   get targetSchema(): JsonSchema {
     return this.innerTargetSchema;
   }
-  addToData(data: object, valueToAdd: object): void {
+  addToData(data: object, valueToAdd: Object): void {
     this.addFunction(data, valueToAdd);
   }
   getData(data: object): { [key: string]: Object } {

--- a/src/core/uischema.registry.ts
+++ b/src/core/uischema.registry.ts
@@ -56,7 +56,7 @@ interface UISchemaDefinition {
  * a combination of schema/data.
  * @type {number}
  */
-export const NOT_APPLICABLE: number = -1;
+export const NOT_APPLICABLE = -1;
 
 /**
  * Default UI schema definition that always returns 0 as its priority.

--- a/src/models/jsonSchema.ts
+++ b/src/models/jsonSchema.ts
@@ -36,7 +36,7 @@ export interface JsonSchema {
    * It is recommended that the meta-schema is
    * included in the root of any JSON Schema
    */
-  $schema?: JsonSchema;
+  $schema?: JsonSchema | string;
   /**
    * Title of the schema
    */

--- a/src/path.util.ts
+++ b/src/path.util.ts
@@ -9,6 +9,30 @@ const isArray = (schema: JsonSchema): boolean => {
 };
 
 /**
+ * Resolves the given local data path against the root data.
+ *
+ * @param rootData the root data to resolve the data from
+ * @param path The path to resolve against the root data
+ * @return the resolved data or {null} if the path is not a valid path in the root data
+ */
+export const resolveLocalData = (rootData: Object, path: string): Object => {
+  let resolvedData = rootData;
+  for (const segment of path.split('/')) {
+    if (segment === '#' || _.isEmpty(segment)) {
+      continue;
+    }
+    if (_.isEmpty(resolvedData) || !resolvedData.hasOwnProperty(segment)) {
+      console.error(`The local path '${path}' cannot be resolved in the given data:`, rootData);
+
+      return null;
+    }
+    resolvedData = resolvedData[segment];
+  }
+
+  return resolvedData;
+};
+
+/**
  * Convert a schema path (i.e. JSON pointer) to an array by splitting
  * at the '/' character and removing all schema-specific keywords.
  *

--- a/src/renderers/additional/tree-renderer.ts
+++ b/src/renderers/additional/tree-renderer.ts
@@ -354,7 +354,8 @@ export class TreeMasterDetailRenderer extends Renderer implements DataChangeList
       li.appendChild(childParent);
     }
 
-    this.expandObject(newData, childParent, schema,  deleteFunction);
+    const created = this.expandObject(newData, childParent, schema,  deleteFunction);
+    this.renderDetail(newData, created, schema);
   }
 
   /**
@@ -370,7 +371,7 @@ export class TreeMasterDetailRenderer extends Renderer implements DataChangeList
     parent: HTMLUListElement,
     schema: JsonSchema,
     deleteFunction: (toDelete: object) => void
-  ): void {
+  ): HTMLLIElement {
     const li = document.createElement('li');
     const div = document.createElement('div');
     if (this.uischema.options !== undefined &&
@@ -379,6 +380,9 @@ export class TreeMasterDetailRenderer extends Renderer implements DataChangeList
       spanIcon.classList.add('icon');
       spanIcon.classList.add(this.uischema.options.imageProvider[schema.id]);
       div.appendChild(spanIcon);
+      spanIcon.onclick = (ev: Event) => {
+        this.renderDetail(data, li, schema);
+      };
     }
     const span = document.createElement('span');
     span.classList.add('label');
@@ -489,6 +493,8 @@ export class TreeMasterDetailRenderer extends Renderer implements DataChangeList
     });
 
     parent.appendChild(li);
+
+    return li;
   }
 
   /**

--- a/src/renderers/controls/enum.control.ts
+++ b/src/renderers/controls/enum.control.ts
@@ -24,6 +24,13 @@ export class EnumControl extends BaseControl<HTMLSelectElement> {
   private options: any[];
 
   /**
+   * @return The label of the default option that is shown if no value has been selected
+   */
+  protected getDefaultOptionLabel(): string {
+    return 'Select Value...';
+  }
+
+  /**
    * @inheritDoc
    */
   protected configureInput(input: HTMLSelectElement): void {
@@ -31,6 +38,15 @@ export class EnumControl extends BaseControl<HTMLSelectElement> {
         this.dataSchema,
         (this.uischema as ControlElement).scope.$ref
     ).enum;
+
+      // add default option which is displayed if no value has been selected
+    const defaultOption = document.createElement('option');
+    defaultOption.selected = true;
+    defaultOption.disabled = true;
+    defaultOption.hidden = true;
+    defaultOption.innerText = this.getDefaultOptionLabel();
+    input.appendChild(defaultOption);
+
     this.options.forEach(optionValue => {
       const option = document.createElement('option');
       option.value = optionValue;

--- a/src/renderers/controls/reference.control.ts
+++ b/src/renderers/controls/reference.control.ts
@@ -78,7 +78,7 @@ export abstract class ReferenceControl extends BaseControl<HTMLSelectElement> {
     const referenceProperty: ReferenceProperty =
       _.head(JsonForms.schemaService.getReferenceProperties(objectSchema));
 
-    const referencees = referenceProperty.findReferenceTargets(this.getRootData());
+    const referencees = referenceProperty.findReferenceTargets();
 
     // add default option which is displayed if no reference target has been selected
     const defaultOption = document.createElement('option');
@@ -88,9 +88,11 @@ export abstract class ReferenceControl extends BaseControl<HTMLSelectElement> {
     defaultOption.innerText = this.getDefaultOptionLabel();
     input.appendChild(defaultOption);
 
+    // TODO ref control for path based references
     // add an option for every possible reference target
-    referencees.forEach((referencee, index) => {
+    Object.keys(referencees).forEach(key => {
       const option = document.createElement('option');
+      const referencee = referencees[key];
       option.value = referencee[this.getIdentifyingProperty()];
       option.label = referencee[this.getLabelProperty()];
       option.innerText = referencee[this.getLabelProperty()];

--- a/src/renderers/controls/reference.path.control.ts
+++ b/src/renderers/controls/reference.path.control.ts
@@ -2,7 +2,6 @@ import * as _ from 'lodash';
 
 import { JsonForms } from '../../core';
 import { BaseControl } from './base.control';
-import { ReferenceProperty } from '../../core/schema.service';
 import { ControlElement } from '../../models/uischema';
 import { resolveSchema } from '../../path.util';
 import { JsonFormsRenderer } from '../renderer.util';

--- a/src/renderers/controls/reference.path.control.ts
+++ b/src/renderers/controls/reference.path.control.ts
@@ -1,0 +1,114 @@
+import * as _ from 'lodash';
+
+import { JsonForms } from '../../core';
+import { BaseControl } from './base.control';
+import { ReferenceProperty } from '../../core/schema.service';
+import { ControlElement } from '../../models/uischema';
+import { resolveSchema } from '../../path.util';
+import { JsonFormsRenderer } from '../renderer.util';
+import { and, optionIs, RankedTester, rankWith, uiTypeIs } from '../../core/testers';
+import { JsonSchema } from '../../models/jsonSchema';
+
+export const refPathTester: RankedTester = rankWith(20, and(
+  uiTypeIs('Control'),
+  optionIs('reference-control', 'path')
+));
+/**
+ * Reference Control for path based referencing.
+ * Use by setting key 'reference-control' with value 'path' as option on the control
+ * describing the property containing the reference
+ */
+@JsonFormsRenderer({
+  selector: 'jsonforms-referencepath',
+  tester: refPathTester
+})
+export class ReferencePathControl extends BaseControl<HTMLSelectElement> {
+
+  protected configureInput(input: HTMLSelectElement): void {
+    this.addOptions(input);
+  }
+
+  protected get valueProperty(): string {
+    return 'value';
+  }
+
+  protected get inputChangeProperty(): string {
+    return 'onchange';
+  }
+
+  protected createInputElement(): HTMLSelectElement {
+    return document.createElement('select');
+  }
+
+  protected convertModelValue(value: any): any {
+    return (value === undefined || value === null) ? undefined : value.toString();
+  }
+
+  /**
+   * Returns the label of the default option.
+   * Might be overwritten by subclasses to change the label.
+   *
+   * @return the label of the default option.
+   */
+  protected getDefaultOptionLabel(): string {
+    return 'Select Reference Path...';
+  }
+
+  /**
+   * Adds all possible reference targets as options to the control's combo box.
+   */
+  protected addOptions(input) {
+    const schema = this.getPropertySchema(this.uischema, this.dataSchema);
+    const propertyKey = _.last((this.uischema as ControlElement).scope.$ref.split('/'));
+    let referenceProperty;
+    for (const refProperty of JsonForms.schemaService.getReferenceProperties(schema)) {
+      if (refProperty.property === propertyKey) {
+        referenceProperty = refProperty;
+        break;
+      }
+    }
+    if (_.isEmpty(referenceProperty)) {
+      console.error(`No suitable reference property was found for property '${propertyKey}'.`);
+
+      return;
+    }
+    // const referenceProperty: ReferenceProperty =
+    //   _.head(JsonForms.schemaService.getReferenceProperties(schema));
+
+    const referencees = referenceProperty.findReferenceTargets();
+
+    // add default option which is displayed if no reference target has been selected
+    const defaultOption: HTMLOptionElement = document.createElement('option');
+    input.appendChild(defaultOption);
+    defaultOption.selected = true;
+    defaultOption.disabled = true;
+    // defaultOption.hidden = true;
+    defaultOption.defaultSelected = true;
+    defaultOption.innerText = this.getDefaultOptionLabel();
+
+    // add an option for every possible reference target
+    Object.keys(referencees).forEach(key => {
+      const option = document.createElement('option');
+      option.value = key;
+      option.label = key;
+      option.innerText = key;
+      input.appendChild(option);
+    });
+
+    input.classList.add('form-control');
+  }
+
+  protected getPropertySchema(uischema, dataSchema): JsonSchema {
+    const ref = (uischema as ControlElement).scope.$ref;
+    const refSegments = ref.split('/');
+    let schema;
+    if (refSegments.length >= 3) {
+      const schemaPath = refSegments.slice(0, -2).join('/');
+      schema = resolveSchema(dataSchema, schemaPath);
+    } else {
+      schema = this.dataSchema;
+    }
+
+    return schema;
+  }
+}

--- a/src/renderers/renderers.ts
+++ b/src/renderers/renderers.ts
@@ -9,6 +9,7 @@ export * from './controls/number.control';
 export * from './controls/date.control';
 export * from './controls/enum.control';
 export * from './controls/reference.control';
+export * from './controls/reference.path.control';
 export * from './controls/textarea.control';
 export * from './layouts/vertical.layout';
 export * from './layouts/horizontal.layout';

--- a/test/data/schema-04.ts
+++ b/test/data/schema-04.ts
@@ -1,0 +1,154 @@
+// does not allow additional properties
+// changed id because it's not the original anymore
+export const jsonSchemaFourMod = {
+    'id': 'http://json-schema.org/draft-04/schema-modified#',
+    '$schema': 'http://json-schema.org/draft-04/schema#',
+    'description': 'Core schema meta-schema',
+    'definitions': {
+        'schemaArray': {
+            'type': 'array',
+            'minItems': 1,
+            'items': { '$ref': '#' }
+        },
+        'positiveInteger': {
+            'type': 'integer',
+            'minimum': 0
+        },
+        'positiveIntegerDefault0': {
+            'allOf': [ { '$ref': '#/definitions/positiveInteger' }, { 'default': 0 } ]
+        },
+        'simpleTypes': {
+            'enum': [ 'array', 'boolean', 'integer', 'null', 'number', 'object', 'string' ]
+        },
+        'stringArray': {
+            'type': 'array',
+            'items': { 'type': 'string' },
+            'minItems': 1,
+            'uniqueItems': true
+        }
+    },
+    'type': 'object',
+    'properties': {
+        'id': {
+            'type': 'string',
+            'format': 'uri'
+        },
+        '$schema': {
+            'type': 'string',
+            'format': 'uri'
+        },
+        'title': {
+            'type': 'string'
+        },
+        'description': {
+            'type': 'string'
+        },
+        'default': {},
+        'multipleOf': {
+            'type': 'number',
+            'minimum': 0,
+            'exclusiveMinimum': true
+        },
+        'maximum': {
+            'type': 'number'
+        },
+        'exclusiveMaximum': {
+            'type': 'boolean',
+            'default': false
+        },
+        'minimum': {
+            'type': 'number'
+        },
+        'exclusiveMinimum': {
+            'type': 'boolean',
+            'default': false
+        },
+        'maxLength': { '$ref': '#/definitions/positiveInteger' },
+        'minLength': { '$ref': '#/definitions/positiveIntegerDefault0' },
+        'pattern': {
+            'type': 'string',
+            'format': 'regex'
+        },
+        'additionalItems': {
+            'anyOf': [
+                { 'type': 'boolean' },
+                { '$ref': '#' }
+            ],
+            'default': {}
+        },
+        'items': {
+            'anyOf': [
+                { '$ref': '#' },
+                { '$ref': '#/definitions/schemaArray' }
+            ],
+            'default': {}
+        },
+        'maxItems': { '$ref': '#/definitions/positiveInteger' },
+        'minItems': { '$ref': '#/definitions/positiveIntegerDefault0' },
+        'uniqueItems': {
+            'type': 'boolean',
+            'default': false
+        },
+        'maxProperties': { '$ref': '#/definitions/positiveInteger' },
+        'minProperties': { '$ref': '#/definitions/positiveIntegerDefault0' },
+        'required': { '$ref': '#/definitions/stringArray' },
+        'additionalProperties': {
+            'anyOf': [
+                { 'type': 'boolean' },
+                { '$ref': '#' }
+            ],
+            'default': {}
+        },
+        'definitions': {
+            'type': 'object',
+            'additionalProperties': { '$ref': '#' },
+            'default': {}
+        },
+        'properties': {
+            'type': 'object',
+            'additionalProperties': { '$ref': '#' },
+            'default': {}
+        },
+        'patternProperties': {
+            'type': 'object',
+            'additionalProperties': { '$ref': '#' },
+            'default': {}
+        },
+        'dependencies': {
+            'type': 'object',
+            'additionalProperties': {
+                'anyOf': [
+                    { '$ref': '#' },
+                    { '$ref': '#/definitions/stringArray' }
+                ]
+            }
+        },
+        'enum': {
+            'type': 'array',
+            'minItems': 1,
+            'uniqueItems': true
+        },
+        'type': {
+            'anyOf': [
+                { '$ref': '#/definitions/simpleTypes' },
+                {
+                    'type': 'array',
+                    'items': { '$ref': '#/definitions/simpleTypes' },
+                    'minItems': 1,
+                    'uniqueItems': true
+                }
+            ]
+        },
+        'allOf': { '$ref': '#/definitions/schemaArray' },
+        'anyOf': { '$ref': '#/definitions/schemaArray' },
+        'oneOf': { '$ref': '#/definitions/schemaArray' },
+        'not': { '$ref': '#' }
+    },
+    'dependencies': {
+        'exclusiveMaximum': [ 'maximum' ],
+        'exclusiveMinimum': [ 'minimum' ]
+    },
+    'default': {},
+    // NOTE this was added manually
+    additionalProperties: false
+}

--- a/test/data/schema-04.ts
+++ b/test/data/schema-04.ts
@@ -150,5 +150,5 @@ export const jsonSchemaFourMod = {
     },
     'default': {},
     // NOTE this was added manually
-    additionalProperties: false
-}
+    'additionalProperties': false
+};

--- a/test/modelmapping.test.ts
+++ b/test/modelmapping.test.ts
@@ -84,6 +84,7 @@ test.beforeEach(t => {
     }
   };
   JsonForms.modelMapping = t.context.modelMapping;
+  JsonForms.config.setIdentifyingProp('_id');
 
 });
 
@@ -99,8 +100,11 @@ test('available options filtering for reference attribute', t => {
 
   const service: SchemaService = new SchemaServiceImpl(testDataSchema);
   const reference = service.getReferenceProperties(testDataSchema.definitions.reference)[0];
-  const availableOptions = reference.findReferenceTargets(t.context.data);
-
-  t.is(Object.keys(availableOptions).length, 2, 'array of length two expected');
+  JsonForms.rootData = t.context.data;
+  const availableOptions = reference.findReferenceTargets();
+  console.log('availableOptions keys', Object.keys(availableOptions));
+  t.is(Object.keys(availableOptions).length, 2, 'obect with two keys expected');
+  t.is(Object.keys(availableOptions)[0], 'id-class-a');
+  t.is(Object.keys(availableOptions)[1], 'id-class-b');
 
 });

--- a/test/renderers/enum.control.test.ts
+++ b/test/renderers/enum.control.test.ts
@@ -167,11 +167,12 @@ test('EnumControl static', t => {
   const input = result.children[1] as HTMLSelectElement;
   t.is(input.tagName, 'SELECT');
   t.is(input.value, 'a');
-  t.is(input.options.length, 2);
-  t.is(input.options.item(0).value, 'a');
-  t.is(input.options.item(0).innerText, 'a');
-  t.is(input.options.item(1).value, 'b');
-  t.is(input.options.item(1).innerText, 'b');
+  t.is(input.options.length, 3);
+  t.is(input.options.item(0).innerText, 'Select Value...');
+  t.is(input.options.item(1).value, 'a');
+  t.is(input.options.item(1).innerText, 'a');
+  t.is(input.options.item(2).value, 'b');
+  t.is(input.options.item(2).innerText, 'b');
   const validation = result.children[2];
   t.is(validation.tagName, 'DIV');
   t.is(validation.children.length, 0);
@@ -200,11 +201,11 @@ test('EnumControl static no label', t => {
   const input = result.children[1] as HTMLSelectElement;
   t.is(input.tagName, 'SELECT');
   t.is(input.value, 'b');
-  t.is(input.options.length, 2);
-  t.is(input.options.item(0).value, 'a');
-  t.is(input.options.item(0).innerText, 'a');
-  t.is(input.options.item(1).value, 'b');
-  t.is(input.options.item(1).innerText, 'b');
+  t.is(input.options.item(0).innerText, 'Select Value...');
+  t.is(input.options.item(1).value, 'a');
+  t.is(input.options.item(1).innerText, 'a');
+  t.is(input.options.item(2).value, 'b');
+  t.is(input.options.item(2).innerText, 'b');
   const validation = result.children[2];
   t.is(validation.tagName, 'DIV');
   t.is(validation.children.length, 0);
@@ -231,11 +232,11 @@ test('EnumControl dataService notification', t => {
   renderer.setUiSchema(t.context.uiSchema);
   renderer.connectedCallback();
   const input = renderer.children[1] as HTMLSelectElement;
-  t.is(input.selectedIndex, 1);
+  t.is(input.selectedIndex, 2);
   t.is(input.value, 'b');
   dataService.notifyAboutDataChange({scope: {$ref: '#/properties/foo'}}, 'a');
   t.is(input.value, 'a');
-  t.is(input.selectedIndex, 0);
+  t.is(input.selectedIndex, 1);
 });
 
 test.failing('EnumControl dataService notification value undefined', t => {
@@ -285,7 +286,7 @@ test('EnumControl dataService notification wrong ref', t => {
       'Bar',
   );
   t.is(input.value, 'a');
-  t.is(input.selectedIndex, 0);
+  t.is(input.selectedIndex, 1);
 });
 
 test('EnumControl dataService notification null ref', t => {
@@ -298,7 +299,7 @@ test('EnumControl dataService notification null ref', t => {
   const input = renderer.children[1] as HTMLSelectElement;
   dataService.notifyAboutDataChange(null, false);
   t.is(input.value, 'a');
-  t.is(input.selectedIndex, 0);
+  t.is(input.selectedIndex, 1);
 });
 
 test('EnumControl dataService notification undefined ref', t => {
@@ -311,7 +312,7 @@ test('EnumControl dataService notification undefined ref', t => {
   const input = renderer.children[1] as HTMLSelectElement;
   dataService.notifyAboutDataChange(undefined, false);
   t.is(input.value, 'a');
-  t.is(input.selectedIndex, 0);
+  t.is(input.selectedIndex, 1);
 });
 
 test('EnumControl dataService no notification after disconnect', t => {
@@ -325,7 +326,7 @@ test('EnumControl dataService no notification after disconnect', t => {
   const input = renderer.children[1] as HTMLSelectElement;
   dataService.notifyAboutDataChange({scope: {$ref: '#/properties/foo'}}, 'Bar');
   t.is(input.value, 'a');
-  t.is(input.selectedIndex, 0);
+  t.is(input.selectedIndex, 1);
 });
 
 test('EnumControl notify visible false', t => {

--- a/test/renderers/reference.path.control.test.ts
+++ b/test/renderers/reference.path.control.test.ts
@@ -6,7 +6,6 @@ declare let global;
 installCE(global, 'force');
 import { JsonForms } from '../../src/core';
 import { DataService } from '../../src/core/data.service';
-import { JsonSchema } from '../../src/models/jsonSchema';
 import { ReferencePathControl } from '../../src/renderers/controls/reference.path.control';
 
 test.beforeEach(t => {
@@ -111,7 +110,6 @@ test('no referene property', t => {
   JsonForms.schema = schema;
   JsonForms.resources.registerResource('data', t.context.refdata, false);
   const renderer: ReferencePathControl = new ReferencePathControl();
-  const dataService = new DataService({ ref: '#/obj/ted' });
   renderer.setDataService(new DataService(t.context.data));
   renderer.setDataSchema(schema);
   renderer.setUiSchema(t.context.uiSchema);

--- a/test/renderers/reference.path.control.test.ts
+++ b/test/renderers/reference.path.control.test.ts
@@ -1,0 +1,130 @@
+import test from 'ava';
+import * as installCE from 'document-register-element/pony';
+// inject window, document etc.
+import 'jsdom-global/register';
+declare let global;
+installCE(global, 'force');
+import { JsonForms } from '../../src/core';
+import { DataService } from '../../src/core/data.service';
+import { JsonSchema } from '../../src/models/jsonSchema';
+import { ReferencePathControl } from '../../src/renderers/controls/reference.path.control';
+
+test.beforeEach(t => {
+  // Reset relevant static variables
+  JsonForms.rootData = undefined;
+  JsonForms.resources.clear();
+
+  t.context.uiSchema = {
+    type: 'Control',
+    scope: {
+      $ref: '#/properties/ref',
+    },
+  };
+
+  const targetSchema = {
+    type: 'object',
+    properties: {
+      a: { type: 'string' }
+    },
+    required: ['a']
+  };
+
+  t.context.schema = {
+    type: 'object',
+    properties: {
+      ref: { type: 'string' }
+    },
+    links: [
+      {
+        href: 'rs://data/{ref}',
+        targetSchema: targetSchema
+      }
+    ]
+  };
+
+  t.context.refdata = {
+    a: 'A',
+    obj: {
+      ted: {
+        a: 'C'
+      }
+    }
+  };
+
+  t.context.data = { ref: '#/obj/ted' };
+});
+
+test('static', t => {
+  JsonForms.schema = t.context.schema;
+  JsonForms.resources.registerResource('data', t.context.refdata, false);
+  const renderer: ReferencePathControl = new ReferencePathControl();
+  renderer.setDataService(new DataService(t.context.data));
+  renderer.setDataSchema(t.context.schema);
+  renderer.setUiSchema(t.context.uiSchema);
+  const result = renderer.render();
+  t.is(result.childNodes.length, 3);
+  const label = result.children[0] as HTMLLabelElement;
+  t.is(label.tagName, 'LABEL');
+  t.is(label.textContent, 'Ref');
+  const input = result.children[1] as HTMLSelectElement;
+  t.is(input.tagName, 'SELECT');
+  t.is(input.options.length, 3);
+  t.is(input.selectedIndex, 2);
+  t.is(input.options.item(0).innerText, 'Select Reference Path...');
+  t.is(input.options.item(1).value, '#');
+  t.is(input.options.item(1).innerText, '#');
+  t.is(input.options.item(2).value, '#/obj/ted');
+  t.is(input.options.item(2).innerText, '#/obj/ted');
+  t.is(input.value, '#/obj/ted');
+  const validation = result.children[2];
+  t.is(validation.tagName, 'DIV');
+  t.is(validation.children.length, 0);
+});
+
+test('data change', t => {
+  JsonForms.schema = t.context.schema;
+  JsonForms.resources.registerResource('data', t.context.refdata, false);
+  const renderer: ReferencePathControl = new ReferencePathControl();
+  const dataService = new DataService({ ref: '#/obj/ted' });
+  renderer.setDataService(dataService);
+  renderer.setDataSchema(t.context.schema);
+  renderer.setUiSchema(t.context.uiSchema);
+  renderer.connectedCallback();
+  // const result = renderer.render();
+  const input = renderer.children[1] as HTMLSelectElement;
+  t.is(input.tagName, 'SELECT');
+  t.is(input.options.length, 3);
+  t.is(input.selectedIndex, 2);
+  t.is(input.value, '#/obj/ted');
+  dataService.notifyAboutDataChange({scope: {$ref: '#/properties/ref'}}, '#');
+  t.is(input.value, '#');
+  t.is(input.selectedIndex, 1);
+});
+
+test('no referene property', t => {
+  const schema = {
+    type: 'object',
+    properties: {
+      ref: { type: 'string' }
+    }
+  };
+  JsonForms.schema = schema;
+  JsonForms.resources.registerResource('data', t.context.refdata, false);
+  const renderer: ReferencePathControl = new ReferencePathControl();
+  const dataService = new DataService({ ref: '#/obj/ted' });
+  renderer.setDataService(new DataService(t.context.data));
+  renderer.setDataSchema(schema);
+  renderer.setUiSchema(t.context.uiSchema);
+  const result = renderer.render();
+  t.is(result.childNodes.length, 3);
+  const label = result.children[0] as HTMLLabelElement;
+  t.is(label.tagName, 'LABEL');
+  t.is(label.textContent, 'Ref');
+  const input = result.children[1] as HTMLSelectElement;
+  t.is(input.tagName, 'SELECT');
+  t.is(input.options.length, 0);
+  t.is(input.value, '');
+  const validation = result.children[2];
+  t.is(validation.tagName, 'DIV');
+  t.is(validation.children.length, 0);
+});

--- a/test/renderers/treemasterdetail.dnd.test.ts
+++ b/test/renderers/treemasterdetail.dnd.test.ts
@@ -44,7 +44,6 @@ test.beforeEach(t => {
 
 test('TreeMasterDetailRenderer Drag And Drop - start handler', t => {
     const schema = t.context.schema;
-    const id = 'testId';
     const root = document.createElement('div');
     const list1 = document.createElement('ul');
     const list2 = document.createElement('ul');

--- a/test/resource-set.test.ts
+++ b/test/resource-set.test.ts
@@ -1,0 +1,22 @@
+// Tests for ResourceSetImpl
+import { ResourceSetImpl } from '../src/core/resource-set';
+import { test } from 'ava';
+
+test('Test ResourceSetImpl', t => {
+  const resourceSet = new ResourceSetImpl();
+
+  const data1 = { a: 1 };
+  const data2 = { b: 'hi' };
+  const name1 = 'erni';
+  t.false(resourceSet.hasResource(name1));
+
+  const register1 = resourceSet.registerResource(name1, data1)
+  t.is(register1, undefined);
+  t.true(resourceSet.hasResource(name1));
+  t.deepEqual(resourceSet.getResource(name1), data1);
+
+  const register2 = resourceSet.registerResource(name1, data2);
+  t.true(resourceSet.hasResource(name1));
+  t.deepEqual(register2, data1);
+  t.deepEqual(resourceSet.getResource(name1), data2);
+});

--- a/test/resource-set.test.ts
+++ b/test/resource-set.test.ts
@@ -10,7 +10,7 @@ test('Test ResourceSetImpl', t => {
   const name1 = 'erni';
   t.false(resourceSet.hasResource(name1));
 
-  const register1 = resourceSet.registerResource(name1, data1)
+  const register1 = resourceSet.registerResource(name1, data1);
   t.is(register1, undefined);
   t.true(resourceSet.hasResource(name1));
   t.deepEqual(resourceSet.getResource(name1), data1);

--- a/test/resource-set.test.ts
+++ b/test/resource-set.test.ts
@@ -19,4 +19,8 @@ test('Test ResourceSetImpl', t => {
   t.true(resourceSet.hasResource(name1));
   t.deepEqual(register2, data1);
   t.deepEqual(resourceSet.getResource(name1), data2);
+
+  resourceSet.clear();
+  t.false(resourceSet.hasResource(name1));
+  t.is(resourceSet.getResource(name1), undefined);
 });

--- a/test/resource-set.test.ts
+++ b/test/resource-set.test.ts
@@ -24,3 +24,26 @@ test('Test ResourceSetImpl', t => {
   t.false(resourceSet.hasResource(name1));
   t.is(resourceSet.getResource(name1), undefined);
 });
+
+test.cb('ResourceSetImpl - resolve references on registrations', t => {
+  const resourceSet = new ResourceSetImpl();
+  const data = {
+    a: 1,
+    b: { $ref: '#/a' },
+    invalidRef: { $ref: '#/invalid' }
+  };
+
+  resourceSet.registerResource('data', data, true);
+  setTimeout(
+    ()  => {
+      const res = resourceSet.getResource('data');
+      const expected = {
+        a: 1,
+        b: 1,
+        invalidRef: { $ref: '#/invalid' }
+      };
+      t.deepEqual(res, expected);
+      t.end();
+  },
+    50);
+});

--- a/test/schema.service.references.test.ts
+++ b/test/schema.service.references.test.ts
@@ -1,0 +1,47 @@
+/* tslint:disable:max-file-line-count */
+import { test } from 'ava';
+import {
+  isContainmentProperty,
+  isReferenceProperty,
+  SchemaService
+} from '../src/core/schema.service';
+import { collectReferencePaths, SchemaServiceImpl } from '../src/core/schema.service.impl';
+import { JsonSchema } from '../src/models/jsonSchema';
+import { JsonForms } from '../src/core';
+
+test.beforeEach(t => {
+  t.context.simpleSchema = {
+    properties: {
+      a: { type: 'string' }
+    },
+    required: ['a']
+  };
+  t.context.data = {
+    a: 'A'
+    // obj: {
+    //   // arr: [
+    //   //   { i: 10 },
+    //   //   { a: 'B'}
+    //   // ],
+    //   ted: {
+    //     a: 'C'
+    //   },
+    //   uhu: {
+    //     x: 2
+    //   }
+    // }
+  };
+});
+
+test.only(t => {
+  const data = t.context.data;
+  const schema = t.context.simpleSchema;
+  const paths = collectReferencePaths(data, '#', schema);
+
+  t.true(Array.isArray(paths));
+  console.log(paths);
+  // t.is(paths.length, 3);
+  // t.true(paths.indexOf('#') > -1);
+  // t.true(paths.indexOf('#/obj/arr/1') > -1);
+  // t.true(paths.indexOf('#/obj/ted') > -1);
+});

--- a/test/schema.service.references.test.ts
+++ b/test/schema.service.references.test.ts
@@ -1,47 +1,123 @@
 /* tslint:disable:max-file-line-count */
 import { test } from 'ava';
-import {
-  isContainmentProperty,
-  isReferenceProperty,
-  SchemaService
-} from '../src/core/schema.service';
-import { collectReferencePaths, SchemaServiceImpl } from '../src/core/schema.service.impl';
+import { collectReferencePaths } from '../src/core/schema.service.impl';
 import { JsonSchema } from '../src/models/jsonSchema';
 import { JsonForms } from '../src/core';
+import { jsonSchemaFourMod } from './data/schema-04';
 
 test.beforeEach(t => {
   t.context.simpleSchema = {
+    type: 'object',
     properties: {
       a: { type: 'string' }
     },
     required: ['a']
   };
   t.context.data = {
-    a: 'A'
-    // obj: {
-    //   // arr: [
-    //   //   { i: 10 },
-    //   //   { a: 'B'}
-    //   // ],
-    //   ted: {
-    //     a: 'C'
-    //   },
-    //   uhu: {
-    //     x: 2
-    //   }
-    // }
+    a: 'A',
+    obj: {
+      arr: [
+        { i: 10 },
+        { a: 'B'}
+      ],
+      ted: {
+        a: 'C'
+      },
+      uhu: {
+        a: 2
+      }
+    }
   };
 });
 
-test.only(t => {
+test('Simple Schema - Root Scope', t => {
   const data = t.context.data;
   const schema = t.context.simpleSchema;
   const paths = collectReferencePaths(data, '#', schema);
 
   t.true(Array.isArray(paths));
-  console.log(paths);
-  // t.is(paths.length, 3);
-  // t.true(paths.indexOf('#') > -1);
-  // t.true(paths.indexOf('#/obj/arr/1') > -1);
-  // t.true(paths.indexOf('#/obj/ted') > -1);
+  t.is(paths.length, 3);
+  t.true(paths.indexOf('#') > -1);
+  t.true(paths.indexOf('#/obj/arr/1') > -1);
+  t.true(paths.indexOf('#/obj/ted') > -1);
+});
+
+test('Simple Schema - Scoped', t => {
+  const data = t.context.data;
+  const schema = t.context.simpleSchema;
+  const paths = collectReferencePaths(data, '#/obj', schema);
+
+  t.true(Array.isArray(paths));
+  t.is(paths.length, 2);
+  t.true(paths.indexOf('#/obj/arr/1') > -1);
+  t.true(paths.indexOf('#/obj/ted') > -1);
+});
+
+test('Simple Schema - Root Scope, undefined data', t => {
+  const schema = t.context.simpleSchema;
+  const paths = collectReferencePaths(undefined, '#', schema);
+
+  t.true(Array.isArray(paths));
+  t.is(paths.length, 0);
+});
+
+test('Simple Schema - Unresolvable Scope Path', t => {
+  const data = t.context.data;
+  const schema = t.context.simpleSchema;
+  const paths = collectReferencePaths(undefined, '#/invalid/obj', schema);
+
+  t.true(Array.isArray(paths));
+  t.is(paths.length, 0);
+});
+
+test('Json Schema 04', t => {
+  const data = {
+    type: 'object',
+    properties: {
+      str: { type: 'string' },
+      obj: {
+        type: 'object',
+        properties: {
+          cascStr: { type: 'string' },
+          cascNum: { type: 'number' }
+        }
+      }
+    },
+    required: ['str']
+  };
+  const paths = collectReferencePaths(data, '#', jsonSchemaFourMod);
+  t.is(paths.length, 5);
+  t.true(paths.indexOf('#') > -1);
+  t.true(paths.indexOf('#/properties/str') > -1);
+  t.true(paths.indexOf('#/properties/obj') > -1);
+  t.true(paths.indexOf('#/properties/obj/properties/cascStr') > -1);
+  t.true(paths.indexOf('#/properties/obj/properties/cascNum') > -1);
+});
+
+test('Json Schema 04 - $ref not allowed', t => {
+  const data = {
+    type: 'object',
+    properties: {
+      str: { type: 'string' },
+      obj: {
+        type: 'object',
+        properties: {
+          cascStr: { type: 'string' },
+          cascNum: { type: 'number' }
+        }
+      },
+      ref: {
+        $ref: '#'
+      }
+    },
+    required: ['str']
+  };
+
+  const paths = collectReferencePaths(data, '#', jsonSchemaFourMod);
+  t.is(paths.length, 4);
+  // path '#' indirectly contains a $ref and is therefore not valid
+  t.true(paths.indexOf('#/properties/str') > -1);
+  t.true(paths.indexOf('#/properties/obj') > -1);
+  t.true(paths.indexOf('#/properties/obj/properties/cascStr') > -1);
+  t.true(paths.indexOf('#/properties/obj/properties/cascNum') > -1);
 });

--- a/test/schema.service.references.test.ts
+++ b/test/schema.service.references.test.ts
@@ -1,9 +1,11 @@
 /* tslint:disable:max-file-line-count */
+/* tslint:disable:no-string-literal */
 import { test } from 'ava';
-import { collectReferencePaths } from '../src/core/schema.service.impl';
+import { collectionHelperMap, SchemaServiceImpl } from '../src/core/schema.service.impl';
 import { JsonSchema } from '../src/models/jsonSchema';
 import { JsonForms } from '../src/core';
 import { jsonSchemaFourMod } from './data/schema-04';
+import { ReferenceProperty, SchemaService } from '../src/core/schema.service';
 
 test.beforeEach(t => {
   t.context.simpleSchema = {
@@ -13,6 +15,18 @@ test.beforeEach(t => {
     },
     required: ['a']
   };
+  t.context.schema = {
+    type: 'object',
+    properties: {
+      ref: { type: 'string' }
+    },
+    links: [
+      {
+        href: '#/{ref}',
+        targetSchema: t.context.simpleSchema
+      }
+    ]
+  }
   t.context.data = {
     a: 'A',
     obj: {
@@ -30,44 +44,92 @@ test.beforeEach(t => {
   };
 });
 
+test('Reference Property - path based - find Ref targets', t => {
+    const data = t.context.data;
+    const schema = t.context.schema;
+    JsonForms.rootData = data;
+
+    const service: SchemaService = new SchemaServiceImpl(schema);
+    const property = service.getReferenceProperties(schema)[0];
+    t.false(property.isIdBased());
+
+    const targets = property.findReferenceTargets();
+    console.log('ref prop path based 01 targets', targets);
+    const keys = Object.keys(targets);
+    t.is(keys.length, 3);
+    t.true(keys.indexOf('#') > -1);
+    t.true(keys.indexOf('#/obj/arr/1') > -1);
+    t.true(keys.indexOf('#/obj/ted') > -1);
+    t.is(targets['#'], data);
+    t.is(targets['#/obj/arr/1'], data.obj.arr[1]);
+    t.is(targets['#/obj/ted'], data.obj.ted);
+});
+
+test('Reference Property - path based - resolve Ref target', t => {
+    const data = t.context.data;
+    const schema = t.context.schema;
+    JsonForms.rootData = data;
+
+    const refData = { ref: '#/obj/ted' };
+    const service: SchemaService = new SchemaServiceImpl(schema);
+    const property = service.getReferenceProperties(schema)[0];
+    t.false(property.isIdBased());
+
+    const resolved = property.getData(refData);
+    console.log('ref prop path based resolved', resolved);
+    const keys = Object.keys(resolved);
+    t.is(keys.length, 1);
+    t.true(keys.indexOf('#/obj/ted') > -1);
+    t.is(resolved['#/obj/ted'], data.obj.ted);
+});
+
+test('Reference Property - path based - add defined and set', t => {
+    const data = t.context.data;
+    const schema = t.context.schema;
+    JsonForms.rootData = data;
+
+    const refData = { ref: '#/obj/ted' };
+    const service: SchemaService = new SchemaServiceImpl(schema);
+    const property = service.getReferenceProperties(schema)[0];
+    t.false(property.isIdBased());
+
+    property.addToData(refData, '#');
+    // t.deepEqual(refData, { ref: '#'});
+});
+
 test('Simple Schema - Root Scope', t => {
   const data = t.context.data;
   const schema = t.context.simpleSchema;
-  const paths = collectReferencePaths(data, '#', schema);
+  const paths = collectionHelperMap('#', data, schema);
 
-  t.true(Array.isArray(paths));
-  t.is(paths.length, 3);
-  t.true(paths.indexOf('#') > -1);
-  t.true(paths.indexOf('#/obj/arr/1') > -1);
-  t.true(paths.indexOf('#/obj/ted') > -1);
+  const keys = Object.keys(paths);
+  t.is(keys.length, 3);
+  t.true(keys.indexOf('#') > -1);
+  t.true(keys.indexOf('#/obj/arr/1') > -1);
+  t.true(keys.indexOf('#/obj/ted') > -1);
+  t.is(paths['#'], data);
+  t.is(paths['#/obj/arr/1'], data.obj.arr[1]);
+  t.is(paths['#/obj/ted'], data.obj.ted);
 });
 
 test('Simple Schema - Scoped', t => {
   const data = t.context.data;
   const schema = t.context.simpleSchema;
-  const paths = collectReferencePaths(data, '#/obj', schema);
+  const paths = collectionHelperMap('#/obj', data.obj, schema);
 
-  t.true(Array.isArray(paths));
-  t.is(paths.length, 2);
-  t.true(paths.indexOf('#/obj/arr/1') > -1);
-  t.true(paths.indexOf('#/obj/ted') > -1);
+  const keys = Object.keys(paths);
+  t.is(keys.length, 2);
+  t.true(keys.indexOf('#/obj/arr/1') > -1);
+  t.true(keys.indexOf('#/obj/ted') > -1);
+  t.is(paths['#/obj/arr/1'], data.obj.arr[1]);
+  t.is(paths['#/obj/ted'], data.obj.ted);
 });
 
 test('Simple Schema - Root Scope, undefined data', t => {
   const schema = t.context.simpleSchema;
-  const paths = collectReferencePaths(undefined, '#', schema);
+  const paths = collectionHelperMap('#', undefined, schema);
 
-  t.true(Array.isArray(paths));
-  t.is(paths.length, 0);
-});
-
-test('Simple Schema - Unresolvable Scope Path', t => {
-  const data = t.context.data;
-  const schema = t.context.simpleSchema;
-  const paths = collectReferencePaths(undefined, '#/invalid/obj', schema);
-
-  t.true(Array.isArray(paths));
-  t.is(paths.length, 0);
+  t.deepEqual(paths, {});
 });
 
 test('Json Schema 04', t => {
@@ -85,13 +147,19 @@ test('Json Schema 04', t => {
     },
     required: ['str']
   };
-  const paths = collectReferencePaths(data, '#', jsonSchemaFourMod);
-  t.is(paths.length, 5);
-  t.true(paths.indexOf('#') > -1);
-  t.true(paths.indexOf('#/properties/str') > -1);
-  t.true(paths.indexOf('#/properties/obj') > -1);
-  t.true(paths.indexOf('#/properties/obj/properties/cascStr') > -1);
-  t.true(paths.indexOf('#/properties/obj/properties/cascNum') > -1);
+  const paths = collectionHelperMap('#', data, jsonSchemaFourMod);
+  const keys = Object.keys(paths);
+  t.is(keys.length, 5);
+  t.true(keys.indexOf('#') > -1);
+  t.true(keys.indexOf('#/properties/str') > -1);
+  t.true(keys.indexOf('#/properties/obj') > -1);
+  t.true(keys.indexOf('#/properties/obj/properties/cascStr') > -1);
+  t.true(keys.indexOf('#/properties/obj/properties/cascNum') > -1);
+  t.is(paths['#'], data);
+  t.is(paths['#/properties/str'], data.properties.str);
+  t.is(paths['#/properties/obj'], data.properties.obj);
+  t.is(paths['#/properties/obj/properties/cascStr'], data.properties.obj.properties.cascStr);
+  t.is(paths['#/properties/obj/properties/cascNum'], data.properties.obj.properties.cascNum);
 });
 
 test('Json Schema 04 - $ref not allowed', t => {
@@ -113,11 +181,16 @@ test('Json Schema 04 - $ref not allowed', t => {
     required: ['str']
   };
 
-  const paths = collectReferencePaths(data, '#', jsonSchemaFourMod);
-  t.is(paths.length, 4);
+  const paths = collectionHelperMap('#', data, jsonSchemaFourMod);
+  const keys = Object.keys(paths);
   // path '#' indirectly contains a $ref and is therefore not valid
-  t.true(paths.indexOf('#/properties/str') > -1);
-  t.true(paths.indexOf('#/properties/obj') > -1);
-  t.true(paths.indexOf('#/properties/obj/properties/cascStr') > -1);
-  t.true(paths.indexOf('#/properties/obj/properties/cascNum') > -1);
+  t.is(keys.length, 4);
+  t.true(keys.indexOf('#/properties/str') > -1);
+  t.true(keys.indexOf('#/properties/obj') > -1);
+  t.true(keys.indexOf('#/properties/obj/properties/cascStr') > -1);
+  t.true(keys.indexOf('#/properties/obj/properties/cascNum') > -1);
+  t.is(paths['#/properties/str'], data.properties.str);
+  t.is(paths['#/properties/obj'], data.properties.obj);
+  t.is(paths['#/properties/obj/properties/cascStr'], data.properties.obj.properties.cascStr);
+  t.is(paths['#/properties/obj/properties/cascNum'], data.properties.obj.properties.cascNum);
 });

--- a/test/schema.service.test.ts
+++ b/test/schema.service.test.ts
@@ -782,7 +782,7 @@ test('reference object properties get', t => {
   const keys = Object.keys(getData);
   t.is(keys.length, 1);
   t.is(keys[0], 'c1');
-  t.is(getData['c1'], data.classes[0]);
+  t.is(getData[keys[0]], data.classes[0]);
 });
 
 test('reference array properties add to undefined', t => {
@@ -827,7 +827,7 @@ test('reference array properties get', t => {
   const keys = Object.keys(getData);
   t.is(keys.length, 1);
   t.is(keys[0], 'c1');
-  t.deepEqual(getData['c1'], data.classes[0]);
+  t.deepEqual(getData[keys[0]], data.classes[0]);
 });
 test('reference array properties get multiple', t => {
   const schema: JsonSchema = t.context.referenceArraySchema;
@@ -843,8 +843,8 @@ test('reference array properties get multiple', t => {
   t.is(keys.length, 2);
   t.is(keys[0], 'c1');
   t.is(keys[1], 'c3');
-  t.deepEqual(getData['c1'], data.classes[0]);
-  t.deepEqual(getData['c3'], data.classes[2]);
+  t.deepEqual(getData[keys[0]], data.classes[0]);
+  t.deepEqual(getData[keys[1]], data.classes[2]);
 });
 test(`reference properties get - linking property's schema without type`, t => {
   const schema = {
@@ -901,8 +901,8 @@ test('reference property find reference targets', t => {
   t.is(keys.length, 2);
   t.is(keys[0], 'c1');
   t.is(keys[1], 'c2');
-  t.deepEqual(targets['c1'], data.classes[0]);
-  t.deepEqual(targets['c2'], data.classes[1]);
+  t.deepEqual(targets[keys[0]], data.classes[0]);
+  t.deepEqual(targets[keys[1]], data.classes[1]);
 });
 test('reference property find reference targets - target container undefined', t => {
   const schema = t.context.referenceFindSchema;
@@ -994,8 +994,8 @@ test('reference property find reference targets - targets are subset of availabl
   t.is(keys.length, 2);
   t.is(keys[0], 'c1');
   t.is(keys[1], 'c2');
-  t.deepEqual(targets['c1'], data.objects[0]);
-  t.deepEqual(targets['c2'], data.objects[2]);
+  t.deepEqual(targets[keys[0]], data.objects[0]);
+  t.deepEqual(targets[keys[1]], data.objects[2]);
 });
 
 test('property type check', t => {

--- a/test/schema.service.test.ts
+++ b/test/schema.service.test.ts
@@ -763,8 +763,10 @@ test('reference object properties add', t => {
   const schema: JsonSchema = t.context.referenceObjectSchema;
   const service: SchemaService = new SchemaServiceImpl(schema);
   const property = service.getReferenceProperties(schema.definitions.class)[0];
+  t.true(property.isIdBased());
   const data = {classes: [{id: 'c1'}, {id: 'c2'}]};
-  property.addToData(data, data.classes[1], data.classes[0]);
+  JsonForms.rootData = data;
+  property.addToData(data.classes[1], data.classes[0]);
   // tslint:disable:no-string-literal
   t.is(data.classes[1]['association'], 'c1');
   // tslint:enable:no-string-literal
@@ -773,9 +775,14 @@ test('reference object properties get', t => {
   const schema: JsonSchema = t.context.referenceObjectSchema;
   const service: SchemaService = new SchemaServiceImpl(schema);
   const property = service.getReferenceProperties(schema.properties.classes.items as JsonSchema)[0];
+  t.true(property.isIdBased());
   const data = {classes: [{id: 'c1'}, {id: 'c2', association: 'c1'}]};
-  const getData = property.getData(data, data.classes[1]);
-  t.is(getData, data.classes[0]);
+  JsonForms.rootData = data;
+  const getData = property.getData(data.classes[1]);
+  const keys = Object.keys(getData);
+  t.is(keys.length, 1);
+  t.is(keys[0], 'c1');
+  t.is(getData['c1'], data.classes[0]);
 });
 
 test('reference array properties add to undefined', t => {
@@ -783,8 +790,10 @@ test('reference array properties add to undefined', t => {
   const service: SchemaService = new SchemaServiceImpl(schema);
   const property =
     service.getReferenceProperties(schema.definitions.class)[0];
+  t.true(property.isIdBased());
   const data = {classes: [{id: 'c1'}, {id: 'c2'}]};
-  property.addToData(data, data.classes[1], data.classes[0]);
+  JsonForms.rootData = data;
+  property.addToData(data.classes[1], data.classes[0]);
   // tslint:disable:no-string-literal
   const associations = data.classes[1]['associations'];
   // tslint:enable:no-string-literal
@@ -796,8 +805,10 @@ test('reference array properties add to defined', t => {
   const service: SchemaService = new SchemaServiceImpl(schema);
   const property =
     service.getReferenceProperties(schema.definitions.class)[0];
+  t.true(property.isIdBased());
   const data = {classes: [{id: 'c1'}, {id: 'c2', associations: []}]};
-  property.addToData(data, data.classes[1], data.classes[0]);
+  JsonForms.rootData = data;
+  property.addToData(data.classes[1], data.classes[0]);
   // tslint:disable:no-string-literal
   const associations = data.classes[1]['associations'];
   // tslint:enable:no-string-literal
@@ -809,24 +820,31 @@ test('reference array properties get', t => {
   const service: SchemaService = new SchemaServiceImpl(schema);
   const property =
     service.getReferenceProperties(schema.definitions.class)[0];
+  t.true(property.isIdBased());
   const data = {classes: [{id: 'c1'}, {id: 'c2', associations: ['c1']}]};
-  const getData = property.getData(data, data.classes[1]);
-  t.true(Array.isArray(getData));
-  t.deepEqual(getData, [data.classes[0]]);
+  JsonForms.rootData = data;
+  const getData = property.getData(data.classes[1]);
+  const keys = Object.keys(getData);
+  t.is(keys.length, 1);
+  t.is(keys[0], 'c1');
+  t.deepEqual(getData['c1'], data.classes[0]);
 });
 test('reference array properties get multiple', t => {
   const schema: JsonSchema = t.context.referenceArraySchema;
   const service: SchemaService = new SchemaServiceImpl(schema);
   const property =
     service.getReferenceProperties(schema.definitions.class)[0];
+  t.true(property.isIdBased());
   const data = {classes: [{id: 'c1'}, {id: 'c2', associations: ['c1', 'c3']}, {id: 'c3'},
                           {id: 'c4'}]};
-  const getData = property.getData(data, data.classes[1]);
-  t.true(Array.isArray(getData));
-  const getDataArray = getData as Object[];
-  t.is(getDataArray.length, 2);
-  t.is(getDataArray[0], data.classes[0]);
-  t.is(getDataArray[1], data.classes[2]);
+  JsonForms.rootData = data;
+  const getData = property.getData(data.classes[1]);
+  const keys = Object.keys(getData);
+  t.is(keys.length, 2);
+  t.is(keys[0], 'c1');
+  t.is(keys[1], 'c3');
+  t.deepEqual(getData['c1'], data.classes[0]);
+  t.deepEqual(getData['c3'], data.classes[2]);
 });
 test(`reference properties get - linking property's schema without type`, t => {
   const schema = {
@@ -861,8 +879,10 @@ test(`reference properties get - linking property's schema without type`, t => {
 
   const service: SchemaService = new SchemaServiceImpl(schema);
   const property = service.getReferenceProperties(schema.properties.classes.items as JsonSchema)[0];
+  t.true(property.isIdBased());
   const data = {classes: [{id: 'c1'}, {id: 'c2', association: 'c1'}]};
-  const error: Error = t.throws(() => property.getData(data, data.classes[1]));
+  JsonForms.rootData = data;
+  const error: Error = t.throws(() => property.getData(data.classes[1]));
   t.is(error.message, `The schema of the property 'association' does not specify a schema type.`);
 });
 
@@ -870,24 +890,31 @@ test('reference property find reference targets', t => {
   const schema = t.context.referenceFindSchema;
   const service: SchemaService = new SchemaServiceImpl(schema);
   const property = service.getReferenceProperties(schema.properties.classes.items as JsonSchema)[0];
+  t.true(property.isIdBased());
   const data = {
     classes: [{id: 'c1'}, {id: 'c2', association: 'c1'}],
     elements: [{id: 'e1'}]
   };
-  const targets = property.findReferenceTargets(data);
-  t.is(targets.length, 2);
-  t.is(targets[0], data.classes[0]);
-  t.is(targets[1], data.classes[1]);
+  JsonForms.rootData = data;
+  const targets = property.findReferenceTargets();
+  const keys = Object.keys(targets);
+  t.is(keys.length, 2);
+  t.is(keys[0], 'c1');
+  t.is(keys[1], 'c2');
+  t.deepEqual(targets['c1'], data.classes[0]);
+  t.deepEqual(targets['c2'], data.classes[1]);
 });
 test('reference property find reference targets - target container undefined', t => {
   const schema = t.context.referenceFindSchema;
   const service: SchemaService = new SchemaServiceImpl(schema);
   const property = service.getReferenceProperties(schema.properties.classes.items as JsonSchema)[0];
+  t.true(property.isIdBased());
   const data = {
     elements: [{id: 'e1'}]
   };
-  const targets = property.findReferenceTargets(data);
-  t.deepEqual(targets, []);
+  JsonForms.rootData = data;
+  const targets = property.findReferenceTargets();
+  t.deepEqual(targets, {});
 });
 test('reference property find reference targets - targets are subset of available objects.', t => {
   const schema = {
@@ -951,6 +978,7 @@ test('reference property find reference targets - targets are subset of availabl
   const service: SchemaService = new SchemaServiceImpl(schema);
   JsonForms.modelMapping = modelMapping;
   const property = service.getReferenceProperties(schema.definitions.class as JsonSchema)[0];
+  t.true(property.isIdBased());
   const data = {
     objects: [
       {id: 'c1', type: 'class'},
@@ -959,10 +987,15 @@ test('reference property find reference targets - targets are subset of availabl
       {id: 'e2', type: 'element'}
     ]
   };
-  const targets = property.findReferenceTargets(data);
-  t.is(targets.length, 2);
-  t.is(targets[0], data.objects[0]);
-  t.is(targets[1], data.objects[2]);
+  JsonForms.rootData = data;
+
+  const targets = property.findReferenceTargets();
+  const keys = Object.keys(targets);
+  t.is(keys.length, 2);
+  t.is(keys[0], 'c1');
+  t.is(keys[1], 'c2');
+  t.deepEqual(targets['c1'], data.objects[0]);
+  t.deepEqual(targets['c2'], data.objects[2]);
 });
 
 test('property type check', t => {


### PR DESCRIPTION
This PR contains PRs #653 and #655. It is assumend they are merged first. Their content is not described here.

- Extended the SchemaService to offer path based referencing in addition to ID based referencing
- Changed return types of ReferenceProperties that return reference data from array to object. The object contains the path or id as key and the data as value.
- Added a ResourceSet to JsonForms that allows to register data resources under a specified name
- For references, allow to specify reference targets inside registered resources
- Allow to load a reference's target schema from a resource
- Add a control for path based references
- Extended the EnumControl by a default option
- Added test cases for the new schema service behavior, the path based reference control, and the changes to the EnumControl
- The TreeRenderer now auto-selects new elements after their creation
