### PR TITLE
Add i18n to store with a translation object and locale value

### DIFF
--- a/packages/core/src/actions/index.ts
+++ b/packages/core/src/actions/index.ts
@@ -12,8 +12,8 @@ export const ADD_RENDERER = `${NAMESPACE}/ADD_RENDERER`;
 export const REMOVE_RENDERER = `${NAMESPACE}/REMOVE_RENDERER`;
 export const ADD_FIELD = `${NAMESPACE}/ADD_FIELD`;
 export const REMOVE_FIELD = `${NAMESPACE}/REMOVE_FIELD`;
-export const SET_TRANSLATIONS = 'SET_TRANSLATIONS';
-export const SET_LOCALE = 'SET_LOCALE';
+export const SET_TRANSLATIONS = `${NAMESPACE}/SET_TRANSLATIONS`;
+export const SET_LOCALE = `${NAMESPACE}/SET_LOCALE`;
 
 // TODO: fix typings
 export const update =

--- a/packages/core/src/actions/index.ts
+++ b/packages/core/src/actions/index.ts
@@ -12,6 +12,8 @@ export const ADD_RENDERER = `${NAMESPACE}/ADD_RENDERER`;
 export const REMOVE_RENDERER = `${NAMESPACE}/REMOVE_RENDERER`;
 export const ADD_FIELD = `${NAMESPACE}/ADD_FIELD`;
 export const REMOVE_FIELD = `${NAMESPACE}/REMOVE_FIELD`;
+export const SET_TRANSLATIONS = 'SET_TRANSLATIONS';
+export const SET_LOCALE = 'SET_LOCALE';
 
 // TODO: fix typings
 export const update =
@@ -57,9 +59,9 @@ export const unregisterRenderer = (
   renderer
 });
 
-export const loadTranslationData = translations => dispatch => {
+export const setTranslationData = translations => dispatch => {
   dispatch({
-    type: LOAD_TRANSLATION,
+    type: SET_TRANSLATIONS,
     translations,
   });
 };

--- a/packages/core/src/actions/index.ts
+++ b/packages/core/src/actions/index.ts
@@ -56,3 +56,17 @@ export const unregisterRenderer = (
   tester,
   renderer
 });
+
+export const loadTranslationData = translations => dispatch => {
+  dispatch({
+    type: LOAD_TRANSLATION,
+    translations,
+  });
+};
+
+export const setLocale = locale => dispatch => {
+  dispatch({
+    type: SET_LOCALE,
+    locale,
+  });
+};

