### PR TITLE
Improve setting up store 

### DIFF
--- a/packages/core/src/actions/index.ts
+++ b/packages/core/src/actions/index.ts
@@ -2,6 +2,8 @@ import { ThunkAction } from 'redux-thunk';
 import { getData } from '../reducers/index';
 import { RankedTester } from '../testers';
 import { Renderer } from '../renderers';
+import { JsonSchema, UISchemaElement } from '../';
+import { generateDefaultUISchema, generateJsonSchema } from '../generators';
 
 const NAMESPACE = 'jsonforms';
 
@@ -12,6 +14,18 @@ export const ADD_RENDERER = `${NAMESPACE}/ADD_RENDERER`;
 export const REMOVE_RENDERER = `${NAMESPACE}/REMOVE_RENDERER`;
 export const ADD_FIELD = `${NAMESPACE}/ADD_FIELD`;
 export const REMOVE_FIELD = `${NAMESPACE}/REMOVE_FIELD`;
+
+export const init = (
+  data: any,
+  schema: JsonSchema = generateJsonSchema(data),
+  uischema: UISchemaElement = generateDefaultUISchema(schema)
+) =>
+    ({
+      type: INIT,
+      data,
+      schema,
+      uischema
+    });
 
 // TODO: fix typings
 export const update =

--- a/packages/core/src/reducers/index.ts
+++ b/packages/core/src/reducers/index.ts
@@ -6,16 +6,21 @@ import { transformPropsReducer } from './transformProps';
 import { commonStateReducer, extractData, extractSchema, extractUiSchema } from './common';
 import { JsonFormsState } from '../store';
 
+export {
+  validationReducer,
+  rendererReducer,
+  fieldReducer,
+  commonStateReducer
+};
+
 export const jsonformsReducer = (additionalReducers = {}): Reducer<JsonFormsState> =>
-  combineReducers({
-    jsonforms: combineReducers({
-      common: commonStateReducer,
-      validation: validationReducer,
-      renderers: rendererReducer,
-      fields: fieldReducer,
-      transformProps: transformPropsReducer,
-      ...additionalReducers
-    })
+  combineReducers<JsonFormsState>({
+    common: commonStateReducer,
+    validation: validationReducer,
+    renderers: rendererReducer,
+    fields: fieldReducer,
+    transformProps: transformPropsReducer,
+    ...additionalReducers
   });
 
 export const getData = state => extractData(state.jsonforms.common);

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -25,29 +25,13 @@ export interface JsonFormsState {
        * The actual data to be rendered.
        */
       data: any;
-      /**
-       * JSON schema describing the data.
-       */
       schema?: JsonSchema;
-      /**
-       * The UI schema describing the form to be rendered.
-       */
       uischema?: UISchemaElement;
     };
-    /**
-     * Contains the current validation state.
-     */
     validation?: ValidationState,
-    /**
-     * Contains all available renderers.
-     */
     renderers?: any[];
-    /**
-     * Contains all available field renderers.
-     */
     fields?: any[];
     // allow additional state for JSONForms
-    [x: string]: any;
+    [additionalState: string]: any;
   };
 }
-

--- a/packages/core/src/util/label.ts
+++ b/packages/core/src/util/label.ts
@@ -55,18 +55,3 @@ export const createLabelDescriptionFrom = (withLabel: ControlElement): LabelDesc
   }
 };
 
-export interface Translations {
-  [key: string]: string;
-}
-
-export const translateLabel: (translations: Translations,
-                              label: LabelDescription) => LabelDescription =
-  (translations, label) => {
-
-    if (translations && _.startsWith(label.text, '%')) {
-      const labelKey = label.text.substr(1, label.text.length);
-      label.text = translations[labelKey] ? translations[labelKey] : label.text;
-    }
-
-    return label;
-  };

--- a/packages/core/test/renderers/DispatchRenderer.test.tsx
+++ b/packages/core/test/renderers/DispatchRenderer.test.tsx
@@ -7,7 +7,7 @@ global.requestAnimationFrame = cb => setTimeout(cb, 0);
 import * as React from 'react';
 import { test } from 'ava';
 import * as _ from 'lodash';
