### PR TITLE
Fix issue #704: Remove warnings during test execution

### DIFF
--- a/src/json-forms.tsx
+++ b/src/json-forms.tsx
@@ -146,9 +146,10 @@ export class JsonFormsElement extends HTMLElement {
     const uischema = this.uiSchema;
 
     this.store = initJsonFormsStore(this.dataObject, schema, uischema);
+    const storeId = new Date().toISOString();
 
     render(
-      <Provider store={this.store}>
+      <Provider store={this.store} key={`${storeId}-store`}>
         <DispatchRenderer uischema={uischema} schema={schema} />
       </Provider>,
       this

--- a/src/reducers/common.ts
+++ b/src/reducers/common.ts
@@ -38,9 +38,9 @@ export const commonStateReducer = (
           schema: state.schema
         };
       } else {
-        const currData = get(state.data, action.path);
-        const data = action.updater(currData);
-        const newState = set(state.data, action.path, data);
+        const oldData = get(state.data, action.path);
+        const newData = action.updater(oldData);
+        const newState = set(state.data, action.path, newData);
 
         return {
           data: newState,

--- a/src/reducers/common.ts
+++ b/src/reducers/common.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { get, set } from 'dot-prop-immutable';
 import { INIT, UPDATE_DATA } from '../actions';
 
@@ -38,7 +39,8 @@ export const commonStateReducer = (
         };
       } else {
         const currData = get(state.data, action.path);
-        const newState = set(state.data, action.path, action.updater(currData));
+        const data = action.updater(currData);
+        const newState = set(state.data, action.path, data);
 
         return {
           data: newState,

--- a/src/renderers/additional/categorization-renderer.tsx
+++ b/src/renderers/additional/categorization-renderer.tsx
@@ -60,16 +60,11 @@ export interface SingleCategoryProps {
   path: string;
 }
 
-export const SingleCategory = ({ category, schema, path }: SingleCategoryProps) => {
+export const SingleCategory = ({ category, schema, path }: SingleCategoryProps) => (
   // TODO: add selected style
-  if (category.elements === undefined) {
-    return (<div id='categorization.detail'/>);
-  }
-
-  return (
-    <div id='categorization.detail'>
-      {
-        (category.elements || []).map((child, index) =>
+  <div id='categorization.detail'>
+    {
+      (category.elements || []).map((child, index) =>
           (
             <DispatchRenderer
               key={path + index.toString()}
@@ -78,16 +73,13 @@ export const SingleCategory = ({ category, schema, path }: SingleCategoryProps) 
               path={path}
             />
           )
-        )
-      }
-    </div>
-  );
-};
+      )
+    }
+  </div>
+);
 
-
-const isCategorization = (category: Category | Categorization): category is Categorization => {
-  return category.type === 'Categorization';
-};
+const isCategorization = (category: Category | Categorization): category is Categorization =>
+  category.type === 'Categorization';
 
 /**
  * Default tester for a categorization.

--- a/src/renderers/controls/boolean.control.tsx
+++ b/src/renderers/controls/boolean.control.tsx
@@ -30,7 +30,7 @@ export class BooleanControl extends Control<ControlProps, ControlState> {
           {label}
         </label>
         <input type='checkbox'
-               checked={this.state.value}
+               checked={this.state.value || ''}
                onChange={(ev: Event<HTMLInputElement>) =>
                  this.handleChange(ev.currentTarget.checked)
                }

--- a/src/renderers/controls/date.control.tsx
+++ b/src/renderers/controls/date.control.tsx
@@ -24,6 +24,7 @@ export class DateControl extends Control<ControlProps, ControlState> {
     const { classNames, id, visible, enabled, errors, label, uischema } = this.props;
     const isValid = errors.length === 0;
     const divClassNames = 'validation' + (isValid ? '' : ' validation_error');
+    const now = new Date().toISOString().substr(0, 10);
 
     return (
       <div className={classNames.wrapper}>
@@ -31,7 +32,7 @@ export class DateControl extends Control<ControlProps, ControlState> {
           {label}
         </label>
         <input type='date'
-               value={this.state.value}
+               value={this.state.value || ''}
                onChange={(ev: Event<HTMLInputElement>) => {
                  if (_.isDate(ev.currentTarget.value)) {
                    this.handleChange(

--- a/src/renderers/controls/date.control.tsx
+++ b/src/renderers/controls/date.control.tsx
@@ -24,7 +24,6 @@ export class DateControl extends Control<ControlProps, ControlState> {
     const { classNames, id, visible, enabled, errors, label, uischema } = this.props;
     const isValid = errors.length === 0;
     const divClassNames = 'validation' + (isValid ? '' : ' validation_error');
-    const now = new Date().toISOString().substr(0, 10);
 
     return (
       <div className={classNames.wrapper}>

--- a/src/renderers/controls/enum.control.tsx
+++ b/src/renderers/controls/enum.control.tsx
@@ -23,8 +23,18 @@ export const enumControlTester: RankedTester = rankWith(2, and(
 export class EnumControl extends Control<ControlProps, ControlState> {
 
   render() {
-    const  { uischema, schema, classNames, id, label,
-      visible, enabled, data, path, errors, dispatch } = this.props;
+    const  {
+      uischema,
+      schema,
+      classNames,
+      id,
+      label,
+      visible,
+      enabled,
+      path,
+      errors,
+      dispatch
+    } = this.props;
 
     const isValid = errors.length === 0;
     const options = resolveSchema(
@@ -42,27 +52,26 @@ export class EnumControl extends Control<ControlProps, ControlState> {
           className={classNames.input}
           hidden={!visible}
           disabled={!enabled}
-          value={this.state.value}
+          value={this.state.value || ''}
           onChange={(ev: Event<HTMLSelectElement>) =>
             dispatch(update(path, () => ev.currentTarget.value))
           }
         >
           {
-            [<option value='' selected={data === undefined}/>]
+            [<option value='' key={'empty'} />]
               .concat(
-                options.map(optionValue => {
-                  return (
-                    <option
-                      value={optionValue}
-                      label={optionValue}
-                      selected={data === optionValue}
-                      key={optionValue}
-                    >
-                      {optionValue}
-                    </option>
-                  );
-                })
-              )
+                options.map(optionValue =>
+                    (
+                      <option
+                        value={optionValue}
+                        label={optionValue}
+                        key={optionValue}
+                      >
+                        {optionValue}
+                      </option>
+                    )
+                )
+            )
           }
         </select>
         <div className={divClassNames}>

--- a/src/renderers/controls/integer.control.tsx
+++ b/src/renderers/controls/integer.control.tsx
@@ -32,7 +32,7 @@ export class IntegerControl extends Control<ControlProps, ControlState> {
         </label>
         <input type='number'
                step='1'
-               value={this.state.value}
+               value={this.state.value || ''}
                onChange={(ev: Event<HTMLInputElement>) =>
                  this.handleChange(_.toInteger(ev.currentTarget.value))
                }

--- a/src/renderers/controls/number.control.tsx
+++ b/src/renderers/controls/number.control.tsx
@@ -32,7 +32,7 @@ export class NumberControl extends Control<ControlProps, ControlState> {
         </label>
         <input type='number'
                step='0.1'
-               value={this.state.value}
+               value={this.state.value || ''}
                onChange={(ev: Event<HTMLInputElement>) =>
                  this.handleChange(_.toNumber(ev.currentTarget.value))
                }

--- a/src/renderers/controls/text.control.tsx
+++ b/src/renderers/controls/text.control.tsx
@@ -26,7 +26,7 @@ export class TextControl extends Control<ControlProps, ControlState> {
         <label htmlFor={id} className={classNames.label}>
           {label}
         </label>
-        <input value={this.state.value}
+        <input value={this.state.value || ''}
                onChange={
                  (ev: Event<HTMLInputElement>) =>
                    this.handleChange(ev.currentTarget.value)

--- a/src/renderers/controls/textarea.control.tsx
+++ b/src/renderers/controls/textarea.control.tsx
@@ -30,7 +30,7 @@ export class TextAreaControl extends Control<ControlProps, ControlState> {
           {label}
         </label>
         <textarea
-          value={this.state.value}
+          value={this.state.value || ''}
           onChange={(ev: Event<HTMLTextAreaElement>) =>
             this.handleChange(ev.currentTarget.value)
           }

--- a/src/renderers/materialized/materialized.boolean.control.tsx
+++ b/src/renderers/materialized/materialized.boolean.control.tsx
@@ -14,7 +14,7 @@ export class BooleanControl extends Control<ControlProps, ControlState> {
     return (
       <div className={className}>
         <input type='checkbox'
-               checked={this.state.value}
+               checked={this.state.value || ''}
                className={classNames.input}
                id={id}
                hidden={!visible}

--- a/src/renderers/materialized/materialized.date.control.tsx
+++ b/src/renderers/materialized/materialized.date.control.tsx
@@ -22,13 +22,14 @@ export class DateControl extends Control<ControlProps, ControlState> {
   render() {
     const { classNames, id, visible, enabled, errors, label, uischema } = this.props;
     classNames.input += ' datepicker';
+
     return (
       <div className={classNames.wrapper}>
         <label htmlFor={id} className={classNames.label} data-error={errors}>
           {label}
         </label>
         <input type='text'
-               value={this.state.value}
+               value={this.state.value || ''}
                onChange={ev => this.handleChange(ev.target.value)}
                className={classNames.input}
                id={id}

--- a/src/renderers/materialized/materialized.enum.control.tsx
+++ b/src/renderers/materialized/materialized.enum.control.tsx
@@ -40,18 +40,17 @@ export class MaterializedEnumControl extends Control<ControlProps, ControlState>
         <select
           className={classNames.input}
           disabled={!enabled}
-          value={this.state.value}
+          value={this.state.value || ''}
           onChange={ev => this.handleChange(ev.target.value) }
         >
           {
-            [<option value='' selected={data === undefined} key={'empty'}/>]
+            [<option value='' key={'empty'}/>]
               .concat(
                 options.map(optionValue => {
                   return (
                     <option
                       value={optionValue}
                       label={optionValue}
-                      selected={data === optionValue}
                       key={optionValue}
                     >
                       {optionValue}

--- a/src/renderers/materialized/materialized.integer.control.tsx
+++ b/src/renderers/materialized/materialized.integer.control.tsx
@@ -18,7 +18,7 @@ export class MaterializedIntegerControl extends Control<ControlProps, ControlSta
         </label>
         <input type='number'
                step='1'
-               value={this.state.value}
+               value={this.state.value || ''}
                onChange={(ev: Event<HTMLInputElement>) =>
                  this.handleChange(_.toInteger(ev.currentTarget.value))
                }

--- a/src/renderers/materialized/materialized.number.control.tsx
+++ b/src/renderers/materialized/materialized.number.control.tsx
@@ -18,7 +18,7 @@ export class NumberControl extends Control<ControlProps, ControlState> {
         </label>
         <input type='number'
                step='0.1'
-               value={this.state.value}
+               value={this.state.value || ''}
                onChange={(ev: Event<HTMLInputElement>) =>
                  this.handleChange(_.toNumber(ev.currentTarget.value))
                }

--- a/src/renderers/materialized/materialized.text.control.tsx
+++ b/src/renderers/materialized/materialized.text.control.tsx
@@ -12,7 +12,7 @@ export class MaterializedTextControl extends Control<ControlProps, ControlState>
 
     return (
       <div className={classNames.wrapper}>
-        <input value={this.state.value}
+        <input value={this.state.value || ''}
                onChange={(ev: Event<HTMLInputElement>) =>
                  this.handleChange(ev.currentTarget.value)
                }

--- a/src/renderers/materialized/materialized.textarea.control.tsx
+++ b/src/renderers/materialized/materialized.textarea.control.tsx
@@ -17,7 +17,7 @@ export class MaterializedTextareaControl extends Control<ControlProps, ControlSt
           {label}
         </label>
         <textarea
-          value={this.state.value}
+          value={this.state.value || ''}
           onChange={(ev: Event<HTMLTextAreaElement>) =>
             this.handleChange(ev.currentTarget.value)
           }

--- a/test/helpers/setup.ts
+++ b/test/helpers/setup.ts
@@ -2,6 +2,7 @@ import 'jsdom-global/register';
 import * as installCE from 'document-register-element/pony';
 declare let global;
 installCE(global, 'force');
+global.requestAnimationFrame = (cb) => setTimeout(cb, 0);
 import { JsonFormsStore } from '../../src/json-forms';
 import { INIT } from '../../src/actions';
 import { JsonSchema } from '../../src/models/jsonSchema';

--- a/test/renderers/boolean.control.test.tsx
+++ b/test/renderers/boolean.control.test.tsx
@@ -312,11 +312,6 @@ test('update via input event', t => {
   const input = findRenderedDOMElementWithTag(tree, 'input') as HTMLInputElement;
   input.checked = false;
   change(input);
-  // const evt = new Event('click', {
-  //   'bubbles': true,
-  //   'cancelable': true
-  // });
-  // input.dispatchEvent(evt);
   t.is(getData(store.getState()).foo, false);
 });
 

--- a/test/renderers/enum.control.test.tsx
+++ b/test/renderers/enum.control.test.tsx
@@ -246,8 +246,8 @@ test('update with undefined value', t => {
       () => undefined
     )
   );
-  t.is(select.selectedIndex, 1);
-  t.is(select.value, 'a');
+  t.is(select.selectedIndex, 0);
+  t.is(select.value, '');
 });
 
 test('update with null value', t => {
@@ -266,8 +266,8 @@ test('update with null value', t => {
       () => null
     )
   );
-  t.is(select.selectedIndex, 1);
-  t.is(select.value, 'a');
+  t.is(select.selectedIndex, 0);
+  t.is(select.value, '');
 });
 
 test('update with wrong ref', t => {

--- a/test/renderers/integer.control.test.tsx
+++ b/test/renderers/integer.control.test.tsx
@@ -309,15 +309,13 @@ test('update with undefined value', t => {
     </Provider>
   );
   const input = findRenderedDOMElementWithTag(tree, 'input') as HTMLInputElement;
-  t.is(input.value, '42');
-
   store.dispatch(
     update(
       'foo',
       () => undefined
     )
   );
-  t.is(input.value, '42');
+  t.is(input.value, '');
 });
 
 test('update with null value', t => {
@@ -337,7 +335,7 @@ test('update with null value', t => {
       () => null
     )
   );
-  t.is(input.value, '42');
+  t.is(input.value, '');
 });
 
 test('update with wrong ref', t => {

--- a/test/renderers/number.control.test.tsx
+++ b/test/renderers/number.control.test.tsx
@@ -360,7 +360,7 @@ test('update with undefined value', t => {
   );
   const input = findRenderedDOMElementWithTag(tree, 'input') as HTMLInputElement;
   store.dispatch(update('foo', () => undefined));
-  t.is(input.value, '3.14');
+  t.is(input.value, '');
 });
 
 test('update with null value', t => {
@@ -374,7 +374,7 @@ test('update with null value', t => {
   );
   const input = findRenderedDOMElementWithTag(tree, 'input') as HTMLInputElement;
   store.dispatch(update('foo', () => null));
-  t.is(input.value, '3.14');
+  t.is(input.value, '');
 });
 
 test('update with wrong ref', t => {

--- a/test/renderers/text.control.test.tsx
+++ b/test/renderers/text.control.test.tsx
@@ -307,7 +307,7 @@ test('update with undefined value', t => {
   );
   const input = findRenderedDOMElementWithTag(tree, 'input') as HTMLTextAreaElement;
   store.dispatch(update('name', () => undefined));
-  t.is(input.value, 'Foo');
+  t.is(input.value, '');
 });
 
 test('update with null value', t => {
@@ -325,7 +325,7 @@ test('update with null value', t => {
   );
   const input = findRenderedDOMElementWithTag(tree, 'input') as HTMLTextAreaElement;
   store.dispatch(update('name', () => null));
-  t.is(input.value, 'Foo');
+  t.is(input.value, '');
 });
 
 test('update with wrong ref', t => {

--- a/test/renderers/textarea.control.test.tsx
+++ b/test/renderers/textarea.control.test.tsx
@@ -274,7 +274,7 @@ test('update with undefined value', t => {
   const textArea = findRenderedDOMElementWithTag(tree, 'textarea') as HTMLTextAreaElement;
   store.dispatch(update('name', () => undefined));
   // keep value
-  t.is(textArea.value, 'Foo');
+  t.is(textArea.value, '');
 });
 
 test('update with null value', t => {
@@ -288,7 +288,7 @@ test('update with null value', t => {
   );
   const textArea = findRenderedDOMElementWithTag(tree, 'textarea') as HTMLTextAreaElement;
   store.dispatch(update('name', () => null));
-  t.is(textArea.value, 'Foo');
+  t.is(textArea.value, '');
 });
 
 test('update with wrong ref', t => {

--- a/test/renderers/textarea.control.test.tsx
+++ b/test/renderers/textarea.control.test.tsx
@@ -273,7 +273,6 @@ test('update with undefined value', t => {
   );
   const textArea = findRenderedDOMElementWithTag(tree, 'textarea') as HTMLTextAreaElement;
   store.dispatch(update('name', () => undefined));
-  // keep value
   t.is(textArea.value, '');
 });
 

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -5,8 +5,8 @@
     "target": "es6"
   },
   "include": [
-    "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    "**/*.ts"
   ],
   "exclude": [
   ],


### PR DESCRIPTION
Fixes #704: Remove warnings during tests

* Add keys where necessary
* Add default values as undefined is not legal
* Replace deleteFunction with update action in tree renderer
* Replace categorization render methods with component
