### PR TITLE
Re-organize example code a bit and improve usage o dispatch renderer in entry point

### DIFF
--- a/packages/core/src/reducers/common.ts
+++ b/packages/core/src/reducers/common.ts
@@ -13,8 +13,8 @@ export const commonStateReducer = (
     case INIT:
       return {
         data: action.data,
-        schema: state.schema,
-        uischema: state.uischema
+        schema: action.schema,
+        uischema: action.uischema
       };
     case UPDATE_DATA: {
       if (action.path === undefined || action.path === null) {

--- a/packages/core/src/renderers/dispatch-renderer.tsx
+++ b/packages/core/src/renderers/dispatch-renderer.tsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { UnknownRenderer } from './unknown.renderer';
 import { RankedTester } from '../testers';
 import { RendererProps } from './renderer';
+import { getSchema, getUiSchema } from '../reducers';
 
 export interface DispatchRendererProps extends RendererProps {
   renderers?: { tester: RankedTester, renderer: any }[];
@@ -27,8 +28,10 @@ const Dispatch = ({ uischema, schema, path, renderers }: DispatchRendererProps) 
   }
 };
 
-const mapStateToProps = state => ({
-  renderers: state.renderers || []
+const mapStateToProps = (state, ownProps) => ({
+  renderers: state.renderers || [],
+  schema: ownProps.schema || getSchema(state),
+  uischema: ownProps.uischema || getUiSchema(state)
 });
 
 export const DispatchRenderer = connect(

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1,11 +1,12 @@
 import thunk from 'redux-thunk';
-import { appReducer } from './reducers/index';
+import { appReducer } from './reducers';
 import { applyMiddleware, createStore } from 'redux';
 import { JsonFormsStore } from './json-forms';
 import { JsonForms } from './core';
 import { INIT, VALIDATE } from './actions';
 import { JsonSchema } from './models/jsonSchema';
 import { UISchemaElement } from './models/uischema';
+import { generateDefaultUISchema } from './generators';
 
 export const createJsonFormsStore = (initialState): JsonFormsStore => {
   // TODO: typing
@@ -18,8 +19,11 @@ export const createJsonFormsStore = (initialState): JsonFormsStore => {
   return store as JsonFormsStore;
 };
 
-export const initJsonFormsStore =
-  (data: any, schema: JsonSchema, uischema: UISchemaElement): JsonFormsStore => {
+export const initJsonFormsStore = (
+  data: any,
+  schema: JsonSchema,
+  uischema: UISchemaElement = generateDefaultUISchema(schema)
+): JsonFormsStore => {
 
     const store = createJsonFormsStore({
       common: {

--- a/packages/examples/package-lock.json
+++ b/packages/examples/package-lock.json
@@ -1,16 +1,254 @@
 {
-  "requires": true,
+  "name": "@jsonforms/examples",
+  "version": "2.0.0-beta.2",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
+    "@jsonforms/core": {
+      "version": "2.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@jsonforms/core/-/core-2.0.0-beta.3.tgz",
+      "integrity": "sha512-aj5Ovz9oVMtF11NtM6n3s2hbdRSCIJfo4XXrexgxZMESLwPP+oMIuUuTD8SWjlOzjvxFM2ccYwjqTlnyp5Q9nw==",
+      "requires": {
+        "@webcomponents/webcomponentsjs": "1.0.22",
+        "ajv": "4.11.8",
+        "dot-prop-immutable": "1.4.0",
+        "es6-shim": "0.35.3",
+        "json-refs": "2.1.7",
+        "lodash": "4.17.4",
+        "react": "16.2.0",
+        "react-dom": "16.2.0",
+        "react-redux": "5.0.6",
+        "redux": "3.7.2",
+        "redux-thunk": "2.2.0",
+        "uuid": "3.1.0"
+      },
+      "dependencies": {
+        "@webcomponents/webcomponentsjs": {
+          "version": "1.0.22",
+          "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.0.22.tgz",
+          "integrity": "sha512-VREMJxIe5ydR6LdMpg27ojyfL635jH03680na5X2LNLY2UF1GOzNrNOAVaEf2mr+SDUpc9Rey+gt+qCvtbCGhQ=="
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "dot-prop-immutable": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/dot-prop-immutable/-/dot-prop-immutable-1.4.0.tgz",
+          "integrity": "sha1-Q8HoTUK9dkPCCpBjwHyZ38kYbuA="
+        },
+        "es6-shim": {
+          "version": "0.35.3",
+          "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.3.tgz",
+          "integrity": "sha1-m/tzY/7//4emzbbNk+QF7DxLbyY="
+        },
+        "json-refs": {
+          "version": "2.1.7",
+          "resolved": "https://registry.npmjs.org/json-refs/-/json-refs-2.1.7.tgz",
+          "integrity": "sha1-uesB/in16j6Sh48VrqEK04taz4k=",
+          "requires": {
+            "commander": "2.12.2",
+            "graphlib": "2.1.5",
+            "js-yaml": "3.10.0",
+            "native-promise-only": "0.8.1",
+            "path-loader": "1.0.4",
+            "slash": "1.0.0",
+            "uri-js": "3.0.2"
+          }
+        },
+        "react-dom": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
+          "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "redux-thunk": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
+          "integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU="
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+        }
+      }
+    },
+    "@jsonforms/material-renderers": {
+      "version": "2.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@jsonforms/material-renderers/-/material-renderers-2.0.0-beta.3.tgz",
+      "integrity": "sha512-UaefIKDK1fqFjmLW5FdmyBG9FUttbxdmM11YGyAu/cW7InmQhk2hcid4xjYwwcZ8OT69AftvkDJ+6pRf2DE57A==",
+      "requires": {
+        "@jsonforms/core": "2.0.0-beta.3",
+        "material-ui": "1.0.0-beta.27",
+        "material-ui-icons": "1.0.0-beta.17",
+        "react": "16.2.0",
+        "react-dom": "16.2.0",
+        "react-redux": "5.0.6",
+        "redux": "3.7.2"
+      },
+      "dependencies": {
+        "react-dom": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
+          "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        }
+      }
+    },
+    "@jsonforms/vanilla-renderers": {
+      "version": "2.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@jsonforms/vanilla-renderers/-/vanilla-renderers-2.0.0-beta.3.tgz",
+      "integrity": "sha512-FTDb0MJAtIMKHpw0MOUC2YaeTjKBQiyAg1TWGaA0HlWVEbbObeks0A1KT20VoAXxfTSEI0g8Ukh+G6YdIQlkWg==",
+      "requires": {
+        "@jsonforms/core": "2.0.0-beta.3",
+        "react": "16.2.0",
+        "react-redux": "5.0.6",
+        "redux": "3.7.2"
+      }
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+        }
+      }
+    },
+    "brcast": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
+      "integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg=="
+    },
+    "chain-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
+      "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
+    },
+    "change-emitter": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
+    },
+    "classnames": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+      "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+    },
+    "cookiejar": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
+      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
+    },
     "core-js": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
       "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "css-vendor": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-0.3.8.tgz",
+      "integrity": "sha1-ZCHP0wNM5mT+dnOXL9ARn8KJQfo=",
+      "requires": {
+        "is-in-browser": "1.1.3"
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deepmerge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.0.1.tgz",
+      "integrity": "sha512-VIPwiMJqJ13ZQfaCsIFnp5Me9tnjURiaIFxfz7EH0Ci0dTSQpZtSLrqOicXqEd/z2r+z+Klk9GzmnRsgpgbOsQ=="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "dom-helpers": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
+      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
+    },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "encoding": {
       "version": "0.1.12",
@@ -19,6 +257,16 @@
       "requires": {
         "iconv-lite": "0.4.19"
       }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "fbjs": {
       "version": "0.8.16",
@@ -34,6 +282,38 @@
         "ua-parser-js": "0.7.17"
       }
     },
+    "form-data": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
+    },
+    "formidable": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
+      "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak="
+    },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "requires": {
+        "min-document": "2.19.0",
+        "process": "0.5.2"
+      }
+    },
+    "graphlib": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
+      "integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
     "hoist-non-react-statics": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
@@ -44,6 +324,11 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
@@ -52,10 +337,38 @@
         "loose-envify": "1.3.1"
       }
     },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+    },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -70,6 +383,125 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "js-yaml": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jss": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-9.5.1.tgz",
