### PR TITLE
Introduce parentPath prop in controls and further minor fixes

### DIFF
--- a/packages/core/src/renderers/Control.ts
+++ b/packages/core/src/renderers/Control.ts
@@ -10,6 +10,7 @@ export interface ControlClassNames {
 export interface ControlProps extends RendererProps {
   data: any;
   path: string;
+  parentPath?: string;
   classNames: ControlClassNames;
   id: string;
   visible: boolean;

--- a/packages/core/src/renderers/dispatch.field.tsx
+++ b/packages/core/src/renderers/dispatch.field.tsx
@@ -24,8 +24,6 @@ const Dispatch = (dispatchFieldProps: DispatchFieldProps) => {
         schema={schema}
         uischema={uischema}
         path={dispatchFieldProps.path}
-        data={dispatchFieldProps.data}
-        class
       />
     );
   }

--- a/packages/core/src/renderers/renderer.util.tsx
+++ b/packages/core/src/renderers/renderer.util.tsx
@@ -174,6 +174,7 @@ export const mapStateToControlProps = (state, ownProps) => {
     enabled,
     id,
     path,
+    parentPath: ownProps.path,
     inputs,
     required
   };

--- a/packages/material/src/complex/MaterialTableControl.tsx
+++ b/packages/material/src/complex/MaterialTableControl.tsx
@@ -13,7 +13,7 @@ import { ValidationIcon } from './ValidationIcon';
 export const MaterialTableControl = props =>  {
     const { data, path, resolvedSchema, numSelected, selectAll } = props;
     const isEmptyTable = !data || !Array.isArray(data) || data.length === 0;
-    const rowCount = data.length;
+    const rowCount = data ? data.length : 0;
 
     return (
         <Table>

--- a/packages/material/src/controls/material-boolean.control.tsx
+++ b/packages/material/src/controls/material-boolean.control.tsx
@@ -13,7 +13,7 @@ import { FormControlLabel } from 'material-ui/Form';
 import MaterialBooleanField from '../fields/material-boolean.field';
 
 export const MaterialBooleanControl =
-    ({ classNames, label, uischema, schema, visible }: ControlProps) => {
+    ({ classNames, label, uischema, schema, visible, parentPath }: ControlProps) => {
     let style = {};
     if (!visible) {
       style = {display: 'none'};
@@ -24,7 +24,7 @@ export const MaterialBooleanControl =
         style={style}
         className={classNames.wrapper}
         label={label}
-        control={<MaterialBooleanField uischema={uischema} schema={schema}/>}
+        control={<MaterialBooleanField uischema={uischema} schema={schema} path={parentPath}/>}
       />
     );
   };

--- a/packages/material/src/controls/material-input.control.tsx
+++ b/packages/material/src/controls/material-input.control.tsx
@@ -21,7 +21,7 @@ import { FormControl, FormHelperText } from 'material-ui/Form';
 
 export class MaterialInputControl extends Control<ControlProps, ControlState> {
   render() {
-    const { classNames, id, errors, label, uischema, schema, visible, required } = this.props;
+    const { classNames, id, errors, label, uischema, schema, visible, required, parentPath } = this.props;
     const isValid = errors.length === 0;
     const trim = uischema.options && uischema.options.trim;
     const controlElement = uischema as ControlElement;
@@ -42,7 +42,7 @@ export class MaterialInputControl extends Control<ControlProps, ControlState> {
         <InputLabel htmlFor={id} className={classNames.label} error={!isValid}>
           {computeLabel(label, required)}
         </InputLabel>
-        <DispatchField uischema={uischema} schema={schema}/>
+      <DispatchField uischema={uischema} schema={schema} path={parentPath}/>
         <FormHelperText
           error={!isValid}
           hidden={isValid && isDescriptionHidden(visible, description, this.state.isFocused)}

--- a/packages/vanilla/src/additional/tree/TreeRenderer.tsx
+++ b/packages/vanilla/src/additional/tree/TreeRenderer.tsx
@@ -107,8 +107,8 @@ export class TreeMasterDetail extends Control<TreeProps, TreeMasterDetailState> 
       }
     });
 
+    const path = Paths.fromScopable(controlElement);
     if (_.isArray(resolvedRootData)) {
-      const path = Paths.fromScopable(controlElement);
       this.setState({
         selected: {
           schema: resolvedSchema.items,
@@ -121,13 +121,13 @@ export class TreeMasterDetail extends Control<TreeProps, TreeMasterDetailState> 
         selected: {
           schema: resolvedSchema,
           data: resolvedRootData,
-          path: ''
+          path: path
         }
       });
     }
   }
 
-  setSelection = (schema, data, path) => () => {
+  setSelection = (schema, data, path) => {
     return () => this.setState({
       selected: {
         schema,
@@ -257,7 +257,7 @@ const mapDispatchToProps = dispatch => ({
           )
         );
       }
-    }
+    };
   }
 });
 

--- a/packages/vanilla/src/controls/input.control.tsx
+++ b/packages/vanilla/src/controls/input.control.tsx
@@ -20,7 +20,7 @@ import { connect } from 'react-redux';
 
 export class InputControl extends Control<ControlProps, ControlState> {
   render() {
-    const { classNames, id, errors, label, uischema, schema, visible, required } = this.props;
+    const { classNames, id, errors, label, uischema, schema, visible, required, parentPath } = this.props;
     const isValid = errors.length === 0;
     const inputDescriptionClassName =
       JsonForms.stylingRegistry.getAsClassName('input-description');
@@ -39,7 +39,7 @@ export class InputControl extends Control<ControlProps, ControlState> {
         <label htmlFor={id} className={classNames.label}>
           {computeLabel(label, required)}
         </label>
-        <DispatchField uischema={uischema} schema={schema}/>
+      <DispatchField uischema={uischema} schema={schema} path={parentPath}/>
         <div
           className={divClassNames}
           hidden={isValid && isDescriptionHidden(visible, description, this.state.isFocused)}


### PR DESCRIPTION
Added a `parentPath` property to input controls.
The parent property points to the data parent data that contains the
property specified in the UI Schema Element

* Hand down the parent path instead of the resolved path to a `DispatchField`
* This is necessary because the `DispatchField` resolves the path again against the UI Schema
* Adapted Vanilla and Material Input Control to propagate the `parentPath`

Other fixes:
* Tree Renderer: fixed `setSelection` method signature
* MaterialTableControl: Set `rowCount` to zero if the table's data is `undefined` or `zero` to avoid errors