-import { applyMiddleware, createStore } from 'redux';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import { JsonSchema, UISchemaElement } from '../../src';
@@ -52,7 +52,7 @@ export const initJsonFormsStore = ({
                                      ...props
                                    }: JsonFormsInitialState): JsonFormsStore => {
   return createStore(
-    jsonformsReducer(),
+    combineReducers({ jsonforms: jsonformsReducer() }),
     {
       jsonforms: {
         common: {

--- a/packages/examples/src/register.ts
+++ b/packages/examples/src/register.ts
@@ -1,7 +1,7 @@
 import { JsonFormsElement } from '@jsonforms/webcomponent';
 import { ExampleDescription } from './example';
 import { JsonForms, jsonformsReducer } from '@jsonforms/core';
-import { applyMiddleware, createStore, Reducer } from 'redux';
+import { applyMiddleware, combineReducers, createStore, Reducer } from 'redux';
 import thunk from 'redux-thunk';
 import { i18nReducer, translateProps } from '@jsonforms/i18n';
 
@@ -50,11 +50,14 @@ export const changeExample = (selectedExample: string, ...additionalStoreParams:
   );
 
   jsonForms.store = createStore(
-    jsonformsReducer(
-      {
-        i18n: i18nReducer,
-        ...additionalReducers
-      },
+    combineReducers({
+        jsonforms: jsonformsReducer(
+          {
+            i18n: i18nReducer,
+            ...additionalReducers
+          },
+        )
+      }
     ),
     {
       jsonforms: {

--- a/packages/i18n/test/json-forms.test.ts
+++ b/packages/i18n/test/json-forms.test.ts
@@ -1,8 +1,8 @@
 import '@jsonforms/test';
 import test from 'ava';
 import { JsonFormsElement } from '@jsonforms/webcomponent';
-import { fakeLayoutTester, FakeLayout } from '@jsonforms/test';
-import { applyMiddleware, createStore } from 'redux';
+import { FakeLayout, fakeLayoutTester } from '@jsonforms/test';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
 import { jsonformsReducer } from '@jsonforms/core';
 import { i18nReducer } from '../src/reducers';
 import thunk from 'redux-thunk';
@@ -36,7 +36,7 @@ test.cb('render with data and translation object', t => {
   t.plan(4);
   const jsonForms = new JsonFormsElement();
   jsonForms.store = createStore(
-    jsonformsReducer({ i18n: i18nReducer }),
+    combineReducers({ jsonforms: jsonformsReducer({ i18n: i18nReducer }) }),
     {
       jsonforms: {
         common: {
@@ -70,7 +70,7 @@ test.cb('render with data,translation object and locale value', t => {
   t.plan(4);
   const jsonForms = new JsonFormsElement();
   jsonForms.store = createStore(
-    jsonformsReducer({ i18n: i18nReducer }),
+    combineReducers({ jsonforms: jsonformsReducer({ i18n: i18nReducer }) }),
     {
       jsonforms: {
         common: {

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -7,11 +7,11 @@ import {
   INIT,
   JsonForms,
   jsonformsReducer,
+  JsonFormsState,
   JsonSchema,
   UISchemaElement
 } from '@jsonforms/core';
-import { applyMiddleware, createStore, Store } from 'redux';
-import { JsonFormsState } from '@jsonforms/core';
+import { applyMiddleware, combineReducers, createStore, Store} from 'redux';
 import thunk from 'redux-thunk';
 
 /**
@@ -46,7 +46,7 @@ export const initJsonFormsStore = ({
                                      ...props
                                    }: JsonFormsInitialState): Store<JsonFormsState> => {
   const store: Store<JsonFormsState> = createStore(
-    jsonformsReducer(),
+    combineReducers({ jsonforms: jsonformsReducer() }),
     {
       jsonforms: {
         common: {

--- a/packages/vanilla/test/vanillaStore.ts
+++ b/packages/vanilla/test/vanillaStore.ts
@@ -1,4 +1,4 @@
-import { applyMiddleware, createStore, Store } from 'redux';
+import { applyMiddleware, combineReducers, createStore, Store } from 'redux';
 import thunk from 'redux-thunk';
 import { Actions, jsonformsReducer, JsonFormsState } from '@jsonforms/core';
 import { vanillaStyles } from '../src/util';
@@ -11,15 +11,10 @@ export const initJsonFormsVanillaStore = ({
   ...other
 }): Store<JsonFormsState> => {
 
-  const store = createStore(
-    jsonformsReducer({ styles: stylingReducer }),
+  const store: Store<JsonFormsState> = createStore(
+    combineReducers({ jsonforms: jsonformsReducer({ styles: stylingReducer }) }),
     {
       jsonforms: {
-        common: {
-          data,
-          schema,
-          uischema
-        },
         styles: vanillaStyles,
         ...other
       }
@@ -27,14 +22,11 @@ export const initJsonFormsVanillaStore = ({
     applyMiddleware(thunk)
   );
 
-  store.dispatch({
-    type: Actions.INIT,
-    schema,
+  store.dispatch(Actions.init(
     data,
+    schema,
     uischema
-  });
-
-  store.dispatch(Actions.validate());
+  ));
 
   return store;
 };

--- a/packages/webcomponent/src/json-forms.tsx
+++ b/packages/webcomponent/src/json-forms.tsx
@@ -3,15 +3,14 @@ import * as ReactDOM from 'react-dom';
 import * as JsonRefs from 'json-refs';
 import { Provider } from 'react-redux';
 import {
+  Actions,
   DispatchRenderer,
   Generate,
   getData,
   getSchema,
   getUiSchema,
-  INIT,
   JsonFormsState,
-  JsonFormsStore,
-  VALIDATE
+  JsonFormsStore
 } from '@jsonforms/core';
 import { Store } from 'redux';
 
@@ -73,17 +72,7 @@ export class JsonFormsElement extends HTMLElement {
    */
   set store(store: Store<JsonFormsState>) {
     const setupStore = (schema, uischema, d) => {
-      store.dispatch({
-        type: INIT,
-        data: d,
-        schema,
-        uischema: uischema || Generate.uiSchema(schema)
-      });
-
-      store.dispatch({
-        type: VALIDATE,
-        data: d
-      });
+      store.dispatch(Actions.init(d, schema, uischema));
 
       return store;
     };

--- a/packages/webcomponent/test/json-forms.test.ts
+++ b/packages/webcomponent/test/json-forms.test.ts
@@ -8,7 +8,7 @@ import {
   getUiSchema,
   jsonformsReducer,
 } from '@jsonforms/core';
-import { applyMiddleware, createStore } from 'redux';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
 import thunk from 'redux-thunk';
 import { FakeControl, fakeControlTester, FakeLayout, fakeLayoutTester } from '@jsonforms/test';
 import { JsonFormsElement } from '../src/json-forms';
@@ -37,7 +37,7 @@ test.cb('render with data set', t => {
   const jsonForms = new JsonFormsElement();
   const jsonSchema = generateJsonSchema(t.context.data);
   jsonForms.store = createStore(
-    jsonformsReducer(),
+    combineReducers({ jsonforms: jsonformsReducer() }),
     {
       jsonforms: {
         common: {
@@ -66,7 +66,7 @@ test.cb('render with data and data schema set', t => {
   t.plan(4);
   const jsonForms = new JsonFormsElement();
   jsonForms.store = createStore(
-    jsonformsReducer(),
+    combineReducers({ jsonforms: jsonformsReducer() }),
     {
       jsonforms: {
         common: {
@@ -103,7 +103,7 @@ test.cb('render with data and UI schema set', t => {
   const jsonForms = new JsonFormsElement();
   const uischema: ControlElement = t.context.uischema;
   jsonForms.store = createStore(
-    jsonformsReducer(),
+    combineReducers({ jsonforms: jsonformsReducer() }),
     {
       jsonforms: {
         common: {
@@ -132,7 +132,7 @@ test.cb('render with data, data schema and UI schema set', t => {
   t.plan(4);
   const jsonForms = new JsonFormsElement();
   jsonForms.store = createStore(
-    jsonformsReducer(),
+    combineReducers({ jsonforms: jsonformsReducer() }),
     {
       jsonforms: {
         common: {
@@ -162,7 +162,7 @@ test.cb('render with data schema and UI schema set', t => {
   t.plan(3);
   const jsonForms = new JsonFormsElement();
   jsonForms.store = createStore(
-    jsonformsReducer(),
+    combineReducers({ jsonforms: jsonformsReducer() }),
     {
       jsonforms: {
         common: {
@@ -187,12 +187,12 @@ test.cb('render with data schema and UI schema set', t => {
     100
   );
 });
-//
+
 test.cb('Connect JSON Forms element and cause re-init store', t => {
   t.plan(6);
   const jsonForms = new JsonFormsElement();
   jsonForms.store = createStore(
-    jsonformsReducer(),
+    combineReducers({ jsonforms: jsonformsReducer() }),
     {
       jsonforms: {
         common: {
@@ -213,7 +213,7 @@ test.cb('Connect JSON Forms element and cause re-init store', t => {
       t.is(verticalLayout1.children.length, 1);
 
       jsonForms.store = createStore(
-        jsonformsReducer(),
+        combineReducers({ jsonforms: jsonformsReducer() }),
         {
           jsonforms: {
             common: {


### PR DESCRIPTION
* Change jsonformsReducer to not contain jsonforms key which improves composability with external reducers, partly fixes #840.
* Provide convenience `Actions.init`action creator.
* Validation reducer also reacts on INIT action, such that calling `validate` initially is obsolete.