+      "integrity": "sha512-py//ogG1xeztpEDmosJtrkfUXibx3qiAr+1GQvfLHp7azpqkzTPLCnainDgH7Zn0q6S7rcM1eINrVT9n/r5f2w==",
+      "requires": {
+        "is-in-browser": "1.1.3",
+        "symbol-observable": "1.1.0",
+        "warning": "3.0.0"
+      }
+    },
+    "jss-camel-case": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/jss-camel-case/-/jss-camel-case-6.0.0.tgz",
+      "integrity": "sha512-XAYa7JpGkLdlLgEfuzSQSVONRzSVvv4Tvyv5H8hLmJuHeFHTWwVrJrW1Cg/buED3izXKwTU2KBGpeXjIR5Eaew=="
+    },
+    "jss-compose": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jss-compose/-/jss-compose-5.0.0.tgz",
+      "integrity": "sha512-YofRYuiA0+VbeOw0VjgkyO380sA4+TWDrW52nSluD9n+1FWOlDzNbgpZ/Sb3Y46+DcAbOS21W5jo6SAqUEiuwA==",
+      "requires": {
+        "warning": "3.0.0"
+      }
+    },
+    "jss-default-unit": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
+      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg=="
+    },
+    "jss-expand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/jss-expand/-/jss-expand-5.1.0.tgz",
+      "integrity": "sha512-WTxmNipgj0V8kr8gc8Gc6Et7uQZH60H7FFNG9zZHjR6TPJoj7TDK+/EBxwRHtCRQD4B8RTwoa7MyEKD4ReKfXw=="
+    },
+    "jss-extend": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jss-extend/-/jss-extend-6.1.0.tgz",
+      "integrity": "sha512-bSNwLDOZnMxABsUqvq2lwLJ/MMFs8ThligiLZBOUeyoZCoHqAbcTghvunk2QDVxiOhRTDS57VvhXVJZETW58Bw==",
+      "requires": {
+        "warning": "3.0.0"
+      }
+    },
+    "jss-global": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
+      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q=="
+    },
+    "jss-nested": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jss-nested/-/jss-nested-6.0.1.tgz",
+      "integrity": "sha512-rn964TralHOZxoyEgeq3hXY8hyuCElnvQoVrQwKHVmu55VRDd6IqExAx9be5HgK0yN/+hQdgAXQl/GUrBbbSTA==",
+      "requires": {
+        "warning": "3.0.0"
+      }
+    },
+    "jss-preset-default": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jss-preset-default/-/jss-preset-default-4.0.1.tgz",
+      "integrity": "sha512-ZBj1ifZAPDn8iiC9PuB1jDCm/I0Bn53UNL9NHBgOY6AyMorDPgEb3IRjt6H+OHKwnEuCHw8tC/e3/q4I4DgTIw==",
+      "requires": {
+        "jss-camel-case": "6.0.0",
+        "jss-compose": "5.0.0",
+        "jss-default-unit": "8.0.2",
+        "jss-expand": "5.1.0",
+        "jss-extend": "6.1.0",
+        "jss-global": "3.0.0",
+        "jss-nested": "6.0.1",
+        "jss-props-sort": "6.0.0",
+        "jss-template": "1.0.0",
+        "jss-vendor-prefixer": "7.0.0"
+      }
+    },
+    "jss-props-sort": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
+      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g=="
+    },
+    "jss-template": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jss-template/-/jss-template-1.0.0.tgz",
+      "integrity": "sha512-NFAgcAp8V2fUxffWGGQ5zAolJq3neAvNjmWIwSmy9M6bmXTK9rnTu0fBlAcUh0ALC94B596/2TRphdkE5WRECQ==",
+      "requires": {
+        "warning": "3.0.0"
+      }
+    },
+    "jss-vendor-prefixer": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz",
+      "integrity": "sha512-Agd+FKmvsI0HLcYXkvy8GYOw3AAASBUpsmIRvVQheps+JWaN892uFOInTr0DRydwaD91vSSUCU4NssschvF7MA==",
+      "requires": {
+        "css-vendor": "0.3.8"
+      }
+    },
+    "keycode": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.1.9.tgz",
+      "integrity": "sha1-lkojxU5IiUBbSGGlyfBIDUUUHfo="
     },
     "lodash": {
       "version": "4.17.4",
@@ -89,6 +521,87 @@
         "js-tokens": "3.0.2"
       }
     },
