### PR TITLE
Remove parameters that haven't been used

### DIFF
--- a/packages/core/src/util/path.ts
+++ b/packages/core/src/util/path.ts
@@ -21,7 +21,7 @@ export const compose = (path1: string, path2: string) => {
  * at the '/' character and removing all schema-specific keywords.
  *
  * The returned value can be used to de-reference a root object by folding over it
- * and derefercing the single segments to obtain a new object.
+ * and de-referencing the single segments to obtain a new object.
  *
  *
  * @param {string} schemaPath the schema path to be converted
@@ -30,17 +30,9 @@ export const compose = (path1: string, path2: string) => {
 export const toDataPathSegments = (schemaPath: string): string[] => {
   const segments = schemaPath.split('/');
   const startFromRoot = segments[0] === '#' || segments[0] === '';
-  if (startFromRoot) {
-    return segments.filter((_segment, index) => {
-      if (index === 0) {
-        return false;
-      } else {
-        return index % 2 !== 1;
-      }
-    });
-  }
+  const startIndex =  startFromRoot ? 2 : 1;
 
-  return segments.filter((_segment, index) => index % 2 !== 0);
+  return _.range(startIndex, segments.length, 2).map(idx => segments[idx]);
 };
 
 /**

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -256,10 +256,9 @@ export const mapDispatchToTableControlProps = (dispatch): DispatchPropsOfTable =
             return [{}];
           }
 
-          const clone = _.clone(array);
-          clone.push({});
+          array.push({});
 
-          return clone;
+          return array;
         }
       )
     );

--- a/packages/vanilla/src/complex/array/ArrayControl.tsx
+++ b/packages/vanilla/src/complex/array/ArrayControl.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import {
   composePaths,
   Generate,
@@ -24,7 +25,7 @@ export const ArrayControl  =
           </legend>
           <div className={classNames.children}>
             {
-              data ? data.map((_child, index) => {
+              data ? _.range(0, data.length).map(index => {
 
                 const generatedUi = Generate.uiSchema(resolvedSchema, 'HorizontalLayout');
                 const childPath = composePaths(path, index + '');

--- a/packages/vanilla/src/complex/array/ArrayControlRenderer.tsx
+++ b/packages/vanilla/src/complex/array/ArrayControlRenderer.tsx
@@ -1,13 +1,12 @@
-import * as _ from 'lodash';
 import * as React from 'react';
 
 import {
   connectToJsonForms,
   ControlElement,
   Helpers,
+  mapDispatchToTableControlProps,
   mapStateToControlProps,
   Resolve,
-  update
 } from '@jsonforms/core';
 import { ArrayControl } from './ArrayControl';
 import { VanillaControlProps } from '../../index';
@@ -57,29 +56,9 @@ const ArrayControlRenderer  =
     );
   };
 
-const mapDispatchToProps = dispatch => ({
-  addItem: (path: string) => () => {
-    dispatch(
-      update(
-        path,
-        array => {
-          if (array === undefined || array === null) {
-            return [{}];
-          }
-
-          const clone = _.clone(array);
-          clone.push({});
-
-          return clone;
-        }
-      )
-    );
-  }
-});
-
 const ConnectedArrayControlRenderer = connectToJsonForms(
   addVanillaControlProps(mapStateToControlProps),
-  mapDispatchToProps
+  mapDispatchToTableControlProps
 )(ArrayControlRenderer);
 
 export default ConnectedArrayControlRenderer;


### PR DESCRIPTION
Furthermore: 
* Re-use mapDispatchToProps for vanilla Array control
* Remove unnecessary cloning of array in addItem (already cloned)

Fixes #742 