### PR TITLE
Using `display:'none'` instead of hidden attribute for hiding

### DIFF
--- a/packages/material/src/controls/material-boolean.control.tsx
+++ b/packages/material/src/controls/material-boolean.control.tsx
@@ -13,10 +13,15 @@ import { FormControlLabel } from 'material-ui/Form';
 import MaterialBooleanField from '../fields/material-boolean.field';
 
 export const MaterialBooleanControl =
-    ({ classNames, label, uischema, schema }: ControlProps) => {
+    ({ classNames, label, uischema, schema, visible }: ControlProps) => {
+    let style = {};
+    if (!visible) {
+      style = {display: 'none'};
+    }
 
     return (
       <FormControlLabel
+        style={style}
         className={classNames.wrapper}
         label={label}
         control={<MaterialBooleanField uischema={uischema} schema={schema}/>}

--- a/packages/material/src/controls/material-input.control.tsx
+++ b/packages/material/src/controls/material-input.control.tsx
@@ -19,8 +19,13 @@ export const MaterialInputControl =
   const isValid = errors.length === 0;
   const trim = uischema.options && uischema.options.trim;
 
+  let style = {};
+  if (!visible) {
+    style = {display: 'none'};
+  }
+
   return (
-    <FormControl className={classNames.wrapper} hidden={!visible} fullWidth={!trim}>
+    <FormControl className={classNames.wrapper} style={style} fullWidth={!trim}>
       <InputLabel htmlFor={id} className={classNames.label} error={!isValid}>
         {computeLabel(label, required)}
       </InputLabel>

--- a/packages/material/test/renderers/input.control.test.tsx
+++ b/packages/material/test/renderers/input.control.test.tsx
@@ -168,7 +168,7 @@ test('hide', t => {
     </Provider>
   );
   const control = findRenderedDOMElementWithClass(tree, 'root_properties_foo') as HTMLElement;
-  t.true(control.hidden);
+  t.is(getComputedStyle(control).display, 'none');
 });
 
 test('show by default', t => {


### PR DESCRIPTION
The hidden attribute is not working with material-ui as the default display is overridden with a class style.
So instead of the hidden attribute we set `display:'none'`.

Fixes #771 
