### PR TITLE
Add check for unused parameters

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -127,7 +127,7 @@ export class JsonForms {
  */
 // Disable rule because it is used as an decorator
 // tslint:disable:variable-name
-export const JsonFormsServiceElement = config => (cls: JsonFormsServiceConstructable) => {
+export const JsonFormsServiceElement = () => (cls: JsonFormsServiceConstructable) => {
   JsonForms.jsonFormsServices.push(cls);
 };
 // tslint:enable:variable-name

--- a/packages/core/src/path.util.ts
+++ b/packages/core/src/path.util.ts
@@ -37,7 +37,7 @@ export const toDataPathSegments = (schemaPath: string): string[] => {
   const segments = schemaPath.split('/');
   const startFromRoot = segments[0] === '#' || segments[0] === '';
   if (startFromRoot) {
-    return segments.filter((segment, index) => {
+    return segments.filter((_segment, index) => {
       if (index === 0) {
         return false;
       } else {
@@ -46,7 +46,7 @@ export const toDataPathSegments = (schemaPath: string): string[] => {
     });
   }
 
-  return segments.filter((segment, index) => index % 2 !== 0);
+  return segments.filter((_segment, index) => index % 2 !== 0);
 };
 
 /**
@@ -75,27 +75,27 @@ export const toDataPath = (schemaPath: string): string => {
  *          the resolved instance as well the last fragment of
  */
 export const getValuePropertyPair = (instance: any, schemaPath: string):
-  {instance: Object, property: string} => {
+  { instance: Object, property: string } => {
   const validPathSegments = toDataPathSegments(schemaPath);
   const resolvedInstance =
-      validPathSegments
-          .slice(0, validPathSegments.length - 1)
-          .map(segment => decodeURIComponent(segment))
-          .reduce(
-              (curInstance, decodedSegment) => {
-                if (!curInstance.hasOwnProperty(decodedSegment)) {
-                  curInstance[decodedSegment] = {};
-                }
+    validPathSegments
+      .slice(0, validPathSegments.length - 1)
+      .map(segment => decodeURIComponent(segment))
+      .reduce(
+      (curInstance, decodedSegment) => {
+        if (!curInstance.hasOwnProperty(decodedSegment)) {
+          curInstance[decodedSegment] = {};
+        }
 
-                return curInstance[decodedSegment];
-              },
-              instance
-          );
+        return curInstance[decodedSegment];
+      },
+      instance
+      );
 
   return {
-      instance: resolvedInstance,
-      property: validPathSegments.length > 0 ?
-        decodeURIComponent(validPathSegments[validPathSegments.length - 1]) : undefined
+    instance: resolvedInstance,
+    property: validPathSegments.length > 0 ?
+      decodeURIComponent(validPathSegments[validPathSegments.length - 1]) : undefined
   };
 };
 
@@ -106,7 +106,7 @@ export const composeWithUi = (scopableUi: Scopable, path: string) => {
 };
 
 export const resolveData = (data, path) =>
- _.isEmpty(path) ? data : _.get<any, any>(data, path);
+  _.isEmpty(path) ? data : _.get<any, any>(data, path);
 
 /**
  * Resolve the given schema path in order to obtain a subschema.
@@ -119,9 +119,9 @@ export const resolveSchema = (schema: JsonSchema, schemaPath: string): JsonSchem
   const invalidSegment =
     pathSegment => pathSegment === '#' || pathSegment === undefined || pathSegment === '';
   const resultSchema = validPathSegments.reduce(
-      (curSchema, pathSegment) =>
-          invalidSegment(pathSegment) ? curSchema : curSchema[pathSegment],
-      schema
+    (curSchema, pathSegment) =>
+      invalidSegment(pathSegment) ? curSchema : curSchema[pathSegment],
+    schema
   );
   if (resultSchema !== undefined && resultSchema.$ref !== undefined) {
     return retrieveResolvableSchema(schema, resultSchema.$ref);
@@ -139,42 +139,42 @@ export const resolveSchema = (schema: JsonSchema, schemaPath: string): JsonSchem
  * @param resolveTuples Whether arrays of tuples should be considered; default: false
  */
 export const findAllRefs =
-    (schema: JsonSchema, result: ReferenceSchemaMap = {}, resolveTuples = false)
+  (schema: JsonSchema, result: ReferenceSchemaMap = {}, resolveTuples = false)
     : ReferenceSchemaMap => {
 
-  if (isObject(schema)) {
-    Object.keys(schema.properties).forEach(key =>
-      findAllRefs(schema.properties[key], result));
-  }
-  if (isArray(schema)) {
-    if (Array.isArray(schema.items)) {
-      if (resolveTuples) {
-        schema.items.forEach(child => findAllRefs(child, result));
-      }
-    } else {
-      findAllRefs(schema.items, result);
+    if (isObject(schema)) {
+      Object.keys(schema.properties).forEach(key =>
+        findAllRefs(schema.properties[key], result));
     }
-  }
-  if (Array.isArray(schema.anyOf)) {
-    schema.anyOf.forEach(child => findAllRefs(child, result));
-  }
-  if (schema.$ref !== undefined) {
-    result[schema.$ref] = schema;
-  }
-
-  // tslint:disable:no-string-literal
-  if (schema['links'] !== undefined) {
-    schema['links'].forEach(link => {
-      if (!_.isEmpty(link.targetSchema.$ref)) {
-        result[link.targetSchema.$ref] = schema;
+    if (isArray(schema)) {
+      if (Array.isArray(schema.items)) {
+        if (resolveTuples) {
+          schema.items.forEach(child => findAllRefs(child, result));
+        }
       } else {
-        findAllRefs(link.targetSchema, result);
+        findAllRefs(schema.items, result);
       }
-    });
-  }
+    }
+    if (Array.isArray(schema.anyOf)) {
+      schema.anyOf.forEach(child => findAllRefs(child, result));
+    }
+    if (schema.$ref !== undefined) {
+      result[schema.$ref] = schema;
+    }
 
-  return result;
-};
+    // tslint:disable:no-string-literal
+    if (schema['links'] !== undefined) {
+      schema['links'].forEach(link => {
+        if (!_.isEmpty(link.targetSchema.$ref)) {
+          result[link.targetSchema.$ref] = schema;
+        } else {
+          findAllRefs(link.targetSchema, result);
+        }
+      });
+    }
+
+    return result;
+  };
 
 /**
  * Normalizes the schema and resolves the given ref.
@@ -186,7 +186,7 @@ export const findAllRefs =
 // disable rule because resolve is mutually recursive
 // tslint:disable:only-arrow-functions
 export function retrieveResolvableSchema(full: JsonSchema, reference: string): JsonSchema {
-// tslint:enable:only-arrow-functions
+  // tslint:enable:only-arrow-functions
   const child = resolveSchema(full, reference);
   const allRefs = findAllRefs(child);
   const innerSelfReference = allRefs[reference];

--- a/packages/core/src/renderers/Control.ts
+++ b/packages/core/src/renderers/Control.ts
@@ -35,7 +35,7 @@ export class Control<P extends ControlProps, S extends ControlState> extends Ren
     // tslint:enable:no-object-literal-type-assertion
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     if (this.props.data !== prevProps.data) {
       this.setState({ value: this.props.data });
     }

--- a/packages/core/src/renderers/label.util.ts
+++ b/packages/core/src/renderers/label.util.ts
@@ -1,8 +1,6 @@
 import * as _ from 'lodash';
 
-import { JsonSchema } from '../models/jsonSchema';
 import { ControlElement, ILabelObject } from '../models/uischema';
-import { resolveSchema } from '../path.util';
 
 class LabelObject implements ILabelObject {
   public text: string;

--- a/packages/core/src/renderers/renderer.util.tsx
+++ b/packages/core/src/renderers/renderer.util.tsx
@@ -1,6 +1,5 @@
 import { JsonSchema } from '../models/jsonSchema';
 import * as React from 'react';
-import { Component } from 'react';
 import { JsonForms } from '../core';
 import {
   convertToClassName,

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,17 +1,7 @@
 {
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
-    "baseUrl": "src",
-    "declaration": true,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "lib": ["es6", "dom"],
-    "module": "commonjs",
-    "moduleResolution": "node",
     "outDir": "dist/ts-build",
-    "sourceMap": true,
-    "target": "es5",
-    "jsx": "react",
-    "typeRoots": ["../../node_modules/@types"]
   },
   "exclude":[
     "node_modules"

--- a/packages/default/src/additional/array-renderer.tsx
+++ b/packages/default/src/additional/array-renderer.tsx
@@ -83,12 +83,12 @@ export const ArrayControlRenderer  =
               +
             </button>
             <label className={'array.label'}>
-              { label.show ? label.text : '' }
+              {label.show ? label.text : ''}
             </label>
           </legend>
           <div className={JsonForms.stylingRegistry.getAsClassName('array.children')}>
             {
-              data ? data.map((child, index) => {
+              data ? data.map((_child, index) => {
 
                 const generatedUi = generateDefaultUISchema(resolvedSchema, 'HorizontalLayout');
                 const childPath = compose(path, index + '');

--- a/packages/default/src/additional/categorization-renderer.tsx
+++ b/packages/default/src/additional/categorization-renderer.tsx
@@ -1,22 +1,21 @@
 import * as _ from 'lodash';
 import * as React from 'react';
-import { Component } from 'react';
 import {
   and,
+  Categorization,
+  Category,
   DispatchRenderer,
   JsonForms,
   JsonSchema,
+  mapStateToLayoutProps,
   RankedTester,
   rankWith,
-  Category,
-  Categorization,
-  RendererProps,
-  mapStateToLayoutProps,
   registerStartupRenderer,
   Renderer,
+  RendererProps,
   uiTypeIs
 } from 'jsonforms-core';
-import {connect} from 'react-redux';
+import { connect } from 'react-redux';
 
 const getCategoryClassName = (category: Category, selectedCategory: Category): string =>
   selectedCategory === category ? 'selected' : '';
@@ -25,7 +24,7 @@ export interface CategorizationProps {
   categorization: Categorization;
   selectedCategory: Category;
   depth: number;
-  onSelect: any
+  onSelect: any;
 }
 
 export const CategorizationList  = ({ categorization, selectedCategory, depth, onSelect }: CategorizationProps) =>
@@ -117,7 +116,7 @@ export const categorizationTester: RankedTester = rankWith(
         ));
 
 export interface CategorizationState {
-  selectedCategory: Category
+  selectedCategory: Category;
 }
 
 class CategorizationRenderer extends Renderer<RendererProps, CategorizationState> {
@@ -142,7 +141,7 @@ class CategorizationRenderer extends Renderer<RendererProps, CategorizationState
             categorization={categorization}
             selectedCategory={selectedCategory}
             depth={0}
-            onSelect={(category) =>
+            onSelect={ category =>
               this.setState({ selectedCategory: category })
             }
           />

--- a/packages/default/src/additional/table-array.control.tsx
+++ b/packages/default/src/additional/table-array.control.tsx
@@ -90,7 +90,7 @@ export class TableArrayControl extends Renderer<ControlProps, void> {
           <label className={labelClass}>
             {label}
           </label>
-          <button className={buttonClass} onClick={ () => this.addNewItem(path) }>
+          <button className={buttonClass} onClick={() => this.addNewItem(path)}>
             Add to {labelObject.text}
           </button>
         </header>
@@ -112,7 +112,7 @@ export class TableArrayControl extends Renderer<ControlProps, void> {
           <tbody>
           {
             (!data || !Array.isArray(data) || data.length === 0) ?
-              <tr><td>No data</td></tr> : data.map((child, index) => {
+              <tr><td>No data</td></tr> : data.map((_child, index) => {
               const childPath = compose(path, index + '');
 
               return (

--- a/packages/default/src/additional/tree-renderer.tsx
+++ b/packages/default/src/additional/tree-renderer.tsx
@@ -24,8 +24,7 @@ import {
   uiTypeIs,
   update
 } from 'jsonforms-core';
-import {connect} from 'react-redux';
-import {SyntheticEvent} from "react";
+import { connect } from 'react-redux';
 
 /**
  * Default tester for a master-detail layout.
@@ -114,12 +113,12 @@ export class TreeMasterDetail extends Control<TreeProps, TreeMasterDetailState> 
       <div hidden={!visible} className={'jsf-treeMasterDetail'}>
         <div className={'jsf-treeMasterDetail-header'}>
           <label>
-            {  typeof controlElement.label === 'string' ? controlElement.label : '' }
+            {typeof controlElement.label === 'string' ? controlElement.label : ''}
           </label>
           {
             Array.isArray(rootData) &&
             <button className='jsf-treeMasterDetail-add'
-                    onClick={() => this.addToRoot() }
+                    onClick={() => this.addToRoot()}
             >
               Add to root
             </button>
@@ -230,11 +229,11 @@ export class TreeMasterDetail extends Control<TreeProps, TreeMasterDetailState> 
     // TODO: so far no drag and drop support
     if (schema.items !== undefined) {
       return (
-        <ul>{ this.expandRootArray(schema.items as JsonSchema) }</ul>
+        <ul>{this.expandRootArray(schema.items as JsonSchema)}</ul>
       );
     }
 
-    return (<ul>{ this.expandObject(this.props.path, schema, null) }</ul>);
+    return (<ul>{this.expandObject(this.props.path, schema, null)}</ul>);
   }
 
   /**
@@ -251,7 +250,7 @@ export class TreeMasterDetail extends Control<TreeProps, TreeMasterDetailState> 
       return;
     }
 
-    return data.map((element, index) => {
+    return data.map((_element, index) => {
       const composedPath = compose(path, index + '');
 
       return this.expandObject(
@@ -279,7 +278,7 @@ export class TreeMasterDetail extends Control<TreeProps, TreeMasterDetailState> 
       return;
     }
 
-    return data.map((element, index) => {
+    return data.map((_element, index) => {
       const composedPath = compose(path, index.toString());
       return this.expandObject(composedPath, property.schema, path);
     });
@@ -334,7 +333,7 @@ export class TreeMasterDetail extends Control<TreeProps, TreeMasterDetailState> 
 
           <span
             className='label'
-            onClick={ev =>
+            onClick={() =>
               this.setState({
                 selected: {
                   schema,
@@ -351,7 +350,7 @@ export class TreeMasterDetail extends Control<TreeProps, TreeMasterDetailState> 
               JsonForms.schemaService.hasContainmentProperties(schema) ?
                 (<span
                   className='add'
-                  onClick={(ev: SyntheticEvent<HTMLSpanElement>) =>
+                  onClick={() =>
                     this.setState({
                       dialog: {
                         open: true,
@@ -366,16 +365,16 @@ export class TreeMasterDetail extends Control<TreeProps, TreeMasterDetailState> 
             }
             {
               parentPath !== null &&
-              <span className='remove' onClick ={() => {
+              <span className='remove' onClick={() => {
                 dispatch(
                   update(
                     parentPath,
                     array => {
                       const copy = array.slice();
-                      return _.filter(copy, el => !_.isEqual(el, data))
+                      return _.filter(copy, el => !_.isEqual(el, data));
                     }
                   )
-                )
+                );
               }}>
                 {'\u274C'}
               </span>
@@ -386,7 +385,7 @@ export class TreeMasterDetail extends Control<TreeProps, TreeMasterDetailState> 
           // render contained children of this element
           JsonForms.schemaService.getContainmentProperties(schema)
             .filter(prop => this.propHasData(prop, data))
-            .map(prop => <ul key={prop.label}>{ this.renderChildren(prop, path, schema) }</ul>)
+            .map(prop => <ul key={prop.label}>{this.renderChildren(prop, path, schema)}</ul>)
         }
       </li>
     );

--- a/packages/default/src/fields/boolean.field.tsx
+++ b/packages/default/src/fields/boolean.field.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import {
-  and,
   FieldProps,
   handleChange,
   isBooleanControl,
   mapStateToInputProps,
   RankedTester,
   rankWith,
-  registerStartupInput,
-  schemaTypeIs,
-  uiTypeIs
+  registerStartupInput
 } from 'jsonforms-core';
 import { connect } from 'react-redux';
 import { SyntheticEvent } from 'react';

--- a/packages/default/src/layouts/group.layout.tsx
+++ b/packages/default/src/layouts/group.layout.tsx
@@ -8,7 +8,6 @@ import {
   GroupLayout,
   JsonForms,
   renderChildren,
-  JsonFormsLayout,
   mapStateToLayoutProps,
   registerStartupRenderer,
 } from 'jsonforms-core';

--- a/packages/default/test/json-forms.test.ts
+++ b/packages/default/test/json-forms.test.ts
@@ -1,6 +1,6 @@
 import './helpers/setup';
 import test from 'ava';
-import { JsonForms, JsonFormsElement } from 'jsonforms-core';
+import { JsonFormsElement } from 'jsonforms-core';
 import '../src/index';
 import { ControlElement, generateDefaultUISchema, generateJsonSchema } from 'jsonforms-core';
 

--- a/packages/default/test/renderers/input.control.test.tsx
+++ b/packages/default/test/renderers/input.control.test.tsx
@@ -131,6 +131,8 @@ test('render', t => {
   t.is(label.textContent, 'Foo');
 
   const input = findRenderedDOMElementWithTag(tree, 'input') as HTMLInputElement;
+  t.not(input, undefined);
+  t.not(input, null);
 
   const validation = findRenderedDOMElementWithClass(tree, 'validation');
   t.is(validation.tagName, 'DIV');
@@ -162,6 +164,8 @@ test('render without label', t => {
   t.is(label.textContent, '');
 
   const input = findRenderedDOMElementWithTag(tree, 'input') as HTMLInputElement;
+  t.not(input, undefined);
+  t.not(input, null);
 
   const validation = findRenderedDOMElementWithClass(tree, 'validation');
   t.is(validation.tagName, 'DIV');

--- a/packages/default/test/renderers/treemasterdetail.array.test.tsx
+++ b/packages/default/test/renderers/treemasterdetail.array.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { initJsonFormsStore } from '../helpers/setup';
 import test from 'ava';
-import { MasterDetailLayout, getData } from 'jsonforms-core';
+import { getData, MasterDetailLayout } from 'jsonforms-core';
 import { JsonForms } from 'jsonforms-core';
 import {
   click,
@@ -10,11 +10,11 @@ import {
   renderIntoDocument
 } from '../helpers/binding';
 import { Provider } from 'react-redux';
-import TreeMasterDetail, { treeMasterDetailTester } from '../../src/additional/tree-renderer';
+import TreeMasterDetail from '../../src/additional/tree-renderer';
 import {
   findRenderedDOMElementWithTag,
   scryRenderedDOMElementsWithClass, scryRenderedDOMElementsWithTag
-} from "../helpers/react-test";
+} from '../helpers/react-test';
 
 test.beforeEach(t => {
   t.context.data = {};

--- a/packages/default/tsconfig.json
+++ b/packages/default/tsconfig.json
@@ -1,17 +1,7 @@
 {
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
-    "baseUrl": "src",
-    "declaration": true,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "lib": ["es6", "dom"],
-    "module": "commonjs",
-    "moduleResolution": "node",
     "outDir": "dist/ts-build",
-    "sourceMap": true,
-    "target": "es5",
-    "jsx": "react",
-    "typeRoots": ["../../node_modules/@types"]
   },
   "exclude":[
     "node_modules"

--- a/packages/materialized/package.json
+++ b/packages/materialized/package.json
@@ -9,8 +9,8 @@
   "directories": {
     "test": "test"
   },
-  "main": "dist/ts-build-materialized/index.js",
-  "typings": "dist/ts-build-materialized/index.d.ts",
+  "main": "dist/ts-build/index.js",
+  "typings": "dist/ts-build/index.d.ts",
   "scripts": {
     "bundle": "../../node_modules/.bin/webpack --config ../../webpack.build.js --env=production --display-error-details",
     "build": "../../node_modules/.bin/tsc",

--- a/packages/materialized/src/complex/table-array.control.tsx
+++ b/packages/materialized/src/complex/table-array.control.tsx
@@ -91,9 +91,9 @@ export class TableArrayControl extends Renderer<ControlProps, void> {
     return (
       <div className={controlClass} hidden={!visible}>
         <Toolbar>
-          <Typography type='title'>{label}</Typography>
+          <Typography type='title' className={labelClass}>{label}</Typography>
           <Button raised color='primary' className={buttonClass}
-            onClick={ () => this.addNewItem(path) }>
+            onClick={() => this.addNewItem(path)}>
             Add to {labelObject.text}
           </Button>
         </Toolbar>
@@ -115,7 +115,7 @@ export class TableArrayControl extends Renderer<ControlProps, void> {
           <TableBody>
           {
             (!data || !Array.isArray(data) || data.length === 0) ?
-              <TableRow><TableCell>No data</TableCell></TableRow> : data.map((child, index) => {
+              <TableRow><TableCell>No data</TableCell></TableRow> : data.map((_child, index) => {
               const childPath = compose(path, index + '');
 
               return (

--- a/packages/materialized/src/controls/material-boolean.control.tsx
+++ b/packages/materialized/src/controls/material-boolean.control.tsx
@@ -13,12 +13,13 @@ import { FormControlLabel } from 'material-ui/Form';
 import MaterialBooleanField from '../fields/material-boolean.field';
 
 export const MaterialBooleanControl =
-    ({ classNames, id, errors, label, uischema, schema }: ControlProps) => {
-    const isValid = errors.length === 0;
+    ({ classNames, label, uischema, schema }: ControlProps) => {
 
     return (
-      <FormControlLabel className={classNames.wrapper} label={label}
-      control={<MaterialBooleanField uischema = {uischema} schema = {schema}/>}
+      <FormControlLabel
+        className={classNames.wrapper}
+        label={label}
+        control={<MaterialBooleanField uischema={uischema} schema={schema}/>}
       />
     );
   };

--- a/packages/materialized/src/fields/material-boolean.field.tsx
+++ b/packages/materialized/src/fields/material-boolean.field.tsx
@@ -14,16 +14,16 @@ import Checkbox from 'material-ui/Checkbox';
 export const MaterialBooleanField = (props: FieldProps) => {
   const { data, className, id, enabled, uischema } = props;
 
-  return <Checkbox
-    checked={data || ''}
-    onChange={ (ev, checked) =>
-      handleChange(props, checked)
-    }
-    className={className}
-    id={id}
-    disabled={!enabled}
-    autoFocus={uischema.options && uischema.options.focus}
-  />;
+  return (
+    <Checkbox
+      checked={data || ''}
+      onChange={(_ev, checked) => handleChange(props, checked)}
+      className={className}
+      id={id}
+      disabled={!enabled}
+      autoFocus={uischema.options && uischema.options.focus}
+    />
+  );
 };
 
 export default registerStartupInput(

--- a/packages/materialized/src/fields/material-slider.field.tsx
+++ b/packages/materialized/src/fields/material-slider.field.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { SyntheticEvent } from 'react';
 import {
   and,
   ControlElement,
@@ -28,7 +27,7 @@ const MaterialSliderField = (props: FieldProps) => {
   return <Input
     type='range'
     value={data || ''}
-    onChange={ ev => handleChange(props, Number(ev.currentTarget.value))}
+    onChange={ev => handleChange(props, Number(ev.currentTarget.value))}
     className={className}
     id={id}
     disabled={!enabled}

--- a/packages/materialized/src/layouts/material-horizontal.layout.tsx
+++ b/packages/materialized/src/layouts/material-horizontal.layout.tsx
@@ -2,17 +2,14 @@ import * as React from 'react';
 import {
   DispatchRenderer,
   HorizontalLayout,
-  JsonSchema,
   mapStateToLayoutProps,
   RankedTester,
   rankWith,
   registerStartupRenderer,
   RendererProps,
-  UISchemaElement,
   uiTypeIs
 } from 'jsonforms-core';
 import { connect } from 'react-redux';
-import * as _ from 'lodash';
 
 import Grid from 'material-ui/Grid';
 
@@ -25,9 +22,10 @@ export const horizontalLayoutTester: RankedTester = rankWith(2, uiTypeIs('Horizo
 export const MaterialHorizontalLayoutRenderer = ({ schema, uischema, path, visible }: RendererProps) => {
 
   const horizontalLayout = uischema as HorizontalLayout;
+  const className = !visible ? 'hidden' : '' ;
 
   return (
-    <Grid container>
+    <Grid container className={className}>
     {
       (horizontalLayout.elements || []).map((child, index) => {
 

--- a/packages/materialized/tsconfig.json
+++ b/packages/materialized/tsconfig.json
@@ -1,17 +1,7 @@
 {
+  "extends": "../../tsconfig.base",
   "compilerOptions": {
-    "baseUrl": "src",
-    "declaration": true,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "lib": ["es6", "dom"],
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "outDir": "dist/ts-build-materialized",
-    "sourceMap": true,
-    "target": "es5",
-    "jsx": "react",
-    "typeRoots": ["../../node_modules/@types"]
+    "outDir": "dist/ts-build",
   },
   "exclude":[
     "node_modules"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src",
+    "declaration": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "lib": ["es6", "dom"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "target": "es5",
+    "jsx": "react",
+    "noUnusedParameters": true,
+    "noUnusedLocals": true
+  }
+}


### PR DESCRIPTION
This introduces a base tsconfig which is extended by the package tsconfigs.
It also adds the `noUnusedLocals` and `noUnusedParameters` compileOptions to the tsconfig.
Finally all unused variables were removed, except in cases where `filter` and `map` methods are used on arrays. In this case the not used parameter is prefixed with `_` as those variables are ignore by the check.  

Fixes #727 