+    "material-ui": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.27.tgz",
+      "integrity": "sha512-23Jyd7eL4VZiILVbrA7srltErzAOwchc1AVCAqR5AxEVrAYHhaO6EsXHdd7Wq7TSeT9Rs1gQvI9z2jI/Qs1fUQ==",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "brcast": "3.0.1",
+        "classnames": "2.2.5",
+        "deepmerge": "2.0.1",
+        "dom-helpers": "3.3.1",
+        "hoist-non-react-statics": "2.3.1",
+        "jss": "9.5.1",
+        "jss-camel-case": "6.0.0",
+        "jss-default-unit": "8.0.2",
+        "jss-global": "3.0.0",
+        "jss-nested": "6.0.1",
+        "jss-props-sort": "6.0.0",
+        "jss-vendor-prefixer": "7.0.0",
+        "keycode": "2.1.9",
+        "lodash": "4.17.4",
+        "normalize-scroll-left": "0.1.2",
+        "prop-types": "15.6.0",
+        "react-event-listener": "0.5.3",
+        "react-jss": "8.2.1",
+        "react-popper": "0.7.5",
+        "react-scrollbar-size": "2.0.2",
+        "react-transition-group": "2.2.1",
+        "recompose": "0.26.0",
+        "scroll": "2.0.1",
+        "warning": "3.0.0"
+      }
+    },
+    "material-ui-icons": {
+      "version": "1.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/material-ui-icons/-/material-ui-icons-1.0.0-beta.17.tgz",
+      "integrity": "sha1-XxmvVKLZnu7zR6VUFKaFPhyFDcM=",
+      "requires": {
+        "recompose": "0.26.0"
+      }
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+    },
+    "mime-types": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "requires": {
+        "dom-walk": "0.1.1"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -98,10 +611,39 @@
         "is-stream": "1.1.0"
       }
     },
