### PR TITLE
Rename schemaMatches and schemaTypeIs testers

### DIFF
--- a/packages/core/src/testers/index.ts
+++ b/packages/core/src/testers/index.ts
@@ -27,7 +27,7 @@ export const isControl = (uischema: any): uischema is ControlElement =>
  * @param {(JsonSchema) => boolean} predicate the predicate that should be
  *        applied to the resolved sub-schema
  */
-export const schemaMatches = (predicate: (schema: JsonSchema) => boolean): Tester =>
+export const boundSchemaMatches = (predicate: (schema: JsonSchema) => boolean): Tester =>
   (uischema: UISchemaElement, schema: JsonSchema): boolean => {
     if (_.isEmpty(uischema) || !isControl(uischema)) {
       return false;
@@ -77,7 +77,7 @@ export const schemaSubPathMatches =
  *
  * @param {string} expectedType the expected type of the resolved sub-schema
  */
-export const schemaTypeIs = (expectedType: string): Tester => schemaMatches(schema =>
+export const boundSchemaTypeIs = (expectedType: string): Tester => boundSchemaMatches(schema =>
   !_.isEmpty(schema) && schema.type === expectedType
 );
 
@@ -90,7 +90,7 @@ export const schemaTypeIs = (expectedType: string): Tester => schemaMatches(sche
  *
  * @param {string} expectedFormat the expected format of the resolved sub-schema
  */
-export const formatIs = (expectedFormat: string): Tester => schemaMatches(schema =>
+export const formatIs = (expectedFormat: string): Tester => boundSchemaMatches(schema =>
   !_.isEmpty(schema)
   && schema.format === expectedFormat
   && schema.type === 'string'
@@ -195,7 +195,7 @@ export const withIncreasedRank = (by: number, rankedTester: RankedTester) =>
  * Default tester for boolean.
  * @type {RankedTester}
  */
-export const isBooleanControl = and(uiTypeIs('Control'), schemaTypeIs('boolean'));
+export const isBooleanControl = and(uiTypeIs('Control'), boundSchemaTypeIs('boolean'));
 
 /**
  * Tests whether the given UI schema is of type Control and if the schema
@@ -211,7 +211,7 @@ export const isDateControl = and(uiTypeIs('Control'), formatIs('date'));
  */
 export const isEnumControl = and(
   uiTypeIs('Control'),
-  schemaMatches(schema => schema.hasOwnProperty('enum'))
+  boundSchemaMatches(schema => schema.hasOwnProperty('enum'))
 );
 
 /**
@@ -221,7 +221,7 @@ export const isEnumControl = and(
  */
 export const isIntegerControl = and(
   uiTypeIs('Control'),
-  schemaTypeIs('integer')
+  boundSchemaTypeIs('integer')
 );
 
 /**
@@ -231,7 +231,7 @@ export const isIntegerControl = and(
  */
 export const isNumberControl = and(
   uiTypeIs('Control'),
-  schemaTypeIs('number')
+  boundSchemaTypeIs('number')
 );
 
 /**
@@ -241,7 +241,7 @@ export const isNumberControl = and(
  */
 export const isStringControl = and(
   uiTypeIs('Control'),
-  schemaTypeIs('string')
+  boundSchemaTypeIs('string')
 );
 
 /**
@@ -268,7 +268,7 @@ export const isTimeControl = and(uiTypeIs('Control'), formatIs('time'));
  */
 export const isArrayObjectControl = and(
   uiTypeIs('Control'),
-  schemaMatches(schema =>
+  boundSchemaMatches(schema =>
     !_.isEmpty(schema)
     && schema.type === 'array'
     && !_.isEmpty(schema.items)

--- a/packages/core/test/testers.test.ts
+++ b/packages/core/test/testers.test.ts
@@ -1,20 +1,20 @@
 import test from 'ava';
 import {
   and,
+  boundSchemaMatches,
+  boundSchemaTypeIs,
   formatIs,
   isArrayObjectControl,
   optionIs,
   or,
   refEndIs,
   refEndsWith,
-  schemaMatches,
-  schemaTypeIs,
   uiTypeIs
 } from '../src/testers';
 import { JsonSchema } from '../src/models/jsonSchema';
 import { ControlElement, LabelElement } from '../src/models/uischema';
 
-test('schemaTypeIs should check type sub-schema of control', t => {
+test('boundSchemaTypeIs should check type sub-schema of control', t => {
   const schema: JsonSchema = {
     type: 'object',
     properties: {
@@ -27,11 +27,11 @@ test('schemaTypeIs should check type sub-schema of control', t => {
       $ref: '#/properties/foo'
     }
   };
-  t.true(schemaTypeIs('string')(uischema, schema));
-  t.false(schemaTypeIs('integer')(uischema, schema));
+  t.true(boundSchemaTypeIs('string')(uischema, schema));
+  t.false(boundSchemaTypeIs('integer')(uischema, schema));
 });
 
-test('schemaTypeIs should return false for non-control UI schema elements', t => {
+test('boundSchemaTypeIs should return false for non-control UI schema elements', t => {
   const schema: JsonSchema = {
     type: 'object',
     properties: {
@@ -42,10 +42,10 @@ test('schemaTypeIs should return false for non-control UI schema elements', t =>
     type: 'Label',
     text: 'some text'
   };
-  t.false(schemaTypeIs('integer')(label, schema));
+  t.false(boundSchemaTypeIs('integer')(label, schema));
 });
 
-test('schemaTypeIs should return false for control pointing to invalid sub-schema', t => {
+test('boundSchemaTypeIs should return false for control pointing to invalid sub-schema', t => {
   const uischema: ControlElement = {
     type: 'Control',
     scope: {
@@ -58,7 +58,7 @@ test('schemaTypeIs should return false for control pointing to invalid sub-schem
       foo: { type: 'string' }
     }
   };
-  t.false(schemaTypeIs('string')(uischema, schema));
+  t.false(boundSchemaTypeIs('string')(uischema, schema));
 });
 
 test('formatIs should check the format of a resolved sub-schema', t => {
@@ -113,7 +113,7 @@ test('optionIs should return false for UI schema elements without options field'
   t.false(optionIs('answer', 42)(control, undefined));
 });
 
-test('schemaMatches should check type sub-schema of control via predicate', t => {
+test('boundSchemaMatches should check type sub-schema of control via predicate', t => {
   const schema: JsonSchema = {
     type: 'object',
     properties: {
@@ -126,10 +126,10 @@ test('schemaMatches should check type sub-schema of control via predicate', t =>
       $ref: '#/properties/foo'
     }
   };
-  t.true(schemaMatches(subSchema => subSchema.type === 'string')(uischema, schema));
+  t.true(boundSchemaMatches(subSchema => subSchema.type === 'string')(uischema, schema));
 });
 
-test('schemaMatches should return false for non-control UI schema elements', t => {
+test('boundSchemaMatches should return false for non-control UI schema elements', t => {
   const schema: JsonSchema = {
     type: 'object',
     properties: {
@@ -140,10 +140,10 @@ test('schemaMatches should return false for non-control UI schema elements', t =
     type: 'Label',
     text: 'some text'
   };
-  t.false(schemaMatches(() => false)(label, schema));
+  t.false(boundSchemaMatches(() => false)(label, schema));
 });
 
-test('schemaMatches should return false for control pointing to invalid subschema', t => {
+test('boundSchemaMatches should return false for control pointing to invalid subschema', t => {
   const schema: JsonSchema = {
     type: 'object',
     properties: {
@@ -156,7 +156,7 @@ test('schemaMatches should return false for control pointing to invalid subschem
       $ref: '#/properties/bar'
     }
   };
-  t.false(schemaMatches(() => false)(uischema, schema));
+  t.false(boundSchemaMatches(() => false)(uischema, schema));
 });
 
 test('refEndsWith checks whether the ref of a control ends with a certain string', t => {
@@ -209,7 +209,7 @@ test('and should allow to compose multiple testers', t => {
     }
   };
   t.true(and(
-    schemaTypeIs('string'),
+    boundSchemaTypeIs('string'),
     refEndIs('foo')
   )(uischema, schema));
 });
@@ -228,7 +228,7 @@ test('or should allow to compose multiple testers', t => {
     }
   };
   t.true(or(
-    schemaTypeIs('integer'),
+    boundSchemaTypeIs('integer'),
     optionIs('slider', true)
   )(uischema, schema));
 });

--- a/packages/material/src/fields/material-slider.field.tsx
+++ b/packages/material/src/fields/material-slider.field.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import {
   and,
+  boundSchemaMatches,
+  boundSchemaTypeIs,
   ControlElement,
   FieldProps,
   mapDispatchToFieldProps,
@@ -10,8 +12,6 @@ import {
   rankWith,
   registerStartupInput,
   resolveSchema,
-  schemaMatches,
-  schemaTypeIs,
   uiTypeIs
 } from '@jsonforms/core';
 import { connect } from 'react-redux';
@@ -44,8 +44,8 @@ const MaterialSliderField = (props: FieldProps) => {
  */
 export const sliderFieldTester: RankedTester = rankWith(4, and(
      uiTypeIs('Control'),
-     or(schemaTypeIs('number'), schemaTypeIs('integer')),
-     schemaMatches(schema =>
+     or(boundSchemaTypeIs('number'), boundSchemaTypeIs('integer')),
+     boundSchemaMatches(schema =>
        schema.hasOwnProperty('maximum') && schema.hasOwnProperty('minimum')
      )
  ));

--- a/packages/vanilla/src/fields/slider.field.tsx
+++ b/packages/vanilla/src/fields/slider.field.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { SyntheticEvent } from 'react';
 import {
   and,
+  boundSchemaMatches,
+  boundSchemaTypeIs,
   ControlElement,
   FieldProps,
   mapDispatchToFieldProps,
@@ -11,8 +13,6 @@ import {
   rankWith,
   registerStartupInput,
   resolveSchema,
-  schemaMatches,
-  schemaTypeIs,
   uiTypeIs
 } from '@jsonforms/core';
 import { connect } from 'react-redux';
@@ -43,8 +43,8 @@ const SliderField = (props: FieldProps) => {
  */
 export const sliderFieldTester: RankedTester = rankWith(4, and(
      uiTypeIs('Control'),
-     or(schemaTypeIs('number'), schemaTypeIs('integer')),
-     schemaMatches(schema =>
+     or(boundSchemaTypeIs('number'), boundSchemaTypeIs('integer')),
+     boundSchemaMatches(schema =>
        schema.hasOwnProperty('maximum') && schema.hasOwnProperty('minimum')
      )
  ));


### PR DESCRIPTION
Proposed naming for #734.

I'm not really happy with it, but it's the best I could come up with (among things like `controlSchemaMatches`, `referencedSchemaMatches`, ...). Any other suggestions?
