### PR TITLE
Updated Example Structure

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -1,6 +1,4 @@
 import { createExampleSelection } from './example';
-import { createThemeSelection } from './theme.switcher';
-import { createStyleSelection } from './style.switcher';
 import './templates/arrays';
 import './templates/day2';
 import './templates/day4';
@@ -19,8 +17,12 @@ import './templates/resolve';
 import './templates/uischema-registry';
 import './templates/ecore';
 
+import '../src/renderers/materialized';
+import { materialize } from '../src/renderers/materialized/index';
+declare let $;
+
 window.onload = ev => {
   const selectExampleElement = createExampleSelection();
-  createThemeSelection();
-  createStyleSelection(selectExampleElement);
+  materialize();
+  $('select').material_select();
 };

--- a/example_materialize/index.html
+++ b/example_materialize/index.html
@@ -8,25 +8,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="assets/native-shim.js"></script>
 
-  <script src="assets/rating.min.js"></script>
-
-  <!-- JQuery is needed for both, Bootstrap 4 as well as materialize -->
+  <!-- JQuery is needed for materialize -->
   <script src="assets/jquery.js"></script>
 
   <!-- Materialize CSS -->
   <link rel="stylesheet" href="assets/materialize.css">
-  <link rel="stylesheet" href="assets/example.css">
-
-  <!-- Bootstrap 4 CSS -->
-  <!--<link rel="stylesheet" href="assets/bootstrap.css">-->
 
   <!-- Plain CSS -->
-  <link rel="stylesheet" href="assets/rating.css">
-  <!--<link rel="stylesheet" href="assets/example.dark.css">-->
-  <!--<link rel="stylesheet" href="assets/example.labelfixed.css">-->
-
-  <!-- Bootstrap JS, if we need it, it must be loaded before materialize JS, otherwise the select elements seem to break -->
-  <!--<script src="assets/bootstrap.js"></script>-->
+  <link rel="stylesheet" href="assets/example.css">
 
   <!-- materialize JS -->
   <script src="assets/materialize.js"></script>
@@ -36,8 +25,6 @@
 <div id="root">
   <div id="toolbar" style="background-color: #00ddfb">
     <div id="examples"></div>
-    <div id="theme"></div>
-    <div id="style"></div>
   </div>
   <div id="view"></div>
 </div>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "typings": "dist/ts-build/index.d.ts",
   "scripts": {
     "start": "npm run dev",
-    "dev": "webpack --config webpack/webpack.dev.js && webpack-dev-server --config webpack/webpack.dev.js --env=dev --inline",
+    "dev": "npm run dev-materialize",
+    "dev-materialize": "webpack --config webpack/webpack.dev.materialize.js && webpack-dev-server --config webpack/webpack.dev.materialize.js --env=dev --inline",
     "dev-default": "webpack --config webpack/webpack.dev.default.js && webpack-dev-server --config webpack/webpack.dev.default.js --env=dev --inline",
     "bundle": "webpack --config webpack/webpack.build.js --env=production --display-error-details",
     "build": "npm run tsc && npm run bundle && ncp example/example.css dist/jsonforms-example.css",

--- a/webpack/webpack.dev.materialize.js
+++ b/webpack/webpack.dev.materialize.js
@@ -24,18 +24,14 @@ module.exports = [{
         extensions: [".ts", ".js", ".tsx"]
     },
     devServer: {
-        contentBase: './example_plain'
+        contentBase: './example_materialize'
     },
     plugins: [
         new webpack.HotModuleReplacementPlugin(),
         new copyWebpackPlugin([
             { from: 'example/example.css' },
-            { from: 'example/example.dark.css' },
-            { from: 'example/example.labelfixed.css' },
             { from: 'lib/native-shim.js'  },
             { from: 'node_modules/jquery/dist/jquery.js'               },
-            { from: 'node_modules/bootstrap/dist/css/bootstrap.css'    },
-            { from: 'node_modules/bootstrap/dist/js/bootstrap.js'      },
             { from: 'node_modules/materialize-css/dist/css/materialize.css' },
             { from: 'node_modules/materialize-css/dist/js/materialize.js'  },
             { from: 'example/icons', to: 'icons' }


### PR DESCRIPTION
Fixes #701

This fixes the example structure by removing the style and theme switcher from the materialize example. Also the folders are named accordingly now.
This is based on #716.