+    "normalize-scroll-left": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz",
+      "integrity": "sha512-F9YMRls0zCF6BFIE2YnXDRpHPpfd91nOIaNdDgrx5YMoPLo8Wqj+6jNXHQsYBavJeXP4ww8HCt0xQAKc5qk2Fg=="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "path-loader": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/path-loader/-/path-loader-1.0.4.tgz",
+      "integrity": "sha512-k/IPo9OWyofATP5gwIehHHQoFShS37zsSIsejKe6fjI+tqK+FnRpiSg4ZfWUpxb0g2PfCreWPqBD4ayjqjqkdQ==",
+      "requires": {
+        "native-promise-only": "0.8.1",
+        "superagent": "3.8.2"
+      }
+    },
+    "popper.js": {
+      "version": "1.12.9",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.12.9.tgz",
+      "integrity": "sha1-DfvC3/lsRRuzMu3Pz6r1ZtMx1bM="
+    },
+    "process": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "promise": {
       "version": "7.3.1",
@@ -121,6 +663,24 @@
         "object-assign": "4.1.1"
       }
     },
+    "punycode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "rafl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rafl/-/rafl-1.2.2.tgz",
+      "integrity": "sha1-/pMPdYIRAg1H44gV9Rlqi+QVB0A=",
+      "requires": {
+        "global": "4.3.2"
+      }
+    },
     "react": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
@@ -129,6 +689,38 @@
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
+        "prop-types": "15.6.0"
+      }
+    },
+    "react-event-listener": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.5.3.tgz",
+      "integrity": "sha512-fTGYvhe7eTsqq0m664Km0rxKQcqLIGZWZINmy1LU0fu312tay8Mt3Twq2P5Xj1dfDVvvzT1Ql3/FDkiMPJ1MOg==",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "fbjs": "0.8.16",
+        "prop-types": "15.6.0",
+        "warning": "3.0.0"
+      }
+    },
+    "react-jss": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/react-jss/-/react-jss-8.2.1.tgz",
+      "integrity": "sha512-H1fm32xG8pi4LMHkXjqpLyFOvSDsravd0HI6Dtlb/iyma1tfi7qqqSH2bf0kKyTAJV5hvYL0ls0qvRJWKfDPcA==",
+      "requires": {
+        "hoist-non-react-statics": "2.3.1",
+        "jss": "9.5.1",
+        "jss-preset-default": "4.0.1",
+        "prop-types": "15.6.0",
+        "theming": "1.3.0"
+      }
+    },
+    "react-popper": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.7.5.tgz",
+      "integrity": "sha512-ya9dhhGCf74JTOB2uyksEHhIGw7w9tNZRUJF73lEq2h4H5JT6MBa4PdT4G+sx6fZwq+xKZAL/sVNAIuojPn7Dg==",
+      "requires": {
+        "popper.js": "1.12.9",
         "prop-types": "15.6.0"
       }
     },
@@ -152,6 +744,54 @@
         }
       }
     },
+    "react-scrollbar-size": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-scrollbar-size/-/react-scrollbar-size-2.0.2.tgz",
+      "integrity": "sha512-scpDs2PZFf9CJteBeDu7jkk7s+YX06Si4rQGVHsH6vjR/p7417q1Jv5SpOblLLesOgNrfWekwoHQG1g0/p3tvw==",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "prop-types": "15.6.0",
+        "react-event-listener": "0.5.3"
+      }
+    },
+    "react-transition-group": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.2.1.tgz",
+      "integrity": "sha512-q54UBM22bs/CekG8r3+vi9TugSqh0t7qcEVycaRc9M0p0aCEu+h6rp/RFiW7fHfgd1IKpd9oILFTl5QK+FpiPA==",
+      "requires": {
+        "chain-function": "1.0.0",
+        "classnames": "2.2.5",
+        "dom-helpers": "3.3.1",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.6.0",
+        "warning": "3.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "recompose": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
+      "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
+      "requires": {
+        "change-emitter": "0.1.6",
+        "fbjs": "0.8.16",
+        "hoist-non-react-statics": "2.3.1",
+        "symbol-observable": "1.1.0"
+      }
+    },
     "redux": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
@@ -163,20 +803,105 @@
         "symbol-observable": "1.1.0"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "scroll": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-2.0.1.tgz",