--- a/packages/core/src/reducers/i18n.ts
+++ b/packages/core/src/reducers/i18n.ts
@@ -3,7 +3,7 @@ import { SET_LOCALE, SET_TRANSLATIONS } from '../actions';
 export const i18nReducer = (
   state = {
     translations: {},
-    locale: navigator.language
+    locale: navigator.languages[0]
   },
   action) => {
   switch (action.type) {

--- a/packages/core/src/reducers/i18n.ts
+++ b/packages/core/src/reducers/i18n.ts
@@ -1,10 +1,7 @@
 import { SET_LOCALE, SET_TRANSLATIONS } from '../actions';
 
 export const i18nReducer = (
-  state = {
-    translations: {},
-    locale: navigator.languages[0]
-  },
+  state = {},
   action) => {
   switch (action.type) {
     case SET_TRANSLATIONS:
@@ -20,4 +17,8 @@ export const i18nReducer = (
     default:
       return state;
   }
+};
+
+export const fetchTranslation = state => {
+  return state.translations ? state.translations[state.locale] : undefined;
 };

--- a/packages/core/src/reducers/i18n.ts
+++ b/packages/core/src/reducers/i18n.ts
@@ -1,13 +1,13 @@
-import { LOAD_TRANSLATION, SET_LOCALE } from '../actions';
+import { SET_LOCALE, SET_TRANSLATIONS } from '../actions';
 
-export const translationReducer = (
+export const i18nReducer = (
   state = {
     translations: {},
-    locale: ''
+    locale: navigator.language
   },
   action) => {
   switch (action.type) {
-    case LOAD_TRANSLATION:
+    case SET_TRANSLATIONS:
       return {
         ...state,
         translations: action.translations

--- a/packages/core/src/reducers/i18n.ts
+++ b/packages/core/src/reducers/i18n.ts
@@ -1,7 +1,9 @@
 import { SET_LOCALE, SET_TRANSLATIONS } from '../actions';
 
 export const i18nReducer = (
-  state = {},
+  state = {
+    locale: navigator.languages[0]
+  },
   action) => {
   switch (action.type) {
     case SET_TRANSLATIONS:
@@ -12,7 +14,7 @@ export const i18nReducer = (
     case SET_LOCALE:
       return {
         ...state,
-        locale: action.locale
+        locale: action.locale === undefined ? navigator.languages[0] : action.locale
       };
     default:
       return state;

--- a/packages/core/src/reducers/index.ts
+++ b/packages/core/src/reducers/index.ts
@@ -35,4 +35,4 @@ export const getErrorAt = instancePath => state => {
 };
 export const getSubErrorsAt = instancePath => state => subErrorsAt(instancePath)(state.jsonforms.validation);
 
-export const getTranslations = state => fetchTranslation(state.i18n);
+export const getTranslations = state => fetchTranslation(state.jsonforms.i18n);

--- a/packages/core/src/reducers/index.ts
+++ b/packages/core/src/reducers/index.ts
@@ -5,11 +5,13 @@ import { fieldReducer } from './fields';
 import { commonStateReducer, extractData, extractSchema, extractUiSchema } from './common';
 import { JsonForms } from '../core';
 import { JsonFormsState } from '../store';
+import { translationReducer } from './translation';
 export {
   validationReducer,
   rendererReducer,
   fieldReducer,
   commonStateReducer,
+  translationReducer
 };
 
 export const jsonformsReducer = (): Reducer<JsonFormsState> =>

--- a/packages/core/src/reducers/index.ts
+++ b/packages/core/src/reducers/index.ts
@@ -5,7 +5,7 @@ import { fieldReducer } from './fields';
 import { commonStateReducer, extractData, extractSchema, extractUiSchema } from './common';
 import { JsonForms } from '../core';
 import { JsonFormsState } from '../store';
-import { i18nReducer } from './i18n';
+import { fetchTranslation, i18nReducer } from './i18n';
 export {
   validationReducer,
   rendererReducer,
@@ -34,3 +34,5 @@ export const getErrorAt = instancePath => state => {
   return errorAt(instancePath)(state.jsonforms.validation);
 };
 export const getSubErrorsAt = instancePath => state => subErrorsAt(instancePath)(state.jsonforms.validation);
+
+export const getTranslations = state => fetchTranslation(state.i18n);

--- a/packages/core/src/reducers/index.ts
+++ b/packages/core/src/reducers/index.ts
@@ -5,13 +5,13 @@ import { fieldReducer } from './fields';
 import { commonStateReducer, extractData, extractSchema, extractUiSchema } from './common';
 import { JsonForms } from '../core';
 import { JsonFormsState } from '../store';
-import { translationReducer } from './translation';
+import { i18nReducer } from './i18n';
 export {
   validationReducer,
   rendererReducer,
   fieldReducer,
   commonStateReducer,
-  translationReducer
+  i18nReducer
 };
 
 export const jsonformsReducer = (): Reducer<JsonFormsState> =>
@@ -21,6 +21,7 @@ export const jsonformsReducer = (): Reducer<JsonFormsState> =>
       validation: validationReducer,
       renderers: rendererReducer,
       fields: fieldReducer,
+      i18n: i18nReducer,
       ...JsonForms.reducers
     })
   });

--- a/packages/core/src/reducers/translation.ts
+++ b/packages/core/src/reducers/translation.ts
@@ -1,0 +1,23 @@
+import { LOAD_TRANSLATION, SET_LOCALE } from '../actions';
+
+export const translationReducer = (
+  state = {
+    translations: {},
+    locale: ''
+  },
+  action) => {
+  switch (action.type) {
+    case LOAD_TRANSLATION:
+      return {
+        ...state,
+        translations: action.translations
+      };
+    case SET_LOCALE:
+      return {
+        ...state,
+        locale: action.locale
+      };
+    default:
+      return state;
+  }
+};

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -26,4 +26,6 @@ export interface JsonFormsInitialState {
   uischema?: UISchemaElement;
   // allow additional state
   [x: string]: any;
+  translations?: any;
+  locale?: String;
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -28,8 +28,8 @@ export interface JsonFormsInitialState {
   data: any;
   schema?: JsonSchema;
   uischema?: UISchemaElement;
-  // allow additional state
-  [x: string]: any;
   translations?: any;
   locale?: String;
+  // allow additional state
+  [x: string]: any;
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -15,6 +15,10 @@ export interface JsonFormsState {
     validation?: ValidationState,
     renderers?: any[];
     fields?: any[];
+    i18n: {
+      translations?: any;
+      locale?: String;
+    };
     // allow additional state for JSONForms
     [x: string]: any;
   };

--- a/packages/core/src/util/index.ts
+++ b/packages/core/src/util/index.ts
@@ -1,5 +1,5 @@
 import { JsonSchema, Scopable } from '../';
-export { createLabelDescriptionFrom } from './label';
+export { createLabelDescriptionFrom, translateLabel } from './label';
 
 export const convertToValidClassName = (s: string): string =>
   s.replace('#', 'root')

--- a/packages/core/src/util/label.ts
+++ b/packages/core/src/util/label.ts
@@ -54,3 +54,12 @@ export const createLabelDescriptionFrom = (withLabel: ControlElement): LabelDesc
     };
   }
 };
+
+export const translateLabel = (translations, label: LabelDescription): LabelDescription => {
+  if (translations && _.startsWith(label.text, '%')) {
+    const labelKey = label.text.substr(1, label.text.length);
+    label.text = translations[labelKey] ? translations[labelKey] : label.text;
+  }
+
+  return label;
+};

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -74,8 +74,7 @@ export const mapStateToControlProps = (state, ownProps) => {
   const path = composeWithUi(ownProps.uischema, ownProps.path);
   const visible = _.has(ownProps, 'visible') ? ownProps.visible :  isVisible(ownProps, state);
   const enabled = _.has(ownProps, 'enabled') ? ownProps.enabled :  isEnabled(ownProps, state);
-  let labelDesc = createLabelDescriptionFrom(ownProps.uischema);
-  labelDesc = translateLabel(getTranslations(state), labelDesc);
+  const labelDesc = translateLabel(getTranslations(state), createLabelDescriptionFrom(ownProps.uischema));
   const label = labelDesc.show ? labelDesc.text : '';
   const errors = getErrorAt(path)(state).map(error => error.message);
   const controlElement = ownProps.uischema as ControlElement;

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -10,7 +10,7 @@ import {
 } from '../util';
 import { RankedTester } from '../testers';
 import { ControlElement } from '../models/uischema';
-import { getData, getErrorAt, getSubErrorsAt } from '../reducers';
+import { getData, getErrorAt, getSubErrorsAt, getTranslations } from '../reducers';
 import { Renderer, RendererProps } from '../renderers/Renderer';
 import { update } from '../actions';
 
@@ -74,7 +74,8 @@ export const mapStateToControlProps = (state, ownProps) => {
   const path = composeWithUi(ownProps.uischema, ownProps.path);
   const visible = _.has(ownProps, 'visible') ? ownProps.visible :  isVisible(ownProps, state);
   const enabled = _.has(ownProps, 'enabled') ? ownProps.enabled :  isEnabled(ownProps, state);
-  const labelDesc = createLabelDescriptionFrom(ownProps.uischema);
+  let labelDesc = createLabelDescriptionFrom(ownProps.uischema);
+  labelDesc = translateLabel(getTranslations(state), labelDesc);
   const label = labelDesc.show ? labelDesc.text : '';
   const errors = getErrorAt(path)(state).map(error => error.message);
   const controlElement = ownProps.uischema as ControlElement;

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -6,7 +6,8 @@ import {
   createLabelDescriptionFrom,
   isEnabled,
   isVisible,
-  Resolve
+  Resolve,
+  translateLabel
 } from '../util';
 import { RankedTester } from '../testers';
 import { ControlElement } from '../models/uischema';

--- a/packages/core/test/renderers/DispatchRenderer.test.tsx
+++ b/packages/core/test/renderers/DispatchRenderer.test.tsx
@@ -24,6 +24,8 @@ export const initJsonFormsStore = ({
                                      data,
                                      schema,
                                      uischema,
+                                     translations,
+                                     locale,
                                      ...props
                                    }: JsonFormsInitialState): JsonFormsStore => {
   return createStore(
@@ -37,6 +39,10 @@ export const initJsonFormsStore = ({
         },
         renderers: JsonForms.renderers,
         fields: JsonForms.fields,
+        i18n: {
+          translations,
+          locale
+        },
         ...props
       }
     },

--- a/packages/core/test/util/label.test.ts
+++ b/packages/core/test/util/label.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 
 import { ControlElement } from '../../src';
-import { createLabelDescriptionFrom } from '../../src/util';
+import { createLabelDescriptionFrom, translateLabel } from '../../src/util';
 
 test('control relative', t => {
   const controlElement: ControlElement = {
@@ -94,4 +94,37 @@ test('control with label object, full', t => {
   const labelObject = createLabelDescriptionFrom(controlElement);
   t.is(labelObject.show, false);
   t.is(labelObject.text, 'mega bar');
+});
+
+test('control with label, with translation object', t => {
+  const controlElement: ControlElement = {
+    type: 'Control',
+    scope: {
+      $ref: '#/properties/foo'
+    },
+    label: {
+      text: '%foo'
+    }
+  };
+  const translationObject = {
+    'foo': 'Foo'
+  };
+  let labelObject = createLabelDescriptionFrom(controlElement);
+  labelObject = translateLabel(translationObject, labelObject);
+  t.is(labelObject.text, 'Foo');
+});
+
+test('control with label, without translation object', t => {
+  const controlElement: ControlElement = {
+    type: 'Control',
+    scope: {
+      $ref: '#/properties/foo'
+    },
+    label: {
+      text: '%foo'
+    }
+  };
+  let labelObject = createLabelDescriptionFrom(controlElement);
+  labelObject = translateLabel(undefined, labelObject);
+  t.is(labelObject.text, '%foo');
 });

--- a/packages/core/test/util/label.test.ts
+++ b/packages/core/test/util/label.test.ts
@@ -99,9 +99,7 @@ test('control with label object, full', t => {
 test('control with label, with translation object', t => {
   const controlElement: ControlElement = {
     type: 'Control',
-    scope: {
-      $ref: '#/properties/foo'
-    },
+    scope: '#/properties/foo',
     label: {
       text: '%foo'
     }
@@ -117,9 +115,7 @@ test('control with label, with translation object', t => {
 test('control with label, without translation object', t => {
   const controlElement: ControlElement = {
     type: 'Control',
-    scope: {
-      $ref: '#/properties/foo'
-    },
+    scope: '#/properties/foo',
     label: {
       text: '%foo'
     }

--- a/packages/core/test/util/renderer.test.ts
+++ b/packages/core/test/util/renderer.test.ts
@@ -48,6 +48,9 @@ const createState = uischema => ({
     },
     validation: {
       errors: []
+    },
+    i18n: {
+      locale: 'en-US'
     }
   }
 });

--- a/packages/examples/src/example.ts
+++ b/packages/examples/src/example.ts
@@ -6,5 +6,7 @@ export interface ExampleDescription {
   data: any;
   schema: JsonSchema;
   uiSchema: UISchemaElement;
+  translations?: any;
+  locale?: String;
   setupCallback?(div: HTMLDivElement): void;
 }

--- a/packages/examples/src/person.ts
+++ b/packages/examples/src/person.ts
@@ -175,8 +175,6 @@ const translations = {
   }
 };
 
-const locale = 'de-DE';
-
 registerExamples([
   {
     name: 'person',
@@ -184,7 +182,6 @@ registerExamples([
     data,
     schema,
     uiSchema: uischema,
-    translations,
-    locale
+    translations
   }
 ]);

--- a/packages/examples/src/person.ts
+++ b/packages/examples/src/person.ts
@@ -65,7 +65,7 @@ export const uischema = {
         {
           type: 'Control',
           label: {
-            text: 'Name',
+            text: '%name',
             show: true
           },
           scope: '#/properties/name'
@@ -73,19 +73,21 @@ export const uischema = {
         {
           type: 'Control',
           label: {
-            text: 'Age'
+            text: '%age'
           },
           scope: '#/properties/personalData/properties/age'
         },
         {
           type: 'Control',
-          label: 'Height',
-          scope: '#/properties/personalData/properties/height'
+          label: '%height',
+          scope: {
+            $ref: '#/properties/personalData/properties/height'
+          }
         },
         {
           type: 'Control',
           label: {
-            text: 'Age'
+            text: '%age'
           },
           scope: '#/properties/personalData/properties/age'
         },
@@ -100,26 +102,33 @@ export const uischema = {
       elements: [
         {
           type: 'Control',
-          label: 'Nationality',
-          scope: '#/properties/nationality'
-
+          label: '%nationality',
+          scope: {
+            $ref: '#/properties/nationality'
+          }
         },
         {
           type: 'Control',
-          label: 'Height',
-          scope: '#/properties/personalData/properties/height'
+          label: '%height',
+          scope: {
+            $ref: '#/properties/personalData/properties/height'
+          }
         },
         {
           type: 'Control',
-          label: 'Occupation',
-          scope: '#/properties/occupation',
+          label: '%occupation',
+          scope: {
+            $ref: '#/properties/occupation'
+          },
           suggestion: ['Accountant', 'Engineer', 'Freelancer',
             'Journalism', 'Physician', 'Student', 'Teacher', 'Other']
         },
         {
           type: 'Control',
-          label: 'Birthday',
-          scope: '#/properties/birthDate'
+          label: '%birthday',
+          scope: {
+            $ref: '#/properties/birthDate'
+          }
         }
       ]
     },
@@ -147,12 +156,35 @@ export const data = {
   postalCode: '12345'
 };
 
+const translations = {
+  'en-US': {
+    name: 'Name',
+    height: 'Height',
+    age: 'Age',
+    nationality: 'Nationality',
+    occupation: 'Occupation',
+    birthday: 'Birthday',
+  },
+  'de-DE': {
+    name: 'Name',
+    height: 'Höhe',
+    age: 'Alter',
+    nationality: 'Staatsangehörigkeit',
+    occupation: 'Besetzung',
+    birthday: 'Geburtstag',
+  }
+};
+
+const locale = 'de-DE';
+
 registerExamples([
   {
     name: 'person',
     label: 'Person',
     data,
     schema,
-    uiSchema: uischema
+    uiSchema: uischema,
+    translations,
+    locale
   }
 ]);

--- a/packages/examples/src/person.ts
+++ b/packages/examples/src/person.ts
@@ -80,9 +80,7 @@ export const uischema = {
         {
           type: 'Control',
           label: '%height',
-          scope: {
-            $ref: '#/properties/personalData/properties/height'
-          }
+          scope: '#/properties/personalData/properties/height'
         },
         {
           type: 'Control',
@@ -93,7 +91,10 @@ export const uischema = {
         },
         {
           type: 'Control',
-          scope: '#/properties/personalData/properties/drivingSkill'
+          scope: '#/properties/personalData/properties/drivingSkill',
+          label: {
+            text: '%drivingskill'
+          }
         },
       ]
     },
@@ -103,32 +104,24 @@ export const uischema = {
         {
           type: 'Control',
           label: '%nationality',
-          scope: {
-            $ref: '#/properties/nationality'
-          }
+          scope: '#/properties/nationality'
         },
         {
           type: 'Control',
           label: '%height',
-          scope: {
-            $ref: '#/properties/personalData/properties/height'
-          }
+          scope: '#/properties/personalData/properties/height'
         },
         {
           type: 'Control',
           label: '%occupation',
-          scope: {
-            $ref: '#/properties/occupation'
-          },
+          scope: '#/properties/occupation',
           suggestion: ['Accountant', 'Engineer', 'Freelancer',
             'Journalism', 'Physician', 'Student', 'Teacher', 'Other']
         },
         {
           type: 'Control',
           label: '%birthday',
-          scope: {
-            $ref: '#/properties/birthDate'
-          }
+          scope: '#/properties/birthDate'
         }
       ]
     },
@@ -138,6 +131,7 @@ export const uischema = {
         {
           type: 'Control',
           scope: '#/properties/postalCode',
+          label: '%postalcode',
           options: {
             trim: true,
             restrict: true
@@ -164,14 +158,18 @@ const translations = {
     nationality: 'Nationality',
     occupation: 'Occupation',
     birthday: 'Birthday',
+    postalcode: 'Postal Code',
+    drivingskill: 'Driving skill'
   },
   'de-DE': {
     name: 'Name',
     height: 'Höhe',
     age: 'Alter',
     nationality: 'Staatsangehörigkeit',
-    occupation: 'Besetzung',
+    occupation: 'Tätigkeit',
     birthday: 'Geburtstag',
+    postalcode: 'Postleitzahl',
+    drivingskill: 'Fahrkönnen'
   }
 };
 

--- a/packages/examples/src/register.ts
+++ b/packages/examples/src/register.ts
@@ -32,7 +32,9 @@ export const changeExample = (selectedExample: string, additionalState: Addition
     data: example.data,
     schema: example.schema,
     uischema: example.uiSchema,
-    ...additionalState,
+    translations: example.translations,
+    locale: example.locale,
+    ...additionalState
   };
 
   body.appendChild(jsonForms);

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -8,7 +8,8 @@ import {
   JsonForms,
   JsonFormsInitialState,
   jsonformsReducer,
-  JsonFormsStore
+  JsonFormsStore,
+  SET_LOCALE
 } from '@jsonforms/core';
 import { applyMiddleware, createStore } from 'redux';
 import thunk from 'redux-thunk';
@@ -18,7 +19,7 @@ export const initJsonFormsStore = ({
                                      schema,
                                      uischema,
                                      translations,
-                                     locale = navigator.languages[0],
+                                     locale,
                                      ...props
                                    }: JsonFormsInitialState): JsonFormsStore => {
   const store = createStore(
@@ -48,6 +49,11 @@ export const initJsonFormsStore = ({
     schema,
     data,
     uischema
+  });
+
+  store.dispatch({
+    type: SET_LOCALE,
+    locale
   });
 
   return store;

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -17,6 +17,8 @@ export const initJsonFormsStore = ({
                                      data,
                                      schema,
                                      uischema,
+                                     translations,
+                                     locale = navigator.languages[0],
                                      ...props
                                    }: JsonFormsInitialState): JsonFormsStore => {
   const store = createStore(
@@ -30,6 +32,10 @@ export const initJsonFormsStore = ({
         },
         renderers: JsonForms.renderers,
         fields: JsonForms.fields,
+        i18n: {
+          translations,
+          locale
+        },
         ...props
       }
     },

--- a/packages/vanilla/webpack/webpack.dev.js
+++ b/packages/vanilla/webpack/webpack.dev.js
@@ -7,7 +7,7 @@ module.exports = merge(baseConfig, {
         new copyWebpackPlugin([
             { from: '../examples/example.css' },
             { from: './example/example.dark.css' },
-            { from: '../examples/vendor/native-shim.js'  },
+            { from: '../examples/vendor/native-shim.js'  }
         ])
     ],
 });

--- a/packages/webcomponent/src/json-forms.tsx
+++ b/packages/webcomponent/src/json-forms.tsx
@@ -13,6 +13,7 @@ import {
   JsonFormsInitialState,
   jsonformsReducer,
   JsonFormsStore,
+  SET_LOCALE,
   VALIDATE
 } from '@jsonforms/core';
 import { applyMiddleware, createStore } from 'redux';
@@ -74,7 +75,7 @@ export class JsonFormsElement extends HTMLElement {
   set state(initialState: JsonFormsInitialState) {
 
     const dataSchema = initialState.schema || generateJsonSchema(initialState.data);
-    const additionalState = _.omit(initialState, ['data', 'schema', 'uischema']);
+    const additionalState = _.omit(initialState, ['data', 'schema', 'uischema', 'translations', 'locale']);
 
     const setupStore = schema => {
       const state = {
@@ -108,6 +109,11 @@ export class JsonFormsElement extends HTMLElement {
       store.dispatch({
         type: VALIDATE,
         data: state.jsonforms.common.data
+      });
+
+      store.dispatch({
+        type: SET_LOCALE,
+        locale: state.jsonforms.i18n.locale
       });
 
       return store;

--- a/packages/webcomponent/src/json-forms.tsx
+++ b/packages/webcomponent/src/json-forms.tsx
@@ -86,6 +86,10 @@ export class JsonFormsElement extends HTMLElement {
           },
           renderers: JsonForms.renderers,
           fields: JsonForms.fields,
+          i18n: {
+            translations: initialState.translations,
+            locale: initialState.locale
+          },
           ...additionalState
         }
       };

--- a/packages/webcomponent/test/json-forms.test.ts
+++ b/packages/webcomponent/test/json-forms.test.ts
@@ -186,25 +186,33 @@ test.cb('Connect JSON Forms element and cause data change', t => {
 
 test('render with data and translation object', t => {
   const jsonForms = new JsonFormsElement();
-  jsonForms.data = t.context.data;
-  jsonForms.translations = t.context.translations;
+  jsonForms.state = {
+    data: t.context.data,
+    uischema: t.context.uischema,
+    styles: vanillaStyles,
+    translations: t.context.translations
+  };
   jsonForms.connectedCallback();
 
   t.is(jsonForms.children.length, 1);
-  t.is(jsonForms.children.item(0).className, 'vertical-layout');
+  t.is(jsonForms.children.item(0).className, 'control root_properties_name');
   t.deepEqual(jsonForms.store.getState().i18n.translations, t.context.translations);
   t.is(jsonForms.store.getState().i18n.locale, navigator.languages[0]);
 });
 
 test('render with data, translation object and locale', t => {
   const jsonForms = new JsonFormsElement();
-  jsonForms.data = t.context.data;
-  jsonForms.locale = t.context.locale;
-  jsonForms.translations = t.context.translations;
+  jsonForms.state = {
+    data: t.context.data,
+    uischema: t.context.uischema,
+    styles: vanillaStyles,
+    translations: t.context.translations,
+    locale: t.context.locale
+  };
   jsonForms.connectedCallback();
 
   t.is(jsonForms.children.length, 1);
-  t.is(jsonForms.children.item(0).className, 'vertical-layout');
+  t.is(jsonForms.children.item(0).className, 'control root_properties_name');
   t.deepEqual(jsonForms.store.getState().i18n.translations, t.context.translations);
   t.is(jsonForms.store.getState().i18n.locale, t.context.locale);
 });

--- a/packages/webcomponent/test/json-forms.test.ts
+++ b/packages/webcomponent/test/json-forms.test.ts
@@ -193,7 +193,7 @@ test('render with data and translation object', t => {
   t.is(jsonForms.children.length, 1);
   t.is(jsonForms.children.item(0).className, 'vertical-layout');
   t.deepEqual(jsonForms.store.getState().i18n.translations, t.context.translations);
-  t.is(jsonForms.store.getState().i18n.locale, navigator.language);
+  t.is(jsonForms.store.getState().i18n.locale, navigator.languages[0]);
 });
 
 test('render with data, translation object and locale', t => {

--- a/packages/webcomponent/test/json-forms.test.ts
+++ b/packages/webcomponent/test/json-forms.test.ts
@@ -25,6 +25,15 @@ test.beforeEach(t => {
     type: 'Control',
     scope: '#/properties/name'
   };
+  t.context.translations = {
+    'en-US': {
+      name: 'foo'
+    },
+    'de-DE': {
+      name: 'bar'
+    }
+  };
+  t.context.locale = 'de-DE';
 });
 
 test.cb('render with data set', t => {
@@ -173,4 +182,29 @@ test.cb('Connect JSON Forms element and cause data change', t => {
     },
     100
   );
+});
+
+test('render with data and translation object', t => {
+  const jsonForms = new JsonFormsElement();
+  jsonForms.data = t.context.data;
+  jsonForms.translations = t.context.translations;
+  jsonForms.connectedCallback();
+
+  t.is(jsonForms.children.length, 1);
+  t.is(jsonForms.children.item(0).className, 'vertical-layout');
+  t.deepEqual(jsonForms.store.getState().i18n.translations, t.context.translations);
+  t.is(jsonForms.store.getState().i18n.locale, navigator.language);
+});
+
+test('render with data, translation object and locale', t => {
+  const jsonForms = new JsonFormsElement();
+  jsonForms.data = t.context.data;
+  jsonForms.locale = t.context.locale;
+  jsonForms.translations = t.context.translations;
+  jsonForms.connectedCallback();
+
+  t.is(jsonForms.children.length, 1);
+  t.is(jsonForms.children.item(0).className, 'vertical-layout');
+  t.deepEqual(jsonForms.store.getState().i18n.translations, t.context.translations);
+  t.is(jsonForms.store.getState().i18n.locale, t.context.locale);
 });

--- a/packages/webcomponent/test/json-forms.test.ts
+++ b/packages/webcomponent/test/json-forms.test.ts
@@ -184,33 +184,45 @@ test.cb('Connect JSON Forms element and cause data change', t => {
   );
 });
 
-test('render with data and translation object', t => {
+test.cb('render with data and translation object', t => {
+  t.plan(4);
   const jsonForms = new JsonFormsElement();
   jsonForms.state = {
     data: t.context.data,
-    uischema: t.context.uischema,
     translations: t.context.translations
   };
-  jsonForms.connectedCallback();
 
-  t.is(jsonForms.children.length, 1);
-  t.is(jsonForms.children.item(0).className, 'root_properties_name');
-  t.deepEqual(jsonForms.store.getState().i18n.translations, t.context.translations);
-  t.is(jsonForms.store.getState().i18n.locale, navigator.languages[0]);
+  setTimeout(
+    () => {
+      jsonForms.connectedCallback();
+      t.is(jsonForms.children.length, 1);
+      t.is(jsonForms.children.item(0).className, 'layout');
+      t.deepEqual(jsonForms.store.getState().jsonforms.i18n.translations, t.context.translations);
+      t.is(jsonForms.store.getState().jsonforms.i18n.locale, navigator.languages[0]);
+      t.end();
+    },
+    100
+  );
 });
 
-test('render with data, translation object and locale', t => {
+test.cb('render with data,translation object and locale value', t => {
+  t.plan(4);
   const jsonForms = new JsonFormsElement();
   jsonForms.state = {
     data: t.context.data,
-    uischema: t.context.uischema,
     translations: t.context.translations,
     locale: t.context.locale
   };
-  jsonForms.connectedCallback();
 
-  t.is(jsonForms.children.length, 1);
-  t.is(jsonForms.children.item(0).className, 'root_properties_name');
-  t.deepEqual(jsonForms.store.getState().i18n.translations, t.context.translations);
-  t.is(jsonForms.store.getState().i18n.locale, t.context.locale);
+  setTimeout(
+    () => {
+      jsonForms.connectedCallback();
+      t.is(jsonForms.children.length, 1);
+      t.is(jsonForms.children.item(0).className, 'layout');
+      t.deepEqual(jsonForms.store.getState().jsonforms.i18n.translations, t.context.translations);
+      t.is(jsonForms.store.getState().jsonforms.i18n.locale, t.context.locale);
+      t.end();
+    },
+    100
+  );
 });

--- a/packages/webcomponent/test/json-forms.test.ts
+++ b/packages/webcomponent/test/json-forms.test.ts
@@ -189,13 +189,12 @@ test('render with data and translation object', t => {
   jsonForms.state = {
     data: t.context.data,
     uischema: t.context.uischema,
-    styles: vanillaStyles,
     translations: t.context.translations
   };
   jsonForms.connectedCallback();
 
   t.is(jsonForms.children.length, 1);
-  t.is(jsonForms.children.item(0).className, 'control root_properties_name');
+  t.is(jsonForms.children.item(0).className, 'root_properties_name');
   t.deepEqual(jsonForms.store.getState().i18n.translations, t.context.translations);
   t.is(jsonForms.store.getState().i18n.locale, navigator.languages[0]);
 });
@@ -205,14 +204,13 @@ test('render with data, translation object and locale', t => {
   jsonForms.state = {
     data: t.context.data,
     uischema: t.context.uischema,
-    styles: vanillaStyles,
     translations: t.context.translations,
     locale: t.context.locale
   };
   jsonForms.connectedCallback();
 
   t.is(jsonForms.children.length, 1);
-  t.is(jsonForms.children.item(0).className, 'control root_properties_name');
+  t.is(jsonForms.children.item(0).className, 'root_properties_name');
   t.deepEqual(jsonForms.store.getState().i18n.translations, t.context.translations);
   t.is(jsonForms.store.getState().i18n.locale, t.context.locale);
 });


### PR DESCRIPTION
This commit includes just a way to add a translation object and locale value on `initJsonFormsStore`. Currently, there is no translating functionality. The next step is to translate labels and descriptions from `schema.json`. As we discussed during the last meeting, what I understood is that we need to translate these information before initializing jsonforms store (or replace values after initializing? ) so that we can use the translated version of `schema.json`. If you can share your feedback, it would be great.