+      "integrity": "sha1-tMfSfovPOuiligQvJyaK4/VfnM0=",
+      "requires": {
+        "rafl": "1.2.2"
+      }
+    },
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "superagent": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
+      "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "cookiejar": "2.1.1",
+        "debug": "3.1.0",
+        "extend": "3.0.1",
+        "form-data": "2.3.1",
+        "formidable": "1.1.1",
+        "methods": "1.1.2",
+        "mime": "1.6.0",
+        "qs": "6.5.1",
+        "readable-stream": "2.3.3"
+      }
     },
     "symbol-observable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
       "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw=="
     },
+    "theming": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/theming/-/theming-1.3.0.tgz",
+      "integrity": "sha512-ya5Ef7XDGbTPBv5ENTwrwkPUexrlPeiAg/EI9kdlUAZhNlRbCdhMKRgjNX1IcmsmiPcqDQZE6BpSaH+cr31FKw==",
+      "requires": {
+        "brcast": "3.0.1",
+        "is-function": "1.0.1",
+        "is-plain-object": "2.0.4",
+        "prop-types": "15.6.0"
+      }
+    },
     "ua-parser-js": {
       "version": "0.7.17",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+    },
+    "uri-js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+      "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+      "requires": {
+        "punycode": "2.1.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
     },
     "whatwg-fetch": {
       "version": "2.0.3",

--- a/packages/examples/src/Rating.tsx
+++ b/packages/examples/src/Rating.tsx
@@ -64,3 +64,5 @@ export class Rating extends Component<RatingProps, RatingState> {
     );
   }
 }
+
+export default Rating;

--- a/packages/examples/src/day1.ts
+++ b/packages/examples/src/day1.ts
@@ -1,0 +1,21 @@
+export const schema = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string'
+    },
+    description: {
+      type: 'string'
+    },
+    done: {
+      type: 'boolean'
+    }
+  },
+  required: ['name']
+};
+
+export const data = {
+  name: 'Send email to Adrian',
+  description: 'Confirm if you have passed the subject\nHereby ...',
+  done: true,
+};

--- a/packages/examples/src/day2.ts
+++ b/packages/examples/src/day2.ts
@@ -1,53 +1,38 @@
 import { registerExamples } from './register';
+import {  data as day1Data, schema as day1Schema } from './day1';
 
-export const schema = {
-  'type': 'object',
-  'properties': {
-    'name': {
-      'type': 'string'
-    },
-    'description': {
-      'type': 'string'
-    },
-    'done': {
-      'type': 'boolean'
-    }
-  },
-  'required': ['name']
-};
+export const schema = day1Schema;
 
 export const uischema = {
-  'type': 'VerticalLayout',
-  'elements': [
+  type: 'VerticalLayout',
+  elements: [
     {
-      'type': 'Control',
-      'scope': {
+      type: 'Control',
+      scope: {
         '$ref': '#/properties/name'
       }
     },
     {
-      'type': 'Control',
-      'label': false,
-      'scope': {
-        '$ref': '#/properties/done'
+      type: 'Control',
+      label: false,
+      scope: {
+        $ref: '#/properties/done'
       }
     },
     {
-      'type': 'Control',
-      'scope': {
-        '$ref': '#/properties/description'
+      type: 'Control',
+      scope: {
+        $ref: '#/properties/description'
       },
-      'options': {
-          'multi': true
+      options: {
+          multi: true
       }
-    }
+    },
   ]
 };
-export const data = {
-    'name': 'Send email to Adrian',
-    'description': 'Confirm if you have passed the subject\nHereby ...',
-    'done': true
-};
+
+export const data = day1Data;
+
 registerExamples([
   {
     name: 'day2',

--- a/packages/examples/src/day3.ts
+++ b/packages/examples/src/day3.ts
@@ -1,0 +1,54 @@
+import { registerExamples } from './register';
+import { schema as day2Schema, uischema as day2UiSchema, data as day2Data } from './day2';
+
+export const schema = {
+  type: 'object',
+  properties: {
+    ...day2Schema.properties,
+    dueDate: {
+      type: 'string',
+      format: 'date'
+    },
+    rating: {
+      type: 'integer',
+      maximum: 5
+    }
+  },
+  required: ['name']
+};
+
+export const uischema = {
+  type: 'VerticalLayout',
+  elements: [
+    ...day2UiSchema.elements,
+    {
+      type: 'Control',
+      scope: {
+        $ref: '#/properties/dueDate'
+      }
+    },
+    {
+      type: 'Control',
+      scope: {
+        $ref: '#/properties/rating'
+      }
+    }
+  ]
+};
+
+export const data = {
+  ...day2Data,
+  rating: 3,
+};
+
+registerExamples(
+  [
+    {
+      name: 'day3',
+      label: 'Day 3',
+      data,
+      schema,
+      uiSchema: uischema
+    }
+  ]
+);

--- a/packages/examples/src/day4.ts
+++ b/packages/examples/src/day4.ts
@@ -1,102 +1,59 @@
 import { registerExamples } from './register';
+import {
+  data as day3Data,
+  schema as day3Schema,
+  uischema as day3UiSchema,
+} from './day3';
 
 export const schema = {
-  'type': 'object',
-  'properties': {
-    'name': {
-      'type': 'string'
+  type: 'object',
+  properties: {
+    ...day3Schema.properties,
+    recurrence: {
+        type: 'string',
+        enum: ['Never', 'Daily', 'Weekly', 'Monthly']
     },
-    'description': {
-      'type': 'string'
-    },
-    'done': {
-      'type': 'boolean'
-    },
-    'due_date': {
-      'type': 'string',
-      'format': 'date'
-    },
-    'rating': {
-      'type': 'integer',
-      'maximum': 5
-    },
-    'recurrence': {
-        'type': 'string',
-        'enum': ['Never', 'Daily', 'Weekly', 'Monthly']
-    },
-    'recurrence_interval': {
-        'type': 'integer'
+    recurrenceInterval: {
+        type: 'integer'
     }
   },
-  'required': ['name']
+  required: ['name']
 };
+
 export const uischema = {
-  'type': 'VerticalLayout',
-  'elements': [
+  type: 'VerticalLayout',
+  elements: [
+    ...day3UiSchema.elements,
     {
-      'type': 'Control',
-      'scope': {
-        '$ref': '#/properties/name'
+      type: 'Control',
+      scope: {
+        $ref: '#/properties/recurrence'
       }
     },
     {
-      'type': 'Control',
-      'label': false,
-      'scope': {
-        '$ref': '#/properties/done'
-      }
-    },
-    {
-      'type': 'Control',
-      'scope': {
-        '$ref': '#/properties/description'
+      type: 'Control',
+      scope: {
+        $ref: '#/properties/recurrenceInterval'
       },
-      'options': {
-        'multi': true
-      }
-    },
-    {
-      'type': 'Control',
-      'scope': {
-        '$ref': '#/properties/due_date'
-      }
-    },
-    {
-      'type': 'Control',
-      'scope': {
-        '$ref': '#/properties/rating'
-      }
-    },
-    {
-      'type': 'Control',
-      'scope': {
-        '$ref': '#/properties/recurrence'
-      }
-    },
-    {
-      'type': 'Control',
-      'scope': {
-        '$ref': '#/properties/recurrence_interval'
-      },
-      'rule': {
-          'effect': 'HIDE',
-          'condition': {
-              'scope': {
-                  '$ref': '#/properties/recurrence'
+      rule: {
+          effect: 'HIDE',
+          condition: {
+              scope: {
+                  $ref: '#/properties/recurrence'
               },
-              'expectedValue': 'Never'
+              expectedValue: 'Never'
           }
       }
     }
   ]
 };
+
 export const data = {
-    'name': 'Send email to Adrian',
-    'description': 'Confirm if you have passed the subject\nHereby ...',
-    'done': true,
-    'recurrence': 'Never',
-    'recurrence_interval': 5
+  ...day3Data,
+  recurrence: 'Daily',
+  recurrenceInterval: 5
 };
+
 registerExamples([
   {
     name: 'day4',

--- a/packages/examples/src/day5.ts
+++ b/packages/examples/src/day5.ts
@@ -1,98 +1,71 @@
 import { registerExamples } from './register';
+import { data as day4Data, schema as day4Schema } from './day4';
 
-export const schema = {
-  'type': 'object',
-  'properties': {
-    'name': {
-      'type': 'string'
-    },
-    'description': {
-      'type': 'string'
-    },
-    'done': {
-      'type': 'boolean'
-    },
-    'due_date': {
-      'type': 'string',
-      'format': 'date'
-    },
-    'rating': {
-      'type': 'integer',
-      'maximum': 5
-    },
-    'recurrence': {
-        'type': 'string',
-        'enum': ['Never', 'Daily', 'Weekly', 'Monthly']
-    },
-    'recurrence_interval': {
-        'type': 'integer'
-    }
-  },
-  'required': ['name']
-};
+export const schema = day4Schema;
+
 export const uischema = {
-  'type': 'VerticalLayout',
-  'elements': [
+  type: 'VerticalLayout',
+  elements: [
     {
-      'type': 'Control',
-      'label': false,
-      'scope': {
-        '$ref': '#/properties/done'
+      type: 'Control',
+      label: false,
+      scope: {
+        $ref: '#/properties/done'
       }
     },
     {
-      'type': 'Control',
-      'scope': {
-        '$ref': '#/properties/name'
+      type: 'Control',
+      scope: {
+        $ref: '#/properties/name'
       }
     },
     {
-      'type': 'HorizontalLayout',
-      'elements': [
+      type: 'HorizontalLayout',
+      elements: [
         {
-          'type': 'Control',
-          'scope': {
-            '$ref': '#/properties/due_date'
+          type: 'Control',
+          scope: {
+            $ref: '#/properties/dueDate'
           }
         },
         {
-          'type': 'Control',
-          'scope': {
-            '$ref': '#/properties/rating'
+          type: 'Control',
+          scope: {
+            $ref: '#/properties/rating'
           }
         }
       ]
     },
     {
-      'type': 'Control',
-      'scope': {
-        '$ref': '#/properties/description'
+      type: 'Control',
+      scope: {
+        $ref: '#/properties/description'
       },
-      'options': {
-          'multi': true
+      options: {
+          multi: true
       }
     },
     {
-      'type': 'HorizontalLayout',
-      'elements': [
+      type: 'HorizontalLayout',
+      elements: [
         {
-          'type': 'Control',
-          'scope': {
-            '$ref': '#/properties/recurrence'
+          type: 'Control',
+          scope: {
+            $ref: '#/properties/recurrence'
           }
         },
         {
-          'type': 'Control',
-          'scope': {
-            '$ref': '#/properties/recurrence_interval'
+          type: 'Control',
+          scope: {
+            $ref: '#/properties/recurrenceInterval'
           },
-          'rule': {
-              'effect': 'HIDE',
-              'condition': {
-                  'scope': {
-                      '$ref': '#/properties/recurrence'
+          rule: {
+              effect: 'HIDE',
+              condition: {
+                  scope: {
+                      $ref: '#/properties/recurrence'
                   },
-                  'expectedValue': 'Never'
+                  expectedValue: 'Never'
               }
           }
         }
@@ -100,79 +73,80 @@ export const uischema = {
     }
   ]
 };
-export const uischemaCategory = {
-  'type': 'Categorization',
-  'elements': [
+
+export const categoryUiSchema = {
+  type: 'Categorization',
+  elements: [
     {
-      'type': 'Category',
-      'label': 'Main',
-      'elements': [
+      type: 'Category',
+      label: 'Main',
+      elements: [
         {
-          'type': 'Control',
-          'label': false,
-          'scope': {
-            '$ref': '#/properties/done'
+          type: 'Control',
+          label: false,
+          scope: {
+            $ref: '#/properties/done'
           }
         },
         {
-          'type': 'Control',
-          'scope': {
-            '$ref': '#/properties/name'
+          type: 'Control',
+          scope: {
+            $ref: '#/properties/name'
           }
         },
         {
-          'type': 'Control',
-          'scope': {
-            '$ref': '#/properties/description'
+          type: 'Control',
+          scope: {
+            $ref: '#/properties/description'
           },
-          'options': {
+          options: {
               'multi': true
           }
         }
       ]
     },
     {
-      'type': 'Category',
-      'label': 'Additional',
-      'elements': [
+      type: 'Category',
+      label: 'Additional',
+      elements: [
         {
-          'type': 'HorizontalLayout',
-          'elements': [
+          type: 'HorizontalLayout',
+          elements: [
             {
-              'type': 'Control',
-              'scope': {
-                '$ref': '#/properties/due_date'
+              type: 'Control',
+              scope: {
+                $ref: '#/properties/dueDate'
               }
             },
             {
-              'type': 'Control',
-              'scope': {
-                '$ref': '#/properties/rating'
+              type: 'Control',
+              scope: {
+                $ref: '#/properties/rating'
               }
             }
           ]
         },
         {
-          'type': 'HorizontalLayout',
-          'elements': [
+          type: 'HorizontalLayout',
+          elements: [
             {
-              'type': 'Control',
-              'scope': {
-                '$ref': '#/properties/recurrence'
+              type: 'Control',
+              scope: {
+                $ref: '#/properties/recurrence'
               }
             },
             {
-              'type': 'Control',
-              'scope': {
-                '$ref': '#/properties/recurrence_interval'
+              type: 'Control',
+              scope: {
+                $ref: '#/properties/recurrenceInterval'
               },
-              'rule': {
-                  'effect': 'HIDE',
-                  'condition': {
-                      'scope': {
-                          '$ref': '#/properties/recurrence'
+              rule: {
+                  effect: 'HIDE',
+                  condition: {
+                      scope: {
+                          $ref: '#/properties/recurrence'
                       },
-                      'expectedValue': 'Never'
+                      expectedValue: 'Never'
                   }
               }
             }
@@ -182,12 +156,9 @@ export const uischemaCategory = {
     }
   ]
 };
-export const data = {
-  'name': 'Send email to Adrian',
-  'description': 'Confirm if you have passed the subject\nHereby ...',
-  'done': true,
-  'recurrence': 'Daily'
-};
+
+export const data = day4Data;
+
 registerExamples([
   {
     name: 'day5',
@@ -197,11 +168,10 @@ registerExamples([
     uiSchema: uischema
   },
   {
-    name: 'day5_categegory',
+    name: 'day5_category',
     label: 'Day 5 With Category',
     data,
     schema,
-    uiSchema: uischemaCategory
+    uiSchema: categoryUiSchema
   }
 ]);
-

--- a/packages/examples/src/day6.tsx
+++ b/packages/examples/src/day6.tsx
@@ -7,114 +7,15 @@ import {
   unregisterRenderer
 } from '@jsonforms/core';
 import { RatingControl, ratingControlTester } from './rating.control';
+import {
+  data as day5Data,
+  schema as day5Schema,
+  uischema as day5UiSchema,
+} from './day5';
 
-const schema = {
-  'type': 'object',
-  'properties': {
-    'name': {
-      'type': 'string'
-    },
-    'description': {
-      'type': 'string'
-    },
-    'done': {
-      'type': 'boolean'
-    },
-    'due_date': {
-      'type': 'string',
-      'format': 'date'
-    },
-    'rating': {
-      'type': 'integer',
-      'maximum': 5
-    },
-    'recurrence': {
-        'type': 'string',
-        'enum': ['Never', 'Daily', 'Weekly', 'Monthly']
-    },
-    'recurrence_interval': {
-        'type': 'integer'
-    }
-  },
-  'required': ['name']
-};
-const uischema = {
-  'type': 'VerticalLayout',
-  'elements': [
-    {
-      'type': 'Control',
-      'label': false,
-      'scope': {
-        '$ref': '#/properties/done'
-      }
-    },
-    {
-      'type': 'Control',
-      'scope': {
-        '$ref': '#/properties/name'
-      }
-    },
-    {
-      'type': 'HorizontalLayout',
-      'elements': [
-        {
-          'type': 'Control',
-          'scope': {
-            '$ref': '#/properties/due_date'
-          }
-        },
-        {
-          'type': 'Control',
-          'scope': {
-            '$ref': '#/properties/rating'
-          }
-        }
-      ]
-    },
-    {
-      'type': 'Control',
-      'scope': {
-        '$ref': '#/properties/description'
-      },
-      'options': {
-          'multi': true
-      }
-    },
-    {
-      'type': 'HorizontalLayout',
-      'elements': [
-        {
-          'type': 'Control',
-          'scope': {
-            '$ref': '#/properties/recurrence'
-          }
-        },
-        {
-          'type': 'Control',
-          'scope': {
-            '$ref': '#/properties/recurrence_interval'
-          },
-          'rule': {
-              'effect': 'HIDE',
-              'condition': {
-                  'scope': {
-                      '$ref': '#/properties/recurrence'
-                  },
-                  'expectedValue': 'Never'
-              }
-          }
-        }
-      ]
-    }
-  ]
-};
-const data =  {
-  'name': 'Send email to Adriana',
-  'description': 'Confirm if you have passed the subject\nHerby ...',
-  'done': true,
-  'recurrence': 'Daily',
-  'rating': 3,
-};
+export const schema = day5Schema;
+export const uischema = day5UiSchema;
+export const data = day5Data;
 
 const setup = (div: HTMLDivElement) => {
   const ConnectedRatingControl = connect(mapStateToControlProps)(RatingControl);

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -1,6 +1,8 @@
 import * as array from './arrays';
 import * as categorization from './categorization';
+import * as day1 from './day1';
 import * as day2 from './day2';
+import * as day3 from './day3';
 import * as day4 from './day4';
 import * as day5 from './day5';
 import * as day6 from './day6';
@@ -15,11 +17,15 @@ import * as rule from './rule';
 import * as masterDetail from './masterdetail';
 import * as resolve from './resolve';
 import * as uischemaRegistry from './uischema-registry';
+import Rating from './Rating';
+import { RatingControl, ratingControlTester } from './rating.control';
 
 export {
   array,
   categorization,
+  day1,
   day2,
+  day3,
   day4,
   day5,
   day6,
@@ -33,5 +39,8 @@ export {
   masterDetail,
   resolve,
   uischemaRegistry,
-  ecore
+  ecore,
+  Rating,
+  RatingControl,
+  ratingControlTester
 };


### PR DESCRIPTION
Minor updates to the structure of the examples:
* Avoid code duplication, instead reference previous days
* Export day 1 and 3 of make it happen example
* Export custom rating control

Furthermore this PR contains commits that improve the usage of `DispatchRenderer` when used as an entry point to rendering. So far we had to specify the `schema` and the `uischema` properties, which actually is not necessary since these are the same as stored in the state container. 

Finally, this PR provides a default value for the uischema within the `initJsonFormsStore` function.