### PR TITLE
Switch to jest for material renderers, add tests for array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,12 @@
 			"integrity": "sha1-0ifxi8uPPxh+FpZfJESFmgRol1g=",
 			"dev": true
 		},
+		"@types/jest": {
+			"version": "22.2.0",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.2.0.tgz",
+			"integrity": "sha512-5DeGD46Goq6+GtEEB57hQzC/BbuEbEj0fUCDm7a5Fm9ZYLL3odPh1kYn9yMtQe1rKNg/BcVmadroBCyih6thtw==",
+			"dev": true
+		},
 		"@types/lodash": {
 			"version": "4.14.74",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.74.tgz",
@@ -1370,6 +1376,7 @@
 			"requires": {
 				"anymatch": "1.3.2",
 				"async-each": "1.0.1",
+				"fsevents": "1.1.3",
 				"glob-parent": "2.0.0",
 				"inherits": "2.0.3",
 				"is-binary-path": "1.0.1",
@@ -2612,6 +2619,910 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
+		},
+		"fsevents": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"nan": "2.9.2",
+				"node-pre-gyp": "0.6.39"
+			},
+			"dependencies": {
+				"abbrev": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"ajv": {
+					"version": "4.11.8",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"aproba": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"delegates": "1.0.0",
+						"readable-stream": "2.2.9"
+					}
+				},
+				"asn1": {
+					"version": "0.2.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"assert-plus": {
+					"version": "0.2.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"aws-sign2": {
+					"version": "0.6.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"aws4": {
+					"version": "1.6.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"balanced-match": {
+					"version": "0.4.2",
+					"bundled": true,
+					"dev": true
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"tweetnacl": "0.14.5"
+					}
+				},
+				"block-stream": {
+					"version": "0.0.9",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"inherits": "2.0.3"
+					}
+				},
+				"boom": {
+					"version": "2.10.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.7",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"balanced-match": "0.4.2",
+						"concat-map": "0.0.1"
+					}
+				},
+				"buffer-shims": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"co": {
+					"version": "4.6.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"combined-stream": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"delayed-stream": "1.0.0"
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"cryptiles": {
+					"version": "2.0.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"boom": "2.10.1"
+					}
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.8",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"deep-extend": {
+					"version": "0.4.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"ecc-jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"extend": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"extsprintf": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"form-data": {
+					"version": "2.1.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.15"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"fstream": {
+					"version": "1.0.11",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"inherits": "2.0.3",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.1"
+					}
+				},
+				"fstream-ignore": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"fstream": "1.0.11",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4"
+					}
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"aproba": "1.1.1",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
+					}
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true,
+					"dev": true
+				},
+				"har-schema": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"har-validator": {
+					"version": "4.2.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ajv": "4.11.8",
+						"har-schema": "1.0.5"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"hawk": {
+					"version": "3.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"boom": "2.10.1",
+						"cryptiles": "2.0.5",
+						"hoek": "2.16.3",
+						"sntp": "1.0.9"
+					}
+				},
+				"hoek": {
+					"version": "2.16.3",
+					"bundled": true,
+					"dev": true
+				},
+				"http-signature": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "0.2.0",
+						"jsprim": "1.4.0",
+						"sshpk": "1.13.0"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"ini": {
+					"version": "1.3.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"jodid25519": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"json-stable-stringify": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"jsonify": "0.0.0"
+					}
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"jsonify": {
+					"version": "0.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"jsprim": {
+					"version": "1.4.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.0.2",
+						"json-schema": "0.2.3",
+						"verror": "1.3.6"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"mime-db": {
+					"version": "1.27.0",
+					"bundled": true,
+					"dev": true
+				},
+				"mime-types": {
+					"version": "2.1.15",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"mime-db": "1.27.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true,
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"node-pre-gyp": {
+					"version": "0.6.39",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"detect-libc": "1.0.2",
+						"hawk": "3.1.3",
+						"mkdirp": "0.5.1",
+						"nopt": "4.0.1",
+						"npmlog": "4.1.0",
+						"rc": "1.2.1",
+						"request": "2.81.0",
+						"rimraf": "2.6.1",
+						"semver": "5.3.0",
+						"tar": "2.2.1",
+						"tar-pack": "3.4.0"
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"abbrev": "1.1.0",
+						"osenv": "0.1.4"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"oauth-sign": {
+					"version": "0.8.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"osenv": {
+					"version": "0.1.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"performance-now": {
+					"version": "0.2.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"bundled": true,
+					"dev": true
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"qs": {
+					"version": "6.4.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"rc": {
+					"version": "1.2.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"deep-extend": "0.4.2",
+						"ini": "1.3.4",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.2.9",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"buffer-shims": "1.0.0",
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "1.0.1",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"request": {
+					"version": "2.81.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "4.2.1",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.15",
+						"oauth-sign": "0.8.2",
+						"performance-now": "0.2.0",
+						"qs": "6.4.0",
+						"safe-buffer": "5.0.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.2",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"semver": {
+					"version": "5.3.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"sntp": {
+					"version": "1.0.9",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"sshpk": {
+					"version": "1.13.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"asn1": "0.2.3",
+						"assert-plus": "1.0.0",
+						"bcrypt-pbkdf": "1.0.1",
+						"dashdash": "1.14.1",
+						"ecc-jsbn": "0.1.1",
+						"getpass": "0.1.7",
+						"jodid25519": "1.0.2",
+						"jsbn": "0.1.1",
+						"tweetnacl": "0.14.5"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"stringstream": {
+					"version": "0.0.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"tar": {
+					"version": "2.2.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"block-stream": "0.0.9",
+						"fstream": "1.0.11",
+						"inherits": "2.0.3"
+					}
+				},
+				"tar-pack": {
+					"version": "3.4.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"debug": "2.6.8",
+						"fstream": "1.0.11",
+						"fstream-ignore": "1.0.5",
+						"once": "1.4.0",
+						"readable-stream": "2.2.9",
+						"rimraf": "2.6.1",
+						"tar": "2.2.1",
+						"uid-number": "0.0.6"
+					}
+				},
+				"tough-cookie": {
+					"version": "2.3.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"punycode": "1.4.1"
+					}
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"uid-number": {
+					"version": "0.0.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"uuid": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"verror": {
+					"version": "1.3.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"extsprintf": "1.0.2"
+					}
+				},
+				"wide-align": {
+					"version": "1.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"string-width": "1.0.2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				}
+			}
 		},
 		"function-name-support": {
 			"version": "0.2.0",
@@ -3957,6 +4868,13 @@
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
 			"dev": true
+		},
+		"nan": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+			"integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+			"dev": true,
+			"optional": true
 		},
 		"node-libs-browser": {
 			"version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,12 @@
 			"integrity": "sha1-0ifxi8uPPxh+FpZfJESFmgRol1g=",
 			"dev": true
 		},
+		"@types/jest": {
+			"version": "22.2.0",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.2.0.tgz",
+			"integrity": "sha512-5DeGD46Goq6+GtEEB57hQzC/BbuEbEj0fUCDm7a5Fm9ZYLL3odPh1kYn9yMtQe1rKNg/BcVmadroBCyih6thtw==",
+			"dev": true
+		},
 		"@types/lodash": {
 			"version": "4.14.74",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.74.tgz",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 		"publishNpmAndGithub": "lerna run clean && lerna run preparePublish && lerna publish"
 	},
 	"devDependencies": {
+		"@types/jest": "^22.2.0",
 		"@types/react": "^16.0.27",
 		"ava": "^0.24.0",
 		"babel-loader": "^7.1.2",

--- a/packages/angular-material/package-lock.json
+++ b/packages/angular-material/package-lock.json
@@ -3,88 +3,88 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@angular-redux/store": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@angular-redux/store/-/store-7.1.0.tgz",
-			"integrity": "sha512-PvPOslHxqKy6HxUYcbuU4l3H/BWApwju15XR2ZbAf+rZ2Vr9eAy9pcNBYqZ60Tsl67ZY1eqcApLApGlSQu0ZFA=="
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@angular-redux/store/-/store-7.1.1.tgz",
+			"integrity": "sha512-Uhj+wzByvQ04j6hh75xYdUMfi/sA71OLcxMl0U8uhfEGsM13GaLmf1cheDfaAMNv04KKNqj72Gdb1j+Ov2S2Nw=="
 		},
 		"@angular/animations": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/@angular/animations/-/animations-5.2.4.tgz",
-			"integrity": "sha512-kLOUORV/2GdYsNSwmUsB3eEL+nAoBZYKgibYLkVy6oecrIbdFMWiNzLcFjX/avcMnb1UNMk24Hd7Of4C2UawPA==",
+			"version": "5.2.8",
+			"resolved": "https://registry.npmjs.org/@angular/animations/-/animations-5.2.8.tgz",
+			"integrity": "sha512-VfHN7ICR9QBaEbA02ip7ipNjD6m9ayfsliIE/ACkTVevObEdL90T3Q/NxiX+JRZSDL09M9XopIi1/WOeOn6Evw==",
 			"requires": {
 				"tslib": "1.9.0"
 			}
 		},
 		"@angular/cdk": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-5.2.0.tgz",
-			"integrity": "sha1-Q2j2dJ6RXNzHXTJa4z/bP4WogQg=",
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-5.2.4.tgz",
+			"integrity": "sha1-wKQpqHENj+2xV/VG4hy0nUM19/c=",
 			"requires": {
 				"tslib": "1.9.0"
 			}
 		},
 		"@angular/common": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/@angular/common/-/common-5.2.4.tgz",
-			"integrity": "sha512-PNtg7lzCBUgYo5Rj+/j11EVKhLfrUkkh81ecBwexk6VcDJebmvBO1HdGppV5UPzEH/StL1mTwLc95dOI0hHSJA==",
+			"version": "5.2.8",
+			"resolved": "https://registry.npmjs.org/@angular/common/-/common-5.2.8.tgz",
+			"integrity": "sha512-vHODEZPDtBU5b7a2GjtQYPYmCPRq5FQsJp696pebGMJEZdvN/Du43z8V7lWEdBBLGD+oNXX6rXGD9Pr4P/Bg9w==",
 			"requires": {
 				"tslib": "1.9.0"
 			}
 		},
 		"@angular/compiler": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-5.2.4.tgz",
-			"integrity": "sha512-KFaGcm/5OKJRxXIxrS53IYPtqta9u2xLLedrWspxIvI59ImfzeZGnLGPhfrI0pbK7wY0rJ5YdGYQnzq33dh01A==",
+			"version": "5.2.8",
+			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-5.2.8.tgz",
+			"integrity": "sha512-xFqY7LDt/LGo6zaYzUwDRGq6Dm2Q9Z2R86ZNdy5wYRzMP+qLnwwENbU74YailKlt02WNtp83R1fdRDDlKI8N+Q==",
 			"requires": {
 				"tslib": "1.9.0"
 			}
 		},
 		"@angular/core": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/@angular/core/-/core-5.2.4.tgz",
-			"integrity": "sha512-GPnxUf7g8Mz0AUttKKcqaw0m2xZujwwzojkg3xUIvHrNFFF5/HH5549PfnE1jD7qkmnDFx5j3IPuNkwYHW6XvA==",
+			"version": "5.2.8",
+			"resolved": "https://registry.npmjs.org/@angular/core/-/core-5.2.8.tgz",
+			"integrity": "sha512-exvh2OY+WDm90bgzZ89Asi2nZc2zrg/OWJuKMbxNfA6nxnyjCQ7uGRjTGr+MOynG+vd54J2Evtg2eDPdbcNg5A==",
 			"requires": {
 				"tslib": "1.9.0"
 			}
 		},
 		"@angular/forms": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/@angular/forms/-/forms-5.2.4.tgz",
-			"integrity": "sha512-0k6rs2k85wcBq0WPAjxNbtBu1wq/1fUSFaBLbpnrwwHeCLJI5aAjG2/f3jv/17a/ek7/WZ3lxXtHzNMMdaD/Iw==",
+			"version": "5.2.8",
+			"resolved": "https://registry.npmjs.org/@angular/forms/-/forms-5.2.8.tgz",
+			"integrity": "sha512-yxpFwZcek7259O1+4p1Zfd8FOEJs8lh6T8n2W7IBT8Q1pcAMBCYfMi/Xga69AbypFIy3P+V6DaJoq8ZZgpwefg==",
 			"requires": {
 				"tslib": "1.9.0"
 			}
 		},
 		"@angular/material": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@angular/material/-/material-5.2.0.tgz",
-			"integrity": "sha1-hZnjFJ1ISH4+kulB+p3FUXbjoM8=",
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/@angular/material/-/material-5.2.4.tgz",
+			"integrity": "sha1-noI3mDJCg9I+qDkVb6xby3NEPVU=",
 			"requires": {
 				"tslib": "1.9.0"
 			}
 		},
 		"@angular/platform-browser": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-5.2.4.tgz",
-			"integrity": "sha512-chv6h2aHQ/QoVA4Y6rpPpSju7vyLg/iMh516GxpGYVk6bHEdrH9pHJPulPcrt/LTd7lMAAHE3YmvYWVU6aDsaQ==",
+			"version": "5.2.8",
+			"resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-5.2.8.tgz",
+			"integrity": "sha512-f0tONG8+ZQOiv5/hLY76Sl1/BY6AR8Zt4buf2klz7zba5SxKLZwcsk6OfJC2PA0WtlJGiz7cSjbPr0B5sZKv8w==",
 			"requires": {
 				"tslib": "1.9.0"
 			}
 		},
 		"@angular/platform-browser-dynamic": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.2.4.tgz",
-			"integrity": "sha512-B3pv6FUTWA1daDYhx6b77FCFCzHQPuCyrsJQwMSSu6Xt+CYn2gc3dS0ph3B6cV6mnt1qIbEpML+Vp5Bi9x0Mkw==",
+			"version": "5.2.8",
+			"resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.2.8.tgz",
+			"integrity": "sha512-FzHVZf5XMty0v+hnWOU5PsXexlebvW4+EhfGG85vWCM/M9y0bF3ZSmdqZoXfGO8/Px2JbcBx0r3+GKUgsCieMA==",
 			"requires": {
 				"tslib": "1.9.0"
 			}
 		},
 		"accepts": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
-			"integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
 			"requires": {
-				"mime-types": "2.1.17",
+				"mime-types": "2.1.18",
 				"negotiator": "0.6.1"
 			}
 		},
@@ -103,7 +103,7 @@
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"requires": {
-				"micromatch": "3.1.5",
+				"micromatch": "3.1.9",
 				"normalize-path": "2.1.1"
 			}
 		},
@@ -206,6 +206,16 @@
 				"isobject": "3.0.1",
 				"mixin-deep": "1.3.1",
 				"pascalcase": "0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				}
 			}
 		},
 		"batch": {
@@ -242,7 +252,7 @@
 				"on-finished": "2.3.0",
 				"qs": "6.5.1",
 				"raw-body": "2.3.2",
-				"type-is": "1.6.15"
+				"type-is": "1.6.16"
 			},
 			"dependencies": {
 				"debug": {
@@ -269,18 +279,18 @@
 			}
 		},
 		"brace-expansion": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
 		"braces": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.0.tgz",
-			"integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
+			"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
 			"requires": {
 				"arr-flatten": "1.1.0",
 				"array-unique": "0.3.2",
@@ -288,11 +298,30 @@
 				"extend-shallow": "2.0.1",
 				"fill-range": "4.0.0",
 				"isobject": "3.0.1",
+				"kind-of": "6.0.2",
 				"repeat-element": "1.1.2",
 				"snapdragon": "0.8.1",
 				"snapdragon-node": "2.1.1",
 				"split-string": "3.1.0",
-				"to-regex": "3.0.1"
+				"to-regex": "3.0.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				}
 			}
 		},
 		"buffer-indexof": {
@@ -311,23 +340,23 @@
 			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
 		},
 		"cacache": {
-			"version": "10.0.2",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.2.tgz",
-			"integrity": "sha512-dljb7dk1jqO5ogE+dRpoR9tpHYv5xz9vPSNunh1+0wRuNdYxmzp9WmsyokgW/DUF1FDRVA/TMsmxt027R8djbQ==",
+			"version": "10.0.4",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
 			"requires": {
 				"bluebird": "3.5.1",
 				"chownr": "1.0.1",
 				"glob": "7.1.2",
 				"graceful-fs": "4.1.11",
 				"lru-cache": "4.1.1",
-				"mississippi": "1.3.1",
+				"mississippi": "2.0.0",
 				"mkdirp": "0.5.1",
 				"move-concurrently": "1.0.1",
 				"promise-inflight": "1.0.1",
 				"rimraf": "2.6.2",
-				"ssri": "5.2.1",
+				"ssri": "5.2.4",
 				"unique-filename": "1.1.0",
-				"y18n": "3.2.1"
+				"y18n": "4.0.0"
 			}
 		},
 		"cache-base": {
@@ -361,13 +390,13 @@
 			}
 		},
 		"chokidar": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.0.tgz",
-			"integrity": "sha512-OgXCNv2U6TnG04D3tth0gsvdbV4zdbxFG3sYUqcoQMoEFVd1j1pZR6TZ8iknC45o9IJ6PeQI/J6wT/+cHcniAw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.2.tgz",
+			"integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
 			"requires": {
 				"anymatch": "2.0.0",
 				"async-each": "1.0.1",
-				"braces": "2.3.0",
+				"braces": "2.3.1",
 				"fsevents": "1.1.3",
 				"glob-parent": "3.1.0",
 				"inherits": "2.0.3",
@@ -375,7 +404,8 @@
 				"is-glob": "4.0.0",
 				"normalize-path": "2.1.1",
 				"path-is-absolute": "1.0.1",
-				"readdirp": "2.1.0"
+				"readdirp": "2.1.0",
+				"upath": "1.0.4"
 			}
 		},
 		"chownr": {
@@ -490,21 +520,21 @@
 			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 		},
 		"compressible": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
-			"integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
+			"integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
 			"requires": {
-				"mime-db": "1.30.0"
+				"mime-db": "1.33.0"
 			}
 		},
 		"compression": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
-			"integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+			"integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
 			"requires": {
-				"accepts": "1.3.4",
+				"accepts": "1.3.5",
 				"bytes": "3.0.0",
-				"compressible": "2.0.12",
+				"compressible": "2.0.13",
 				"debug": "2.6.9",
 				"on-headers": "1.0.1",
 				"safe-buffer": "5.1.1",
@@ -527,12 +557,12 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
+			"integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
 			"requires": {
 				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
+				"readable-stream": "2.3.5",
 				"typedarray": "0.0.6"
 			}
 		},
@@ -580,19 +610,17 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"copy-webpack-plugin": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.3.1.tgz",
-			"integrity": "sha512-xlcFiW/U7KrpS6dFuWq3r8Wb7koJx7QVc7LDFCosqkikaVSxkaYOnwDLwilbjrszZ0LYZXThDAJKcQCSrvdShQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.5.0.tgz",
+			"integrity": "sha512-ROQ85fWKuhJfUkBTdHvfV+Zv6Ltm3G/vPVFdLPFwzWzd9RUY1yLw3rt6FmKK2PaeNQCNvmwgFhuarkjuV4PVDQ==",
 			"requires": {
-				"cacache": "10.0.2",
+				"cacache": "10.0.4",
 				"find-cache-dir": "1.0.0",
 				"globby": "7.1.1",
 				"is-glob": "4.0.0",
-				"loader-utils": "0.2.17",
-				"lodash": "4.17.5",
+				"loader-utils": "1.1.0",
 				"minimatch": "3.0.4",
 				"p-limit": "1.2.0",
-				"pify": "3.0.0",
 				"serialize-javascript": "1.4.0"
 			}
 		},
@@ -652,11 +680,12 @@
 			}
 		},
 		"define-property": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-			"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"requires": {
-				"is-descriptor": "1.0.2"
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
 			}
 		},
 		"del": {
@@ -740,13 +769,13 @@
 			}
 		},
 		"duplexify": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
-			"integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
+			"integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
 			"requires": {
 				"end-of-stream": "1.4.1",
 				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
+				"readable-stream": "2.3.5",
 				"stream-shift": "1.0.0"
 			}
 		},
@@ -774,9 +803,9 @@
 			}
 		},
 		"errno": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
-			"integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 			"requires": {
 				"prr": "1.0.1"
 			}
@@ -843,9 +872,9 @@
 				"define-property": "0.2.5",
 				"extend-shallow": "2.0.1",
 				"posix-character-classes": "0.1.1",
-				"regex-not": "1.0.0",
+				"regex-not": "1.0.2",
 				"snapdragon": "0.8.1",
-				"to-regex": "3.0.1"
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"debug": {
@@ -862,6 +891,14 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
 						"is-descriptor": "0.1.6"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -968,7 +1005,7 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
 			"integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
 			"requires": {
-				"accepts": "1.3.4",
+				"accepts": "1.3.5",
 				"array-flatten": "1.1.1",
 				"body-parser": "1.18.2",
 				"content-disposition": "0.5.2",
@@ -987,7 +1024,7 @@
 				"on-finished": "2.3.0",
 				"parseurl": "1.3.2",
 				"path-to-regexp": "0.1.7",
-				"proxy-addr": "2.0.2",
+				"proxy-addr": "2.0.3",
 				"qs": "6.5.1",
 				"range-parser": "1.2.0",
 				"safe-buffer": "5.1.1",
@@ -995,7 +1032,7 @@
 				"serve-static": "1.13.1",
 				"setprototypeof": "1.1.0",
 				"statuses": "1.3.1",
-				"type-is": "1.6.15",
+				"type-is": "1.6.16",
 				"utils-merge": "1.0.1",
 				"vary": "1.1.2"
 			},
@@ -1016,11 +1053,22 @@
 			}
 		},
 		"extend-shallow": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"requires": {
-				"is-extendable": "0.1.1"
+				"assign-symbols": "1.0.0",
+				"is-extendable": "1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "2.0.4"
+					}
+				}
 			}
 		},
 		"extglob": {
@@ -1033,9 +1081,27 @@
 				"expand-brackets": "2.1.4",
 				"extend-shallow": "2.0.1",
 				"fragment-cache": "0.2.1",
-				"regex-not": "1.0.0",
+				"regex-not": "1.0.2",
 				"snapdragon": "0.8.1",
-				"to-regex": "3.0.1"
+				"to-regex": "3.0.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				}
 			}
 		},
 		"faye-websocket": {
@@ -1060,6 +1126,16 @@
 				"is-number": "3.0.0",
 				"repeat-string": "1.6.1",
 				"to-regex-range": "2.1.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				}
 			}
 		},
 		"finalhandler": {
@@ -1092,7 +1168,7 @@
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
 			"requires": {
 				"commondir": "1.0.1",
-				"make-dir": "1.1.0",
+				"make-dir": "1.2.0",
 				"pkg-dir": "2.0.0"
 			}
 		},
@@ -1110,7 +1186,7 @@
 			"integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
 			"requires": {
 				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"readable-stream": "2.3.5"
 			}
 		},
 		"for-in": {
@@ -1155,7 +1231,7 @@
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 			"requires": {
 				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"readable-stream": "2.3.5"
 			}
 		},
 		"fs-write-stream-atomic": {
@@ -1166,7 +1242,7 @@
 				"graceful-fs": "4.1.11",
 				"iferr": "0.1.5",
 				"imurmurhash": "0.1.4",
-				"readable-stream": "2.3.3"
+				"readable-stream": "2.3.5"
 			}
 		},
 		"fs.realpath": {
@@ -1180,20 +1256,18 @@
 			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
 			"optional": true,
 			"requires": {
-				"nan": "2.8.0",
+				"nan": "2.9.2",
 				"node-pre-gyp": "0.6.39"
 			},
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"ajv": {
 					"version": "4.11.8",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"co": "4.6.0",
@@ -1202,19 +1276,16 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"aproba": {
 					"version": "1.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "1.0.0",
@@ -1224,42 +1295,35 @@
 				"asn1": {
 					"version": "0.2.3",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"assert-plus": {
 					"version": "0.2.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"aws-sign2": {
 					"version": "0.6.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"aws4": {
 					"version": "1.6.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"balanced-match": {
 					"version": "0.4.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"tweetnacl": "0.14.5"
@@ -1268,7 +1332,6 @@
 				"block-stream": {
 					"version": "0.0.9",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"inherits": "2.0.3"
 					}
@@ -1276,7 +1339,6 @@
 				"boom": {
 					"version": "2.10.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -1284,7 +1346,6 @@
 				"brace-expansion": {
 					"version": "1.1.7",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"balanced-match": "0.4.2",
 						"concat-map": "0.0.1"
@@ -1292,53 +1353,44 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"caseless": {
 					"version": "0.12.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"co": {
 					"version": "4.6.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"combined-stream": {
 					"version": "1.0.5",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"delayed-stream": "1.0.0"
 					}
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"boom": "2.10.1"
 					}
@@ -1346,7 +1398,6 @@
 				"dashdash": {
 					"version": "1.14.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -1355,7 +1406,6 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -1371,30 +1421,25 @@
 				"deep-extend": {
 					"version": "0.4.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"ecc-jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -1403,18 +1448,15 @@
 				"extend": {
 					"version": "3.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"extsprintf": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"forever-agent": {
 					"version": "0.6.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"form-data": {
@@ -1429,13 +1471,11 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"fstream": {
 					"version": "1.0.11",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"inherits": "2.0.3",
@@ -1446,7 +1486,6 @@
 				"fstream-ignore": {
 					"version": "1.0.5",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"fstream": "1.0.11",
@@ -1457,7 +1496,6 @@
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "1.1.1",
@@ -1473,7 +1511,6 @@
 				"getpass": {
 					"version": "0.1.7",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -1482,7 +1519,6 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -1490,7 +1526,6 @@
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -1502,13 +1537,11 @@
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"har-schema": {
 					"version": "1.0.5",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"har-validator": {
@@ -1523,13 +1556,11 @@
 				"has-unicode": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"hawk": {
 					"version": "3.1.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"boom": "2.10.1",
 						"cryptiles": "2.0.5",
@@ -1539,13 +1570,11 @@
 				},
 				"hoek": {
 					"version": "2.16.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"http-signature": {
 					"version": "1.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "0.2.0",
@@ -1556,7 +1585,6 @@
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -1564,13 +1592,11 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"ini": {
 					"version": "1.3.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
@@ -1583,24 +1609,20 @@
 				"is-typedarray": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"isstream": {
 					"version": "0.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"jodid25519": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -1609,19 +1631,16 @@
 				"jsbn": {
 					"version": "0.1.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"json-stable-stringify": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsonify": "0.0.0"
@@ -1630,19 +1649,16 @@
 				"json-stringify-safe": {
 					"version": "5.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"jsonify": {
 					"version": "0.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"jsprim": {
 					"version": "1.4.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0",
@@ -1695,7 +1711,6 @@
 				"node-pre-gyp": {
 					"version": "0.6.39",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "1.0.2",
@@ -1714,7 +1729,6 @@
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1.1.0",
@@ -1724,7 +1738,6 @@
 				"npmlog": {
 					"version": "4.1.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "1.1.4",
@@ -1750,7 +1763,6 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -1776,36 +1788,30 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"performance-now": {
 					"version": "0.2.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"punycode": {
 					"version": "1.4.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"qs": {
 					"version": "6.4.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "0.4.2",
@@ -1817,7 +1823,6 @@
 						"minimist": {
 							"version": "1.2.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -1825,7 +1830,6 @@
 				"readable-stream": {
 					"version": "2.2.9",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"buffer-shims": "1.0.0",
 						"core-util-is": "1.0.2",
@@ -1839,7 +1843,6 @@
 				"request": {
 					"version": "2.81.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"aws-sign2": "0.6.0",
@@ -1869,38 +1872,32 @@
 				"rimraf": {
 					"version": "2.6.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
 					"version": "5.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"semver": {
 					"version": "5.3.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"sntp": {
 					"version": "1.0.9",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -1908,7 +1905,6 @@
 				"sshpk": {
 					"version": "1.13.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"asn1": "0.2.3",
@@ -1925,7 +1921,6 @@
 						"assert-plus": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -1933,7 +1928,6 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -1943,7 +1937,6 @@
 				"string_decoder": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
 					}
@@ -1951,13 +1944,11 @@
 				"stringstream": {
 					"version": "0.0.5",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -1965,13 +1956,11 @@
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "2.2.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"block-stream": "0.0.9",
 						"fstream": "1.0.11",
@@ -1981,7 +1970,6 @@
 				"tar-pack": {
 					"version": "3.4.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "2.6.8",
@@ -1997,7 +1985,6 @@
 				"tough-cookie": {
 					"version": "2.3.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"punycode": "1.4.1"
@@ -2006,7 +1993,6 @@
 				"tunnel-agent": {
 					"version": "0.6.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
@@ -2015,30 +2001,25 @@
 				"tweetnacl": {
 					"version": "0.14.5",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"uuid": {
 					"version": "3.0.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"verror": {
 					"version": "1.3.6",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"extsprintf": "1.0.2"
@@ -2047,7 +2028,6 @@
 				"wide-align": {
 					"version": "1.1.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "1.0.2"
@@ -2055,8 +2035,7 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				}
 			}
 		},
@@ -2176,9 +2155,9 @@
 			}
 		},
 		"has-flag": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -2210,9 +2189,9 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
 		},
 		"hpack.js": {
 			"version": "2.1.6",
@@ -2221,7 +2200,7 @@
 			"requires": {
 				"inherits": "2.0.3",
 				"obuf": "1.1.1",
-				"readable-stream": "2.3.3",
+				"readable-stream": "2.3.5",
 				"wbuf": "1.7.2"
 			}
 		},
@@ -2259,9 +2238,9 @@
 			}
 		},
 		"http-parser-js": {
-			"version": "0.4.10",
-			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
-			"integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.11.tgz",
+			"integrity": "sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA=="
 		},
 		"http-proxy": {
 			"version": "1.16.2",
@@ -2452,9 +2431,9 @@
 			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
 		},
 		"ipaddr.js": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
-			"integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+			"integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
 		},
 		"is-accessor-descriptor": {
 			"version": "1.0.0",
@@ -2584,11 +2563,18 @@
 			}
 		},
 		"is-odd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
-			"integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
 			"requires": {
-				"is-number": "3.0.0"
+				"is-number": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+				}
 			}
 		},
 		"is-path-cwd": {
@@ -2647,6 +2633,11 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
 			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
 		},
 		"is-wsl": {
 			"version": "1.1.0",
@@ -2724,14 +2715,13 @@
 			}
 		},
 		"loader-utils": {
-			"version": "0.2.17",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-			"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
 			"requires": {
 				"big.js": "3.2.0",
 				"emojis-list": "2.1.0",
-				"json5": "0.5.1",
-				"object-assign": "4.1.1"
+				"json5": "0.5.1"
 			}
 		},
 		"locate-path": {
@@ -2749,9 +2739,9 @@
 			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
 		},
 		"lodash-es": {
-			"version": "4.17.5",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
-			"integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
+			"version": "4.17.7",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.7.tgz",
+			"integrity": "sha512-jzqTi3vk4J5Dxq43cNjB0ekfCjPLHixoY2Sc0WHTo+0r928taLqe/VCt02vY5uQBvg0rdXgL3xWkK4X0MCmZcw=="
 		},
 		"loglevel": {
 			"version": "1.6.1",
@@ -2785,9 +2775,9 @@
 			}
 		},
 		"make-dir": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-			"integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
+			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
 			"requires": {
 				"pify": "3.0.0"
 			}
@@ -2820,8 +2810,8 @@
 			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 			"requires": {
-				"errno": "0.1.6",
-				"readable-stream": "2.3.3"
+				"errno": "0.1.7",
+				"readable-stream": "2.3.5"
 			}
 		},
 		"meow": {
@@ -2859,23 +2849,23 @@
 			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
 		"micromatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.5.tgz",
-			"integrity": "sha512-ykttrLPQrz1PUJcXjwsTUjGoPJ64StIGNE2lGVD1c9CuguJ+L7/navsE8IcDNndOoCMvYV0qc/exfVbMHkUhvA==",
+			"version": "3.1.9",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
+			"integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
 			"requires": {
 				"arr-diff": "4.0.0",
 				"array-unique": "0.3.2",
-				"braces": "2.3.0",
-				"define-property": "1.0.0",
-				"extend-shallow": "2.0.1",
+				"braces": "2.3.1",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
 				"extglob": "2.0.4",
 				"fragment-cache": "0.2.1",
 				"kind-of": "6.0.2",
-				"nanomatch": "1.2.7",
+				"nanomatch": "1.2.9",
 				"object.pick": "1.3.0",
-				"regex-not": "1.0.0",
+				"regex-not": "1.0.2",
 				"snapdragon": "0.8.1",
-				"to-regex": "3.0.1"
+				"to-regex": "3.0.2"
 			}
 		},
 		"mime": {
@@ -2884,16 +2874,16 @@
 			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
 		},
 		"mime-db": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-			"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
 		},
 		"mime-types": {
-			"version": "2.1.17",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"requires": {
-				"mime-db": "1.30.0"
+				"mime-db": "1.33.0"
 			}
 		},
 		"minimalistic-assert": {
@@ -2906,7 +2896,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "1.1.8"
+				"brace-expansion": "1.1.11"
 			}
 		},
 		"minimist": {
@@ -2915,17 +2905,17 @@
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"mississippi": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.1.tgz",
-			"integrity": "sha512-/6rB8YXFbAtsUVRphIRQqB0+9c7VaPHCjVtvto+JqwVxgz8Zz+I+f68/JgQ+Pb4VlZb2svA9OtdXnHHsZz7ltg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
 			"requires": {
-				"concat-stream": "1.6.0",
-				"duplexify": "3.5.3",
+				"concat-stream": "1.6.1",
+				"duplexify": "3.5.4",
 				"end-of-stream": "1.4.1",
 				"flush-write-stream": "1.0.2",
 				"from2": "2.3.0",
 				"parallel-transform": "1.1.0",
-				"pump": "1.0.3",
+				"pump": "2.0.1",
 				"pumpify": "1.4.0",
 				"stream-each": "1.2.2",
 				"through2": "2.0.3"
@@ -2991,35 +2981,28 @@
 			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
 		},
 		"nan": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-			"integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-			"dev": true,
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+			"integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
 			"optional": true
 		},
 		"nanomatch": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.7.tgz",
-			"integrity": "sha512-/5ldsnyurvEw7wNpxLFgjVvBLMta43niEYOy0CJ4ntcYSbx6bugRUTQeFb4BR/WanEL1o3aQgHuVLHQaB6tOqg==",
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
 			"requires": {
 				"arr-diff": "4.0.0",
 				"array-unique": "0.3.2",
-				"define-property": "1.0.0",
-				"extend-shallow": "2.0.1",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
 				"fragment-cache": "0.2.1",
-				"is-odd": "1.0.0",
-				"kind-of": "5.1.0",
+				"is-odd": "2.0.0",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
 				"object.pick": "1.3.0",
-				"regex-not": "1.0.0",
+				"regex-not": "1.0.2",
 				"snapdragon": "0.8.1",
-				"to-regex": "3.0.1"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-				}
+				"to-regex": "3.0.2"
 			}
 		},
 		"negotiator": {
@@ -3037,10 +3020,10 @@
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"requires": {
-				"hosted-git-info": "2.5.0",
+				"hosted-git-info": "2.6.0",
 				"is-builtin-module": "1.0.0",
 				"semver": "5.5.0",
-				"validate-npm-package-license": "3.0.1"
+				"validate-npm-package-license": "3.0.3"
 			}
 		},
 		"normalize-path": {
@@ -3246,7 +3229,7 @@
 			"requires": {
 				"cyclist": "0.2.2",
 				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"readable-stream": "2.3.5"
 			}
 		},
 		"parse-glob": {
@@ -3383,9 +3366,9 @@
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
 		},
 		"process-nextick-args": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"promise-inflight": {
 			"version": "1.0.1",
@@ -3393,12 +3376,12 @@
 			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
 		},
 		"proxy-addr": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
-			"integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+			"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
 			"requires": {
 				"forwarded": "0.1.2",
-				"ipaddr.js": "1.5.2"
+				"ipaddr.js": "1.6.0"
 			}
 		},
 		"prr": {
@@ -3412,9 +3395,9 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"pump": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-			"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 			"requires": {
 				"end-of-stream": "1.4.1",
 				"once": "1.4.0"
@@ -3425,20 +3408,9 @@
 			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
 			"integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
 			"requires": {
-				"duplexify": "3.5.3",
+				"duplexify": "3.5.4",
 				"inherits": "2.0.3",
 				"pump": "2.0.1"
-			},
-			"dependencies": {
-				"pump": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-					"requires": {
-						"end-of-stream": "1.4.1",
-						"once": "1.4.0"
-					}
-				}
 			}
 		},
 		"qs": {
@@ -3542,14 +3514,14 @@
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
 				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
+				"process-nextick-args": "2.0.0",
 				"safe-buffer": "5.1.1",
 				"string_decoder": "1.0.3",
 				"util-deprecate": "1.0.2"
@@ -3562,7 +3534,7 @@
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"minimatch": "3.0.4",
-				"readable-stream": "2.3.3",
+				"readable-stream": "2.3.5",
 				"set-immediate-shim": "1.0.1"
 			}
 		},
@@ -3581,15 +3553,10 @@
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
 			"requires": {
 				"lodash": "4.17.5",
-				"lodash-es": "4.17.5",
+				"lodash-es": "4.17.7",
 				"loose-envify": "1.3.1",
 				"symbol-observable": "1.2.0"
 			}
-		},
-		"redux-thunk": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
-			"integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU="
 		},
 		"regex-cache": {
 			"version": "0.4.4",
@@ -3600,11 +3567,12 @@
 			}
 		},
 		"regex-not": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
-			"integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"requires": {
-				"extend-shallow": "2.0.1"
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"remove-trailing-separator": {
@@ -3663,6 +3631,11 @@
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
 		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+		},
 		"rimraf": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -3698,6 +3671,14 @@
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
 			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"requires": {
+				"ret": "0.1.15"
+			}
 		},
 		"select-hose": {
 			"version": "2.0.0",
@@ -3757,12 +3738,12 @@
 			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
 			"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
 			"requires": {
-				"accepts": "1.3.4",
+				"accepts": "1.3.5",
 				"batch": "0.6.1",
 				"debug": "2.6.9",
 				"escape-html": "1.0.3",
 				"http-errors": "1.6.2",
-				"mime-types": "2.1.17",
+				"mime-types": "2.1.18",
 				"parseurl": "1.3.2"
 			},
 			"dependencies": {
@@ -3814,6 +3795,16 @@
 				"is-extendable": "0.1.1",
 				"is-plain-object": "2.0.4",
 				"split-string": "3.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				}
 			}
 		},
 		"setprototypeof": {
@@ -3860,6 +3851,14 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
 						"is-descriptor": "0.1.6"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -3923,6 +3922,16 @@
 				"define-property": "1.0.0",
 				"isobject": "3.0.1",
 				"snapdragon-util": "3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				}
 			}
 		},
 		"snapdragon-util": {
@@ -4006,22 +4015,32 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"spdx-correct": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 			"requires": {
-				"spdx-license-ids": "1.2.2"
+				"spdx-expression-parse": "3.0.0",
+				"spdx-license-ids": "3.0.0"
 			}
 		},
+		"spdx-exceptions": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+		},
 		"spdx-expression-parse": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"requires": {
+				"spdx-exceptions": "2.1.0",
+				"spdx-license-ids": "3.0.0"
+			}
 		},
 		"spdx-license-ids": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
 		},
 		"spdy": {
 			"version": "3.4.7",
@@ -4055,7 +4074,7 @@
 				"detect-node": "2.0.3",
 				"hpack.js": "2.1.6",
 				"obuf": "1.1.1",
-				"readable-stream": "2.3.3",
+				"readable-stream": "2.3.5",
 				"safe-buffer": "5.1.1",
 				"wbuf": "1.7.2"
 			},
@@ -4076,31 +4095,12 @@
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"requires": {
 				"extend-shallow": "3.0.2"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-					"requires": {
-						"assign-symbols": "1.0.0",
-						"is-extendable": "1.0.1"
-					}
-				},
-				"is-extendable": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"requires": {
-						"is-plain-object": "2.0.4"
-					}
-				}
 			}
 		},
 		"ssri": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.2.1.tgz",
-			"integrity": "sha512-y4PjOWlAuxt+yAcXitQYOnOzZpKaH3+f/qGV3OWxbyC2noC9FA9GNC9uILnVdV7jruA1aDKr4OKz3ZDBcVZwFQ==",
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.2.4.tgz",
+			"integrity": "sha512-UnEAgMZa15973iH7cUi0AHjJn1ACDIkaMyZILoqwN6yzt+4P81I8tBc5Hl+qwi5auMplZtPQsHrPBR5vJLcQtQ==",
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -4237,11 +4237,11 @@
 			}
 		},
 		"supports-color": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-			"integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+			"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 			"requires": {
-				"has-flag": "2.0.0"
+				"has-flag": "3.0.0"
 			}
 		},
 		"symbol-observable": {
@@ -4254,7 +4254,7 @@
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"requires": {
-				"readable-stream": "2.3.3",
+				"readable-stream": "2.3.5",
 				"xtend": "4.0.1"
 			}
 		},
@@ -4287,74 +4287,14 @@
 			}
 		},
 		"to-regex": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz",
-			"integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"requires": {
-				"define-property": "0.2.5",
-				"extend-shallow": "2.0.1",
-				"regex-not": "1.0.0"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "0.2.5",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"requires": {
-						"is-descriptor": "0.1.6"
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
-				},
-				"is-data-descriptor": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
-				},
-				"is-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
-					}
-				},
-				"kind-of": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-				}
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -4377,12 +4317,12 @@
 			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
 		},
 		"type-is": {
-			"version": "1.6.15",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-			"integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+			"version": "1.6.16",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
 			"requires": {
 				"media-typer": "0.3.0",
-				"mime-types": "2.1.17"
+				"mime-types": "2.1.18"
 			}
 		},
 		"typedarray": {
@@ -4401,6 +4341,14 @@
 				"set-value": "0.4.3"
 			},
 			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				},
 				"set-value": {
 					"version": "0.4.3",
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
@@ -4470,6 +4418,11 @@
 					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
 				}
 			}
+		},
+		"upath": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
+			"integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw=="
 		},
 		"urix": {
 			"version": "0.1.0",
@@ -4579,12 +4532,12 @@
 			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
 		},
 		"validate-npm-package-license": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
 			"requires": {
-				"spdx-correct": "1.0.2",
-				"spdx-expression-parse": "1.0.4"
+				"spdx-correct": "3.0.0",
+				"spdx-expression-parse": "3.0.0"
 			}
 		},
 		"vary": {
@@ -4620,15 +4573,15 @@
 			}
 		},
 		"webpack-dev-server": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.1.tgz",
-			"integrity": "sha512-ombhu5KsO/85sVshIDTyQ5HF3xjZR3N0sf5Ao6h3vFwpNyzInEzA1GV3QPVjTMLTNckp8PjfG1PFGznzBwS5lg==",
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz",
+			"integrity": "sha512-zrPoX97bx47vZiAXfDrkw8pe9QjJ+lunQl3dypojyWwWr1M5I2h0VSrMPfTjopHQPRNn+NqfjcMmhoLcUJe2gA==",
 			"requires": {
 				"ansi-html": "0.0.7",
 				"array-includes": "3.0.3",
 				"bonjour": "3.5.0",
-				"chokidar": "2.0.0",
-				"compression": "1.7.1",
+				"chokidar": "2.0.2",
+				"compression": "1.7.2",
 				"connect-history-api-fallback": "1.5.0",
 				"debug": "3.1.0",
 				"del": "3.0.0",
@@ -4648,7 +4601,7 @@
 				"sockjs-client": "1.1.4",
 				"spdy": "3.4.7",
 				"strip-ansi": "3.0.1",
-				"supports-color": "5.1.0",
+				"supports-color": "5.3.0",
 				"webpack-dev-middleware": "1.12.2",
 				"yargs": "6.6.0"
 			}
@@ -4658,7 +4611,7 @@
 			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
 			"integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
 			"requires": {
-				"http-parser-js": "0.4.10",
+				"http-parser-js": "0.4.11",
 				"websocket-extensions": "0.1.3"
 			}
 		},
@@ -4692,9 +4645,9 @@
 			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 		},
 		"y18n": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 		},
 		"yallist": {
 			"version": "2.1.2",
@@ -4725,6 +4678,11 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
 					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 				}
 			}
 		},

--- a/packages/angular-material/package.json
+++ b/packages/angular-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonforms/angular-material",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "description": "Material Renderer Set for Angular module of JSON Forms",
   "repository": "https://github.com/eclipsesource/jsonforms",
   "bugs": "https://github.com/eclipsesource/jsonforms/issues",
@@ -49,8 +49,8 @@
     "@angular/material": "^5.2.0",
     "@angular/platform-browser": "^5.2.4",
     "@angular/platform-browser-dynamic": "^5.2.4",
-    "@jsonforms/angular": "^2.0.0-rc.2",
-    "@jsonforms/core": "^2.0.0-rc.2",
+    "@jsonforms/angular": "^2.0.0-rc.3",
+    "@jsonforms/core": "^2.0.0-rc.3",
     "core-js": "^2.5.3",
     "redux": "^3.7.2",
     "rxjs": "^5.5.6",

--- a/packages/angular/package-lock.json
+++ b/packages/angular/package-lock.json
@@ -3,32 +3,32 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@angular-redux/store": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@angular-redux/store/-/store-7.1.0.tgz",
-			"integrity": "sha512-PvPOslHxqKy6HxUYcbuU4l3H/BWApwju15XR2ZbAf+rZ2Vr9eAy9pcNBYqZ60Tsl67ZY1eqcApLApGlSQu0ZFA=="
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@angular-redux/store/-/store-7.1.1.tgz",
+			"integrity": "sha512-Uhj+wzByvQ04j6hh75xYdUMfi/sA71OLcxMl0U8uhfEGsM13GaLmf1cheDfaAMNv04KKNqj72Gdb1j+Ov2S2Nw=="
 		},
 		"@angular/common": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/@angular/common/-/common-5.2.4.tgz",
-			"integrity": "sha512-PNtg7lzCBUgYo5Rj+/j11EVKhLfrUkkh81ecBwexk6VcDJebmvBO1HdGppV5UPzEH/StL1mTwLc95dOI0hHSJA==",
+			"version": "5.2.8",
+			"resolved": "https://registry.npmjs.org/@angular/common/-/common-5.2.8.tgz",
+			"integrity": "sha512-vHODEZPDtBU5b7a2GjtQYPYmCPRq5FQsJp696pebGMJEZdvN/Du43z8V7lWEdBBLGD+oNXX6rXGD9Pr4P/Bg9w==",
 			"requires": {
 				"tslib": "1.9.0"
 			}
 		},
 		"@angular/core": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/@angular/core/-/core-5.2.4.tgz",
-			"integrity": "sha512-GPnxUf7g8Mz0AUttKKcqaw0m2xZujwwzojkg3xUIvHrNFFF5/HH5549PfnE1jD7qkmnDFx5j3IPuNkwYHW6XvA==",
+			"version": "5.2.8",
+			"resolved": "https://registry.npmjs.org/@angular/core/-/core-5.2.8.tgz",
+			"integrity": "sha512-exvh2OY+WDm90bgzZ89Asi2nZc2zrg/OWJuKMbxNfA6nxnyjCQ7uGRjTGr+MOynG+vd54J2Evtg2eDPdbcNg5A==",
 			"requires": {
 				"tslib": "1.9.0"
 			}
 		},
 		"accepts": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
-			"integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
 			"requires": {
-				"mime-types": "2.1.17",
+				"mime-types": "2.1.18",
 				"negotiator": "0.6.1"
 			}
 		},
@@ -47,7 +47,7 @@
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"requires": {
-				"micromatch": "3.1.5",
+				"micromatch": "3.1.9",
 				"normalize-path": "2.1.1"
 			}
 		},
@@ -148,8 +148,18 @@
 				"component-emitter": "1.2.1",
 				"define-property": "1.0.0",
 				"isobject": "3.0.1",
-				"mixin-deep": "1.3.0",
+				"mixin-deep": "1.3.1",
 				"pascalcase": "0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				}
 			}
 		},
 		"batch": {
@@ -186,7 +196,7 @@
 				"on-finished": "2.3.0",
 				"qs": "6.5.1",
 				"raw-body": "2.3.2",
-				"type-is": "1.6.15"
+				"type-is": "1.6.16"
 			},
 			"dependencies": {
 				"debug": {
@@ -213,18 +223,18 @@
 			}
 		},
 		"brace-expansion": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
 		"braces": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.0.tgz",
-			"integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
+			"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
 			"requires": {
 				"arr-flatten": "1.1.0",
 				"array-unique": "0.3.2",
@@ -232,11 +242,30 @@
 				"extend-shallow": "2.0.1",
 				"fill-range": "4.0.0",
 				"isobject": "3.0.1",
+				"kind-of": "6.0.2",
 				"repeat-element": "1.1.2",
 				"snapdragon": "0.8.1",
 				"snapdragon-node": "2.1.1",
 				"split-string": "3.1.0",
-				"to-regex": "3.0.1"
+				"to-regex": "3.0.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				}
 			}
 		},
 		"buffer-indexof": {
@@ -255,23 +284,23 @@
 			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
 		},
 		"cacache": {
-			"version": "10.0.2",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.2.tgz",
-			"integrity": "sha512-dljb7dk1jqO5ogE+dRpoR9tpHYv5xz9vPSNunh1+0wRuNdYxmzp9WmsyokgW/DUF1FDRVA/TMsmxt027R8djbQ==",
+			"version": "10.0.4",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
 			"requires": {
 				"bluebird": "3.5.1",
 				"chownr": "1.0.1",
 				"glob": "7.1.2",
 				"graceful-fs": "4.1.11",
 				"lru-cache": "4.1.1",
-				"mississippi": "1.3.1",
+				"mississippi": "2.0.0",
 				"mkdirp": "0.5.1",
 				"move-concurrently": "1.0.1",
 				"promise-inflight": "1.0.1",
 				"rimraf": "2.6.2",
-				"ssri": "5.1.0",
+				"ssri": "5.2.4",
 				"unique-filename": "1.1.0",
-				"y18n": "3.2.1"
+				"y18n": "4.0.0"
 			}
 		},
 		"cache-base": {
@@ -305,13 +334,13 @@
 			}
 		},
 		"chokidar": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.0.tgz",
-			"integrity": "sha512-OgXCNv2U6TnG04D3tth0gsvdbV4zdbxFG3sYUqcoQMoEFVd1j1pZR6TZ8iknC45o9IJ6PeQI/J6wT/+cHcniAw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.2.tgz",
+			"integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
 			"requires": {
 				"anymatch": "2.0.0",
 				"async-each": "1.0.1",
-				"braces": "2.3.0",
+				"braces": "2.3.1",
 				"fsevents": "1.1.3",
 				"glob-parent": "3.1.0",
 				"inherits": "2.0.3",
@@ -319,7 +348,8 @@
 				"is-glob": "4.0.0",
 				"normalize-path": "2.1.1",
 				"path-is-absolute": "1.0.1",
-				"readdirp": "2.1.0"
+				"readdirp": "2.1.0",
+				"upath": "1.0.4"
 			}
 		},
 		"chownr": {
@@ -434,21 +464,21 @@
 			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 		},
 		"compressible": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
-			"integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
+			"integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
 			"requires": {
-				"mime-db": "1.30.0"
+				"mime-db": "1.33.0"
 			}
 		},
 		"compression": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
-			"integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+			"integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
 			"requires": {
-				"accepts": "1.3.4",
+				"accepts": "1.3.5",
 				"bytes": "3.0.0",
-				"compressible": "2.0.12",
+				"compressible": "2.0.13",
 				"debug": "2.6.9",
 				"on-headers": "1.0.1",
 				"safe-buffer": "5.1.1",
@@ -471,12 +501,12 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
+			"integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
 			"requires": {
 				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
+				"readable-stream": "2.3.5",
 				"typedarray": "0.0.6"
 			}
 		},
@@ -524,19 +554,17 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"copy-webpack-plugin": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.3.1.tgz",
-			"integrity": "sha512-xlcFiW/U7KrpS6dFuWq3r8Wb7koJx7QVc7LDFCosqkikaVSxkaYOnwDLwilbjrszZ0LYZXThDAJKcQCSrvdShQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.5.0.tgz",
+			"integrity": "sha512-ROQ85fWKuhJfUkBTdHvfV+Zv6Ltm3G/vPVFdLPFwzWzd9RUY1yLw3rt6FmKK2PaeNQCNvmwgFhuarkjuV4PVDQ==",
 			"requires": {
-				"cacache": "10.0.2",
+				"cacache": "10.0.4",
 				"find-cache-dir": "1.0.0",
 				"globby": "7.1.1",
 				"is-glob": "4.0.0",
-				"loader-utils": "0.2.17",
-				"lodash": "4.17.5",
+				"loader-utils": "1.1.0",
 				"minimatch": "3.0.4",
 				"p-limit": "1.2.0",
-				"pify": "3.0.0",
 				"serialize-javascript": "1.4.0"
 			}
 		},
@@ -591,11 +619,12 @@
 			}
 		},
 		"define-property": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-			"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"requires": {
-				"is-descriptor": "1.0.2"
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
 			}
 		},
 		"del": {
@@ -679,13 +708,13 @@
 			}
 		},
 		"duplexify": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
-			"integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
+			"integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
 			"requires": {
 				"end-of-stream": "1.4.1",
 				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
+				"readable-stream": "2.3.5",
 				"stream-shift": "1.0.0"
 			}
 		},
@@ -713,9 +742,9 @@
 			}
 		},
 		"errno": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
-			"integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 			"requires": {
 				"prr": "1.0.1"
 			}
@@ -782,9 +811,9 @@
 				"define-property": "0.2.5",
 				"extend-shallow": "2.0.1",
 				"posix-character-classes": "0.1.1",
-				"regex-not": "1.0.0",
+				"regex-not": "1.0.2",
 				"snapdragon": "0.8.1",
-				"to-regex": "3.0.1"
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"debug": {
@@ -801,6 +830,14 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
 						"is-descriptor": "0.1.6"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -907,7 +944,7 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
 			"integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
 			"requires": {
-				"accepts": "1.3.4",
+				"accepts": "1.3.5",
 				"array-flatten": "1.1.1",
 				"body-parser": "1.18.2",
 				"content-disposition": "0.5.2",
@@ -926,7 +963,7 @@
 				"on-finished": "2.3.0",
 				"parseurl": "1.3.2",
 				"path-to-regexp": "0.1.7",
-				"proxy-addr": "2.0.2",
+				"proxy-addr": "2.0.3",
 				"qs": "6.5.1",
 				"range-parser": "1.2.0",
 				"safe-buffer": "5.1.1",
@@ -934,7 +971,7 @@
 				"serve-static": "1.13.1",
 				"setprototypeof": "1.1.0",
 				"statuses": "1.3.1",
-				"type-is": "1.6.15",
+				"type-is": "1.6.16",
 				"utils-merge": "1.0.1",
 				"vary": "1.1.2"
 			},
@@ -955,11 +992,22 @@
 			}
 		},
 		"extend-shallow": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"requires": {
-				"is-extendable": "0.1.1"
+				"assign-symbols": "1.0.0",
+				"is-extendable": "1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "2.0.4"
+					}
+				}
 			}
 		},
 		"extglob": {
@@ -972,9 +1020,27 @@
 				"expand-brackets": "2.1.4",
 				"extend-shallow": "2.0.1",
 				"fragment-cache": "0.2.1",
-				"regex-not": "1.0.0",
+				"regex-not": "1.0.2",
 				"snapdragon": "0.8.1",
-				"to-regex": "3.0.1"
+				"to-regex": "3.0.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				}
 			}
 		},
 		"faye-websocket": {
@@ -999,6 +1065,16 @@
 				"is-number": "3.0.0",
 				"repeat-string": "1.6.1",
 				"to-regex-range": "2.1.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				}
 			}
 		},
 		"finalhandler": {
@@ -1031,7 +1107,7 @@
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
 			"requires": {
 				"commondir": "1.0.1",
-				"make-dir": "1.1.0",
+				"make-dir": "1.2.0",
 				"pkg-dir": "2.0.0"
 			}
 		},
@@ -1049,7 +1125,7 @@
 			"integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
 			"requires": {
 				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"readable-stream": "2.3.5"
 			}
 		},
 		"for-in": {
@@ -1094,7 +1170,7 @@
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 			"requires": {
 				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"readable-stream": "2.3.5"
 			}
 		},
 		"fs-write-stream-atomic": {
@@ -1105,7 +1181,7 @@
 				"graceful-fs": "4.1.11",
 				"iferr": "0.1.5",
 				"imurmurhash": "0.1.4",
-				"readable-stream": "2.3.3"
+				"readable-stream": "2.3.5"
 			}
 		},
 		"fs.realpath": {
@@ -1119,7 +1195,7 @@
 			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
 			"optional": true,
 			"requires": {
-				"nan": "2.8.0",
+				"nan": "2.9.2",
 				"node-pre-gyp": "0.6.39"
 			},
 			"dependencies": {
@@ -2018,9 +2094,9 @@
 			}
 		},
 		"has-flag": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -2052,9 +2128,9 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
 		},
 		"hpack.js": {
 			"version": "2.1.6",
@@ -2063,7 +2139,7 @@
 			"requires": {
 				"inherits": "2.0.3",
 				"obuf": "1.1.1",
-				"readable-stream": "2.3.3",
+				"readable-stream": "2.3.5",
 				"wbuf": "1.7.2"
 			}
 		},
@@ -2101,9 +2177,9 @@
 			}
 		},
 		"http-parser-js": {
-			"version": "0.4.10",
-			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
-			"integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.11.tgz",
+			"integrity": "sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA=="
 		},
 		"http-proxy": {
 			"version": "1.16.2",
@@ -2294,9 +2370,9 @@
 			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
 		},
 		"ipaddr.js": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
-			"integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+			"integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
 		},
 		"is-accessor-descriptor": {
 			"version": "1.0.0",
@@ -2426,11 +2502,18 @@
 			}
 		},
 		"is-odd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
-			"integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
 			"requires": {
-				"is-number": "3.0.0"
+				"is-number": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+				}
 			}
 		},
 		"is-path-cwd": {
@@ -2489,6 +2572,11 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
 			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
 		},
 		"is-wsl": {
 			"version": "1.1.0",
@@ -2566,14 +2654,13 @@
 			}
 		},
 		"loader-utils": {
-			"version": "0.2.17",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-			"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
 			"requires": {
 				"big.js": "3.2.0",
 				"emojis-list": "2.1.0",
-				"json5": "0.5.1",
-				"object-assign": "4.1.1"
+				"json5": "0.5.1"
 			}
 		},
 		"locate-path": {
@@ -2591,9 +2678,9 @@
 			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
 		},
 		"lodash-es": {
-			"version": "4.17.5",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
-			"integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
+			"version": "4.17.7",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.7.tgz",
+			"integrity": "sha512-jzqTi3vk4J5Dxq43cNjB0ekfCjPLHixoY2Sc0WHTo+0r928taLqe/VCt02vY5uQBvg0rdXgL3xWkK4X0MCmZcw=="
 		},
 		"loglevel": {
 			"version": "1.6.1",
@@ -2627,9 +2714,9 @@
 			}
 		},
 		"make-dir": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-			"integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
+			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
 			"requires": {
 				"pify": "3.0.0"
 			}
@@ -2662,8 +2749,8 @@
 			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 			"requires": {
-				"errno": "0.1.6",
-				"readable-stream": "2.3.3"
+				"errno": "0.1.7",
+				"readable-stream": "2.3.5"
 			}
 		},
 		"meow": {
@@ -2701,23 +2788,23 @@
 			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
 		"micromatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.5.tgz",
-			"integrity": "sha512-ykttrLPQrz1PUJcXjwsTUjGoPJ64StIGNE2lGVD1c9CuguJ+L7/navsE8IcDNndOoCMvYV0qc/exfVbMHkUhvA==",
+			"version": "3.1.9",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
+			"integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
 			"requires": {
 				"arr-diff": "4.0.0",
 				"array-unique": "0.3.2",
-				"braces": "2.3.0",
-				"define-property": "1.0.0",
-				"extend-shallow": "2.0.1",
+				"braces": "2.3.1",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
 				"extglob": "2.0.4",
 				"fragment-cache": "0.2.1",
 				"kind-of": "6.0.2",
-				"nanomatch": "1.2.7",
+				"nanomatch": "1.2.9",
 				"object.pick": "1.3.0",
-				"regex-not": "1.0.0",
+				"regex-not": "1.0.2",
 				"snapdragon": "0.8.1",
-				"to-regex": "3.0.1"
+				"to-regex": "3.0.2"
 			}
 		},
 		"mime": {
@@ -2726,16 +2813,16 @@
 			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
 		},
 		"mime-db": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-			"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
 		},
 		"mime-types": {
-			"version": "2.1.17",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"requires": {
-				"mime-db": "1.30.0"
+				"mime-db": "1.33.0"
 			}
 		},
 		"minimalistic-assert": {
@@ -2748,7 +2835,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "1.1.8"
+				"brace-expansion": "1.1.11"
 			}
 		},
 		"minimist": {
@@ -2757,26 +2844,26 @@
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"mississippi": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.1.tgz",
-			"integrity": "sha512-/6rB8YXFbAtsUVRphIRQqB0+9c7VaPHCjVtvto+JqwVxgz8Zz+I+f68/JgQ+Pb4VlZb2svA9OtdXnHHsZz7ltg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
 			"requires": {
-				"concat-stream": "1.6.0",
-				"duplexify": "3.5.3",
+				"concat-stream": "1.6.1",
+				"duplexify": "3.5.4",
 				"end-of-stream": "1.4.1",
 				"flush-write-stream": "1.0.2",
 				"from2": "2.3.0",
 				"parallel-transform": "1.1.0",
-				"pump": "1.0.3",
+				"pump": "2.0.1",
 				"pumpify": "1.4.0",
 				"stream-each": "1.2.2",
 				"through2": "2.0.3"
 			}
 		},
 		"mixin-deep": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.0.tgz",
-			"integrity": "sha512-dgaCvoh6i1nosAUBKb0l0pfJ78K8+S9fluyIR2YvAeUD/QuMahnFnF3xYty5eYXMjhGSsB0DsW6A0uAZyetoAg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"requires": {
 				"for-in": "1.0.2",
 				"is-extendable": "1.0.1"
@@ -2833,34 +2920,28 @@
 			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
 		},
 		"nan": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-			"integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+			"integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
 			"optional": true
 		},
 		"nanomatch": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.7.tgz",
-			"integrity": "sha512-/5ldsnyurvEw7wNpxLFgjVvBLMta43niEYOy0CJ4ntcYSbx6bugRUTQeFb4BR/WanEL1o3aQgHuVLHQaB6tOqg==",
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
 			"requires": {
 				"arr-diff": "4.0.0",
 				"array-unique": "0.3.2",
-				"define-property": "1.0.0",
-				"extend-shallow": "2.0.1",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
 				"fragment-cache": "0.2.1",
-				"is-odd": "1.0.0",
-				"kind-of": "5.1.0",
+				"is-odd": "2.0.0",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
 				"object.pick": "1.3.0",
-				"regex-not": "1.0.0",
+				"regex-not": "1.0.2",
 				"snapdragon": "0.8.1",
-				"to-regex": "3.0.1"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-				}
+				"to-regex": "3.0.2"
 			}
 		},
 		"negotiator": {
@@ -2878,10 +2959,10 @@
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"requires": {
-				"hosted-git-info": "2.5.0",
+				"hosted-git-info": "2.6.0",
 				"is-builtin-module": "1.0.0",
 				"semver": "5.5.0",
-				"validate-npm-package-license": "3.0.1"
+				"validate-npm-package-license": "3.0.3"
 			}
 		},
 		"normalize-path": {
@@ -3087,7 +3168,7 @@
 			"requires": {
 				"cyclist": "0.2.2",
 				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"readable-stream": "2.3.5"
 			}
 		},
 		"parse-glob": {
@@ -3224,9 +3305,9 @@
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
 		},
 		"process-nextick-args": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"promise-inflight": {
 			"version": "1.0.1",
@@ -3234,12 +3315,12 @@
 			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
 		},
 		"proxy-addr": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
-			"integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+			"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
 			"requires": {
 				"forwarded": "0.1.2",
-				"ipaddr.js": "1.5.2"
+				"ipaddr.js": "1.6.0"
 			}
 		},
 		"prr": {
@@ -3253,9 +3334,9 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"pump": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-			"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 			"requires": {
 				"end-of-stream": "1.4.1",
 				"once": "1.4.0"
@@ -3266,20 +3347,9 @@
 			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
 			"integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
 			"requires": {
-				"duplexify": "3.5.3",
+				"duplexify": "3.5.4",
 				"inherits": "2.0.3",
 				"pump": "2.0.1"
-			},
-			"dependencies": {
-				"pump": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-					"requires": {
-						"end-of-stream": "1.4.1",
-						"once": "1.4.0"
-					}
-				}
 			}
 		},
 		"qs": {
@@ -3383,14 +3453,14 @@
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
 				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
+				"process-nextick-args": "2.0.0",
 				"safe-buffer": "5.1.1",
 				"string_decoder": "1.0.3",
 				"util-deprecate": "1.0.2"
@@ -3403,7 +3473,7 @@
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"minimatch": "3.0.4",
-				"readable-stream": "2.3.3",
+				"readable-stream": "2.3.5",
 				"set-immediate-shim": "1.0.1"
 			}
 		},
@@ -3422,7 +3492,7 @@
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
 			"requires": {
 				"lodash": "4.17.5",
-				"lodash-es": "4.17.5",
+				"lodash-es": "4.17.7",
 				"loose-envify": "1.3.1",
 				"symbol-observable": "1.2.0"
 			}
@@ -3436,11 +3506,12 @@
 			}
 		},
 		"regex-not": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
-			"integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"requires": {
-				"extend-shallow": "2.0.1"
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"remove-trailing-separator": {
@@ -3499,6 +3570,11 @@
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
 		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+		},
 		"rimraf": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -3534,6 +3610,14 @@
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
 			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"requires": {
+				"ret": "0.1.15"
+			}
 		},
 		"select-hose": {
 			"version": "2.0.0",
@@ -3593,12 +3677,12 @@
 			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
 			"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
 			"requires": {
-				"accepts": "1.3.4",
+				"accepts": "1.3.5",
 				"batch": "0.6.1",
 				"debug": "2.6.9",
 				"escape-html": "1.0.3",
 				"http-errors": "1.6.2",
-				"mime-types": "2.1.17",
+				"mime-types": "2.1.18",
 				"parseurl": "1.3.2"
 			},
 			"dependencies": {
@@ -3650,6 +3734,16 @@
 				"is-extendable": "0.1.1",
 				"is-plain-object": "2.0.4",
 				"split-string": "3.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				}
 			}
 		},
 		"setprototypeof": {
@@ -3696,6 +3790,14 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
 						"is-descriptor": "0.1.6"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -3759,6 +3861,16 @@
 				"define-property": "1.0.0",
 				"isobject": "3.0.1",
 				"snapdragon-util": "3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				}
 			}
 		},
 		"snapdragon-util": {
@@ -3842,22 +3954,32 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"spdx-correct": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 			"requires": {
-				"spdx-license-ids": "1.2.2"
+				"spdx-expression-parse": "3.0.0",
+				"spdx-license-ids": "3.0.0"
 			}
 		},
+		"spdx-exceptions": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+		},
 		"spdx-expression-parse": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"requires": {
+				"spdx-exceptions": "2.1.0",
+				"spdx-license-ids": "3.0.0"
+			}
 		},
 		"spdx-license-ids": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
 		},
 		"spdy": {
 			"version": "3.4.7",
@@ -3891,7 +4013,7 @@
 				"detect-node": "2.0.3",
 				"hpack.js": "2.1.6",
 				"obuf": "1.1.1",
-				"readable-stream": "2.3.3",
+				"readable-stream": "2.3.5",
 				"safe-buffer": "5.1.1",
 				"wbuf": "1.7.2"
 			},
@@ -3912,31 +4034,12 @@
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"requires": {
 				"extend-shallow": "3.0.2"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-					"requires": {
-						"assign-symbols": "1.0.0",
-						"is-extendable": "1.0.1"
-					}
-				},
-				"is-extendable": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"requires": {
-						"is-plain-object": "2.0.4"
-					}
-				}
 			}
 		},
 		"ssri": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.1.0.tgz",
-			"integrity": "sha512-TevC8fgxQKTfQ1nWtM9GNzr3q5rrHNntG9CDMH1k3QhSZI6Kb+NbjLRs8oPFZa2Hgo7zoekL+UTvoEk7tsbjQg==",
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.2.4.tgz",
+			"integrity": "sha512-UnEAgMZa15973iH7cUi0AHjJn1ACDIkaMyZILoqwN6yzt+4P81I8tBc5Hl+qwi5auMplZtPQsHrPBR5vJLcQtQ==",
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -4073,11 +4176,11 @@
 			}
 		},
 		"supports-color": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-			"integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+			"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 			"requires": {
-				"has-flag": "2.0.0"
+				"has-flag": "3.0.0"
 			}
 		},
 		"symbol-observable": {
@@ -4090,7 +4193,7 @@
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"requires": {
-				"readable-stream": "2.3.3",
+				"readable-stream": "2.3.5",
 				"xtend": "4.0.1"
 			}
 		},
@@ -4123,74 +4226,14 @@
 			}
 		},
 		"to-regex": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz",
-			"integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"requires": {
-				"define-property": "0.2.5",
-				"extend-shallow": "2.0.1",
-				"regex-not": "1.0.0"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "0.2.5",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"requires": {
-						"is-descriptor": "0.1.6"
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
-				},
-				"is-data-descriptor": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
-				},
-				"is-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
-					}
-				},
-				"kind-of": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-				}
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -4213,12 +4256,12 @@
 			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
 		},
 		"type-is": {
-			"version": "1.6.15",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-			"integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+			"version": "1.6.16",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
 			"requires": {
 				"media-typer": "0.3.0",
-				"mime-types": "2.1.17"
+				"mime-types": "2.1.18"
 			}
 		},
 		"typedarray": {
@@ -4237,6 +4280,14 @@
 				"set-value": "0.4.3"
 			},
 			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				},
 				"set-value": {
 					"version": "0.4.3",
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
@@ -4306,6 +4357,11 @@
 					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
 				}
 			}
+		},
+		"upath": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
+			"integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw=="
 		},
 		"urix": {
 			"version": "0.1.0",
@@ -4415,12 +4471,12 @@
 			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
 		},
 		"validate-npm-package-license": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
 			"requires": {
-				"spdx-correct": "1.0.2",
-				"spdx-expression-parse": "1.0.4"
+				"spdx-correct": "3.0.0",
+				"spdx-expression-parse": "3.0.0"
 			}
 		},
 		"vary": {
@@ -4456,15 +4512,15 @@
 			}
 		},
 		"webpack-dev-server": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.1.tgz",
-			"integrity": "sha512-ombhu5KsO/85sVshIDTyQ5HF3xjZR3N0sf5Ao6h3vFwpNyzInEzA1GV3QPVjTMLTNckp8PjfG1PFGznzBwS5lg==",
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz",
+			"integrity": "sha512-zrPoX97bx47vZiAXfDrkw8pe9QjJ+lunQl3dypojyWwWr1M5I2h0VSrMPfTjopHQPRNn+NqfjcMmhoLcUJe2gA==",
 			"requires": {
 				"ansi-html": "0.0.7",
 				"array-includes": "3.0.3",
 				"bonjour": "3.5.0",
-				"chokidar": "2.0.0",
-				"compression": "1.7.1",
+				"chokidar": "2.0.2",
+				"compression": "1.7.2",
 				"connect-history-api-fallback": "1.5.0",
 				"debug": "3.1.0",
 				"del": "3.0.0",
@@ -4484,7 +4540,7 @@
 				"sockjs-client": "1.1.4",
 				"spdy": "3.4.7",
 				"strip-ansi": "3.0.1",
-				"supports-color": "5.1.0",
+				"supports-color": "5.3.0",
 				"webpack-dev-middleware": "1.12.2",
 				"yargs": "6.6.0"
 			}
@@ -4494,7 +4550,7 @@
 			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
 			"integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
 			"requires": {
-				"http-parser-js": "0.4.10",
+				"http-parser-js": "0.4.11",
 				"websocket-extensions": "0.1.3"
 			}
 		},
@@ -4528,9 +4584,9 @@
 			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 		},
 		"y18n": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 		},
 		"yallist": {
 			"version": "2.1.2",
@@ -4561,6 +4617,11 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
 					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 				}
 			}
 		},

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonforms/angular",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "description": "Angular module of JSON Forms",
   "repository": "https://github.com/eclipsesource/jsonforms",
   "bugs": "https://github.com/eclipsesource/jsonforms/issues",
@@ -41,7 +41,7 @@
     "@angular-redux/store": "^7.1.0",
     "@angular/common": "^5.2.4",
     "@angular/core": "^5.2.4",
-    "@jsonforms/core": "^2.0.0-rc.2",
+    "@jsonforms/core": "^2.0.0-rc.3",
     "redux": "^3.7.2",
     "rxjs": "^5.5.6"
   },

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,860 +1,883 @@
 {
-  "requires": true,
-  "lockfileVersion": 1,
-  "dependencies": {
-    "@types/node": {
-      "version": "8.0.57",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.57.tgz",
-      "integrity": "sha512-ZxrhcBxlZA7tn0HFf7ebUYfR9aHyBgjyavBLzyrYMYuAMbONBPY4S5O35562iV2FfwnZCjQky3gTDy1B3jSZ2Q=="
-    },
-    "abab": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
-    },
-    "acorn": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
-    },
-    "acorn-globals": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
-      "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
-      "requires": {
-        "acorn": "5.2.1"
-      }
-    },
-    "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
-      }
-    },
-    "array-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
-    "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
-    "browser-process-hrtime": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
-      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
-    "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
-    },
-    "content-type-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
-      }
-    },
-    "cssom": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
-    },
-    "cssstyle": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-      "requires": {
-        "cssom": "0.3.2"
-      }
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
-    },
-    "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "document-register-element": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.7.0.tgz",
-      "integrity": "sha512-qAoWcNm1zW3LVO0KSblYISM0oLQzlNtns2gd1O/YS3QvFYFidG6lF73fC98fIbfPQkws698L0/URrtmN8+ADbQ=="
-    },
-    "domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.0.tgz",
-      "integrity": "sha512-WpwuBlZ2lQRFa4H/4w49deb9rJLot9KmqrKKjMc9qBl7CID+DdC2swoa34ccRl+anL2B6bLp6TjFdIdnzekMBQ=="
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.19"
-      }
-    },
-    "escodegen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
-      "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-        }
-      }
-    },
-    "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
-    },
-    "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
-    },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-    },
-    "fbjs": {
-      "version": "0.8.16",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
-      "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.12"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        }
-      }
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
-      }
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "requires": {
-        "ajv": "5.5.1",
-        "har-schema": "2.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.5.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
-          "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
-        }
-      }
-    },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
-      }
-    },
-    "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-    },
-    "html-encoding-sniffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-      "requires": {
-        "whatwg-encoding": "1.0.3"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
-      }
-    },
-    "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
-      }
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
-    },
-    "jsdom": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.5.1.tgz",
-      "integrity": "sha512-89ztIZ03aYK9f1uUrLXLsZndRge/JnZjzjpaN+lrse3coqz+8PR/dX4WLHpbF5fIKTXhDjFODOJw2328lPJ90g==",
-      "requires": {
-        "abab": "1.0.4",
-        "acorn": "5.2.1",
-        "acorn-globals": "4.1.0",
-        "array-equal": "1.0.0",
-        "browser-process-hrtime": "0.1.2",
-        "content-type-parser": "1.0.2",
-        "cssom": "0.3.2",
-        "cssstyle": "0.2.37",
-        "domexception": "1.0.0",
-        "escodegen": "1.9.0",
-        "html-encoding-sniffer": "1.0.2",
-        "left-pad": "1.2.0",
-        "nwmatcher": "1.4.3",
-        "parse5": "3.0.3",
-        "pn": "1.0.0",
-        "request": "2.83.0",
-        "request-promise-native": "1.0.5",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.3",
-        "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.3",
-        "whatwg-url": "6.4.0",
-        "xml-name-validator": "2.0.1"
-      }
-    },
-    "jsdom-global": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
-      "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk="
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "0.0.0"
-      }
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
-    "left-pad": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
-      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
-    },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
-      }
-    },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-    },
-    "lodash-es": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-    },
-    "lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
-    },
-    "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "requires": {
-        "js-tokens": "3.0.2"
-      }
-    },
-    "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
-    },
-    "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-      "requires": {
-        "mime-db": "1.30.0"
-      }
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
-    },
-    "nwmatcher": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw=="
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
-      }
-    },
-    "parse5": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-      "requires": {
-        "@types/node": "8.0.57"
-      }
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
-    "pn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pn/-/pn-1.0.0.tgz",
-      "integrity": "sha1-HPWjCw2AbNGPiPxBprXUrWFbO6k="
-    },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-    },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "2.0.6"
-      }
-    },
-    "prop-types": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
-    },
-    "punycode": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
-    },
-    "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-    },
-    "react-dom": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
-      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
-      }
-    },
-    "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
-      "requires": {
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
-        "loose-envify": "1.3.1",
-        "symbol-observable": "1.0.4"
-      }
-    },
-    "redux-mock-store": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.4.0.tgz",
-      "integrity": "sha512-y+SGh/SONWwqs4DiyHjd0H6NMgz368wXDiUjSHuOnMEr4dN9PmjV6N3bNvxoILaIQ7zeVKclLyxsCQ2TwGZfEw==",
-      "requires": {
-        "lodash.isplainobject": "4.0.6"
-      }
-    },
-    "request": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-      "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
-      }
-    },
-    "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-      "requires": {
-        "lodash": "4.17.4"
-      }
-    },
-    "request-promise-native": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
-      "requires": {
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.3"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-    },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "optional": true
-    },
-    "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-    },
-    "symbol-observable": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
-    },
-    "symbol-tree": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
-    },
-    "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-      "requires": {
-        "punycode": "1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        }
-      }
-    },
-    "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "requires": {
-        "punycode": "2.1.0"
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
-    },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "requires": {
-        "prelude-ls": "1.1.2"
-      }
-    },
-    "ua-parser-js": {
-      "version": "0.7.12",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz",
-      "integrity": "sha1-BMgamb3V3FImPqKdJMa/jUgYpLs="
-    },
-    "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      }
-    },
-    "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-    },
-    "whatwg-encoding": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-      "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
-      "requires": {
-        "iconv-lite": "0.4.19"
-      }
-    },
-    "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
-    },
-    "whatwg-url": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
-      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
-      "requires": {
-        "lodash.sortby": "4.7.0",
-        "tr46": "1.0.1",
-        "webidl-conversions": "4.0.2"
-      }
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-    },
-    "xml-name-validator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
-    }
-  }
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"abab": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+		},
+		"acorn": {
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
+		},
+		"acorn-globals": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+			"requires": {
+				"acorn": "5.5.3"
+			}
+		},
+		"ajv": {
+			"version": "4.11.8",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+			"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+			"requires": {
+				"co": "4.6.0",
+				"json-stable-stringify": "1.0.1"
+			}
+		},
+		"array-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+		},
+		"aws4": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"optional": true,
+			"requires": {
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"boom": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+			"requires": {
+				"hoek": "4.2.1"
+			}
+		},
+		"browser-process-hrtime": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+		},
+		"combined-stream": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"requires": {
+				"delayed-stream": "1.0.0"
+			}
+		},
+		"content-type-parser": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
+		},
+		"core-js": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"cryptiles": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+			"requires": {
+				"boom": "5.2.0"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+					"requires": {
+						"hoek": "4.2.1"
+					}
+				}
+			}
+		},
+		"cssom": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+		},
+		"cssstyle": {
+			"version": "0.2.37",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"requires": {
+				"cssom": "0.3.2"
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			}
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
+		"document-register-element": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.7.2.tgz",
+			"integrity": "sha512-E+y3qJgckbXK/Ev+jPIF+ussxJRaFRIxYCAkxeYcTdccuQoPw5emVWXkox6JnMejFryjlCs/sw2cokMO2lHxjQ==",
+			"requires": {
+				"lightercollective": "0.0.0"
+			}
+		},
+		"domexception": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"requires": {
+				"webidl-conversions": "4.0.2"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"optional": true,
+			"requires": {
+				"jsbn": "0.1.1"
+			}
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"escodegen": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+			"requires": {
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.6.1"
+			}
+		},
+		"esprima": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"fast-deep-equal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+		},
+		"fbjs": {
+			"version": "0.8.16",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"requires": {
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.17"
+			}
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+		},
+		"form-data": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"requires": {
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.6",
+				"mime-types": "2.1.18"
+			}
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			}
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+		},
+		"har-validator": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"requires": {
+				"ajv": "5.5.2",
+				"har-schema": "2.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "5.5.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+					"requires": {
+						"co": "4.6.0",
+						"fast-deep-equal": "1.1.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1"
+					}
+				}
+			}
+		},
+		"hawk": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+			"requires": {
+				"boom": "4.3.1",
+				"cryptiles": "3.1.2",
+				"hoek": "4.2.1",
+				"sntp": "2.1.0"
+			}
+		},
+		"hoek": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+		},
+		"html-encoding-sniffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"requires": {
+				"whatwg-encoding": "1.0.3"
+			}
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.13.1"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.3"
+			}
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"optional": true
+		},
+		"jsdom": {
+			"version": "11.6.2",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
+			"integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
+			"requires": {
+				"abab": "1.0.4",
+				"acorn": "5.5.3",
+				"acorn-globals": "4.1.0",
+				"array-equal": "1.0.0",
+				"browser-process-hrtime": "0.1.2",
+				"content-type-parser": "1.0.2",
+				"cssom": "0.3.2",
+				"cssstyle": "0.2.37",
+				"domexception": "1.0.1",
+				"escodegen": "1.9.1",
+				"html-encoding-sniffer": "1.0.2",
+				"left-pad": "1.2.0",
+				"nwmatcher": "1.4.3",
+				"parse5": "4.0.0",
+				"pn": "1.1.0",
+				"request": "2.83.0",
+				"request-promise-native": "1.0.5",
+				"sax": "1.2.4",
+				"symbol-tree": "3.2.2",
+				"tough-cookie": "2.3.4",
+				"w3c-hr-time": "1.0.1",
+				"webidl-conversions": "4.0.2",
+				"whatwg-encoding": "1.0.3",
+				"whatwg-url": "6.4.0",
+				"ws": "4.1.0",
+				"xml-name-validator": "3.0.0"
+			}
+		},
+		"jsdom-global": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
+			"integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk="
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"requires": {
+				"jsonify": "0.0.0"
+			}
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			}
+		},
+		"left-pad": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
+			"integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"requires": {
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
+			}
+		},
+		"lightercollective": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/lightercollective/-/lightercollective-0.0.0.tgz",
+			"integrity": "sha512-4SdGgHgQjlqhk90QxAYsltGEI6HHt30xy9fOIPKi+c3vcGRcpPDtzm6+kxr1N9ixkrx/ngMhTCe/VpBc/HmNBQ=="
+		},
+		"lodash": {
+			"version": "4.17.4",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+		},
+		"lodash-es": {
+			"version": "4.17.7",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.7.tgz",
+			"integrity": "sha512-jzqTi3vk4J5Dxq43cNjB0ekfCjPLHixoY2Sc0WHTo+0r928taLqe/VCt02vY5uQBvg0rdXgL3xWkK4X0MCmZcw=="
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"requires": {
+				"js-tokens": "3.0.2"
+			}
+		},
+		"mime-db": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+		},
+		"mime-types": {
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+			"requires": {
+				"mime-db": "1.33.0"
+			}
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
+			}
+		},
+		"nwmatcher": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
+			"integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw=="
+		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"requires": {
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
+			}
+		},
+		"parse5": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+		},
+		"pn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "2.0.6"
+			}
+		},
+		"prop-types": {
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			}
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+		},
+		"qs": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+		},
+		"react-dom": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
+			"integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
+			}
+		},
+		"redux": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"requires": {
+				"lodash": "4.17.4",
+				"lodash-es": "4.17.7",
+				"loose-envify": "1.3.1",
+				"symbol-observable": "1.2.0"
+			}
+		},
+		"redux-mock-store": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.4.0.tgz",
+			"integrity": "sha512-y+SGh/SONWwqs4DiyHjd0H6NMgz368wXDiUjSHuOnMEr4dN9PmjV6N3bNvxoILaIQ7zeVKclLyxsCQ2TwGZfEw==",
+			"requires": {
+				"lodash.isplainobject": "4.0.6"
+			}
+		},
+		"request": {
+			"version": "2.83.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+			"requires": {
+				"aws-sign2": "0.7.0",
+				"aws4": "1.6.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.6",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.2",
+				"har-validator": "5.0.3",
+				"hawk": "6.0.2",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.18",
+				"oauth-sign": "0.8.2",
+				"performance-now": "2.1.0",
+				"qs": "6.5.1",
+				"safe-buffer": "5.1.1",
+				"stringstream": "0.0.5",
+				"tough-cookie": "2.3.4",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.2.1"
+			}
+		},
+		"request-promise-core": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"requires": {
+				"lodash": "4.17.4"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"requires": {
+				"request-promise-core": "1.1.1",
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.3.4"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+		},
+		"sntp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+			"requires": {
+				"hoek": "4.2.1"
+			}
+		},
+		"source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"optional": true
+		},
+		"sshpk": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"requires": {
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+		},
+		"stringstream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+		},
+		"symbol-observable": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+		},
+		"symbol-tree": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+		},
+		"tough-cookie": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+			"requires": {
+				"punycode": "1.4.1"
+			}
+		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"requires": {
+				"punycode": "2.1.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+				}
+			}
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"optional": true
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"requires": {
+				"prelude-ls": "1.1.2"
+			}
+		},
+		"ua-parser-js": {
+			"version": "0.7.17",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+		},
+		"uuid": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "1.3.0"
+			}
+		},
+		"w3c-hr-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"requires": {
+				"browser-process-hrtime": "0.1.2"
+			}
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+		},
+		"whatwg-encoding": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"whatwg-fetch": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+		},
+		"whatwg-url": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+			"integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+			"requires": {
+				"lodash.sortby": "4.7.0",
+				"tr46": "1.0.1",
+				"webidl-conversions": "4.0.2"
+			}
+		},
+		"wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+		},
+		"ws": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+			"requires": {
+				"async-limiter": "1.0.0",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"xml-name-validator": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+		}
+	}
 }

--- a/packages/core/src/util/path.ts
+++ b/packages/core/src/util/path.ts
@@ -28,6 +28,7 @@ export const compose = (path1: string, path2: string) => {
  * @returns {string[]} an array containing only non-schema-specific segments
  */
 export const toDataPathSegments = (schemaPath: string): string[] => {
+
   const segments = schemaPath.split('/');
   const startFromRoot = segments[0] === '#' || segments[0] === '';
   const startIndex =  startFromRoot ? 2 : 1;
@@ -47,8 +48,12 @@ export const toDataPath = (schemaPath: string): string => {
   return toDataPathSegments(schemaPath).join('.');
 };
 
-export const composeWithUi = (scopableUi: Scopable, path: string) => {
+export const composeWithUi = (scopableUi: Scopable, path: string): string => {
   const segments = toDataPathSegments(scopableUi.scope);
+
+  if (_.isEmpty(segments) && path === undefined) {
+    return '';
+  }
 
   return _.isEmpty(segments) ? path : compose(path, segments.join('.'));
 };

--- a/packages/examples/package-lock.json
+++ b/packages/examples/package-lock.json
@@ -1,194 +1,185 @@
 {
-  "name": "@jsonforms/examples",
-  "version": "2.0.0-rc.2",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.19"
-      }
-    },
-    "fbjs": {
-      "version": "0.8.16",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
-      "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.17"
-      }
-    },
-    "hoist-non-react-statics": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
-      "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
-    },
-    "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-    },
-    "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
-      }
-    },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-    },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-    },
-    "lodash-es": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
-    },
-    "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "requires": {
-        "js-tokens": "3.0.2"
-      }
-    },
-    "moment": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "2.0.6"
-      }
-    },
-    "prop-types": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
-    },
-    "react": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
-      "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
-      }
-    },
-    "react-redux": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz",
-      "integrity": "sha512-8taaaGu+J7PMJQDJrk/xiWEYQmdo3mkXw6wPr3K3LxvXis3Fymiq7c13S+Tpls/AyNUAsoONkU81AP0RA6y6Vw==",
-      "requires": {
-        "hoist-non-react-statics": "2.3.1",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
-        "loose-envify": "1.3.1",
-        "prop-types": "15.6.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        }
-      }
-    },
-    "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
-      "requires": {
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
-        "loose-envify": "1.3.1",
-        "symbol-observable": "1.1.0"
-      }
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-    },
-    "symbol-observable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
-      "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw=="
-    },
-    "ua-parser-js": {
-      "version": "0.7.17",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
-    },
-    "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
-    }
-  }
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+		},
+		"core-js": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.16",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"requires": {
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.17"
+			}
+		},
+		"hoist-non-react-statics": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
+			"integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+		},
+		"invariant": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
+			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+			"requires": {
+				"loose-envify": "1.3.1"
+			}
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.3"
+			}
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"lodash": {
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+		},
+		"lodash-es": {
+			"version": "4.17.7",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.7.tgz",
+			"integrity": "sha512-jzqTi3vk4J5Dxq43cNjB0ekfCjPLHixoY2Sc0WHTo+0r928taLqe/VCt02vY5uQBvg0rdXgL3xWkK4X0MCmZcw=="
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"requires": {
+				"js-tokens": "3.0.2"
+			}
+		},
+		"moment": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+			"integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "2.0.6"
+			}
+		},
+		"prop-types": {
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			}
+		},
+		"react": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
+			"integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
+			}
+		},
+		"react-redux": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+			"integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+			"requires": {
+				"hoist-non-react-statics": "2.5.0",
+				"invariant": "2.2.3",
+				"lodash": "4.17.5",
+				"lodash-es": "4.17.7",
+				"loose-envify": "1.3.1",
+				"prop-types": "15.6.1"
+			}
+		},
+		"redux": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"requires": {
+				"lodash": "4.17.5",
+				"lodash-es": "4.17.7",
+				"loose-envify": "1.3.1",
+				"symbol-observable": "1.2.0"
+			}
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+		},
+		"symbol-observable": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+		},
+		"ua-parser-js": {
+			"version": "0.7.17",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+		},
+		"whatwg-fetch": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+		}
+	}
 }

--- a/packages/i18n/package-lock.json
+++ b/packages/i18n/package-lock.json
@@ -1,46 +1,40 @@
 {
-	"name": "@jsonforms/i18n",
-	"version": "2.0.0-rc.2",
-	"lockfileVersion": 1,
 	"requires": true,
+	"lockfileVersion": 1,
 	"dependencies": {
 		"abab": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
-			"dev": true
+			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
 		},
 		"acorn": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-			"integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
-			"dev": true
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
 		},
 		"acorn-globals": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
 			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
-			"dev": true,
 			"requires": {
-				"acorn": "5.3.0"
+				"acorn": "5.5.3"
 			}
 		},
 		"ajv": {
 			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-			"dev": true,
 			"requires": {
 				"co": "4.6.0",
-				"fast-deep-equal": "1.0.0",
+				"fast-deep-equal": "1.1.0",
 				"fast-json-stable-stringify": "2.0.0",
 				"json-schema-traverse": "0.3.1"
 			}
 		},
 		"argparse": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
 				"sprintf-js": "1.0.3"
 			}
@@ -48,8 +42,7 @@
 		"array-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-			"dev": true
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
 		},
 		"asap": {
 			"version": "2.0.6",
@@ -59,20 +52,17 @@
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-			"dev": true
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"async-limiter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-			"dev": true
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -82,20 +72,17 @@
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"dev": true
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-			"dev": true
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"tweetnacl": "0.14.5"
@@ -105,41 +92,37 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-			"dev": true,
 			"requires": {
-				"hoek": "4.2.0"
+				"hoek": "4.2.1"
 			}
 		},
 		"browser-process-hrtime": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
-			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
-			"dev": true
+			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"dev": true
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-			"dev": true
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
 		},
 		"combined-stream": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"requires": {
 				"delayed-stream": "1.0.0"
 			}
 		},
 		"commander": {
-			"version": "2.13.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-			"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
+			"integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg=="
 		},
 		"component-emitter": {
 			"version": "1.2.1",
@@ -149,8 +132,7 @@
 		"content-type-parser": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
-			"dev": true
+			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
 		},
 		"cookiejar": {
 			"version": "2.1.1",
@@ -171,7 +153,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
 			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-			"dev": true,
 			"requires": {
 				"boom": "5.2.0"
 			},
@@ -180,9 +161,8 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-					"dev": true,
 					"requires": {
-						"hoek": "4.2.0"
+						"hoek": "4.2.1"
 					}
 				}
 			}
@@ -190,14 +170,12 @@
 		"cssom": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
-			"dev": true
+			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
 		},
 		"cssstyle": {
 			"version": "0.2.37",
 			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
 			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-			"dev": true,
 			"requires": {
 				"cssom": "0.3.2"
 			}
@@ -206,7 +184,6 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0"
 			}
@@ -222,8 +199,7 @@
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-			"dev": true
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
@@ -234,7 +210,6 @@
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.7.2.tgz",
 			"integrity": "sha512-E+y3qJgckbXK/Ev+jPIF+ussxJRaFRIxYCAkxeYcTdccuQoPw5emVWXkox6JnMejFryjlCs/sw2cokMO2lHxjQ==",
-			"dev": true,
 			"requires": {
 				"lightercollective": "0.0.0"
 			}
@@ -243,7 +218,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
-			"dev": true,
 			"requires": {
 				"webidl-conversions": "4.0.2"
 			}
@@ -252,7 +226,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"jsbn": "0.1.1"
@@ -272,35 +245,31 @@
 			"integrity": "sha1-m/tzY/7//4emzbbNk+QF7DxLbyY="
 		},
 		"escodegen": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-			"integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
-			"dev": true,
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
 			"requires": {
 				"esprima": "3.1.3",
 				"estraverse": "4.2.0",
 				"esutils": "2.0.2",
 				"optionator": "0.8.2",
-				"source-map": "0.5.7"
+				"source-map": "0.6.1"
 			}
 		},
 		"esprima": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-			"dev": true
+			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
 		},
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-			"dev": true
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-			"dev": true
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
 		"extend": {
 			"version": "3.0.1",
@@ -310,26 +279,22 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
-			"dev": true
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-			"dev": true
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-			"dev": true
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"fbjs": {
 			"version": "0.8.16",
@@ -348,29 +313,27 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-			"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
 				"asynckit": "0.4.0",
-				"combined-stream": "1.0.5",
-				"mime-types": "2.1.17"
+				"combined-stream": "1.0.6",
+				"mime-types": "2.1.18"
 			}
 		},
 		"formidable": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
-			"integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.0.tgz",
+			"integrity": "sha512-hr9aT30rAi7kf8Q2aaTpSP7xGMhlJ+MdrUDVZs3rxbD3L/K46A86s2VY7qC2D2kGYGBtiT/3j6wTx1eeUq5xAQ=="
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0"
 			}
@@ -380,20 +343,18 @@
 			"resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
 			"integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
 			"requires": {
-				"lodash": "4.17.4"
+				"lodash": "4.17.5"
 			}
 		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"dev": true
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 		},
 		"har-validator": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"har-schema": "2.0.0"
@@ -403,30 +364,27 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
 			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-			"dev": true,
 			"requires": {
 				"boom": "4.3.1",
 				"cryptiles": "3.1.2",
-				"hoek": "4.2.0",
+				"hoek": "4.2.1",
 				"sntp": "2.1.0"
 			}
 		},
 		"hoek": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-			"integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-			"dev": true
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
 		},
 		"hoist-non-react-statics": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
-			"integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
+			"integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
 		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-			"dev": true,
 			"requires": {
 				"whatwg-encoding": "1.0.3"
 			}
@@ -435,7 +393,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"jsprim": "1.4.1",
@@ -453,9 +410,9 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"invariant": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
+			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
 			"requires": {
 				"loose-envify": "1.3.1"
 			}
@@ -468,8 +425,7 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -488,8 +444,7 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"js-tokens": {
 			"version": "3.0.2",
@@ -497,11 +452,11 @@
 			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
 		"js-yaml": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
 			"requires": {
-				"argparse": "1.0.9",
+				"argparse": "1.0.10",
 				"esprima": "4.0.0"
 			},
 			"dependencies": {
@@ -516,17 +471,15 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true,
 			"optional": true
 		},
 		"jsdom": {
 			"version": "11.6.2",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
 			"integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
-			"dev": true,
 			"requires": {
 				"abab": "1.0.4",
-				"acorn": "5.3.0",
+				"acorn": "5.5.3",
 				"acorn-globals": "4.1.0",
 				"array-equal": "1.0.0",
 				"browser-process-hrtime": "0.1.2",
@@ -534,7 +487,7 @@
 				"cssom": "0.3.2",
 				"cssstyle": "0.2.37",
 				"domexception": "1.0.1",
-				"escodegen": "1.9.0",
+				"escodegen": "1.9.1",
 				"html-encoding-sniffer": "1.0.2",
 				"left-pad": "1.2.0",
 				"nwmatcher": "1.4.3",
@@ -544,29 +497,28 @@
 				"request-promise-native": "1.0.5",
 				"sax": "1.2.4",
 				"symbol-tree": "3.2.2",
-				"tough-cookie": "2.3.3",
+				"tough-cookie": "2.3.4",
 				"w3c-hr-time": "1.0.1",
 				"webidl-conversions": "4.0.2",
 				"whatwg-encoding": "1.0.3",
 				"whatwg-url": "6.4.0",
-				"ws": "4.0.0",
+				"ws": "4.1.0",
 				"xml-name-validator": "3.0.0"
 			}
 		},
 		"jsdom-global": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
-			"integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
-			"dev": true
+			"integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk="
 		},
 		"json-refs": {
 			"version": "2.1.7",
 			"resolved": "https://registry.npmjs.org/json-refs/-/json-refs-2.1.7.tgz",
 			"integrity": "sha1-uesB/in16j6Sh48VrqEK04taz4k=",
 			"requires": {
-				"commander": "2.13.0",
+				"commander": "2.15.0",
 				"graphlib": "2.1.5",
-				"js-yaml": "3.10.0",
+				"js-yaml": "3.11.0",
 				"native-promise-only": "0.8.1",
 				"path-loader": "1.0.4",
 				"slash": "1.0.0",
@@ -576,26 +528,22 @@
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"dev": true
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-			"dev": true
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -606,14 +554,12 @@
 		"left-pad": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
-			"integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
-			"dev": true
+			"integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
 		},
 		"levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2",
 				"type-check": "0.3.2"
@@ -622,24 +568,22 @@
 		"lightercollective": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/lightercollective/-/lightercollective-0.0.0.tgz",
-			"integrity": "sha512-4SdGgHgQjlqhk90QxAYsltGEI6HHt30xy9fOIPKi+c3vcGRcpPDtzm6+kxr1N9ixkrx/ngMhTCe/VpBc/HmNBQ==",
-			"dev": true
+			"integrity": "sha512-4SdGgHgQjlqhk90QxAYsltGEI6HHt30xy9fOIPKi+c3vcGRcpPDtzm6+kxr1N9ixkrx/ngMhTCe/VpBc/HmNBQ=="
 		},
 		"lodash": {
-			"version": "4.17.4",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
 		},
 		"lodash-es": {
-			"version": "4.17.4",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-			"integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+			"version": "4.17.7",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.7.tgz",
+			"integrity": "sha512-jzqTi3vk4J5Dxq43cNjB0ekfCjPLHixoY2Sc0WHTo+0r928taLqe/VCt02vY5uQBvg0rdXgL3xWkK4X0MCmZcw=="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-			"dev": true
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
 		},
 		"loose-envify": {
 			"version": "1.3.1",
@@ -660,22 +604,22 @@
 			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
 		},
 		"mime-db": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-			"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
 		},
 		"mime-types": {
-			"version": "2.1.17",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"requires": {
-				"mime-db": "1.30.0"
+				"mime-db": "1.33.0"
 			}
 		},
 		"moment": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-			"integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+			"integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
 		},
 		"ms": {
 			"version": "2.0.0",
@@ -699,14 +643,12 @@
 		"nwmatcher": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-			"integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
-			"dev": true
+			"integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw=="
 		},
 		"oauth-sign": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-			"dev": true
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -717,7 +659,6 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-			"dev": true,
 			"requires": {
 				"deep-is": "0.1.3",
 				"fast-levenshtein": "2.0.6",
@@ -730,8 +671,7 @@
 		"parse5": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
-			"dev": true
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
 		},
 		"path-loader": {
 			"version": "1.0.4",
@@ -745,25 +685,22 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-			"dev": true
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-			"dev": true
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
 		"process-nextick-args": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"promise": {
 			"version": "7.3.1",
@@ -774,9 +711,9 @@
 			}
 		},
 		"prop-types": {
-			"version": "15.6.0",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-			"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 			"requires": {
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
@@ -786,8 +723,7 @@
 		"punycode": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-			"dev": true
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
 		},
 		"qs": {
 			"version": "6.5.1",
@@ -802,7 +738,7 @@
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
 				"object-assign": "4.1.1",
-				"prop-types": "15.6.0"
+				"prop-types": "15.6.1"
 			}
 		},
 		"react-dom": {
@@ -813,31 +749,31 @@
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
 				"object-assign": "4.1.1",
-				"prop-types": "15.6.0"
+				"prop-types": "15.6.1"
 			}
 		},
 		"react-redux": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz",
-			"integrity": "sha512-8taaaGu+J7PMJQDJrk/xiWEYQmdo3mkXw6wPr3K3LxvXis3Fymiq7c13S+Tpls/AyNUAsoONkU81AP0RA6y6Vw==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+			"integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
 			"requires": {
-				"hoist-non-react-statics": "2.3.1",
-				"invariant": "2.2.2",
-				"lodash": "4.17.4",
-				"lodash-es": "4.17.4",
+				"hoist-non-react-statics": "2.5.0",
+				"invariant": "2.2.3",
+				"lodash": "4.17.5",
+				"lodash-es": "4.17.7",
 				"loose-envify": "1.3.1",
-				"prop-types": "15.6.0"
+				"prop-types": "15.6.1"
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
 				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
+				"process-nextick-args": "2.0.0",
 				"safe-buffer": "5.1.1",
 				"string_decoder": "1.0.3",
 				"util-deprecate": "1.0.2"
@@ -848,8 +784,8 @@
 			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
 			"requires": {
-				"lodash": "4.17.4",
-				"lodash-es": "4.17.4",
+				"lodash": "4.17.5",
+				"lodash-es": "4.17.7",
 				"loose-envify": "1.3.1",
 				"symbol-observable": "1.2.0"
 			}
@@ -858,28 +794,27 @@
 			"version": "2.83.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
 			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-			"dev": true,
 			"requires": {
 				"aws-sign2": "0.7.0",
 				"aws4": "1.6.0",
 				"caseless": "0.12.0",
-				"combined-stream": "1.0.5",
+				"combined-stream": "1.0.6",
 				"extend": "3.0.1",
 				"forever-agent": "0.6.1",
-				"form-data": "2.3.1",
+				"form-data": "2.3.2",
 				"har-validator": "5.0.3",
 				"hawk": "6.0.2",
 				"http-signature": "1.2.0",
 				"is-typedarray": "1.0.0",
 				"isstream": "0.1.2",
 				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.17",
+				"mime-types": "2.1.18",
 				"oauth-sign": "0.8.2",
 				"performance-now": "2.1.0",
 				"qs": "6.5.1",
 				"safe-buffer": "5.1.1",
 				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.3",
+				"tough-cookie": "2.3.4",
 				"tunnel-agent": "0.6.0",
 				"uuid": "3.2.1"
 			}
@@ -888,20 +823,18 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-			"dev": true,
 			"requires": {
-				"lodash": "4.17.4"
+				"lodash": "4.17.5"
 			}
 		},
 		"request-promise-native": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
 			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
-			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.1",
 				"stealthy-require": "1.1.1",
-				"tough-cookie": "2.3.3"
+				"tough-cookie": "2.3.4"
 			}
 		},
 		"safe-buffer": {
@@ -912,8 +845,7 @@
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-			"dev": true
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"setimmediate": {
 			"version": "1.0.5",
@@ -929,16 +861,14 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
 			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-			"dev": true,
 			"requires": {
-				"hoek": "4.2.0"
+				"hoek": "4.2.1"
 			}
 		},
 		"source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-			"dev": true,
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"optional": true
 		},
 		"sprintf-js": {
@@ -950,7 +880,6 @@
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
 			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-			"dev": true,
 			"requires": {
 				"asn1": "0.2.3",
 				"assert-plus": "1.0.0",
@@ -965,8 +894,7 @@
 		"stealthy-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-			"dev": true
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
 		},
 		"string_decoder": {
 			"version": "1.0.3",
@@ -979,8 +907,7 @@
 		"stringstream": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-			"dev": true
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
 		},
 		"superagent": {
 			"version": "3.8.2",
@@ -991,12 +918,12 @@
 				"cookiejar": "2.1.1",
 				"debug": "3.1.0",
 				"extend": "3.0.1",
-				"form-data": "2.3.1",
-				"formidable": "1.1.1",
+				"form-data": "2.3.2",
+				"formidable": "1.2.0",
 				"methods": "1.1.2",
 				"mime": "1.6.0",
 				"qs": "6.5.1",
-				"readable-stream": "2.3.3"
+				"readable-stream": "2.3.5"
 			}
 		},
 		"symbol-observable": {
@@ -1007,14 +934,12 @@
 		"symbol-tree": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
-			"dev": true
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
 		},
 		"tough-cookie": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-			"dev": true,
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 			"requires": {
 				"punycode": "1.4.1"
 			}
@@ -1023,7 +948,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-			"dev": true,
 			"requires": {
 				"punycode": "2.1.0"
 			},
@@ -1031,8 +955,7 @@
 				"punycode": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
-					"dev": true
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
 				}
 			}
 		},
@@ -1040,7 +963,6 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -1049,14 +971,12 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true,
 			"optional": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2"
 			}
@@ -1065,12 +985,6 @@
 			"version": "0.7.17",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
 			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
-		},
-		"ultron": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-			"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-			"dev": true
 		},
 		"uri-js": {
 			"version": "3.0.2",
@@ -1095,14 +1009,12 @@
 		"uuid": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-			"dev": true
+			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
 		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
@@ -1113,7 +1025,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
-			"dev": true,
 			"requires": {
 				"browser-process-hrtime": "0.1.2"
 			}
@@ -1121,14 +1032,12 @@
 		"webidl-conversions": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-			"dev": true
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"whatwg-encoding": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
 			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
-			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.19"
 			}
@@ -1142,7 +1051,6 @@
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
 			"integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
-			"dev": true,
 			"requires": {
 				"lodash.sortby": "4.7.0",
 				"tr46": "1.0.1",
@@ -1152,25 +1060,21 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-			"dev": true
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
 		},
 		"ws": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-4.0.0.tgz",
-			"integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
-			"dev": true,
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
 			"requires": {
 				"async-limiter": "1.0.0",
-				"safe-buffer": "5.1.1",
-				"ultron": "1.1.1"
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
-			"dev": true
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
 		}
 	}
 }

--- a/packages/material/__mocks__/popper.js.ts
+++ b/packages/material/__mocks__/popper.js.ts
@@ -1,0 +1,10 @@
+import PopperJs from 'popper.js';
+
+export default class Popper {
+  constructor() {
+    return {
+      destroy: () => {},
+      scheduleUpdate: () => {}
+    };
+  }
+}

--- a/packages/material/package-lock.json
+++ b/packages/material/package-lock.json
@@ -1,20 +1,16 @@
 {
-  "name": "@jsonforms/material-renderers",
-  "version": "2.0.0-rc.3",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@ava/babel-plugin-throws-helper": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-2.0.0.tgz",
-      "integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw=",
-      "dev": true
+      "integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw="
     },
     "@ava/babel-preset-stage-4": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-1.1.0.tgz",
       "integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
-      "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
         "babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -34,7 +30,6 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
           "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-          "dev": true,
           "requires": {
             "md5-o-matic": "0.1.1"
           }
@@ -43,7 +38,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-1.2.0.tgz",
           "integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
-          "dev": true,
           "requires": {
             "md5-hex": "1.3.0"
           }
@@ -54,7 +48,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-3.0.0.tgz",
       "integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
-      "dev": true,
       "requires": {
         "@ava/babel-plugin-throws-helper": "2.0.0",
         "babel-plugin-espower": "2.3.2"
@@ -64,7 +57,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ava/write-file-atomic/-/write-file-atomic-2.2.0.tgz",
       "integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
@@ -75,7 +67,6 @@
       "version": "7.0.0-beta.40",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
       "integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "7.0.0-beta.40"
       }
@@ -84,7 +75,6 @@
       "version": "7.0.0-beta.40",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
       "integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
-      "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "esutils": "2.0.2",
@@ -95,7835 +85,24 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz",
       "integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
-      "dev": true,
       "requires": {
         "arrify": "1.0.1"
-      }
-    },
-    "@jsonforms/core": {
-      "version": "2.0.0-rc.3",
-      "requires": {
-        "ajv": "4.11.8",
-        "lodash": "4.17.4",
-        "redux": "3.7.2",
-        "uuid": "3.1.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.0.57",
-          "bundled": true
-        },
-        "abab": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "acorn": {
-          "version": "5.2.1",
-          "bundled": true
-        },
-        "acorn-globals": {
-          "version": "4.1.0",
-          "bundled": true,
-          "requires": {
-            "acorn": "5.2.1"
-          }
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "array-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asap": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "boom": {
-          "version": "4.3.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "browser-process-hrtime": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "content-type-parser": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "cssom": {
-          "version": "0.3.2",
-          "bundled": true
-        },
-        "cssstyle": {
-          "version": "0.2.37",
-          "bundled": true,
-          "requires": {
-            "cssom": "0.3.2"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "deep-is": {
-          "version": "0.1.3",
-          "bundled": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "document-register-element": {
-          "version": "1.7.0",
-          "bundled": true
-        },
-        "domexception": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "0.4.19"
-          }
-        },
-        "escodegen": {
-          "version": "1.9.0",
-          "bundled": true,
-          "requires": {
-            "esprima": "3.1.3",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.5.7"
-          },
-          "dependencies": {
-            "esprima": {
-              "version": "3.1.3",
-              "bundled": true
-            }
-          }
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "fast-deep-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "fbjs": {
-          "version": "0.8.16",
-          "bundled": true,
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.12"
-          },
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.7",
-              "bundled": true
-            }
-          }
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "bundled": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "bundled": true,
-          "requires": {
-            "ajv": "5.5.1",
-            "har-schema": "2.0.0"
-          },
-          "dependencies": {
-            "ajv": {
-              "version": "5.5.1",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
-              }
-            }
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "bundled": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.1.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "hoist-non-react-statics": {
-          "version": "2.3.1",
-          "bundled": true
-        },
-        "html-encoding-sniffer": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "whatwg-encoding": "1.0.3"
-          }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "bundled": true
-        },
-        "invariant": {
-          "version": "2.2.2",
-          "bundled": true,
-          "requires": {
-            "loose-envify": "1.3.1"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "node-fetch": "1.7.3",
-            "whatwg-fetch": "2.0.3"
-          }
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "jsdom": {
-          "version": "11.5.1",
-          "bundled": true,
-          "requires": {
-            "abab": "1.0.4",
-            "acorn": "5.2.1",
-            "acorn-globals": "4.1.0",
-            "array-equal": "1.0.0",
-            "browser-process-hrtime": "0.1.2",
-            "content-type-parser": "1.0.2",
-            "cssom": "0.3.2",
-            "cssstyle": "0.2.37",
-            "domexception": "1.0.0",
-            "escodegen": "1.9.0",
-            "html-encoding-sniffer": "1.0.2",
-            "left-pad": "1.2.0",
-            "nwmatcher": "1.4.3",
-            "parse5": "3.0.3",
-            "pn": "1.0.0",
-            "request": "2.83.0",
-            "request-promise-native": "1.0.5",
-            "sax": "1.2.4",
-            "symbol-tree": "3.2.2",
-            "tough-cookie": "2.3.3",
-            "webidl-conversions": "4.0.2",
-            "whatwg-encoding": "1.0.3",
-            "whatwg-url": "6.4.0",
-            "xml-name-validator": "2.0.1"
-          }
-        },
-        "jsdom-global": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "bundled": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "left-pad": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "levn": {
-          "version": "0.3.0",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash-es": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash.isplainobject": {
-          "version": "4.0.6",
-          "bundled": true
-        },
-        "lodash.sortby": {
-          "version": "4.7.0",
-          "bundled": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "js-tokens": "3.0.2"
-          }
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "bundled": true,
-          "requires": {
-            "encoding": "0.1.12",
-            "is-stream": "1.1.0"
-          }
-        },
-        "nwmatcher": {
-          "version": "1.4.3",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "optionator": {
-          "version": "0.8.2",
-          "bundled": true,
-          "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.6",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
-          }
-        },
-        "parse5": {
-          "version": "3.0.3",
-          "bundled": true,
-          "requires": {
-            "@types/node": "8.0.57"
-          }
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "pn": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "bundled": true,
-          "requires": {
-            "asap": "2.0.6"
-          }
-        },
-        "prop-types": {
-          "version": "15.6.0",
-          "bundled": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
-          }
-        },
-        "punycode": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.5.1",
-          "bundled": true
-        },
-        "react": {
-          "version": "16.2.0",
-          "bundled": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "react-dom": {
-          "version": "16.2.0",
-          "bundled": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "react-redux": {
-          "version": "5.0.6",
-          "bundled": true,
-          "requires": {
-            "hoist-non-react-statics": "2.3.1",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4",
-            "lodash-es": "4.17.4",
-            "loose-envify": "1.3.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "redux": {
-          "version": "3.7.2",
-          "bundled": true,
-          "requires": {
-            "lodash": "4.17.4",
-            "lodash-es": "4.17.4",
-            "loose-envify": "1.3.1",
-            "symbol-observable": "1.0.4"
-          }
-        },
-        "redux-mock-store": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "lodash.isplainobject": "4.0.6"
-          }
-        },
-        "request": {
-          "version": "2.83.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
-          }
-        },
-        "request-promise-core": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "request-promise-native": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "request-promise-core": "1.1.1",
-            "stealthy-require": "1.1.1",
-            "tough-cookie": "2.3.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true,
-          "optional": true
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "stealthy-require": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
-        "symbol-observable": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "symbol-tree": {
-          "version": "3.2.2",
-          "bundled": true
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "bundled": true,
-          "requires": {
-            "punycode": "1.4.1"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            }
-          }
-        },
-        "tr46": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "punycode": "2.1.0"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2"
-          }
-        },
-        "ua-parser-js": {
-          "version": "0.7.12",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
-        },
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "bundled": true
-        },
-        "whatwg-encoding": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "0.4.19"
-          }
-        },
-        "whatwg-fetch": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "whatwg-url": {
-          "version": "6.4.0",
-          "bundled": true,
-          "requires": {
-            "lodash.sortby": "4.7.0",
-            "tr46": "1.0.1",
-            "webidl-conversions": "4.0.2"
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "xml-name-validator": {
-          "version": "2.0.1",
-          "bundled": true
-        }
-      }
-    },
-    "@jsonforms/react": {
-      "version": "2.0.0-rc.3",
-      "requires": {
-        "@jsonforms/core": "2.0.0-rc.3",
-        "lodash": "4.17.4",
-        "react": "16.2.0",
-        "react-redux": "5.0.6"
-      },
-      "dependencies": {
-        "@jsonforms/core": {
-          "version": "2.0.0-rc.3",
-          "bundled": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "lodash": "4.17.4",
-            "redux": "3.7.2",
-            "uuid": "3.1.0"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "8.0.57",
-              "bundled": true
-            },
-            "abab": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "acorn": {
-              "version": "5.2.1",
-              "bundled": true
-            },
-            "acorn-globals": {
-              "version": "4.1.0",
-              "bundled": true,
-              "requires": {
-                "acorn": "5.2.1"
-              }
-            },
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
-              }
-            },
-            "array-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asap": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "boom": {
-              "version": "4.3.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "browser-process-hrtime": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "content-type-parser": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "boom": "5.2.0"
-              },
-              "dependencies": {}
-            },
-            "cssom": {
-              "version": "0.3.2",
-              "bundled": true
-            },
-            "cssstyle": {
-              "version": "0.2.37",
-              "bundled": true,
-              "requires": {
-                "cssom": "0.3.2"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "deep-is": {
-              "version": "0.1.3",
-              "bundled": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "document-register-element": {
-              "version": "1.7.0",
-              "bundled": true
-            },
-            "domexception": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "escodegen": {
-              "version": "1.9.0",
-              "bundled": true,
-              "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.5.7"
-              },
-              "dependencies": {}
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "fast-deep-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "fast-levenshtein": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "fbjs": {
-              "version": "0.8.16",
-              "bundled": true,
-              "requires": {
-                "core-js": "1.2.7",
-                "isomorphic-fetch": "2.2.1",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "promise": "7.3.1",
-                "setimmediate": "1.0.5",
-                "ua-parser-js": "0.7.12"
-              },
-              "dependencies": {}
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.1",
-              "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "har-schema": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "5.5.1",
-                "har-schema": "2.0.0"
-              },
-              "dependencies": {}
-            },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.1.0"
-              }
-            },
-            "hoek": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "hoist-non-react-statics": {
-              "version": "2.3.1",
-              "bundled": true
-            },
-            "html-encoding-sniffer": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "whatwg-encoding": "1.0.3"
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.19",
-              "bundled": true
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "1.3.1"
-              }
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "node-fetch": "1.7.3",
-                "whatwg-fetch": "2.0.3"
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "jsdom": {
-              "version": "11.5.1",
-              "bundled": true,
-              "requires": {
-                "abab": "1.0.4",
-                "acorn": "5.2.1",
-                "acorn-globals": "4.1.0",
-                "array-equal": "1.0.0",
-                "browser-process-hrtime": "0.1.2",
-                "content-type-parser": "1.0.2",
-                "cssom": "0.3.2",
-                "cssstyle": "0.2.37",
-                "domexception": "1.0.0",
-                "escodegen": "1.9.0",
-                "html-encoding-sniffer": "1.0.2",
-                "left-pad": "1.2.0",
-                "nwmatcher": "1.4.3",
-                "parse5": "3.0.3",
-                "pn": "1.0.0",
-                "request": "2.83.0",
-                "request-promise-native": "1.0.5",
-                "sax": "1.2.4",
-                "symbol-tree": "3.2.2",
-                "tough-cookie": "2.3.3",
-                "webidl-conversions": "4.0.2",
-                "whatwg-encoding": "1.0.3",
-                "whatwg-url": "6.4.0",
-                "xml-name-validator": "2.0.1"
-              }
-            },
-            "jsdom-global": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "bundled": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              }
-            },
-            "left-pad": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "levn": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
-              }
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash-es": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash.isplainobject": {
-              "version": "4.0.6",
-              "bundled": true
-            },
-            "lodash.sortby": {
-              "version": "4.7.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "3.0.2"
-              }
-            },
-            "mime-db": {
-              "version": "1.30.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              }
-            },
-            "node-fetch": {
-              "version": "1.7.3",
-              "bundled": true,
-              "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
-              }
-            },
-            "nwmatcher": {
-              "version": "1.4.3",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "bundled": true,
-              "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
-              }
-            },
-            "parse5": {
-              "version": "3.0.3",
-              "bundled": true,
-              "requires": {
-                "@types/node": "8.0.57"
-              }
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "pn": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "prelude-ls": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "promise": {
-              "version": "7.3.1",
-              "bundled": true,
-              "requires": {
-                "asap": "2.0.6"
-              }
-            },
-            "prop-types": {
-              "version": "15.6.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1"
-              }
-            },
-            "punycode": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
-            "react": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-dom": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-redux": {
-              "version": "5.0.6",
-              "bundled": true,
-              "requires": {
-                "hoist-non-react-statics": "2.3.1",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "redux": {
-              "version": "3.7.2",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "symbol-observable": "1.0.4"
-              }
-            },
-            "redux-mock-store": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.isplainobject": "4.0.6"
-              }
-            },
-            "request": {
-              "version": "2.83.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
-              }
-            },
-            "request-promise-core": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4"
-              }
-            },
-            "request-promise-native": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "bundled": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "sntp": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true,
-              "optional": true
-            },
-            "sshpk": {
-              "version": "1.13.1",
-              "bundled": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "stealthy-require": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "symbol-observable": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "symbol-tree": {
-              "version": "3.2.2",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              },
-              "dependencies": {}
-            },
-            "tr46": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "punycode": "2.1.0"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2"
-              }
-            },
-            "ua-parser-js": {
-              "version": "0.7.12",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "bundled": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              }
-            },
-            "webidl-conversions": {
-              "version": "4.0.2",
-              "bundled": true
-            },
-            "whatwg-encoding": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "whatwg-fetch": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "whatwg-url": {
-              "version": "6.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.sortby": "4.7.0",
-                "tr46": "1.0.1",
-                "webidl-conversions": "4.0.2"
-              }
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "xml-name-validator": {
-              "version": "2.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "abab": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "acorn": {
-          "version": "5.4.1",
-          "bundled": true
-        },
-        "acorn-globals": {
-          "version": "4.1.0",
-          "bundled": true,
-          "requires": {
-            "acorn": "5.4.1"
-          }
-        },
-        "ajv": {
-          "version": "5.5.2",
-          "bundled": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
-        },
-        "array-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asap": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "async-limiter": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "boom": {
-          "version": "4.3.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "browser-process-hrtime": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "content-type-parser": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "cssom": {
-          "version": "0.3.2",
-          "bundled": true
-        },
-        "cssstyle": {
-          "version": "0.2.37",
-          "bundled": true,
-          "requires": {
-            "cssom": "0.3.2"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "deep-is": {
-          "version": "0.1.3",
-          "bundled": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "document-register-element": {
-          "version": "1.7.2",
-          "bundled": true,
-          "requires": {
-            "lightercollective": "0.0.0"
-          }
-        },
-        "domexception": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "webidl-conversions": "4.0.2"
-          }
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "0.4.19"
-          }
-        },
-        "escodegen": {
-          "version": "1.9.0",
-          "bundled": true,
-          "requires": {
-            "esprima": "3.1.3",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.5.7"
-          }
-        },
-        "esprima": {
-          "version": "3.1.3",
-          "bundled": true
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "fast-deep-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "fbjs": {
-          "version": "0.8.16",
-          "bundled": true,
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.17"
-          }
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "bundled": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "bundled": true,
-          "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "bundled": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.1.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "hoist-non-react-statics": {
-          "version": "2.3.1",
-          "bundled": true
-        },
-        "html-encoding-sniffer": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "whatwg-encoding": "1.0.3"
-          }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "bundled": true
-        },
-        "invariant": {
-          "version": "2.2.2",
-          "bundled": true,
-          "requires": {
-            "loose-envify": "1.3.1"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "node-fetch": "1.7.3",
-            "whatwg-fetch": "2.0.3"
-          }
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "jsdom": {
-          "version": "11.6.2",
-          "bundled": true,
-          "requires": {
-            "abab": "1.0.4",
-            "acorn": "5.4.1",
-            "acorn-globals": "4.1.0",
-            "array-equal": "1.0.0",
-            "browser-process-hrtime": "0.1.2",
-            "content-type-parser": "1.0.2",
-            "cssom": "0.3.2",
-            "cssstyle": "0.2.37",
-            "domexception": "1.0.1",
-            "escodegen": "1.9.0",
-            "html-encoding-sniffer": "1.0.2",
-            "left-pad": "1.2.0",
-            "nwmatcher": "1.4.3",
-            "parse5": "4.0.0",
-            "pn": "1.1.0",
-            "request": "2.83.0",
-            "request-promise-native": "1.0.5",
-            "sax": "1.2.4",
-            "symbol-tree": "3.2.2",
-            "tough-cookie": "2.3.3",
-            "w3c-hr-time": "1.0.1",
-            "webidl-conversions": "4.0.2",
-            "whatwg-encoding": "1.0.3",
-            "whatwg-url": "6.4.0",
-            "ws": "4.0.0",
-            "xml-name-validator": "3.0.0"
-          }
-        },
-        "jsdom-global": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "bundled": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "left-pad": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "levn": {
-          "version": "0.3.0",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
-          }
-        },
-        "lightercollective": {
-          "version": "0.0.0",
-          "bundled": true
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash-es": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash.isplainobject": {
-          "version": "4.0.6",
-          "bundled": true
-        },
-        "lodash.sortby": {
-          "version": "4.7.0",
-          "bundled": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "js-tokens": "3.0.2"
-          }
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "bundled": true,
-          "requires": {
-            "encoding": "0.1.12",
-            "is-stream": "1.1.0"
-          }
-        },
-        "nwmatcher": {
-          "version": "1.4.3",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "optionator": {
-          "version": "0.8.2",
-          "bundled": true,
-          "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.6",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
-          }
-        },
-        "parse5": {
-          "version": "4.0.0",
-          "bundled": true
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "pn": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "bundled": true,
-          "requires": {
-            "asap": "2.0.6"
-          }
-        },
-        "prop-types": {
-          "version": "15.6.0",
-          "bundled": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
-          }
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.5.1",
-          "bundled": true
-        },
-        "react": {
-          "version": "16.2.0",
-          "bundled": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "react-dom": {
-          "version": "16.2.0",
-          "bundled": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "react-redux": {
-          "version": "5.0.6",
-          "bundled": true,
-          "requires": {
-            "hoist-non-react-statics": "2.3.1",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4",
-            "lodash-es": "4.17.4",
-            "loose-envify": "1.3.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "redux": {
-          "version": "3.7.2",
-          "bundled": true,
-          "requires": {
-            "lodash": "4.17.4",
-            "lodash-es": "4.17.4",
-            "loose-envify": "1.3.1",
-            "symbol-observable": "1.2.0"
-          }
-        },
-        "redux-mock-store": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "lodash.isplainobject": "4.0.6"
-          }
-        },
-        "request": {
-          "version": "2.83.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
-          }
-        },
-        "request-promise-core": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "request-promise-native": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "request-promise-core": "1.1.1",
-            "stealthy-require": "1.1.1",
-            "tough-cookie": "2.3.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true,
-          "optional": true
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "stealthy-require": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
-        "symbol-observable": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "symbol-tree": {
-          "version": "3.2.2",
-          "bundled": true
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "bundled": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tr46": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "punycode": "2.1.0"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "2.1.0",
-              "bundled": true
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2"
-          }
-        },
-        "ua-parser-js": {
-          "version": "0.7.17",
-          "bundled": true
-        },
-        "ultron": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.2.1",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
-        },
-        "w3c-hr-time": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "browser-process-hrtime": "0.1.2"
-          }
-        },
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "bundled": true
-        },
-        "whatwg-encoding": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "0.4.19"
-          }
-        },
-        "whatwg-fetch": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "whatwg-url": {
-          "version": "6.4.0",
-          "bundled": true,
-          "requires": {
-            "lodash.sortby": "4.7.0",
-            "tr46": "1.0.1",
-            "webidl-conversions": "4.0.2"
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "ws": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "async-limiter": "1.0.0",
-            "safe-buffer": "5.1.1",
-            "ultron": "1.1.1"
-          }
-        },
-        "xml-name-validator": {
-          "version": "3.0.0",
-          "bundled": true
-        }
-      }
-    },
-    "@jsonforms/test": {
-      "version": "2.0.0-rc.3",
-      "dev": true,
-      "dependencies": {
-        "@jsonforms/core": {
-          "bundled": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "lodash": "4.17.4",
-            "redux": "3.7.2",
-            "uuid": "3.1.0"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "8.0.57",
-              "bundled": true
-            },
-            "abab": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "acorn": {
-              "version": "5.2.1",
-              "bundled": true
-            },
-            "acorn-globals": {
-              "version": "4.1.0",
-              "bundled": true,
-              "requires": {
-                "acorn": "5.2.1"
-              }
-            },
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
-              }
-            },
-            "array-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asap": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "boom": {
-              "version": "4.3.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "browser-process-hrtime": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "content-type-parser": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "boom": "5.2.0"
-              },
-              "dependencies": {}
-            },
-            "cssom": {
-              "version": "0.3.2",
-              "bundled": true
-            },
-            "cssstyle": {
-              "version": "0.2.37",
-              "bundled": true,
-              "requires": {
-                "cssom": "0.3.2"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "deep-is": {
-              "version": "0.1.3",
-              "bundled": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "document-register-element": {
-              "version": "1.7.0",
-              "bundled": true
-            },
-            "domexception": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "escodegen": {
-              "version": "1.9.0",
-              "bundled": true,
-              "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.5.7"
-              },
-              "dependencies": {}
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "fast-deep-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "fast-levenshtein": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "fbjs": {
-              "version": "0.8.16",
-              "bundled": true,
-              "requires": {
-                "core-js": "1.2.7",
-                "isomorphic-fetch": "2.2.1",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "promise": "7.3.1",
-                "setimmediate": "1.0.5",
-                "ua-parser-js": "0.7.12"
-              },
-              "dependencies": {}
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.1",
-              "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "har-schema": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "5.5.1",
-                "har-schema": "2.0.0"
-              },
-              "dependencies": {}
-            },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.1.0"
-              }
-            },
-            "hoek": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "hoist-non-react-statics": {
-              "version": "2.3.1",
-              "bundled": true
-            },
-            "html-encoding-sniffer": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "whatwg-encoding": "1.0.3"
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.19",
-              "bundled": true
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "1.3.1"
-              }
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "node-fetch": "1.7.3",
-                "whatwg-fetch": "2.0.3"
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "jsdom": {
-              "version": "11.5.1",
-              "bundled": true,
-              "requires": {
-                "abab": "1.0.4",
-                "acorn": "5.2.1",
-                "acorn-globals": "4.1.0",
-                "array-equal": "1.0.0",
-                "browser-process-hrtime": "0.1.2",
-                "content-type-parser": "1.0.2",
-                "cssom": "0.3.2",
-                "cssstyle": "0.2.37",
-                "domexception": "1.0.0",
-                "escodegen": "1.9.0",
-                "html-encoding-sniffer": "1.0.2",
-                "left-pad": "1.2.0",
-                "nwmatcher": "1.4.3",
-                "parse5": "3.0.3",
-                "pn": "1.0.0",
-                "request": "2.83.0",
-                "request-promise-native": "1.0.5",
-                "sax": "1.2.4",
-                "symbol-tree": "3.2.2",
-                "tough-cookie": "2.3.3",
-                "webidl-conversions": "4.0.2",
-                "whatwg-encoding": "1.0.3",
-                "whatwg-url": "6.4.0",
-                "xml-name-validator": "2.0.1"
-              }
-            },
-            "jsdom-global": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "bundled": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              }
-            },
-            "left-pad": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "levn": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
-              }
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash-es": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash.isplainobject": {
-              "version": "4.0.6",
-              "bundled": true
-            },
-            "lodash.sortby": {
-              "version": "4.7.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "3.0.2"
-              }
-            },
-            "mime-db": {
-              "version": "1.30.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              }
-            },
-            "node-fetch": {
-              "version": "1.7.3",
-              "bundled": true,
-              "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
-              }
-            },
-            "nwmatcher": {
-              "version": "1.4.3",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "bundled": true,
-              "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
-              }
-            },
-            "parse5": {
-              "version": "3.0.3",
-              "bundled": true,
-              "requires": {
-                "@types/node": "8.0.57"
-              }
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "pn": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "prelude-ls": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "promise": {
-              "version": "7.3.1",
-              "bundled": true,
-              "requires": {
-                "asap": "2.0.6"
-              }
-            },
-            "prop-types": {
-              "version": "15.6.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1"
-              }
-            },
-            "punycode": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
-            "react": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-dom": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-redux": {
-              "version": "5.0.6",
-              "bundled": true,
-              "requires": {
-                "hoist-non-react-statics": "2.3.1",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "redux": {
-              "version": "3.7.2",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "symbol-observable": "1.0.4"
-              }
-            },
-            "redux-mock-store": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.isplainobject": "4.0.6"
-              }
-            },
-            "request": {
-              "version": "2.83.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
-              }
-            },
-            "request-promise-core": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4"
-              }
-            },
-            "request-promise-native": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "bundled": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "sntp": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true,
-              "optional": true
-            },
-            "sshpk": {
-              "version": "1.13.1",
-              "bundled": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "stealthy-require": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "symbol-observable": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "symbol-tree": {
-              "version": "3.2.2",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              },
-              "dependencies": {}
-            },
-            "tr46": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "punycode": "2.1.0"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2"
-              }
-            },
-            "ua-parser-js": {
-              "version": "0.7.12",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "bundled": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              }
-            },
-            "webidl-conversions": {
-              "version": "4.0.2",
-              "bundled": true
-            },
-            "whatwg-encoding": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "whatwg-fetch": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "whatwg-url": {
-              "version": "6.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.sortby": "4.7.0",
-                "tr46": "1.0.1",
-                "webidl-conversions": "4.0.2"
-              }
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "xml-name-validator": {
-              "version": "2.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "@jsonforms/react": {
-          "bundled": true,
-          "requires": {
-            "@jsonforms/core": "2.0.0-rc.3",
-            "lodash": "4.17.4",
-            "react": "16.2.0",
-            "react-redux": "5.0.6"
-          },
-          "dependencies": {
-            "@jsonforms/core": {
-              "version": "2.0.0-rc.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "4.11.8",
-                "lodash": "4.17.4",
-                "redux": "3.7.2",
-                "uuid": "3.1.0"
-              },
-              "dependencies": {}
-            },
-            "abab": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "acorn": {
-              "version": "5.4.1",
-              "bundled": true
-            },
-            "acorn-globals": {
-              "version": "4.1.0",
-              "bundled": true,
-              "requires": {
-                "acorn": "5.4.1"
-              }
-            },
-            "ajv": {
-              "version": "5.5.2",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
-              }
-            },
-            "array-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asap": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "async-limiter": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "boom": {
-              "version": "4.3.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "browser-process-hrtime": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "content-type-parser": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "core-js": {
-              "version": "1.2.7",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "boom": "5.2.0"
-              },
-              "dependencies": {}
-            },
-            "cssom": {
-              "version": "0.3.2",
-              "bundled": true
-            },
-            "cssstyle": {
-              "version": "0.2.37",
-              "bundled": true,
-              "requires": {
-                "cssom": "0.3.2"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "deep-is": {
-              "version": "0.1.3",
-              "bundled": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "document-register-element": {
-              "version": "1.7.2",
-              "bundled": true,
-              "requires": {
-                "lightercollective": "0.0.0"
-              }
-            },
-            "domexception": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "webidl-conversions": "4.0.2"
-              }
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "escodegen": {
-              "version": "1.9.0",
-              "bundled": true,
-              "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.5.7"
-              }
-            },
-            "esprima": {
-              "version": "3.1.3",
-              "bundled": true
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "fast-deep-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "fast-levenshtein": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "fbjs": {
-              "version": "0.8.16",
-              "bundled": true,
-              "requires": {
-                "core-js": "1.2.7",
-                "isomorphic-fetch": "2.2.1",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "promise": "7.3.1",
-                "setimmediate": "1.0.5",
-                "ua-parser-js": "0.7.17"
-              }
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.1",
-              "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "har-schema": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
-              }
-            },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.1.0"
-              }
-            },
-            "hoek": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "hoist-non-react-statics": {
-              "version": "2.3.1",
-              "bundled": true
-            },
-            "html-encoding-sniffer": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "whatwg-encoding": "1.0.3"
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.19",
-              "bundled": true
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "1.3.1"
-              }
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "node-fetch": "1.7.3",
-                "whatwg-fetch": "2.0.3"
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "jsdom": {
-              "version": "11.6.2",
-              "bundled": true,
-              "requires": {
-                "abab": "1.0.4",
-                "acorn": "5.4.1",
-                "acorn-globals": "4.1.0",
-                "array-equal": "1.0.0",
-                "browser-process-hrtime": "0.1.2",
-                "content-type-parser": "1.0.2",
-                "cssom": "0.3.2",
-                "cssstyle": "0.2.37",
-                "domexception": "1.0.1",
-                "escodegen": "1.9.0",
-                "html-encoding-sniffer": "1.0.2",
-                "left-pad": "1.2.0",
-                "nwmatcher": "1.4.3",
-                "parse5": "4.0.0",
-                "pn": "1.1.0",
-                "request": "2.83.0",
-                "request-promise-native": "1.0.5",
-                "sax": "1.2.4",
-                "symbol-tree": "3.2.2",
-                "tough-cookie": "2.3.3",
-                "w3c-hr-time": "1.0.1",
-                "webidl-conversions": "4.0.2",
-                "whatwg-encoding": "1.0.3",
-                "whatwg-url": "6.4.0",
-                "ws": "4.0.0",
-                "xml-name-validator": "3.0.0"
-              }
-            },
-            "jsdom-global": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "bundled": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              }
-            },
-            "left-pad": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "levn": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
-              }
-            },
-            "lightercollective": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash-es": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash.isplainobject": {
-              "version": "4.0.6",
-              "bundled": true
-            },
-            "lodash.sortby": {
-              "version": "4.7.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "3.0.2"
-              }
-            },
-            "mime-db": {
-              "version": "1.30.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              }
-            },
-            "node-fetch": {
-              "version": "1.7.3",
-              "bundled": true,
-              "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
-              }
-            },
-            "nwmatcher": {
-              "version": "1.4.3",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "bundled": true,
-              "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
-              }
-            },
-            "parse5": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "pn": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "prelude-ls": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "promise": {
-              "version": "7.3.1",
-              "bundled": true,
-              "requires": {
-                "asap": "2.0.6"
-              }
-            },
-            "prop-types": {
-              "version": "15.6.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1"
-              }
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
-            "react": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-dom": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-redux": {
-              "version": "5.0.6",
-              "bundled": true,
-              "requires": {
-                "hoist-non-react-statics": "2.3.1",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "redux": {
-              "version": "3.7.2",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "symbol-observable": "1.2.0"
-              }
-            },
-            "redux-mock-store": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.isplainobject": "4.0.6"
-              }
-            },
-            "request": {
-              "version": "2.83.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
-              }
-            },
-            "request-promise-core": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4"
-              }
-            },
-            "request-promise-native": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "bundled": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "sntp": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true,
-              "optional": true
-            },
-            "sshpk": {
-              "version": "1.13.1",
-              "bundled": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "stealthy-require": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "symbol-observable": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "symbol-tree": {
-              "version": "3.2.2",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              }
-            },
-            "tr46": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "punycode": "2.1.0"
-              },
-              "dependencies": {}
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2"
-              }
-            },
-            "ua-parser-js": {
-              "version": "0.7.17",
-              "bundled": true
-            },
-            "ultron": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.2.1",
-              "bundled": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              }
-            },
-            "w3c-hr-time": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "browser-process-hrtime": "0.1.2"
-              }
-            },
-            "webidl-conversions": {
-              "version": "4.0.2",
-              "bundled": true
-            },
-            "whatwg-encoding": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "whatwg-fetch": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "whatwg-url": {
-              "version": "6.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.sortby": "4.7.0",
-                "tr46": "1.0.1",
-                "webidl-conversions": "4.0.2"
-              }
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "ws": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "async-limiter": "1.0.0",
-                "safe-buffer": "5.1.1",
-                "ultron": "1.1.1"
-              }
-            },
-            "xml-name-validator": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "@types/node": {
-          "version": "8.5.7",
-          "bundled": true
-        },
-        "abab": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "acorn": {
-          "version": "5.3.0",
-          "bundled": true
-        },
-        "acorn-globals": {
-          "version": "4.1.0",
-          "bundled": true,
-          "requires": {
-            "acorn": "5.3.0"
-          }
-        },
-        "ajv": {
-          "version": "5.5.2",
-          "bundled": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
-        },
-        "array-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asap": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "boom": {
-          "version": "4.3.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "browser-process-hrtime": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "content-type-parser": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "cssom": {
-          "version": "0.3.2",
-          "bundled": true
-        },
-        "cssstyle": {
-          "version": "0.2.37",
-          "bundled": true,
-          "requires": {
-            "cssom": "0.3.2"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "deep-is": {
-          "version": "0.1.3",
-          "bundled": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "document-register-element": {
-          "version": "1.7.0",
-          "bundled": true
-        },
-        "domexception": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "0.4.19"
-          }
-        },
-        "escodegen": {
-          "version": "1.9.0",
-          "bundled": true,
-          "requires": {
-            "esprima": "3.1.3",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.5.7"
-          }
-        },
-        "esprima": {
-          "version": "3.1.3",
-          "bundled": true
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "fast-deep-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "fbjs": {
-          "version": "0.8.16",
-          "bundled": true,
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.17"
-          }
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "bundled": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "bundled": true,
-          "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "bundled": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.1.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "hoist-non-react-statics": {
-          "version": "2.3.1",
-          "bundled": true
-        },
-        "html-encoding-sniffer": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "whatwg-encoding": "1.0.3"
-          }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "bundled": true
-        },
-        "invariant": {
-          "version": "2.2.2",
-          "bundled": true,
-          "requires": {
-            "loose-envify": "1.3.1"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "node-fetch": "1.7.3",
-            "whatwg-fetch": "2.0.3"
-          }
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "jsdom": {
-          "version": "11.5.1",
-          "bundled": true,
-          "requires": {
-            "abab": "1.0.4",
-            "acorn": "5.3.0",
-            "acorn-globals": "4.1.0",
-            "array-equal": "1.0.0",
-            "browser-process-hrtime": "0.1.2",
-            "content-type-parser": "1.0.2",
-            "cssom": "0.3.2",
-            "cssstyle": "0.2.37",
-            "domexception": "1.0.0",
-            "escodegen": "1.9.0",
-            "html-encoding-sniffer": "1.0.2",
-            "left-pad": "1.2.0",
-            "nwmatcher": "1.4.3",
-            "parse5": "3.0.3",
-            "pn": "1.1.0",
-            "request": "2.83.0",
-            "request-promise-native": "1.0.5",
-            "sax": "1.2.4",
-            "symbol-tree": "3.2.2",
-            "tough-cookie": "2.3.3",
-            "webidl-conversions": "4.0.2",
-            "whatwg-encoding": "1.0.3",
-            "whatwg-url": "6.4.0",
-            "xml-name-validator": "2.0.1"
-          }
-        },
-        "jsdom-global": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "bundled": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "left-pad": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "levn": {
-          "version": "0.3.0",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash-es": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash.sortby": {
-          "version": "4.7.0",
-          "bundled": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "js-tokens": "3.0.2"
-          }
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "bundled": true,
-          "requires": {
-            "encoding": "0.1.12",
-            "is-stream": "1.1.0"
-          }
-        },
-        "nwmatcher": {
-          "version": "1.4.3",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "optionator": {
-          "version": "0.8.2",
-          "bundled": true,
-          "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.6",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
-          }
-        },
-        "parse5": {
-          "version": "3.0.3",
-          "bundled": true,
-          "requires": {
-            "@types/node": "8.5.7"
-          }
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "pn": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "bundled": true,
-          "requires": {
-            "asap": "2.0.6"
-          }
-        },
-        "prop-types": {
-          "version": "15.6.0",
-          "bundled": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
-          }
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.5.1",
-          "bundled": true
-        },
-        "react": {
-          "version": "16.2.0",
-          "bundled": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "react-dom": {
-          "version": "16.2.0",
-          "bundled": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "react-redux": {
-          "version": "5.0.6",
-          "bundled": true,
-          "requires": {
-            "hoist-non-react-statics": "2.3.1",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4",
-            "lodash-es": "4.17.4",
-            "loose-envify": "1.3.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "redux": {
-          "version": "3.7.2",
-          "bundled": true,
-          "requires": {
-            "lodash": "4.17.4",
-            "lodash-es": "4.17.4",
-            "loose-envify": "1.3.1",
-            "symbol-observable": "1.1.0"
-          }
-        },
-        "request": {
-          "version": "2.83.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
-          }
-        },
-        "request-promise-core": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "request-promise-native": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "request-promise-core": "1.1.1",
-            "stealthy-require": "1.1.1",
-            "tough-cookie": "2.3.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true,
-          "optional": true
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "stealthy-require": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
-        "symbol-observable": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "symbol-tree": {
-          "version": "3.2.2",
-          "bundled": true
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "bundled": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tr46": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "punycode": "2.1.0"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "2.1.0",
-              "bundled": true
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2"
-          }
-        },
-        "ua-parser-js": {
-          "version": "0.7.17",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
-        },
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "bundled": true
-        },
-        "whatwg-encoding": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "0.4.19"
-          }
-        },
-        "whatwg-fetch": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "whatwg-url": {
-          "version": "6.4.0",
-          "bundled": true,
-          "requires": {
-            "lodash.sortby": "4.7.0",
-            "tr46": "1.0.1",
-            "webidl-conversions": "4.0.2"
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "xml-name-validator": {
-          "version": "2.0.1",
-          "bundled": true
-        }
-      }
-    },
-    "@jsonforms/webcomponent": {
-      "version": "2.0.0-rc.3",
-      "dev": true,
-      "requires": {
-        "@jsonforms/core": "2.0.0-rc.3",
-        "@jsonforms/react": "2.0.0-rc.3",
-        "@webcomponents/webcomponentsjs": "1.0.22",
-        "es6-shim": "0.35.3",
-        "json-refs": "2.1.7",
-        "react": "16.2.0",
-        "react-dom": "16.2.0",
-        "react-redux": "5.0.6",
-        "redux": "3.7.2"
-      },
-      "dependencies": {
-        "@jsonforms/core": {
-          "version": "2.0.0-rc.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "lodash": "4.17.4",
-            "redux": "3.7.2",
-            "uuid": "3.1.0"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "8.0.57",
-              "bundled": true
-            },
-            "abab": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "acorn": {
-              "version": "5.2.1",
-              "bundled": true
-            },
-            "acorn-globals": {
-              "version": "4.1.0",
-              "bundled": true,
-              "requires": {
-                "acorn": "5.2.1"
-              }
-            },
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
-              }
-            },
-            "array-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asap": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "boom": {
-              "version": "4.3.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "browser-process-hrtime": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "content-type-parser": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "boom": "5.2.0"
-              },
-              "dependencies": {}
-            },
-            "cssom": {
-              "version": "0.3.2",
-              "bundled": true
-            },
-            "cssstyle": {
-              "version": "0.2.37",
-              "bundled": true,
-              "requires": {
-                "cssom": "0.3.2"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "deep-is": {
-              "version": "0.1.3",
-              "bundled": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "document-register-element": {
-              "version": "1.7.0",
-              "bundled": true
-            },
-            "domexception": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "escodegen": {
-              "version": "1.9.0",
-              "bundled": true,
-              "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.5.7"
-              },
-              "dependencies": {}
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "fast-deep-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "fast-levenshtein": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "fbjs": {
-              "version": "0.8.16",
-              "bundled": true,
-              "requires": {
-                "core-js": "1.2.7",
-                "isomorphic-fetch": "2.2.1",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "promise": "7.3.1",
-                "setimmediate": "1.0.5",
-                "ua-parser-js": "0.7.12"
-              },
-              "dependencies": {}
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.1",
-              "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "har-schema": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "5.5.1",
-                "har-schema": "2.0.0"
-              },
-              "dependencies": {}
-            },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.1.0"
-              }
-            },
-            "hoek": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "hoist-non-react-statics": {
-              "version": "2.3.1",
-              "bundled": true
-            },
-            "html-encoding-sniffer": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "whatwg-encoding": "1.0.3"
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.19",
-              "bundled": true
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "1.3.1"
-              }
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "node-fetch": "1.7.3",
-                "whatwg-fetch": "2.0.3"
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "jsdom": {
-              "version": "11.5.1",
-              "bundled": true,
-              "requires": {
-                "abab": "1.0.4",
-                "acorn": "5.2.1",
-                "acorn-globals": "4.1.0",
-                "array-equal": "1.0.0",
-                "browser-process-hrtime": "0.1.2",
-                "content-type-parser": "1.0.2",
-                "cssom": "0.3.2",
-                "cssstyle": "0.2.37",
-                "domexception": "1.0.0",
-                "escodegen": "1.9.0",
-                "html-encoding-sniffer": "1.0.2",
-                "left-pad": "1.2.0",
-                "nwmatcher": "1.4.3",
-                "parse5": "3.0.3",
-                "pn": "1.0.0",
-                "request": "2.83.0",
-                "request-promise-native": "1.0.5",
-                "sax": "1.2.4",
-                "symbol-tree": "3.2.2",
-                "tough-cookie": "2.3.3",
-                "webidl-conversions": "4.0.2",
-                "whatwg-encoding": "1.0.3",
-                "whatwg-url": "6.4.0",
-                "xml-name-validator": "2.0.1"
-              }
-            },
-            "jsdom-global": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "bundled": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              }
-            },
-            "left-pad": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "levn": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
-              }
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash-es": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash.isplainobject": {
-              "version": "4.0.6",
-              "bundled": true
-            },
-            "lodash.sortby": {
-              "version": "4.7.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "3.0.2"
-              }
-            },
-            "mime-db": {
-              "version": "1.30.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              }
-            },
-            "node-fetch": {
-              "version": "1.7.3",
-              "bundled": true,
-              "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
-              }
-            },
-            "nwmatcher": {
-              "version": "1.4.3",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "bundled": true,
-              "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
-              }
-            },
-            "parse5": {
-              "version": "3.0.3",
-              "bundled": true,
-              "requires": {
-                "@types/node": "8.0.57"
-              }
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "pn": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "prelude-ls": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "promise": {
-              "version": "7.3.1",
-              "bundled": true,
-              "requires": {
-                "asap": "2.0.6"
-              }
-            },
-            "prop-types": {
-              "version": "15.6.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1"
-              }
-            },
-            "punycode": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
-            "react": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-dom": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-redux": {
-              "version": "5.0.6",
-              "bundled": true,
-              "requires": {
-                "hoist-non-react-statics": "2.3.1",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "redux": {
-              "version": "3.7.2",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "symbol-observable": "1.0.4"
-              }
-            },
-            "redux-mock-store": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.isplainobject": "4.0.6"
-              }
-            },
-            "request": {
-              "version": "2.83.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
-              }
-            },
-            "request-promise-core": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4"
-              }
-            },
-            "request-promise-native": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "bundled": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "sntp": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true,
-              "optional": true
-            },
-            "sshpk": {
-              "version": "1.13.1",
-              "bundled": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "stealthy-require": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "symbol-observable": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "symbol-tree": {
-              "version": "3.2.2",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              },
-              "dependencies": {}
-            },
-            "tr46": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "punycode": "2.1.0"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2"
-              }
-            },
-            "ua-parser-js": {
-              "version": "0.7.12",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "bundled": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              }
-            },
-            "webidl-conversions": {
-              "version": "4.0.2",
-              "bundled": true
-            },
-            "whatwg-encoding": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "whatwg-fetch": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "whatwg-url": {
-              "version": "6.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.sortby": "4.7.0",
-                "tr46": "1.0.1",
-                "webidl-conversions": "4.0.2"
-              }
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "xml-name-validator": {
-              "version": "2.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "@jsonforms/react": {
-          "version": "2.0.0-rc.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@jsonforms/core": "2.0.0-rc.3",
-            "lodash": "4.17.4",
-            "react": "16.2.0",
-            "react-redux": "5.0.6"
-          },
-          "dependencies": {
-            "@jsonforms/core": {
-              "version": "2.0.0-rc.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "4.11.8",
-                "lodash": "4.17.4",
-                "redux": "3.7.2",
-                "uuid": "3.1.0"
-              },
-              "dependencies": {}
-            },
-            "abab": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "acorn": {
-              "version": "5.4.1",
-              "bundled": true
-            },
-            "acorn-globals": {
-              "version": "4.1.0",
-              "bundled": true,
-              "requires": {
-                "acorn": "5.4.1"
-              }
-            },
-            "ajv": {
-              "version": "5.5.2",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
-              }
-            },
-            "array-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asap": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "async-limiter": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "boom": {
-              "version": "4.3.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "browser-process-hrtime": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "content-type-parser": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "core-js": {
-              "version": "1.2.7",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "boom": "5.2.0"
-              },
-              "dependencies": {}
-            },
-            "cssom": {
-              "version": "0.3.2",
-              "bundled": true
-            },
-            "cssstyle": {
-              "version": "0.2.37",
-              "bundled": true,
-              "requires": {
-                "cssom": "0.3.2"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "deep-is": {
-              "version": "0.1.3",
-              "bundled": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "document-register-element": {
-              "version": "1.7.2",
-              "bundled": true,
-              "requires": {
-                "lightercollective": "0.0.0"
-              }
-            },
-            "domexception": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "webidl-conversions": "4.0.2"
-              }
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "escodegen": {
-              "version": "1.9.0",
-              "bundled": true,
-              "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.5.7"
-              }
-            },
-            "esprima": {
-              "version": "3.1.3",
-              "bundled": true
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "fast-deep-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "fast-levenshtein": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "fbjs": {
-              "version": "0.8.16",
-              "bundled": true,
-              "requires": {
-                "core-js": "1.2.7",
-                "isomorphic-fetch": "2.2.1",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "promise": "7.3.1",
-                "setimmediate": "1.0.5",
-                "ua-parser-js": "0.7.17"
-              }
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.1",
-              "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "har-schema": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
-              }
-            },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.1.0"
-              }
-            },
-            "hoek": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "hoist-non-react-statics": {
-              "version": "2.3.1",
-              "bundled": true
-            },
-            "html-encoding-sniffer": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "whatwg-encoding": "1.0.3"
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.19",
-              "bundled": true
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "1.3.1"
-              }
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "node-fetch": "1.7.3",
-                "whatwg-fetch": "2.0.3"
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "jsdom": {
-              "version": "11.6.2",
-              "bundled": true,
-              "requires": {
-                "abab": "1.0.4",
-                "acorn": "5.4.1",
-                "acorn-globals": "4.1.0",
-                "array-equal": "1.0.0",
-                "browser-process-hrtime": "0.1.2",
-                "content-type-parser": "1.0.2",
-                "cssom": "0.3.2",
-                "cssstyle": "0.2.37",
-                "domexception": "1.0.1",
-                "escodegen": "1.9.0",
-                "html-encoding-sniffer": "1.0.2",
-                "left-pad": "1.2.0",
-                "nwmatcher": "1.4.3",
-                "parse5": "4.0.0",
-                "pn": "1.1.0",
-                "request": "2.83.0",
-                "request-promise-native": "1.0.5",
-                "sax": "1.2.4",
-                "symbol-tree": "3.2.2",
-                "tough-cookie": "2.3.3",
-                "w3c-hr-time": "1.0.1",
-                "webidl-conversions": "4.0.2",
-                "whatwg-encoding": "1.0.3",
-                "whatwg-url": "6.4.0",
-                "ws": "4.0.0",
-                "xml-name-validator": "3.0.0"
-              }
-            },
-            "jsdom-global": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "bundled": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              }
-            },
-            "left-pad": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "levn": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
-              }
-            },
-            "lightercollective": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash-es": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash.isplainobject": {
-              "version": "4.0.6",
-              "bundled": true
-            },
-            "lodash.sortby": {
-              "version": "4.7.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "3.0.2"
-              }
-            },
-            "mime-db": {
-              "version": "1.30.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              }
-            },
-            "node-fetch": {
-              "version": "1.7.3",
-              "bundled": true,
-              "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
-              }
-            },
-            "nwmatcher": {
-              "version": "1.4.3",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "bundled": true,
-              "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
-              }
-            },
-            "parse5": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "pn": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "prelude-ls": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "promise": {
-              "version": "7.3.1",
-              "bundled": true,
-              "requires": {
-                "asap": "2.0.6"
-              }
-            },
-            "prop-types": {
-              "version": "15.6.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1"
-              }
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
-            "react": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-dom": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-redux": {
-              "version": "5.0.6",
-              "bundled": true,
-              "requires": {
-                "hoist-non-react-statics": "2.3.1",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "redux": {
-              "version": "3.7.2",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "symbol-observable": "1.2.0"
-              }
-            },
-            "redux-mock-store": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.isplainobject": "4.0.6"
-              }
-            },
-            "request": {
-              "version": "2.83.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
-              }
-            },
-            "request-promise-core": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4"
-              }
-            },
-            "request-promise-native": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "bundled": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "sntp": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true,
-              "optional": true
-            },
-            "sshpk": {
-              "version": "1.13.1",
-              "bundled": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "stealthy-require": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "symbol-observable": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "symbol-tree": {
-              "version": "3.2.2",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              }
-            },
-            "tr46": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "punycode": "2.1.0"
-              },
-              "dependencies": {}
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2"
-              }
-            },
-            "ua-parser-js": {
-              "version": "0.7.17",
-              "bundled": true
-            },
-            "ultron": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.2.1",
-              "bundled": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              }
-            },
-            "w3c-hr-time": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "browser-process-hrtime": "0.1.2"
-              }
-            },
-            "webidl-conversions": {
-              "version": "4.0.2",
-              "bundled": true
-            },
-            "whatwg-encoding": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "whatwg-fetch": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "whatwg-url": {
-              "version": "6.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.sortby": "4.7.0",
-                "tr46": "1.0.1",
-                "webidl-conversions": "4.0.2"
-              }
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "ws": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "async-limiter": "1.0.0",
-                "safe-buffer": "5.1.1",
-                "ultron": "1.1.1"
-              }
-            },
-            "xml-name-validator": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "@jsonforms/test": {
-          "bundled": true,
-          "dependencies": {
-            "@jsonforms/core": {
-              "bundled": true,
-              "requires": {
-                "ajv": "4.11.8",
-                "lodash": "4.17.4",
-                "redux": "3.7.2",
-                "uuid": "3.1.0"
-              },
-              "dependencies": {}
-            },
-            "@jsonforms/react": {
-              "bundled": true,
-              "requires": {
-                "@jsonforms/core": "2.0.0-rc.3",
-                "lodash": "4.17.4",
-                "react": "16.2.0",
-                "react-redux": "5.0.6"
-              },
-              "dependencies": {}
-            },
-            "@types/node": {
-              "version": "8.5.7",
-              "bundled": true
-            },
-            "abab": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "acorn": {
-              "version": "5.3.0",
-              "bundled": true
-            },
-            "acorn-globals": {
-              "version": "4.1.0",
-              "bundled": true,
-              "requires": {
-                "acorn": "5.3.0"
-              }
-            },
-            "ajv": {
-              "version": "5.5.2",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
-              }
-            },
-            "array-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asap": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "boom": {
-              "version": "4.3.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "browser-process-hrtime": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "content-type-parser": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "core-js": {
-              "version": "1.2.7",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "boom": "5.2.0"
-              },
-              "dependencies": {}
-            },
-            "cssom": {
-              "version": "0.3.2",
-              "bundled": true
-            },
-            "cssstyle": {
-              "version": "0.2.37",
-              "bundled": true,
-              "requires": {
-                "cssom": "0.3.2"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "deep-is": {
-              "version": "0.1.3",
-              "bundled": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "document-register-element": {
-              "version": "1.7.0",
-              "bundled": true
-            },
-            "domexception": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "escodegen": {
-              "version": "1.9.0",
-              "bundled": true,
-              "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.5.7"
-              }
-            },
-            "esprima": {
-              "version": "3.1.3",
-              "bundled": true
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "fast-deep-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "fast-levenshtein": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "fbjs": {
-              "version": "0.8.16",
-              "bundled": true,
-              "requires": {
-                "core-js": "1.2.7",
-                "isomorphic-fetch": "2.2.1",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "promise": "7.3.1",
-                "setimmediate": "1.0.5",
-                "ua-parser-js": "0.7.17"
-              }
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.1",
-              "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "har-schema": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
-              }
-            },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.1.0"
-              }
-            },
-            "hoek": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "hoist-non-react-statics": {
-              "version": "2.3.1",
-              "bundled": true
-            },
-            "html-encoding-sniffer": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "whatwg-encoding": "1.0.3"
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.19",
-              "bundled": true
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "1.3.1"
-              }
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "node-fetch": "1.7.3",
-                "whatwg-fetch": "2.0.3"
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "jsdom": {
-              "version": "11.5.1",
-              "bundled": true,
-              "requires": {
-                "abab": "1.0.4",
-                "acorn": "5.3.0",
-                "acorn-globals": "4.1.0",
-                "array-equal": "1.0.0",
-                "browser-process-hrtime": "0.1.2",
-                "content-type-parser": "1.0.2",
-                "cssom": "0.3.2",
-                "cssstyle": "0.2.37",
-                "domexception": "1.0.0",
-                "escodegen": "1.9.0",
-                "html-encoding-sniffer": "1.0.2",
-                "left-pad": "1.2.0",
-                "nwmatcher": "1.4.3",
-                "parse5": "3.0.3",
-                "pn": "1.1.0",
-                "request": "2.83.0",
-                "request-promise-native": "1.0.5",
-                "sax": "1.2.4",
-                "symbol-tree": "3.2.2",
-                "tough-cookie": "2.3.3",
-                "webidl-conversions": "4.0.2",
-                "whatwg-encoding": "1.0.3",
-                "whatwg-url": "6.4.0",
-                "xml-name-validator": "2.0.1"
-              }
-            },
-            "jsdom-global": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "bundled": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              }
-            },
-            "left-pad": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "levn": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
-              }
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash-es": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash.sortby": {
-              "version": "4.7.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "3.0.2"
-              }
-            },
-            "mime-db": {
-              "version": "1.30.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              }
-            },
-            "node-fetch": {
-              "version": "1.7.3",
-              "bundled": true,
-              "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
-              }
-            },
-            "nwmatcher": {
-              "version": "1.4.3",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "bundled": true,
-              "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
-              }
-            },
-            "parse5": {
-              "version": "3.0.3",
-              "bundled": true,
-              "requires": {
-                "@types/node": "8.5.7"
-              }
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "pn": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "prelude-ls": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "promise": {
-              "version": "7.3.1",
-              "bundled": true,
-              "requires": {
-                "asap": "2.0.6"
-              }
-            },
-            "prop-types": {
-              "version": "15.6.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1"
-              }
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
-            "react": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-dom": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-redux": {
-              "version": "5.0.6",
-              "bundled": true,
-              "requires": {
-                "hoist-non-react-statics": "2.3.1",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "redux": {
-              "version": "3.7.2",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "symbol-observable": "1.1.0"
-              }
-            },
-            "request": {
-              "version": "2.83.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
-              }
-            },
-            "request-promise-core": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4"
-              }
-            },
-            "request-promise-native": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "bundled": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "sntp": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true,
-              "optional": true
-            },
-            "sshpk": {
-              "version": "1.13.1",
-              "bundled": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "stealthy-require": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "symbol-observable": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "symbol-tree": {
-              "version": "3.2.2",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              }
-            },
-            "tr46": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "punycode": "2.1.0"
-              },
-              "dependencies": {}
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2"
-              }
-            },
-            "ua-parser-js": {
-              "version": "0.7.17",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "bundled": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              }
-            },
-            "webidl-conversions": {
-              "version": "4.0.2",
-              "bundled": true
-            },
-            "whatwg-encoding": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "whatwg-fetch": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "whatwg-url": {
-              "version": "6.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.sortby": "4.7.0",
-                "tr46": "1.0.1",
-                "webidl-conversions": "4.0.2"
-              }
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "xml-name-validator": {
-              "version": "2.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "@types/node": {
-          "version": "9.3.0",
-          "bundled": true
-        },
-        "@webcomponents/webcomponentsjs": {
-          "version": "1.0.22",
-          "bundled": true,
-          "dev": true
-        },
-        "abab": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "acorn": {
-          "version": "5.3.0",
-          "bundled": true
-        },
-        "acorn-globals": {
-          "version": "4.1.0",
-          "bundled": true,
-          "requires": {
-            "acorn": "5.3.0"
-          }
-        },
-        "argparse": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "sprintf-js": "1.0.3"
-          }
-        },
-        "array-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asap": {
-          "version": "2.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "boom": {
-          "version": "4.3.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "browser-process-hrtime": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "commander": {
-          "version": "2.13.0",
-          "bundled": true,
-          "dev": true
-        },
-        "component-emitter": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "content-type-parser": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cookiejar": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "cssom": {
-          "version": "0.3.2",
-          "bundled": true
-        },
-        "cssstyle": {
-          "version": "0.2.37",
-          "bundled": true,
-          "requires": {
-            "cssom": "0.3.2"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-is": {
-          "version": "0.1.3",
-          "bundled": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "document-register-element": {
-          "version": "1.7.0",
-          "bundled": true
-        },
-        "domexception": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "iconv-lite": "0.4.19"
-          }
-        },
-        "es6-shim": {
-          "version": "0.35.3",
-          "bundled": true,
-          "dev": true
-        },
-        "escodegen": {
-          "version": "1.9.0",
-          "bundled": true,
-          "requires": {
-            "esprima": "3.1.3",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.5.7"
-          }
-        },
-        "esprima": {
-          "version": "3.1.3",
-          "bundled": true
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "fast-deep-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "fbjs": {
-          "version": "0.8.16",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.17"
-          }
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "bundled": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "formidable": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "graphlib": {
-          "version": "2.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "bundled": true,
-          "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
-          },
-          "dependencies": {
-            "ajv": {
-              "version": "5.5.2",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
-              }
-            }
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "bundled": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.1.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "hoist-non-react-statics": {
-          "version": "2.3.1",
-          "bundled": true,
-          "dev": true
-        },
-        "html-encoding-sniffer": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "whatwg-encoding": "1.0.3"
-          }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "bundled": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "invariant": {
-          "version": "2.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "1.3.1"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "node-fetch": "1.7.3",
-            "whatwg-fetch": "2.0.3"
-          }
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.10.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
-          },
-          "dependencies": {
-            "esprima": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "jsdom": {
-          "version": "11.5.1",
-          "bundled": true,
-          "requires": {
-            "abab": "1.0.4",
-            "acorn": "5.3.0",
-            "acorn-globals": "4.1.0",
-            "array-equal": "1.0.0",
-            "browser-process-hrtime": "0.1.2",
-            "content-type-parser": "1.0.2",
-            "cssom": "0.3.2",
-            "cssstyle": "0.2.37",
-            "domexception": "1.0.0",
-            "escodegen": "1.9.0",
-            "html-encoding-sniffer": "1.0.2",
-            "left-pad": "1.2.0",
-            "nwmatcher": "1.4.3",
-            "parse5": "3.0.3",
-            "pn": "1.1.0",
-            "request": "2.83.0",
-            "request-promise-native": "1.0.5",
-            "sax": "1.2.4",
-            "symbol-tree": "3.2.2",
-            "tough-cookie": "2.3.3",
-            "webidl-conversions": "4.0.2",
-            "whatwg-encoding": "1.0.3",
-            "whatwg-url": "6.4.0",
-            "xml-name-validator": "2.0.1"
-          }
-        },
-        "jsdom-global": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "json-refs": {
-          "version": "2.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "commander": "2.13.0",
-            "graphlib": "2.1.5",
-            "js-yaml": "3.10.0",
-            "native-promise-only": "0.8.1",
-            "path-loader": "1.0.4",
-            "slash": "1.0.0",
-            "uri-js": "3.0.2"
-          }
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "bundled": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "left-pad": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "levn": {
-          "version": "0.3.0",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash-es": {
-          "version": "4.17.4",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.sortby": {
-          "version": "4.7.0",
-          "bundled": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "3.0.2"
-          }
-        },
-        "methods": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "mime": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "native-promise-only": {
-          "version": "0.8.1",
-          "bundled": true,
-          "dev": true
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "encoding": "0.1.12",
-            "is-stream": "1.1.0"
-          }
-        },
-        "nwmatcher": {
-          "version": "1.4.3",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "optionator": {
-          "version": "0.8.2",
-          "bundled": true,
-          "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.6",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
-          }
-        },
-        "parse5": {
-          "version": "3.0.3",
-          "bundled": true,
-          "requires": {
-            "@types/node": "9.3.0"
-          }
-        },
-        "path-loader": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "native-promise-only": "0.8.1",
-            "superagent": "3.8.2"
-          }
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "pn": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "asap": "2.0.6"
-          }
-        },
-        "prop-types": {
-          "version": "15.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
-          }
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.5.1",
-          "bundled": true
-        },
-        "react": {
-          "version": "16.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "react-dom": {
-          "version": "16.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "react-redux": {
-          "version": "5.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoist-non-react-statics": "2.3.1",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4",
-            "lodash-es": "4.17.4",
-            "loose-envify": "1.3.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "redux": {
-          "version": "3.7.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4",
-            "lodash-es": "4.17.4",
-            "loose-envify": "1.3.1",
-            "symbol-observable": "1.1.0"
-          }
-        },
-        "request": {
-          "version": "2.83.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
-          }
-        },
-        "request-promise-core": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "request-promise-native": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "request-promise-core": "1.1.1",
-            "stealthy-require": "1.1.1",
-            "tough-cookie": "2.3.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "slash": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true,
-          "optional": true
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "stealthy-require": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
-        "superagent": {
-          "version": "3.8.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "component-emitter": "1.2.1",
-            "cookiejar": "2.1.1",
-            "debug": "3.1.0",
-            "extend": "3.0.1",
-            "form-data": "2.3.1",
-            "formidable": "1.1.1",
-            "methods": "1.1.2",
-            "mime": "1.6.0",
-            "qs": "6.5.1",
-            "readable-stream": "2.3.3"
-          }
-        },
-        "symbol-observable": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "symbol-tree": {
-          "version": "3.2.2",
-          "bundled": true
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "bundled": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tr46": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "punycode": "2.1.0"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "2.1.0",
-              "bundled": true
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2"
-          }
-        },
-        "ua-parser-js": {
-          "version": "0.7.17",
-          "bundled": true,
-          "dev": true
-        },
-        "uri-js": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "punycode": "2.1.0"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.2.1",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
-        },
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "bundled": true
-        },
-        "whatwg-encoding": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "0.4.19"
-          }
-        },
-        "whatwg-fetch": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "whatwg-url": {
-          "version": "6.4.0",
-          "bundled": true,
-          "requires": {
-            "lodash.sortby": "4.7.0",
-            "tr46": "1.0.1",
-            "webidl-conversions": "4.0.2"
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "xml-name-validator": {
-          "version": "2.0.1",
-          "bundled": true
-        }
       }
     },
     "@types/node": {
       "version": "8.5.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.5.tgz",
-      "integrity": "sha512-JRnfoh0Ll4ElmIXKxbUfcOodkGvcNHljct6mO1X9hE/mlrMzAx0hYCLAD7sgT53YAY1HdlpzUcV0CkmDqUqTuA==",
-      "dev": true
+      "integrity": "sha512-JRnfoh0Ll4ElmIXKxbUfcOodkGvcNHljct6mO1X9hE/mlrMzAx0hYCLAD7sgT53YAY1HdlpzUcV0CkmDqUqTuA=="
     },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
-      "dev": true
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
     },
     "accepts": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
       "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
-      "dev": true,
       "requires": {
         "mime-types": "2.1.17",
         "negotiator": "0.6.1"
@@ -7932,14 +111,12 @@
     "acorn": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
-      "dev": true
+      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
     },
     "acorn-globals": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
-      "dev": true,
       "requires": {
         "acorn": "5.3.0"
       }
@@ -7948,7 +125,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2",
         "longest": "1.0.1",
@@ -7958,14 +134,12 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-      "dev": true,
       "requires": {
         "string-width": "2.1.1"
       },
@@ -7973,20 +147,17 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -7996,7 +167,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -8006,26 +176,22 @@
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
-      "dev": true
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
     },
     "ansi-html": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
-      "dev": true
+      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
     },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-      "dev": true,
       "requires": {
         "color-convert": "1.9.1"
       }
@@ -8034,7 +200,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-      "dev": true,
       "requires": {
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
@@ -8044,7 +209,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
       "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-      "dev": true,
       "requires": {
         "default-require-extensions": "1.0.0"
       }
@@ -8052,14 +216,12 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
       }
@@ -8068,7 +230,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
       "requires": {
         "arr-flatten": "1.1.0"
       }
@@ -8076,50 +237,42 @@
     "arr-exclude": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/arr-exclude/-/arr-exclude-1.0.0.tgz",
-      "integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE=",
-      "dev": true
+      "integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE="
     },
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "array-differ": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-      "dev": true
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
     },
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-      "dev": true
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-filter": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
-      "dev": true
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
     },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "array-flatten": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-      "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
-      "dev": true
+      "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
     },
     "array-includes": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
-      "dev": true,
       "requires": {
         "define-properties": "1.1.2",
         "es-abstract": "1.10.0"
@@ -8128,20 +281,17 @@
     "array-map": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
-      "dev": true
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
     },
     "array-reduce": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
-      "dev": true
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
     },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
       "requires": {
         "array-uniq": "1.0.3"
       }
@@ -8149,20 +299,17 @@
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-      "dev": true
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
     },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asap": {
       "version": "2.0.6",
@@ -8172,26 +319,22 @@
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-      "dev": true
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
     },
     "async": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-      "dev": true,
       "requires": {
         "lodash": "4.17.4"
       }
@@ -8199,26 +342,22 @@
     "async-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-      "dev": true
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "auto-bind": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-1.1.0.tgz",
-      "integrity": "sha1-k7hk3H7gGjJigXddXHXKCnUeWWE=",
-      "dev": true
+      "integrity": "sha1-k7hk3H7gGjJigXddXHXKCnUeWWE="
     },
     "ava": {
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/ava/-/ava-0.24.0.tgz",
       "integrity": "sha512-o/ykNzsWB5qgh1cR9jzVw0E1y4E219aXl9njNFGSamSCsD7VhPd3aoZabNZuG1PSVMZmQ8RuwKnTuz/loNhKnw==",
-      "dev": true,
       "requires": {
         "@ava/babel-preset-stage-4": "1.1.0",
         "@ava/babel-preset-transform-test-files": "3.0.0",
@@ -8308,14 +447,12 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "globby": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "dev": true,
           "requires": {
             "array-union": "1.0.2",
             "glob": "7.1.2",
@@ -8327,14 +464,12 @@
         "indent-string": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-          "dev": true
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
         },
         "is-observable": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
           "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-          "dev": true,
           "requires": {
             "symbol-observable": "1.1.0"
           }
@@ -8342,14 +477,12 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -8358,7 +491,6 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
           "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -8369,7 +501,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/ava-init/-/ava-init-0.2.1.tgz",
       "integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
-      "dev": true,
       "requires": {
         "arr-exclude": "1.0.0",
         "execa": "0.7.0",
@@ -8382,7 +513,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "parse-json": "2.2.0",
@@ -8394,7 +524,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
           "requires": {
             "pify": "2.3.0"
           }
@@ -8402,14 +531,12 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         },
         "read-pkg": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
           "requires": {
             "load-json-file": "2.0.0",
             "normalize-package-data": "2.4.0",
@@ -8420,7 +547,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
           "requires": {
             "find-up": "2.1.0",
             "read-pkg": "2.0.0"
@@ -8429,28 +555,24 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         }
       }
     },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-      "dev": true
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
@@ -8460,14 +582,12 @@
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
           "requires": {
             "ansi-styles": "2.2.1",
             "escape-string-regexp": "1.0.5",
@@ -8479,8 +599,7 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -8488,7 +607,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "babel-generator": "6.26.0",
@@ -8515,7 +633,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -8523,8 +640,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -8532,7 +648,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
-      "dev": true,
       "requires": {
         "babel-messages": "6.23.0",
         "babel-runtime": "6.26.0",
@@ -8547,14 +662,12 @@
         "jsesc": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-          "dev": true
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
         },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -8562,7 +675,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "dev": true,
       "requires": {
         "babel-helper-explode-assignable-expression": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -8573,7 +685,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true,
       "requires": {
         "babel-helper-hoist-variables": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -8585,7 +696,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-traverse": "6.26.0",
@@ -8596,7 +706,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true,
       "requires": {
         "babel-helper-get-function-arity": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -8609,7 +718,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -8619,7 +727,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -8629,7 +736,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
@@ -8640,7 +746,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -8653,7 +758,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0"
@@ -8663,7 +767,6 @@
       "version": "22.4.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.1.tgz",
       "integrity": "sha512-rEdN/jevSuX0IQKcUqwqOGa0gDNis4jGY52Rq53aizfDGPwQYNJq+f9NCMT1HUhtUZhYSjvfGUfHQWBRT1/icA==",
-      "dev": true,
       "requires": {
         "babel-plugin-istanbul": "4.1.5",
         "babel-preset-jest": "22.4.1"
@@ -8673,7 +776,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -8682,7 +784,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -8691,7 +792,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-2.3.2.tgz",
       "integrity": "sha1-VRa4/NsmyfDh2BYHSfbkxl5xJx4=",
-      "dev": true,
       "requires": {
         "babel-generator": "6.26.0",
         "babylon": "6.18.0",
@@ -8705,8 +805,7 @@
         "core-js": {
           "version": "2.5.3",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-          "dev": true
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
         }
       }
     },
@@ -8714,7 +813,6 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
       "integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
-      "dev": true,
       "requires": {
         "find-up": "2.1.0",
         "istanbul-lib-instrument": "1.9.2",
@@ -8724,38 +822,32 @@
     "babel-plugin-jest-hoist": {
       "version": "22.4.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.1.tgz",
-      "integrity": "sha512-gmj5FvFflXSnRapWmF/jDjx5Lof1kX0OwXibCxMOx38V3CFMOnTxLTUrAFfLkhCey3FJvv0ACvv/+h4nzFRxhg==",
-      "dev": true
+      "integrity": "sha512-gmj5FvFflXSnRapWmF/jDjx5Lof1kX0OwXibCxMOx38V3CFMOnTxLTUrAFfLkhCey3FJvv0ACvv/+h4nzFRxhg=="
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-      "dev": true
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-      "dev": true
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-      "dev": true
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-      "dev": true
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "dev": true,
       "requires": {
         "babel-helper-remap-async-to-generator": "6.24.1",
         "babel-plugin-syntax-async-functions": "6.13.0",
@@ -8766,7 +858,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -8775,7 +866,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -8786,7 +876,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
-      "dev": true,
       "requires": {
         "babel-plugin-transform-strict-mode": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -8798,7 +887,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true,
       "requires": {
         "babel-helper-call-delegate": "6.24.1",
         "babel-helper-get-function-arity": "6.24.1",
@@ -8812,7 +900,6 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -8821,7 +908,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true,
       "requires": {
         "babel-helper-regex": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -8832,7 +918,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true,
       "requires": {
         "babel-helper-regex": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -8843,7 +928,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "dev": true,
       "requires": {
         "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
         "babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -8854,7 +938,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -8864,7 +947,6 @@
       "version": "22.4.1",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.1.tgz",
       "integrity": "sha512-gW3+spyB8fkSAI9fX+41BQMwar5LjR+nyKa2QRvK22snxnI29+jJVAMfId+osucFJzJJvhlvzKWnfwX8Omodvg==",
-      "dev": true,
       "requires": {
         "babel-plugin-jest-hoist": "22.4.1",
         "babel-plugin-syntax-object-rest-spread": "6.13.0"
@@ -8874,7 +956,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "dev": true,
       "requires": {
         "babel-core": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -8888,20 +969,17 @@
         "core-js": {
           "version": "2.5.3",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-          "dev": true
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
         },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "source-map-support": {
           "version": "0.4.18",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-          "dev": true,
           "requires": {
             "source-map": "0.5.7"
           }
@@ -8928,7 +1006,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-traverse": "6.26.0",
@@ -8941,7 +1018,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "babel-messages": "6.23.0",
@@ -8958,7 +1034,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -8969,7 +1044,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
@@ -8980,26 +1054,22 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
-      "dev": true
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
@@ -9008,26 +1078,22 @@
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-      "dev": true
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
-      "dev": true
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
     },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-      "dev": true
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "body-parser": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "content-type": "1.0.4",
@@ -9045,7 +1111,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -9056,7 +1121,6 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
-      "dev": true,
       "requires": {
         "array-flatten": "2.1.1",
         "deep-equal": "1.0.1",
@@ -9070,7 +1134,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "dev": true,
       "requires": {
         "hoek": "4.2.0"
       }
@@ -9079,7 +1142,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-      "dev": true,
       "requires": {
         "ansi-align": "2.0.0",
         "camelcase": "4.1.0",
@@ -9093,26 +1155,22 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -9122,7 +1180,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -9133,7 +1190,6 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -9143,7 +1199,6 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true,
       "requires": {
         "expand-range": "1.8.2",
         "preserve": "0.2.0",
@@ -9158,14 +1213,12 @@
     "browser-process-hrtime": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
-      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
-      "dev": true
+      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
     },
     "browser-resolve": {
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
       "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
-      "dev": true,
       "requires": {
         "resolve": "1.1.7"
       }
@@ -9174,7 +1227,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
-      "dev": true,
       "requires": {
         "node-int64": "0.4.0"
       }
@@ -9182,32 +1234,27 @@
     "buf-compare": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
-      "integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=",
-      "dev": true
+      "integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o="
     },
     "buffer-indexof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
-      "dev": true
+      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
     },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
     },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-      "dev": true
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cacache": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.1.tgz",
       "integrity": "sha512-dRHYcs9LvG9cHgdPzjiI+/eS7e1xRhULrcyOx04RZQsszNJXU2SL9CyG60yLnge282Qq5nwTv+ieK2fH+WPZmA==",
-      "dev": true,
       "requires": {
         "bluebird": "3.5.1",
         "chownr": "1.0.1",
@@ -9228,7 +1275,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
       "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
-      "dev": true,
       "requires": {
         "md5-hex": "1.3.0",
         "mkdirp": "0.5.1",
@@ -9239,7 +1285,6 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
           "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-          "dev": true,
           "requires": {
             "md5-o-matic": "0.1.1"
           }
@@ -9248,7 +1293,6 @@
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "imurmurhash": "0.1.4",
@@ -9261,7 +1305,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.0.1.tgz",
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
-      "dev": true,
       "requires": {
         "core-js": "2.5.3",
         "deep-equal": "1.0.1",
@@ -9272,34 +1315,29 @@
         "core-js": {
           "version": "2.5.3",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-          "dev": true
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
         }
       }
     },
     "call-signature": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
-      "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
-      "dev": true
+      "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY="
     },
     "callsites": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-      "dev": true
+      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
     },
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-      "dev": true
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
     },
     "camelcase-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true,
       "requires": {
         "camelcase": "2.1.1",
         "map-obj": "1.0.1"
@@ -9308,20 +1346,17 @@
     "capture-stack-trace": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-      "dev": true
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
     },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4",
@@ -9337,7 +1372,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
       "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-      "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
@@ -9353,7 +1387,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "dev": true,
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
@@ -9369,14 +1402,12 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
           "requires": {
             "is-extglob": "1.0.0"
           }
@@ -9386,14 +1417,12 @@
     "chownr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-      "dev": true
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
     },
     "ci-info": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
-      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
-      "dev": true
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA=="
     },
     "classnames": {
       "version": "2.2.5",
@@ -9403,26 +1432,22 @@
     "clean-stack": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
-      "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE=",
-      "dev": true
+      "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
     },
     "clean-yaml-object": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
-      "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
-      "dev": true
+      "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g="
     },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-      "dev": true
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
     },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
       "requires": {
         "restore-cursor": "2.0.0"
       }
@@ -9430,14 +1455,12 @@
     "cli-spinners": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
-      "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
-      "dev": true
+      "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY="
     },
     "cli-truncate": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
       "integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
-      "dev": true,
       "requires": {
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
@@ -9446,20 +1469,17 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -9469,7 +1489,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -9480,7 +1499,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "dev": true,
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1",
@@ -9490,14 +1508,12 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "co-with-promise": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co-with-promise/-/co-with-promise-4.6.0.tgz",
       "integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
-      "dev": true,
       "requires": {
         "pinkie-promise": "1.0.0"
       },
@@ -9505,14 +1521,12 @@
         "pinkie": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-          "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
-          "dev": true
+          "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q="
         },
         "pinkie-promise": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
           "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
-          "dev": true,
           "requires": {
             "pinkie": "1.0.0"
           }
@@ -9523,7 +1537,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.0.tgz",
       "integrity": "sha1-XcwIHoj0p+O1VOnjXX7yMtR/gUc=",
-      "dev": true,
       "requires": {
         "convert-to-spaces": "1.0.2"
       }
@@ -9531,14 +1544,12 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -9546,14 +1557,12 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -9561,20 +1570,17 @@
     "common-path-prefix": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
-      "integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA=",
-      "dev": true
+      "integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA="
     },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "compressible": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
       "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
-      "dev": true,
       "requires": {
         "mime-db": "1.30.0"
       }
@@ -9583,7 +1589,6 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
       "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
-      "dev": true,
       "requires": {
         "accepts": "1.3.4",
         "bytes": "3.0.0",
@@ -9598,7 +1603,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -9608,14 +1612,12 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
@@ -9626,7 +1628,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/concordance/-/concordance-3.0.0.tgz",
       "integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
-      "dev": true,
       "requires": {
         "date-time": "2.1.0",
         "esutils": "2.0.2",
@@ -9645,7 +1646,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
       "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
-      "dev": true,
       "requires": {
         "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
@@ -9658,56 +1658,47 @@
     "connect-history-api-fallback": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-      "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
-      "dev": true
+      "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
     },
     "content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-      "dev": true
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-      "dev": true
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "content-type-parser": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
-      "dev": true
+      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
     },
     "convert-source-map": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-      "dev": true
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
     },
     "convert-to-spaces": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
-      "integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU=",
-      "dev": true
+      "integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU="
     },
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-      "dev": true
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-      "dev": true
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
-      "dev": true,
       "requires": {
         "aproba": "1.2.0",
         "fs-write-stream-atomic": "1.0.10",
@@ -9721,7 +1712,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.3.0.tgz",
       "integrity": "sha512-5o1/xyWm8OYDmLFKAWMuPU3A/jZ4Z6kZSZGh36KD2XmtxnRa8lQyLx7bCNQm08BPaR/oqUdtJOr9jWfnYINp9g==",
-      "dev": true,
       "requires": {
         "cacache": "10.0.1",
         "find-cache-dir": "1.0.0",
@@ -9739,7 +1729,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
       "integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
-      "dev": true,
       "requires": {
         "buf-compare": "1.0.1",
         "is-error": "2.2.1"
@@ -9753,14 +1742,12 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cpx": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/cpx/-/cpx-1.5.0.tgz",
       "integrity": "sha1-GFvgGFEdhycN7czCkxceN2VauI8=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "chokidar": "1.7.0",
@@ -9779,7 +1766,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
       "requires": {
         "capture-stack-trace": "1.0.0"
       }
@@ -9788,7 +1774,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true,
       "requires": {
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
@@ -9799,7 +1784,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "dev": true,
       "requires": {
         "boom": "5.2.0"
       },
@@ -9808,7 +1792,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "dev": true,
           "requires": {
             "hoek": "4.2.0"
           }
@@ -9818,8 +1801,7 @@
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-      "dev": true
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
     "css-vendor": {
       "version": "0.3.8",
@@ -9832,14 +1814,12 @@
     "cssom": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
-      "dev": true
+      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
     },
     "cssstyle": {
       "version": "0.2.37",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-      "dev": true,
       "requires": {
         "cssom": "0.3.2"
       }
@@ -9848,7 +1828,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true,
       "requires": {
         "array-find-index": "1.0.2"
       }
@@ -9856,8 +1835,7 @@
     "cyclist": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
-      "dev": true
+      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
     },
     "d": {
       "version": "1.0.0",
@@ -9871,7 +1849,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       }
@@ -9880,7 +1857,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
       "integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
-      "dev": true,
       "requires": {
         "time-zone": "1.0.0"
       }
@@ -9889,7 +1865,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -9897,26 +1872,22 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
     },
     "deep-extend": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-      "dev": true
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
     },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
       "version": "2.0.1",
@@ -9927,7 +1898,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-      "dev": true,
       "requires": {
         "strip-bom": "2.0.0"
       }
@@ -9936,7 +1906,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true,
       "requires": {
         "foreach": "2.0.5",
         "object-keys": "1.0.11"
@@ -9946,7 +1915,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
-      "dev": true,
       "requires": {
         "globby": "6.1.0",
         "is-path-cwd": "1.0.0",
@@ -9960,7 +1928,6 @@
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "dev": true,
           "requires": {
             "array-union": "1.0.2",
             "glob": "7.1.2",
@@ -9972,8 +1939,7 @@
             "pify": {
               "version": "2.3.0",
               "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-              "dev": true
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
             }
           }
         }
@@ -9982,26 +1948,22 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-      "dev": true
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
     },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "dev": true
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
       "requires": {
         "repeating": "2.0.1"
       }
@@ -10009,26 +1971,22 @@
     "detect-newline": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
-      "dev": true
+      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
     },
     "detect-node": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
-      "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=",
-      "dev": true
+      "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
     },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
     "dir-glob": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
       "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
-      "dev": true,
       "requires": {
         "arrify": "1.0.1",
         "path-type": "3.0.0"
@@ -10037,14 +1995,12 @@
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
-      "dev": true
+      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
     },
     "dns-packet": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.2.2.tgz",
       "integrity": "sha512-kN+DjfGF7dJGUL7nWRktL9Z18t1rWP3aQlyZdY8XlpvU3Nc6GeFTQApftcjtWKxAZfiggZSGrCEoszNgvnpwDg==",
-      "dev": true,
       "requires": {
         "ip": "1.1.5",
         "safe-buffer": "5.1.1"
@@ -10054,7 +2010,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
-      "dev": true,
       "requires": {
         "buffer-indexof": "1.1.1"
       }
@@ -10062,8 +2017,7 @@
     "document-register-element": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.7.0.tgz",
-      "integrity": "sha512-qAoWcNm1zW3LVO0KSblYISM0oLQzlNtns2gd1O/YS3QvFYFidG6lF73fC98fIbfPQkws698L0/URrtmN8+ADbQ==",
-      "dev": true
+      "integrity": "sha512-qAoWcNm1zW3LVO0KSblYISM0oLQzlNtns2gd1O/YS3QvFYFidG6lF73fC98fIbfPQkws698L0/URrtmN8+ADbQ=="
     },
     "dom-helpers": {
       "version": "3.3.1",
@@ -10078,14 +2032,12 @@
     "domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.0.tgz",
-      "integrity": "sha512-WpwuBlZ2lQRFa4H/4w49deb9rJLot9KmqrKKjMc9qBl7CID+DdC2swoa34ccRl+anL2B6bLp6TjFdIdnzekMBQ==",
-      "dev": true
+      "integrity": "sha512-WpwuBlZ2lQRFa4H/4w49deb9rJLot9KmqrKKjMc9qBl7CID+DdC2swoa34ccRl+anL2B6bLp6TjFdIdnzekMBQ=="
     },
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-      "dev": true,
       "requires": {
         "is-obj": "1.0.1"
       }
@@ -10093,20 +2045,17 @@
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-      "dev": true
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-      "dev": true
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "duplexify": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
       "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
-      "dev": true,
       "requires": {
         "end-of-stream": "1.4.0",
         "inherits": "2.0.3",
@@ -10118,7 +2067,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
@@ -10127,20 +2075,17 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "empower-core": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
       "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
-      "dev": true,
       "requires": {
         "call-signature": "0.0.2",
         "core-js": "2.5.3"
@@ -10149,16 +2094,14 @@
         "core-js": {
           "version": "2.5.3",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-          "dev": true
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
         }
       }
     },
     "encodeurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
-      "dev": true
+      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
     },
     "encoding": {
       "version": "0.1.12",
@@ -10172,7 +2115,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-      "dev": true,
       "requires": {
         "once": "1.4.0"
       }
@@ -10181,7 +2123,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
       "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "memory-fs": "0.4.1",
@@ -10192,14 +2133,12 @@
     "equal-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/equal-length/-/equal-length-1.0.1.tgz",
-      "integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w=",
-      "dev": true
+      "integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w="
     },
     "errno": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
       "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
-      "dev": true,
       "requires": {
         "prr": "1.0.1"
       }
@@ -10208,7 +2147,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
       }
@@ -10217,7 +2155,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
         "function-bind": "1.1.1",
@@ -10230,7 +2167,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true,
       "requires": {
         "is-callable": "1.1.3",
         "is-date-object": "1.0.1",
@@ -10249,8 +2185,7 @@
     "es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
     },
     "es6-iterator": {
       "version": "2.0.3",
@@ -10274,20 +2209,17 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
       "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
-      "dev": true,
       "requires": {
         "esprima": "3.1.3",
         "estraverse": "4.2.0",
@@ -10299,14 +2231,12 @@
         "esprima": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
         },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true,
           "optional": true
         }
       }
@@ -10315,7 +2245,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
       "integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
-      "dev": true,
       "requires": {
         "is-url": "1.2.2",
         "path-is-absolute": "1.0.1",
@@ -10326,22 +2255,19 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "espurify": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
-      "dev": true,
       "requires": {
         "core-js": "2.5.3"
       },
@@ -10349,40 +2275,34 @@
         "core-js": {
           "version": "2.5.3",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-          "dev": true
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
         }
       }
     },
     "estraverse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-      "dev": true
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "dev": true
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eventemitter3": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
-      "dev": true
+      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
     },
     "eventsource": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
-      "dev": true,
       "requires": {
         "original": "1.0.0"
       }
@@ -10391,7 +2311,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
       "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
-      "dev": true,
       "requires": {
         "merge": "1.2.0"
       }
@@ -10400,7 +2319,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "dev": true,
       "requires": {
         "cross-spawn": "5.1.0",
         "get-stream": "3.0.0",
@@ -10414,14 +2332,12 @@
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
     },
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true,
       "requires": {
         "is-posix-bracket": "0.1.1"
       }
@@ -10430,7 +2346,6 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
       "requires": {
         "fill-range": "2.2.3"
       }
@@ -10439,7 +2354,6 @@
       "version": "22.4.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-22.4.0.tgz",
       "integrity": "sha512-Fiy862jT3qc70hwIHwwCBNISmaqBrfWKKrtqyMJ6iwZr+6KXtcnHojZFtd63TPRvRl8EQTJ+YXYy2lK6/6u+Hw==",
-      "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
         "jest-diff": "22.4.0",
@@ -10453,7 +2367,6 @@
       "version": "4.16.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
       "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
-      "dev": true,
       "requires": {
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
@@ -10490,14 +2403,12 @@
         "array-flatten": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-          "dev": true
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -10507,14 +2418,12 @@
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true,
       "requires": {
         "is-extglob": "1.0.0"
       },
@@ -10522,46 +2431,39 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         }
       }
     },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
-      "dev": true
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
     },
     "fast-diff": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
-      "dev": true
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "faye-websocket": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-      "dev": true,
       "requires": {
         "websocket-driver": "0.7.0"
       }
@@ -10570,7 +2472,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
-      "dev": true,
       "requires": {
         "bser": "2.0.0"
       }
@@ -10593,7 +2494,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true,
       "requires": {
         "escape-string-regexp": "1.0.5"
       }
@@ -10601,14 +2501,12 @@
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "dev": true
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
     "fileset": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-      "dev": true,
       "requires": {
         "glob": "7.1.2",
         "minimatch": "3.0.4"
@@ -10618,7 +2516,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true,
       "requires": {
         "is-number": "2.1.0",
         "isobject": "2.1.0",
@@ -10631,7 +2528,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
           "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
           "requires": {
             "isarray": "1.0.0"
           }
@@ -10642,7 +2538,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
       "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "1.0.1",
@@ -10657,7 +2552,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -10668,7 +2562,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-      "dev": true,
       "requires": {
         "commondir": "1.0.1",
         "make-dir": "1.1.0",
@@ -10678,14 +2571,12 @@
     "find-index": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-      "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
-      "dev": true
+      "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ="
     },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-      "dev": true,
       "requires": {
         "locate-path": "2.0.0"
       }
@@ -10694,7 +2585,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
       "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "readable-stream": "2.3.3"
@@ -10703,20 +2593,17 @@
     "fn-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
-      "dev": true
+      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc="
     },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
       "requires": {
         "for-in": "1.0.2"
       }
@@ -10724,20 +2611,17 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-      "dev": true,
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
@@ -10747,20 +2631,17 @@
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-      "dev": true
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "dev": true
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "readable-stream": "2.3.3"
@@ -10770,7 +2651,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
       "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "jsonfile": "4.0.0",
@@ -10781,7 +2661,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "iferr": "0.1.5",
@@ -10792,14 +2671,12 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-      "dev": true,
       "optional": true,
       "requires": {
         "nan": "2.9.2",
@@ -10809,7 +2686,6 @@
         "abbrev": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "ajv": {
@@ -10824,13 +2700,11 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
@@ -10846,37 +2720,31 @@
         "asn1": {
           "version": "0.2.3",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "aws4": {
           "version": "1.6.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
@@ -10906,7 +2774,6 @@
         "brace-expansion": {
           "version": "1.1.7",
           "bundled": true,
-          "dev": true,
           "requires": {
             "balanced-match": "0.4.2",
             "concat-map": "0.0.1"
@@ -10914,48 +2781,40 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "caseless": {
           "version": "0.12.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "co": {
           "version": "4.6.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
-          "dev": true,
           "requires": {
             "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "cryptiles": {
           "version": "2.0.5",
@@ -10968,7 +2827,6 @@
         "dashdash": {
           "version": "1.14.1",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
@@ -10977,7 +2835,6 @@
             "assert-plus": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
               "optional": true
             }
           }
@@ -10994,24 +2851,20 @@
         "deep-extend": {
           "version": "0.4.2",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
@@ -11026,18 +2879,15 @@
         "extend": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "forever-agent": {
           "version": "0.6.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "form-data": {
@@ -11053,8 +2903,7 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "fstream": {
           "version": "1.0.11",
@@ -11097,7 +2946,6 @@
         "getpass": {
           "version": "0.1.7",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
@@ -11106,7 +2954,6 @@
             "assert-plus": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
               "optional": true
             }
           }
@@ -11126,13 +2973,11 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "har-schema": {
           "version": "1.0.5",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "har-validator": {
@@ -11702,44 +3547,37 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "function-name-support": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/function-name-support/-/function-name-support-0.2.0.tgz",
-      "integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE=",
-      "dev": true
+      "integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE="
     },
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-      "dev": true
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
     "get-port": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
-      "dev": true
+      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
     },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-      "dev": true
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
     },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       }
@@ -11748,7 +3586,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -11762,7 +3599,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
       "requires": {
         "glob-parent": "2.0.0",
         "is-glob": "2.0.1"
@@ -11771,14 +3607,12 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
           "requires": {
             "is-extglob": "1.0.0"
           }
@@ -11789,7 +3623,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true,
       "requires": {
         "is-glob": "2.0.1"
       },
@@ -11797,14 +3630,12 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
           "requires": {
             "is-extglob": "1.0.0"
           }
@@ -11815,7 +3646,6 @@
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-      "dev": true,
       "requires": {
         "find-index": "0.1.1"
       }
@@ -11833,7 +3663,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-      "dev": true,
       "requires": {
         "ini": "1.3.5"
       }
@@ -11841,14 +3670,12 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
     "globby": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
       "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-      "dev": true,
       "requires": {
         "array-union": "1.0.2",
         "dir-glob": "2.0.0",
@@ -11862,7 +3689,6 @@
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-      "dev": true,
       "requires": {
         "create-error-class": "3.0.2",
         "duplexer3": "0.1.4",
@@ -11880,26 +3706,22 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
     "handle-thing": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
-      "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
-      "dev": true
+      "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
     },
     "handlebars": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-      "dev": true,
       "requires": {
         "async": "1.5.2",
         "optimist": "0.6.1",
@@ -11910,14 +3732,12 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
           "requires": {
             "amdefine": "1.0.1"
           }
@@ -11927,14 +3747,12 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "dev": true,
       "requires": {
         "ajv": "5.5.2",
         "har-schema": "2.0.0"
@@ -11944,7 +3762,6 @@
           "version": "5.5.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "dev": true,
           "requires": {
             "co": "4.6.0",
             "fast-deep-equal": "1.0.0",
@@ -11958,7 +3775,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true,
       "requires": {
         "function-bind": "1.1.1"
       }
@@ -11967,7 +3783,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -11975,26 +3790,22 @@
     "has-color": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-      "dev": true
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
     },
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-      "dev": true
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "has-yarn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
-      "integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
-      "dev": true
+      "integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac="
     },
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "dev": true,
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
@@ -12005,8 +3816,7 @@
     "hoek": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-      "dev": true
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "hoist-non-react-statics": {
       "version": "2.3.1",
@@ -12017,7 +3827,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
@@ -12026,14 +3835,12 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-      "dev": true
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
     },
     "hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "obuf": "1.1.1",
@@ -12045,7 +3852,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-      "dev": true,
       "requires": {
         "whatwg-encoding": "1.0.3"
       }
@@ -12053,20 +3859,17 @@
     "html-entities": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
-      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
-      "dev": true
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
     "http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
-      "dev": true
+      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
     },
     "http-errors": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
       "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-      "dev": true,
       "requires": {
         "depd": "1.1.1",
         "inherits": "2.0.3",
@@ -12077,22 +3880,19 @@
         "setprototypeof": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-          "dev": true
+          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
         }
       }
     },
     "http-parser-js": {
       "version": "0.4.9",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz",
-      "integrity": "sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE=",
-      "dev": true
+      "integrity": "sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE="
     },
     "http-proxy": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
-      "dev": true,
       "requires": {
         "eventemitter3": "1.2.0",
         "requires-port": "1.0.0"
@@ -12102,7 +3902,6 @@
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
       "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
-      "dev": true,
       "requires": {
         "http-proxy": "1.16.2",
         "is-glob": "3.1.0",
@@ -12114,7 +3913,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
           "requires": {
             "is-extglob": "2.1.1"
           }
@@ -12125,7 +3923,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
@@ -12136,7 +3933,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.1.1.tgz",
       "integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
-      "dev": true,
       "requires": {
         "dot-prop": "4.2.0",
         "es6-error": "4.1.1",
@@ -12157,8 +3953,7 @@
         "indent-string": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-          "dev": true
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
         }
       }
     },
@@ -12170,32 +3965,27 @@
     "iferr": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-      "dev": true
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
     },
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
-      "dev": true
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
     },
     "ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
-      "dev": true
+      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk="
     },
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-      "dev": true
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
     },
     "import-local": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
       "integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
-      "dev": true,
       "requires": {
         "pkg-dir": "2.0.0",
         "resolve-cwd": "2.0.0"
@@ -12204,14 +3994,12 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent-string": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true,
       "requires": {
         "repeating": "2.0.1"
       }
@@ -12220,7 +4008,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -12229,20 +4016,17 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "internal-ip": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
       "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
-      "dev": true,
       "requires": {
         "meow": "3.7.0"
       }
@@ -12251,7 +4035,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -12259,38 +4042,32 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-      "dev": true
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ipaddr.js": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
-      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
-      "dev": true
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
     },
     "irregular-plurals": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
-      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
-      "dev": true
+      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
     },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true,
       "requires": {
         "binary-extensions": "1.11.0"
       }
@@ -12298,14 +4075,12 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
       "requires": {
         "builtin-modules": "1.1.1"
       }
@@ -12313,14 +4088,12 @@
     "is-callable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-      "dev": true
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
     },
     "is-ci": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
-      "dev": true,
       "requires": {
         "ci-info": "1.1.2"
       }
@@ -12328,20 +4101,17 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
       "requires": {
         "is-primitive": "2.0.0"
       }
@@ -12349,26 +4119,22 @@
     "is-error": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz",
-      "integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw=",
-      "dev": true
+      "integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw="
     },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -12377,7 +4143,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -12390,14 +4155,12 @@
     "is-generator-fn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-      "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
-      "dev": true
+      "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
     },
     "is-glob": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
       "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-      "dev": true,
       "requires": {
         "is-extglob": "2.1.1"
       }
@@ -12411,7 +4174,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-      "dev": true,
       "requires": {
         "global-dirs": "0.1.1",
         "is-path-inside": "1.0.1"
@@ -12420,14 +4182,12 @@
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-      "dev": true
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
     },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2"
       }
@@ -12435,14 +4195,12 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-observable": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
       "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
-      "dev": true,
       "requires": {
         "symbol-observable": "0.2.4"
       },
@@ -12450,22 +4208,19 @@
         "symbol-observable": {
           "version": "0.2.4",
           "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
-          "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
-          "dev": true
+          "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A="
         }
       }
     },
     "is-path-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
     },
     "is-path-in-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true,
       "requires": {
         "is-path-inside": "1.0.1"
       }
@@ -12474,7 +4229,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
       }
@@ -12482,8 +4236,7 @@
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -12496,32 +4249,27 @@
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
     },
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "dev": true
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
     },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
       "requires": {
         "has": "1.0.1"
       }
@@ -12529,8 +4277,7 @@
     "is-retry-allowed": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-      "dev": true
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -12540,44 +4287,37 @@
     "is-symbol": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-      "dev": true
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
     },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-url": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
-      "integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY=",
-      "dev": true
+      "integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY="
     },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-wsl": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-      "dev": true
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -12596,14 +4336,12 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-api": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.2.tgz",
       "integrity": "sha512-kH5YRdqdbs5hiH4/Rr1Q0cSAGgjh3jTtg8vu9NLebBAoK3adVO4jk81J+TYOkTr2+Q4NLeb1ACvmEt65iG/Vbw==",
-      "dev": true,
       "requires": {
         "async": "2.6.0",
         "fileset": "2.0.3",
@@ -12621,14 +4359,12 @@
     "istanbul-lib-coverage": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.2.tgz",
-      "integrity": "sha512-tZYA0v5A7qBSsOzcebJJ/z3lk3oSzH62puG78DbBA1+zupipX2CakDyiPV3pOb8He+jBwVimuwB0dTnh38hX0w==",
-      "dev": true
+      "integrity": "sha512-tZYA0v5A7qBSsOzcebJJ/z3lk3oSzH62puG78DbBA1+zupipX2CakDyiPV3pOb8He+jBwVimuwB0dTnh38hX0w=="
     },
     "istanbul-lib-hook": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
       "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
-      "dev": true,
       "requires": {
         "append-transform": "0.4.0"
       }
@@ -12637,7 +4373,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.2.tgz",
       "integrity": "sha512-nz8t4HQ2206a/3AXi+NHFWEa844DMpPsgbcUteJbt1j8LX1xg56H9rOMnhvcvVvPbW60qAIyrSk44H8ZDqaSSA==",
-      "dev": true,
       "requires": {
         "babel-generator": "6.26.0",
         "babel-template": "6.26.0",
@@ -12652,7 +4387,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
       "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
-      "dev": true,
       "requires": {
         "istanbul-lib-coverage": "1.1.2",
         "mkdirp": "0.5.1",
@@ -12663,14 +4397,12 @@
         "has-flag": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
           "requires": {
             "has-flag": "1.0.0"
           }
@@ -12681,7 +4413,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
       "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
-      "dev": true,
       "requires": {
         "debug": "3.1.0",
         "istanbul-lib-coverage": "1.1.2",
@@ -12693,8 +4424,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -12702,7 +4432,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.4.tgz",
       "integrity": "sha512-DfSTVOTkuO+kRmbO8Gk650Wqm1WRGr6lrdi2EwDK1vxpS71vdlLd613EpzOKdIFioB5f/scJTjeWBnvd1FWejg==",
-      "dev": true,
       "requires": {
         "handlebars": "4.0.11"
       }
@@ -12711,7 +4440,6 @@
       "version": "22.4.2",
       "resolved": "https://registry.npmjs.org/jest/-/jest-22.4.2.tgz",
       "integrity": "sha512-wD7dXWtfaQAgbNVsjFqzmuhg6nzwGsTRVea3FpSJ7GURhG+J536fw4mdoLB01DgiEozDDeF1ZMR/UlUszTsCrg==",
-      "dev": true,
       "requires": {
         "import-local": "1.0.0",
         "jest-cli": "22.4.2"
@@ -12720,20 +4448,17 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "cliui": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
           "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
-          "dev": true,
           "requires": {
             "string-width": "2.1.1",
             "strip-ansi": "4.0.0",
@@ -12744,7 +4469,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
           "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
-          "dev": true,
           "requires": {
             "pkg-dir": "2.0.0",
             "resolve-cwd": "2.0.0"
@@ -12753,14 +4477,12 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "jest-cli": {
           "version": "22.4.2",
           "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.2.tgz",
           "integrity": "sha512-ebo6ZWK2xDSs7LGnLvM16SZOIJ2dj0B6/oERmGcal32NHkks450nNfGrGTyOSPgJDgH8DFhVdBXgSamN7mtZ0Q==",
-          "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
             "chalk": "2.3.0",
@@ -12802,7 +4524,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
           "requires": {
             "execa": "0.7.0",
             "lcid": "1.0.0",
@@ -12813,7 +4534,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -12823,7 +4543,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -12831,14 +4550,12 @@
         "which-module": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-          "dev": true
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
         },
         "yargs": {
           "version": "10.1.2",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
           "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
-          "dev": true,
           "requires": {
             "cliui": "4.0.0",
             "decamelize": "1.2.0",
@@ -12858,7 +4575,6 @@
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
           "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
-          "dev": true,
           "requires": {
             "camelcase": "4.1.0"
           }
@@ -12869,7 +4585,6 @@
       "version": "22.2.0",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.2.0.tgz",
       "integrity": "sha512-SzqOvoPMrXB0NPvDrSPeKETpoUNCtNDOsFbCzAGWxqWVvNyrIMLpUjVExT3u3LfdVrENlrNGCfh5YoFd8+ZeXg==",
-      "dev": true,
       "requires": {
         "throat": "4.1.0"
       }
@@ -12878,7 +4593,6 @@
       "version": "22.4.2",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.2.tgz",
       "integrity": "sha512-oG31qYO73/3vj/Q8aM2RgzmHndTkz9nRk8ISybfuJqqbf0RW7OUjHVOZPLOUiwLWtz52Yq2HkjIblsyhbA7vrg==",
-      "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "glob": "7.1.2",
@@ -12897,7 +4611,6 @@
       "version": "22.4.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.0.tgz",
       "integrity": "sha512-+/t20WmnkOkB8MOaGaPziI8zWKxquMvYw4Ub+wOzi7AUhmpFXz43buWSxVoZo4J5RnCozpGbX3/FssjJ5KV9Nw==",
-      "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "diff": "3.5.0",
@@ -12909,7 +4622,6 @@
       "version": "22.4.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.0.tgz",
       "integrity": "sha512-lDY7GZ+/CJb02oULYLBDj7Hs5shBhVpDYpIm8LUyqw9X2J22QRsM19gmGQwIFqGSJmpc/LRrSYudeSrG510xlQ==",
-      "dev": true,
       "requires": {
         "detect-newline": "2.1.0"
       }
@@ -12918,7 +4630,6 @@
       "version": "22.4.1",
       "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.1.tgz",
       "integrity": "sha512-x/JzAoH+dWPBnIMv5OQKiIR0TYf6UvbRjsIuDZ11yDFXkHKGJZg6jNnLAsokAm3cq9kUa2hH5BPUC9XU4n1ELQ==",
-      "dev": true,
       "requires": {
         "jest-mock": "22.2.0",
         "jest-util": "22.4.1",
@@ -12929,7 +4640,6 @@
       "version": "22.4.1",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.1.tgz",
       "integrity": "sha512-wj9+zzfRgnUbm5VwFOCGgG1QmbucUyrjPKBKUJdLW8K5Ss5zrNc1k+v6feZhFg6sS3ZGnjgtIyklaxEARxu+LQ==",
-      "dev": true,
       "requires": {
         "jest-mock": "22.2.0",
         "jest-util": "22.4.1"
@@ -12938,14 +4648,12 @@
     "jest-get-type": {
       "version": "22.1.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.1.0.tgz",
-      "integrity": "sha512-nD97IVOlNP6fjIN5i7j5XRH+hFsHL7VlauBbzRvueaaUe70uohrkz7pL/N8lx/IAwZRTJ//wOdVgh85OgM7g3w==",
-      "dev": true
+      "integrity": "sha512-nD97IVOlNP6fjIN5i7j5XRH+hFsHL7VlauBbzRvueaaUe70uohrkz7pL/N8lx/IAwZRTJ//wOdVgh85OgM7g3w=="
     },
     "jest-haste-map": {
       "version": "22.4.2",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.2.tgz",
       "integrity": "sha512-EdQADHGXRqHJYAr7q9B9YYHZnrlcMwhx1+DnIgc9uN05nCW3RvGCxJ91MqWXcC1AzatLoSv7SNd0qXMp2jKBDA==",
-      "dev": true,
       "requires": {
         "fb-watchman": "2.0.0",
         "graceful-fs": "4.1.11",
@@ -12960,7 +4668,6 @@
       "version": "22.4.2",
       "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.2.tgz",
       "integrity": "sha512-KZaIHpXQ0AIlvQJFCU0uoXxtz5GG47X14r9upMe7VXE55UazoMZBFnQb9TX2HoYX2/AxJYnjHuvwKVCFqOrEtw==",
-      "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "co": "4.6.0",
@@ -12979,7 +4686,6 @@
       "version": "22.4.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.0.tgz",
       "integrity": "sha512-r3NEIVNh4X3fEeJtUIrKXWKhNokwUM2ILp5LD8w1KrEanPsFtZmYjmyZYjDTX2dXYr33TW65OvbRE3hWFAyq6g==",
-      "dev": true,
       "requires": {
         "pretty-format": "22.4.0"
       }
@@ -12988,7 +4694,6 @@
       "version": "22.4.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.0.tgz",
       "integrity": "sha512-03m3issxUXpWMwDYTfmL8hRNewUB0yCRTeXPm+eq058rZxLHD9f5NtSSO98CWHqe4UyISIxd9Ao9iDVjHWd2qg==",
-      "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "jest-get-type": "22.1.0",
@@ -12999,7 +4704,6 @@
       "version": "22.4.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.0.tgz",
       "integrity": "sha512-eyCJB0T3hrlpFF2FqQoIB093OulP+1qvATQmD3IOgJgMGqPL6eYw8TbC5P/VCWPqKhGL51xvjIIhow5eZ2wHFw==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0-beta.40",
         "chalk": "2.3.0",
@@ -13011,20 +4715,17 @@
     "jest-mock": {
       "version": "22.2.0",
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.2.0.tgz",
-      "integrity": "sha512-eOfoUYLOB/JlxChOFkh/bzpWGqUXb9I+oOpkprHHs9L7nUNfL8Rk28h1ycWrqzWCEQ/jZBg/xIv7VdQkfAkOhw==",
-      "dev": true
+      "integrity": "sha512-eOfoUYLOB/JlxChOFkh/bzpWGqUXb9I+oOpkprHHs9L7nUNfL8Rk28h1ycWrqzWCEQ/jZBg/xIv7VdQkfAkOhw=="
     },
     "jest-regex-util": {
       "version": "22.1.0",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.1.0.tgz",
-      "integrity": "sha512-on0LqVS6Xeh69sw3d1RukVnur+lVOl3zkmb0Q54FHj9wHoq6dbtWqb3TSlnVUyx36hqjJhjgs/QLqs07Bzu72Q==",
-      "dev": true
+      "integrity": "sha512-on0LqVS6Xeh69sw3d1RukVnur+lVOl3zkmb0Q54FHj9wHoq6dbtWqb3TSlnVUyx36hqjJhjgs/QLqs07Bzu72Q=="
     },
     "jest-resolve": {
       "version": "22.4.2",
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.2.tgz",
       "integrity": "sha512-P1hSfcc2HJYT5t+WPu/11OfFMa7m8pBb2Gf2vm6W9OVs7YTXQ5RCC3nDqaYZQaTqxEM1ZZaTcQGcE6U2xMOsqQ==",
-      "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
         "chalk": "2.3.0"
@@ -13034,7 +4735,6 @@
       "version": "22.1.0",
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.1.0.tgz",
       "integrity": "sha512-76Ll61bD/Sus8wK8d+lw891EtiBJGJkWG8OuVDTEX0z3z2+jPujvQqSB2eQ+kCHyCsRwJ2PSjhn3UHqae/oEtA==",
-      "dev": true,
       "requires": {
         "jest-regex-util": "22.1.0"
       }
@@ -13043,7 +4743,6 @@
       "version": "22.4.2",
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.2.tgz",
       "integrity": "sha512-W4vwgiVQS0NyXt8hgpw7i0YUtsfoChiQcoHWBJeq2ocV4VF2osEZx8HYgpH5HfNe1Cb5LZeZWxX8Dr3hesbGFg==",
-      "dev": true,
       "requires": {
         "exit": "0.1.2",
         "jest-config": "22.4.2",
@@ -13062,7 +4761,6 @@
       "version": "22.4.2",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.2.tgz",
       "integrity": "sha512-9/Fxbj99cqxI7o2nTNzevnI38eDBstkwve8ZeaAD/Kz0fbU3i3eRv2QPEmzbmyCyBvUWxCT7BzNLTzTqH1+pyA==",
-      "dev": true,
       "requires": {
         "babel-core": "6.26.0",
         "babel-jest": "22.4.1",
@@ -13089,20 +4787,17 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "cliui": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
           "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
-          "dev": true,
           "requires": {
             "string-width": "2.1.1",
             "strip-ansi": "4.0.0",
@@ -13112,14 +4807,12 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
           "requires": {
             "execa": "0.7.0",
             "lcid": "1.0.0",
@@ -13130,7 +4823,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -13140,7 +4832,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -13148,20 +4839,17 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         },
         "which-module": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-          "dev": true
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
         },
         "yargs": {
           "version": "10.1.2",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
           "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
-          "dev": true,
           "requires": {
             "cliui": "4.0.0",
             "decamelize": "1.2.0",
@@ -13181,7 +4869,6 @@
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
           "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
-          "dev": true,
           "requires": {
             "camelcase": "4.1.0"
           }
@@ -13191,14 +4878,12 @@
     "jest-serializer": {
       "version": "22.4.0",
       "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.0.tgz",
-      "integrity": "sha512-dnqde95MiYfdc1ZJpjEiHCRvRGGJHPsZQARJFucEGIaOzxqqS9/tt2WzD/OUSGT6kxaEGLQE92faVJGdoCu+Rw==",
-      "dev": true
+      "integrity": "sha512-dnqde95MiYfdc1ZJpjEiHCRvRGGJHPsZQARJFucEGIaOzxqqS9/tt2WzD/OUSGT6kxaEGLQE92faVJGdoCu+Rw=="
     },
     "jest-snapshot": {
       "version": "22.4.0",
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.0.tgz",
       "integrity": "sha512-6Zz4F9G1Nbr93kfm5h3A2+OkE+WGpgJlskYE4iSNN2uYfoTL5b9W6aB9Orpx+ueReHyqmy7HET7Z3EmYlL3hKw==",
-      "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "jest-diff": "22.4.0",
@@ -13212,7 +4897,6 @@
       "version": "22.4.1",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.1.tgz",
       "integrity": "sha512-9ySBdJY2qVWpg0OvZbGcFXE2NgwccpZVj384E9bx7brKFc7l5anpqah15mseWcz7FLDk7/N+LyYgqFme7Rez2Q==",
-      "dev": true,
       "requires": {
         "callsites": "2.0.0",
         "chalk": "2.3.0",
@@ -13227,7 +4911,6 @@
       "version": "22.4.2",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.2.tgz",
       "integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
-      "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "jest-config": "22.4.2",
@@ -13240,7 +4923,6 @@
       "version": "22.2.2",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.2.2.tgz",
       "integrity": "sha512-ZylDXjrFNt/OP6cUxwJFWwDgazP7hRjtCQbocFHyiwov+04Wm1x5PYzMGNJT53s4nwr0oo9ocYTImS09xOlUnw==",
-      "dev": true,
       "requires": {
         "merge-stream": "1.0.1"
       }
@@ -13248,8 +4930,7 @@
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
-      "dev": true
+      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -13260,7 +4941,6 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-      "dev": true,
       "requires": {
         "argparse": "1.0.9",
         "esprima": "4.0.0"
@@ -13270,14 +4950,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
       "optional": true
     },
     "jsdom": {
       "version": "11.5.1",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.5.1.tgz",
       "integrity": "sha512-89ztIZ03aYK9f1uUrLXLsZndRge/JnZjzjpaN+lrse3coqz+8PR/dX4WLHpbF5fIKTXhDjFODOJw2328lPJ90g==",
-      "dev": true,
       "requires": {
         "abab": "1.0.4",
         "acorn": "5.3.0",
@@ -13308,38 +4986,32 @@
     "jsdom-global": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
-      "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
-      "dev": true
+      "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk="
     },
     "jsesc": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-      "dev": true
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
     },
     "json-parse-better-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
-      "dev": true
+      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
     },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
       "requires": {
         "jsonify": "0.0.0"
       }
@@ -13347,26 +5019,22 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json3": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-      "dev": true
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
     },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -13374,14 +5042,12 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -13489,14 +5155,12 @@
     "killable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz",
-      "integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms=",
-      "dev": true
+      "integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms="
     },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
       "requires": {
         "is-buffer": "1.1.6"
       }
@@ -13505,7 +5169,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/last-line-stream/-/last-line-stream-1.0.0.tgz",
       "integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
-      "dev": true,
       "requires": {
         "through2": "2.0.3"
       }
@@ -13514,7 +5177,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-      "dev": true,
       "requires": {
         "package-json": "4.0.1"
       }
@@ -13523,14 +5185,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
       "optional": true
     },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
       "requires": {
         "invert-kv": "1.0.0"
       }
@@ -13538,20 +5198,17 @@
     "left-pad": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
-      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
-      "dev": true
+      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
     },
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
-      "dev": true
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
     },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
@@ -13561,7 +5218,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "parse-json": "2.2.0",
@@ -13573,8 +5229,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
     },
@@ -13582,7 +5237,6 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-      "dev": true,
       "requires": {
         "big.js": "3.2.0",
         "emojis-list": "2.1.0",
@@ -13594,7 +5248,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true,
       "requires": {
         "p-locate": "2.0.0",
         "path-exists": "3.0.0"
@@ -13613,74 +5266,62 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.clonedeepwith": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
-      "integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ=",
-      "dev": true
+      "integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ="
     },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-      "dev": true
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
     },
     "lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-      "dev": true
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-      "dev": true
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
     },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-      "dev": true
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "dev": true
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.merge": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
-      "dev": true
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
     },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "loglevel": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.0.tgz",
-      "integrity": "sha1-rgyqVhERSYxboTcj1vtjHSQAOTQ=",
-      "dev": true
+      "integrity": "sha1-rgyqVhERSYxboTcj1vtjHSQAOTQ="
     },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -13694,7 +5335,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true,
       "requires": {
         "currently-unhandled": "0.4.1",
         "signal-exit": "3.0.2"
@@ -13703,14 +5343,12 @@
     "lowercase-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-      "dev": true
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
     },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -13720,7 +5358,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
       "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
-      "dev": true,
       "requires": {
         "pify": "3.0.0"
       }
@@ -13729,7 +5366,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-      "dev": true,
       "requires": {
         "tmpl": "1.0.4"
       }
@@ -13737,14 +5373,12 @@
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
     "matcher": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.0.0.tgz",
       "integrity": "sha1-qvDEgW62m5IJRnQXViXzRmsOPhk=",
-      "dev": true,
       "requires": {
         "escape-string-regexp": "1.0.5"
       }
@@ -13797,7 +5431,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
       "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
-      "dev": true,
       "requires": {
         "md5-o-matic": "0.1.1"
       }
@@ -13805,20 +5438,17 @@
     "md5-o-matic": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-      "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
-      "dev": true
+      "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
     },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-      "dev": true
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
       "requires": {
         "mimic-fn": "1.1.0"
       }
@@ -13827,7 +5457,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-      "dev": true,
       "requires": {
         "errno": "0.1.6",
         "readable-stream": "2.3.3"
@@ -13837,7 +5466,6 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "dev": true,
       "requires": {
         "camelcase-keys": "2.1.0",
         "decamelize": "1.2.0",
@@ -13854,28 +5482,24 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
     "merge": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
-      "dev": true
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
     },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "merge-stream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-      "dev": true,
       "requires": {
         "readable-stream": "2.3.3"
       }
@@ -13883,14 +5507,12 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true,
       "requires": {
         "arr-diff": "2.0.0",
         "array-unique": "0.2.1",
@@ -13910,14 +5532,12 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
           "requires": {
             "is-extglob": "1.0.0"
           }
@@ -13927,20 +5547,17 @@
     "mime": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-      "dev": true
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-      "dev": true
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
     },
     "mime-types": {
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-      "dev": true,
       "requires": {
         "mime-db": "1.30.0"
       }
@@ -13948,8 +5565,7 @@
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-      "dev": true
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
     },
     "min-document": {
       "version": "2.19.0",
@@ -13962,14 +5578,12 @@
     "minimalistic-assert": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
-      "dev": true
+      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -13977,14 +5591,12 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mississippi": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
       "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
-      "dev": true,
       "requires": {
         "concat-stream": "1.6.0",
         "duplexify": "3.5.1",
@@ -14002,7 +5614,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -14024,7 +5635,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-      "dev": true,
       "requires": {
         "aproba": "1.2.0",
         "copy-concurrently": "1.0.5",
@@ -14037,14 +5647,12 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multicast-dns": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.1.tgz",
       "integrity": "sha512-uV3/ckdsffHx9IrGQrx613mturMdMqQ06WTq+C09NsStJ9iNG6RcUWgPKs1Rfjy+idZT6tfQoXEusGNnEZhT3w==",
-      "dev": true,
       "requires": {
         "dns-packet": "1.2.2",
         "thunky": "0.1.0"
@@ -14053,14 +5661,12 @@
     "multicast-dns-service-types": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
-      "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
-      "dev": true
+      "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
     },
     "multimatch": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-      "dev": true,
       "requires": {
         "array-differ": "1.0.0",
         "array-union": "1.0.2",
@@ -14072,20 +5678,17 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
       "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
-      "dev": true,
       "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-      "dev": true
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "node-fetch": {
       "version": "1.7.3",
@@ -14099,20 +5702,17 @@
     "node-forge": {
       "version": "0.6.33",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.33.tgz",
-      "integrity": "sha1-RjgRh59XPUUVWtap9D3ClujoXrw=",
-      "dev": true
+      "integrity": "sha1-RjgRh59XPUUVWtap9D3ClujoXrw="
     },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
-      "dev": true
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
     },
     "node-notifier": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
       "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
-      "dev": true,
       "requires": {
         "growly": "1.3.0",
         "semver": "5.4.1",
@@ -14124,7 +5724,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
@@ -14136,7 +5735,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
       "requires": {
         "remove-trailing-separator": "1.1.0"
       }
@@ -14150,7 +5748,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
       "requires": {
         "path-key": "2.0.1"
       }
@@ -14158,20 +5755,17 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwmatcher": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
-      "dev": true
+      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw=="
     },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -14181,14 +5775,12 @@
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-      "dev": true
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
     },
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-      "dev": true,
       "requires": {
         "define-properties": "1.1.2",
         "es-abstract": "1.10.0"
@@ -14198,7 +5790,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
       "requires": {
         "for-own": "0.1.5",
         "is-extendable": "0.1.1"
@@ -14208,7 +5799,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-0.5.0.tgz",
       "integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
-      "dev": true,
       "requires": {
         "is-observable": "0.2.0",
         "symbol-observable": "1.1.0"
@@ -14217,14 +5807,12 @@
     "obuf": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
-      "integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4=",
-      "dev": true
+      "integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4="
     },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -14232,14 +5820,12 @@
     "on-headers": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
-      "dev": true
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -14248,7 +5834,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
       "requires": {
         "mimic-fn": "1.1.0"
       }
@@ -14257,7 +5842,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
       "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
-      "dev": true,
       "requires": {
         "is-wsl": "1.1.0"
       }
@@ -14266,7 +5850,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8",
         "wordwrap": "0.0.3"
@@ -14275,22 +5858,19 @@
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         }
       }
     },
     "option-chain": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/option-chain/-/option-chain-1.0.0.tgz",
-      "integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI=",
-      "dev": true
+      "integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI="
     },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
       "requires": {
         "deep-is": "0.1.3",
         "fast-levenshtein": "2.0.6",
@@ -14304,7 +5884,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
       "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
-      "dev": true,
       "requires": {
         "url-parse": "1.0.5"
       },
@@ -14313,7 +5892,6 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
           "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
-          "dev": true,
           "requires": {
             "querystringify": "0.0.4",
             "requires-port": "1.0.0"
@@ -14324,14 +5902,12 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true,
       "requires": {
         "lcid": "1.0.0"
       }
@@ -14339,26 +5915,22 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
     },
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
       "requires": {
         "p-limit": "1.1.0"
       }
@@ -14366,14 +5938,12 @@
     "p-map": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
-      "dev": true
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
     },
     "package-hash": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
       "integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "lodash.flattendeep": "4.4.0",
@@ -14385,7 +5955,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-      "dev": true,
       "requires": {
         "got": "6.7.1",
         "registry-auth-token": "3.3.1",
@@ -14397,7 +5966,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
-      "dev": true,
       "requires": {
         "cyclist": "0.2.2",
         "inherits": "2.0.3",
@@ -14408,7 +5976,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
       "requires": {
         "glob-base": "0.3.0",
         "is-dotfile": "1.0.3",
@@ -14419,14 +5986,12 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
           "requires": {
             "is-extglob": "1.0.0"
           }
@@ -14437,7 +6002,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
       "requires": {
         "error-ex": "1.3.1"
       }
@@ -14445,14 +6009,12 @@
     "parse-ms": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
-      "dev": true
+      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0="
     },
     "parse5": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-      "dev": true,
       "requires": {
         "@types/node": "8.5.5"
       }
@@ -14460,50 +6022,42 @@
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
-      "dev": true
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
     },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-      "dev": true
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "dev": true,
       "requires": {
         "pify": "3.0.0"
       }
@@ -14511,26 +6065,22 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "dev": true
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
       "requires": {
         "pinkie": "2.0.4"
       }
@@ -14539,7 +6089,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
       "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
-      "dev": true,
       "requires": {
         "find-up": "2.1.0",
         "load-json-file": "4.0.0"
@@ -14549,7 +6098,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "parse-json": "4.0.0",
@@ -14561,7 +6109,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
           "requires": {
             "error-ex": "1.3.1",
             "json-parse-better-errors": "1.0.1"
@@ -14570,8 +6117,7 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         }
       }
     },
@@ -14579,7 +6125,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-      "dev": true,
       "requires": {
         "find-up": "2.1.0"
       }
@@ -14588,7 +6133,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
-      "dev": true,
       "requires": {
         "irregular-plurals": "1.4.0"
       }
@@ -14596,8 +6140,7 @@
     "pn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-      "dev": true
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
     },
     "popper.js": {
       "version": "1.12.9",
@@ -14608,7 +6151,6 @@
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
       "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
-      "dev": true,
       "requires": {
         "async": "1.5.2",
         "debug": "2.6.9",
@@ -14618,14 +6160,12 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -14635,26 +6175,22 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prepend-http": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "dev": true
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "pretty-format": {
       "version": "22.4.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.0.tgz",
       "integrity": "sha512-pvCxP2iODIIk9adXlo4S3GRj0BrJiil68kByAa1PrgG97c1tClh9dLMgp3Z6cHFZrclaABt0UH8PIhwHuFLqYA==",
-      "dev": true,
       "requires": {
         "ansi-regex": "3.0.0",
         "ansi-styles": "3.2.0"
@@ -14663,8 +6199,7 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         }
       }
     },
@@ -14672,7 +6207,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
       "integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
-      "dev": true,
       "requires": {
         "parse-ms": "1.0.1",
         "plur": "2.1.2"
@@ -14681,8 +6215,7 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-      "dev": true
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "process": {
       "version": "0.5.2",
@@ -14692,8 +6225,7 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "promise": {
       "version": "7.3.1",
@@ -14706,8 +6238,7 @@
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
-      "dev": true
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
     "prop-types": {
       "version": "15.6.0",
@@ -14723,7 +6254,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
       "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
-      "dev": true,
       "requires": {
         "forwarded": "0.1.2",
         "ipaddr.js": "1.5.2"
@@ -14732,20 +6262,17 @@
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "pump": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
       "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-      "dev": true,
       "requires": {
         "end-of-stream": "1.4.0",
         "once": "1.4.0"
@@ -14755,7 +6282,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
       "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
-      "dev": true,
       "requires": {
         "duplexify": "3.5.1",
         "inherits": "2.0.3",
@@ -14765,20 +6291,17 @@
     "punycode": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
-      "dev": true
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
     },
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-      "dev": true
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "querystringify": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
-      "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw=",
-      "dev": true
+      "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw="
     },
     "rafl": {
       "version": "1.2.2",
@@ -14792,7 +6315,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-      "dev": true,
       "requires": {
         "is-number": "3.0.0",
         "kind-of": "4.0.0"
@@ -14802,7 +6324,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
           "requires": {
             "kind-of": "3.2.2"
           },
@@ -14811,7 +6332,6 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
               "requires": {
                 "is-buffer": "1.1.6"
               }
@@ -14822,7 +6342,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
           "requires": {
             "is-buffer": "1.1.6"
           }
@@ -14832,14 +6351,12 @@
     "range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-      "dev": true
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "raw-body": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
       "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "http-errors": "1.6.2",
@@ -14851,7 +6368,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
       "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
-      "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
         "ini": "1.3.5",
@@ -14862,8 +6378,7 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
@@ -14882,7 +6397,6 @@
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
       "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
-      "dev": true,
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -14926,7 +6440,6 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz",
       "integrity": "sha512-8taaaGu+J7PMJQDJrk/xiWEYQmdo3mkXw6wPr3K3LxvXis3Fymiq7c13S+Tpls/AyNUAsoONkU81AP0RA6y6Vw==",
-      "dev": true,
       "requires": {
         "hoist-non-react-statics": "2.3.1",
         "invariant": "2.2.2",
@@ -14972,7 +6485,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
       "requires": {
         "load-json-file": "1.1.0",
         "normalize-package-data": "2.4.0",
@@ -14983,7 +6495,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "pify": "2.3.0",
@@ -14993,8 +6504,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
     },
@@ -15002,7 +6512,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
       "requires": {
         "find-up": "1.1.2",
         "read-pkg": "1.1.0"
@@ -15012,7 +6521,6 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
           "requires": {
             "path-exists": "2.1.0",
             "pinkie-promise": "2.0.1"
@@ -15022,7 +6530,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
           "requires": {
             "pinkie-promise": "2.0.1"
           }
@@ -15033,7 +6540,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -15048,7 +6554,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "minimatch": "3.0.4",
@@ -15060,7 +6565,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
       "integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
-      "dev": true,
       "requires": {
         "util.promisify": "1.0.0"
       }
@@ -15080,7 +6584,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true,
       "requires": {
         "indent-string": "2.1.0",
         "strip-indent": "1.0.1"
@@ -15101,7 +6604,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.1.tgz",
       "integrity": "sha512-B+iZ98ESHw4EAWVLKUknQlop1OdLKOayGRmd6KavNtC0zoSsycD8hTt0hEr1eUTw2gmYJOdfBY5QAgZweTUcLQ==",
-      "dev": true,
       "requires": {
         "lodash.isplainobject": "4.0.6"
       }
@@ -15109,8 +6611,7 @@
     "regenerate": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
-      "dev": true
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
     },
     "regenerator-runtime": {
       "version": "0.11.1",
@@ -15121,7 +6622,6 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "dev": true,
       "requires": {
         "is-equal-shallow": "0.1.3"
       }
@@ -15130,7 +6630,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true,
       "requires": {
         "regenerate": "1.3.3",
         "regjsgen": "0.2.0",
@@ -15141,7 +6640,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
-      "dev": true,
       "requires": {
         "rc": "1.2.2",
         "safe-buffer": "5.1.1"
@@ -15151,7 +6649,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "dev": true,
       "requires": {
         "rc": "1.2.2"
       }
@@ -15159,14 +6656,12 @@
     "regjsgen": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-      "dev": true
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
     },
     "regjsparser": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true,
       "requires": {
         "jsesc": "0.5.0"
       }
@@ -15175,7 +6670,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
       "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
-      "dev": true,
       "requires": {
         "es6-error": "4.1.1"
       }
@@ -15183,26 +6677,22 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
       "requires": {
         "is-finite": "1.0.2"
       }
@@ -15211,7 +6701,6 @@
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-      "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
@@ -15240,8 +6729,7 @@
         "uuid": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-          "dev": true
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
         }
       }
     },
@@ -15249,7 +6737,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-      "dev": true,
       "requires": {
         "lodash": "4.17.4"
       }
@@ -15258,7 +6745,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
       "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
-      "dev": true,
       "requires": {
         "request-promise-core": "1.1.1",
         "stealthy-require": "1.1.1",
@@ -15268,38 +6754,32 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-      "dev": true
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
     "require-precompiled": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
-      "integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo=",
-      "dev": true
+      "integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo="
     },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-      "dev": true
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
     },
     "resolve-cwd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-      "dev": true,
       "requires": {
         "resolve-from": "3.0.0"
       }
@@ -15307,14 +6787,12 @@
     "resolve-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-      "dev": true
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
     },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
       "requires": {
         "onetime": "2.0.1",
         "signal-exit": "3.0.2"
@@ -15324,7 +6802,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4"
@@ -15334,7 +6811,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
       "requires": {
         "glob": "7.1.2"
       }
@@ -15343,7 +6819,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
-      "dev": true,
       "requires": {
         "aproba": "1.2.0"
       }
@@ -15351,14 +6826,12 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sane": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/sane/-/sane-2.4.1.tgz",
       "integrity": "sha512-fW9svvNd81XzHDZyis9/tEY1bZikDGryy8Hi1BErPyNPYv47CdLseUN+tI5FBHWXEENRtj1SWtX/jBnggLaP0w==",
-      "dev": true,
       "requires": {
         "anymatch": "1.3.2",
         "exec-sh": "0.2.1",
@@ -15373,16 +6846,14 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scroll": {
       "version": "2.0.1",
@@ -15395,14 +6866,12 @@
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
-      "dev": true
+      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selfsigned": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.1.tgz",
       "integrity": "sha1-v4y3uDJWxFUeMTR8YxF3jbme7FI=",
-      "dev": true,
       "requires": {
         "node-forge": "0.6.33"
       }
@@ -15410,14 +6879,12 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "semver-diff": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "dev": true,
       "requires": {
         "semver": "5.4.1"
       }
@@ -15426,7 +6893,6 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
       "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "depd": "1.1.1",
@@ -15447,7 +6913,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -15457,14 +6922,12 @@
     "serialize-javascript": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
-      "integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU=",
-      "dev": true
+      "integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU="
     },
     "serve-index": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
-      "dev": true,
       "requires": {
         "accepts": "1.3.4",
         "batch": "0.6.1",
@@ -15479,7 +6942,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -15490,7 +6952,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
       "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
-      "dev": true,
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
@@ -15501,14 +6962,12 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -15518,14 +6977,12 @@
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-      "dev": true
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "1.0.0"
       }
@@ -15533,14 +6990,12 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shell-quote": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-      "dev": true,
       "requires": {
         "array-filter": "0.0.1",
         "array-map": "0.0.0",
@@ -15551,26 +7006,22 @@
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
     },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-      "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
       },
@@ -15578,22 +7029,19 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         }
       }
     },
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-      "dev": true
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
     "sntp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "dev": true,
       "requires": {
         "hoek": "4.2.0"
       }
@@ -15602,7 +7050,6 @@
       "version": "0.3.18",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
       "integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
-      "dev": true,
       "requires": {
         "faye-websocket": "0.10.0",
         "uuid": "2.0.3"
@@ -15612,7 +7059,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
       "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "eventsource": "0.1.6",
@@ -15626,7 +7072,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -15635,7 +7080,6 @@
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
           "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
-          "dev": true,
           "requires": {
             "websocket-driver": "0.7.0"
           }
@@ -15646,7 +7090,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
       "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-      "dev": true,
       "requires": {
         "is-plain-obj": "1.1.0"
       }
@@ -15654,14 +7097,12 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-loader": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.3.tgz",
       "integrity": "sha512-MYbFX9DYxmTQFfy2v8FC1XZwpwHKYxg3SK8Wb7VPBKuhDjz8gi9re2819MsG4p49HDyiOSUKlmZ+nQBArW5CGw==",
-      "dev": true,
       "requires": {
         "async": "2.6.0",
         "loader-utils": "0.2.17",
@@ -15672,7 +7113,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
       "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
-      "dev": true,
       "requires": {
         "source-map": "0.6.1"
       }
@@ -15681,7 +7121,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true,
       "requires": {
         "spdx-license-ids": "1.2.2"
       }
@@ -15689,20 +7128,17 @@
     "spdx-expression-parse": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-      "dev": true
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
     },
     "spdx-license-ids": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-      "dev": true
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
     },
     "spdy": {
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "handle-thing": "1.2.5",
@@ -15716,7 +7152,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -15727,7 +7162,6 @@
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
       "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "detect-node": "2.0.3",
@@ -15742,7 +7176,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -15752,14 +7185,12 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "dev": true,
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -15775,7 +7206,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz",
       "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -15783,20 +7213,17 @@
     "stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-      "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
-      "dev": true
+      "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
     },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-      "dev": true
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
     },
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "dev": true
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stifle": {
       "version": "1.0.4",
@@ -15807,7 +7234,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
       "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
-      "dev": true,
       "requires": {
         "end-of-stream": "1.4.0",
         "stream-shift": "1.0.0"
@@ -15816,14 +7242,12 @@
     "stream-shift": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-      "dev": true
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
-      "dev": true,
       "requires": {
         "astral-regex": "1.0.0",
         "strip-ansi": "4.0.0"
@@ -15832,14 +7256,12 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -15850,7 +7272,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
       "requires": {
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
@@ -15861,7 +7282,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -15869,14 +7289,12 @@
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -15885,7 +7303,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
       "requires": {
         "is-utf8": "0.2.1"
       }
@@ -15894,7 +7311,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
       "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
-      "dev": true,
       "requires": {
         "is-utf8": "0.2.1"
       }
@@ -15902,14 +7318,12 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true,
       "requires": {
         "get-stdin": "4.0.1"
       }
@@ -15917,14 +7331,12 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "subarg": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
-      "dev": true,
       "requires": {
         "minimist": "1.2.0"
       },
@@ -15932,8 +7344,7 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
@@ -15941,7 +7352,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
       "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-      "dev": true,
       "requires": {
         "has-flag": "2.0.0"
       }
@@ -15954,20 +7364,17 @@
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
-      "dev": true
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
     },
     "tapable": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
-      "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
-      "dev": true
+      "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
     },
     "term-size": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "dev": true,
       "requires": {
         "execa": "0.7.0"
       }
@@ -15976,7 +7383,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.0.tgz",
       "integrity": "sha512-8hMFzjxbPv6xSlwGhXSvOMJ/vTy3bkng+2pxmf6E1z6VF7I9nIyNfvHtaw+NBPgvz647gADBbMSbwLfZYppT/w==",
-      "dev": true,
       "requires": {
         "arrify": "1.0.1",
         "micromatch": "2.3.11",
@@ -15988,8 +7394,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "theming": {
       "version": "1.3.0",
@@ -16005,14 +7410,12 @@
     "throat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
-      "dev": true
+      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
     },
     "through2": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-      "dev": true,
       "requires": {
         "readable-stream": "2.3.3",
         "xtend": "4.0.1"
@@ -16021,14 +7424,12 @@
     "thunky": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
-      "integrity": "sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4=",
-      "dev": true
+      "integrity": "sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4="
     },
     "time-require": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/time-require/-/time-require-0.1.2.tgz",
       "integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
-      "dev": true,
       "requires": {
         "chalk": "0.4.0",
         "date-time": "0.1.1",
@@ -16039,14 +7440,12 @@
         "ansi-styles": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-          "dev": true
+          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
         },
         "chalk": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "dev": true,
           "requires": {
             "ansi-styles": "1.0.0",
             "has-color": "0.1.7",
@@ -16056,20 +7455,17 @@
         "date-time": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
-          "integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
-          "dev": true
+          "integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc="
         },
         "parse-ms": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
-          "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
-          "dev": true
+          "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4="
         },
         "pretty-ms": {
           "version": "0.2.2",
           "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
           "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
-          "dev": true,
           "requires": {
             "parse-ms": "0.1.2"
           }
@@ -16077,46 +7473,39 @@
         "strip-ansi": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-          "dev": true
+          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
         }
       }
     },
     "time-stamp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
-      "integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=",
-      "dev": true
+      "integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c="
     },
     "time-zone": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
-      "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
-      "dev": true
+      "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0="
     },
     "timed-out": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
-      "dev": true
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
     },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
     "tough-cookie": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-      "dev": true,
       "requires": {
         "punycode": "1.4.1"
       },
@@ -16124,8 +7513,7 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
       }
     },
@@ -16133,7 +7521,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
       "requires": {
         "punycode": "2.1.0"
       }
@@ -16141,26 +7528,22 @@
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-      "dev": true
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
     },
     "trim-off-newlines": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
-      "dev": true
+      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
     },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "ts-jest": {
       "version": "22.4.1",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-22.4.1.tgz",
       "integrity": "sha512-6D3rWDiIuuRmtnoxDK0s69VK8Zw+JTdOkG9KeqQJF1U4ODlvAXg7ZLHfjZTmRFEshitFFeSmJ/reKzufYeibWA==",
-      "dev": true,
       "requires": {
         "babel-core": "6.26.0",
         "babel-plugin-istanbul": "4.1.5",
@@ -16176,20 +7559,17 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "cliui": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
           "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
-          "dev": true,
           "requires": {
             "string-width": "2.1.1",
             "strip-ansi": "4.0.0",
@@ -16199,14 +7579,12 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
           "requires": {
             "execa": "0.7.0",
             "lcid": "1.0.0",
@@ -16217,7 +7595,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -16227,7 +7604,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -16235,14 +7611,12 @@
         "which-module": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-          "dev": true
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
         },
         "yargs": {
           "version": "11.0.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
           "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
-          "dev": true,
           "requires": {
             "cliui": "4.0.0",
             "decamelize": "1.2.0",
@@ -16262,7 +7636,6 @@
           "version": "9.0.2",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-          "dev": true,
           "requires": {
             "camelcase": "4.1.0"
           }
@@ -16273,7 +7646,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-3.2.0.tgz",
       "integrity": "sha512-4g8BF3gKWBHeM1jAFmMPHofuJlwTUU4iHJ0i3mwXRHwy74RU6VBOgl9kDVMGpapvGcMlVqV5G6v9XmV66Qqd7w==",
-      "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "enhanced-resolve": "3.4.1",
@@ -16285,7 +7657,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true,
           "requires": {
             "big.js": "3.2.0",
             "emojis-list": "2.1.0",
@@ -16298,7 +7669,6 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/tslint-loader/-/tslint-loader-3.5.3.tgz",
       "integrity": "sha1-ND90Ei2U81a2iUV9P1n2SmmrYG8=",
-      "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
         "mkdirp": "0.5.1",
@@ -16311,7 +7681,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true,
           "requires": {
             "big.js": "3.2.0",
             "emojis-list": "2.1.0",
@@ -16324,7 +7693,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -16333,14 +7701,12 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
       "optional": true
     },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "1.1.2"
       }
@@ -16349,7 +7715,6 @@
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "dev": true,
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "2.1.17"
@@ -16358,8 +7723,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "ua-parser-js": {
       "version": "0.7.17",
@@ -16370,7 +7734,6 @@
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "dev": true,
       "optional": true,
       "requires": {
         "source-map": "0.5.7",
@@ -16382,14 +7745,12 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true,
           "optional": true
         },
         "cliui": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
           "optional": true,
           "requires": {
             "center-align": "0.1.3",
@@ -16401,21 +7762,18 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
           "optional": true
         },
         "yargs": {
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
           "optional": true,
           "requires": {
             "camelcase": "1.2.1",
@@ -16430,20 +7788,17 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
       "optional": true
     },
     "uid2": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
-      "dev": true
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "unique-filename": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
       "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
-      "dev": true,
       "requires": {
         "unique-slug": "2.0.0"
       }
@@ -16452,7 +7807,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
       "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-      "dev": true,
       "requires": {
         "imurmurhash": "0.1.4"
       }
@@ -16461,7 +7815,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "dev": true,
       "requires": {
         "crypto-random-string": "1.0.0"
       }
@@ -16470,7 +7823,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
       "integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
-      "dev": true,
       "requires": {
         "mkdirp": "0.5.1",
         "os-tmpdir": "1.0.2",
@@ -16480,26 +7832,22 @@
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-      "dev": true
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "dev": true
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unzip-response": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-      "dev": true
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
     },
     "update-notifier": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
       "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
-      "dev": true,
       "requires": {
         "boxen": "1.3.0",
         "chalk": "2.3.0",
@@ -16516,7 +7864,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
       "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
-      "dev": true,
       "requires": {
         "querystringify": "1.0.0",
         "requires-port": "1.0.0"
@@ -16525,8 +7872,7 @@
         "querystringify": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
-          "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
-          "dev": true
+          "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
         }
       }
     },
@@ -16534,7 +7880,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true,
       "requires": {
         "prepend-http": "1.0.4"
       }
@@ -16542,14 +7887,12 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-      "dev": true,
       "requires": {
         "define-properties": "1.1.2",
         "object.getownpropertydescriptors": "2.0.3"
@@ -16558,20 +7901,17 @@
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-      "dev": true
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-      "dev": true
+      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true,
       "requires": {
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
@@ -16580,14 +7920,12 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-      "dev": true
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
@@ -16598,7 +7936,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-      "dev": true,
       "requires": {
         "makeerror": "1.0.11"
       }
@@ -16615,7 +7952,6 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
       "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
-      "dev": true,
       "requires": {
         "exec-sh": "0.2.1",
         "minimist": "1.2.0"
@@ -16624,8 +7960,7 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
@@ -16633,7 +7968,6 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
       "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
-      "dev": true,
       "requires": {
         "minimalistic-assert": "1.0.0"
       }
@@ -16641,14 +7975,12 @@
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "webpack-dev-middleware": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
       "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
-      "dev": true,
       "requires": {
         "memory-fs": "0.4.1",
         "mime": "1.6.0",
@@ -16660,8 +7992,7 @@
         "mime": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-          "dev": true
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
         }
       }
     },
@@ -16669,7 +8000,6 @@
       "version": "2.9.7",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.7.tgz",
       "integrity": "sha512-Pu7uoQFgQj5RE5wmlfkpYSzihMKxulwEuO2xCsaMnAnyRSApwoVi3B8WCm9XbigyWTHaIMzYGkB90Vr6leAeTQ==",
-      "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
         "array-includes": "3.0.3",
@@ -16704,7 +8034,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
-      "dev": true,
       "requires": {
         "http-parser-js": "0.4.9",
         "websocket-extensions": "0.1.3"
@@ -16713,20 +8042,17 @@
     "websocket-extensions": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
-      "dev": true
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
     },
     "well-known-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-1.0.0.tgz",
-      "integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg=",
-      "dev": true
+      "integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg="
     },
     "whatwg-encoding": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
       "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
-      "dev": true,
       "requires": {
         "iconv-lite": "0.4.19"
       }
@@ -16740,7 +8066,6 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
       "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
-      "dev": true,
       "requires": {
         "lodash.sortby": "4.7.0",
         "tr46": "1.0.1",
@@ -16751,7 +8076,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "dev": true,
       "requires": {
         "isexe": "2.0.0"
       }
@@ -16759,14 +8083,12 @@
     "which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-      "dev": true
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
     },
     "widest-line": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
-      "dev": true,
       "requires": {
         "string-width": "2.1.1"
       },
@@ -16774,20 +8096,17 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -16797,7 +8116,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -16808,20 +8126,17 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
       "optional": true
     },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true,
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1"
@@ -16830,14 +8145,12 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
@@ -16848,7 +8161,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
       "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
-      "dev": true,
       "requires": {
         "detect-indent": "5.0.0",
         "graceful-fs": "4.1.11",
@@ -16861,8 +8173,7 @@
         "detect-indent": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-          "dev": true
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
         }
       }
     },
@@ -16870,7 +8181,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.1.0.tgz",
       "integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
-      "dev": true,
       "requires": {
         "sort-keys": "2.0.0",
         "write-json-file": "2.3.0"
@@ -16879,38 +8189,32 @@
     "xdg-basedir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-      "dev": true
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
     },
     "xml-name-validator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
-      "dev": true
+      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
     },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-      "dev": true
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
       "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-      "dev": true,
       "requires": {
         "camelcase": "3.0.0",
         "cliui": "3.2.0",
@@ -16930,8 +8234,7 @@
         "camelcase": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
         }
       }
     },
@@ -16939,7 +8242,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
       "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-      "dev": true,
       "requires": {
         "camelcase": "3.0.0"
       },
@@ -16947,8 +8249,7 @@
         "camelcase": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
         }
       }
     }

--- a/packages/material/package-lock.json
+++ b/packages/material/package-lock.json
@@ -1,16835 +1,9646 @@
 {
-  "name": "@jsonforms/material-renderers",
-  "version": "2.0.0-rc.3",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "@ava/babel-plugin-throws-helper": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-2.0.0.tgz",
-      "integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw=",
-      "dev": true
-    },
-    "@ava/babel-preset-stage-4": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-1.1.0.tgz",
-      "integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "package-hash": "1.2.0"
-      },
-      "dependencies": {
-        "md5-hex": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-          "dev": true,
-          "requires": {
-            "md5-o-matic": "0.1.1"
-          }
-        },
-        "package-hash": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-1.2.0.tgz",
-          "integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
-          "dev": true,
-          "requires": {
-            "md5-hex": "1.3.0"
-          }
-        }
-      }
-    },
-    "@ava/babel-preset-transform-test-files": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-3.0.0.tgz",
-      "integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
-      "dev": true,
-      "requires": {
-        "@ava/babel-plugin-throws-helper": "2.0.0",
-        "babel-plugin-espower": "2.3.2"
-      }
-    },
-    "@ava/write-file-atomic": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@ava/write-file-atomic/-/write-file-atomic-2.2.0.tgz",
-      "integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
-      }
-    },
-    "@concordance/react": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz",
-      "integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
-      "dev": true,
-      "requires": {
-        "arrify": "1.0.1"
-      }
-    },
-    "@jsonforms/core": {
-      "version": "2.0.0-rc.3",
-      "requires": {
-        "ajv": "4.11.8",
-        "lodash": "4.17.4",
-        "redux": "3.7.2",
-        "uuid": "3.1.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.0.57",
-          "bundled": true
-        },
-        "abab": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "acorn": {
-          "version": "5.2.1",
-          "bundled": true
-        },
-        "acorn-globals": {
-          "version": "4.1.0",
-          "bundled": true,
-          "requires": {
-            "acorn": "5.2.1"
-          }
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "array-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asap": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "boom": {
-          "version": "4.3.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "browser-process-hrtime": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "content-type-parser": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "cssom": {
-          "version": "0.3.2",
-          "bundled": true
-        },
-        "cssstyle": {
-          "version": "0.2.37",
-          "bundled": true,
-          "requires": {
-            "cssom": "0.3.2"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "deep-is": {
-          "version": "0.1.3",
-          "bundled": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "document-register-element": {
-          "version": "1.7.0",
-          "bundled": true
-        },
-        "domexception": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "0.4.19"
-          }
-        },
-        "escodegen": {
-          "version": "1.9.0",
-          "bundled": true,
-          "requires": {
-            "esprima": "3.1.3",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.5.7"
-          },
-          "dependencies": {
-            "esprima": {
-              "version": "3.1.3",
-              "bundled": true
-            }
-          }
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "fast-deep-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "fbjs": {
-          "version": "0.8.16",
-          "bundled": true,
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.12"
-          },
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.7",
-              "bundled": true
-            }
-          }
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "bundled": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "bundled": true,
-          "requires": {
-            "ajv": "5.5.1",
-            "har-schema": "2.0.0"
-          },
-          "dependencies": {
-            "ajv": {
-              "version": "5.5.1",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
-              }
-            }
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "bundled": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.1.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "html-encoding-sniffer": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "whatwg-encoding": "1.0.3"
-          }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "bundled": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "node-fetch": "1.7.3",
-            "whatwg-fetch": "2.0.3"
-          }
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "jsdom": {
-          "version": "11.5.1",
-          "bundled": true,
-          "requires": {
-            "abab": "1.0.4",
-            "acorn": "5.2.1",
-            "acorn-globals": "4.1.0",
-            "array-equal": "1.0.0",
-            "browser-process-hrtime": "0.1.2",
-            "content-type-parser": "1.0.2",
-            "cssom": "0.3.2",
-            "cssstyle": "0.2.37",
-            "domexception": "1.0.0",
-            "escodegen": "1.9.0",
-            "html-encoding-sniffer": "1.0.2",
-            "left-pad": "1.2.0",
-            "nwmatcher": "1.4.3",
-            "parse5": "3.0.3",
-            "pn": "1.0.0",
-            "request": "2.83.0",
-            "request-promise-native": "1.0.5",
-            "sax": "1.2.4",
-            "symbol-tree": "3.2.2",
-            "tough-cookie": "2.3.3",
-            "webidl-conversions": "4.0.2",
-            "whatwg-encoding": "1.0.3",
-            "whatwg-url": "6.4.0",
-            "xml-name-validator": "2.0.1"
-          }
-        },
-        "jsdom-global": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "bundled": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "left-pad": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "levn": {
-          "version": "0.3.0",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash-es": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash.isplainobject": {
-          "version": "4.0.6",
-          "bundled": true
-        },
-        "lodash.sortby": {
-          "version": "4.7.0",
-          "bundled": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "js-tokens": "3.0.2"
-          }
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "bundled": true,
-          "requires": {
-            "encoding": "0.1.12",
-            "is-stream": "1.1.0"
-          }
-        },
-        "nwmatcher": {
-          "version": "1.4.3",
-          "bundled": true
-        },
-        "nyc": {
-          "version": "11.4.1",
-          "bundled": true,
-          "requires": {
-            "archy": "1.0.0",
-            "arrify": "1.0.1",
-            "caching-transform": "1.0.1",
-            "convert-source-map": "1.5.1",
-            "debug-log": "1.0.1",
-            "default-require-extensions": "1.0.0",
-            "find-cache-dir": "0.1.1",
-            "find-up": "2.1.0",
-            "foreground-child": "1.5.6",
-            "glob": "7.1.2",
-            "istanbul-lib-coverage": "1.1.1",
-            "istanbul-lib-hook": "1.1.0",
-            "istanbul-lib-instrument": "1.9.1",
-            "istanbul-lib-report": "1.1.2",
-            "istanbul-lib-source-maps": "1.2.2",
-            "istanbul-reports": "1.1.3",
-            "md5-hex": "1.3.0",
-            "merge-source-map": "1.0.4",
-            "micromatch": "2.3.11",
-            "mkdirp": "0.5.1",
-            "resolve-from": "2.0.0",
-            "rimraf": "2.6.2",
-            "signal-exit": "3.0.2",
-            "spawn-wrap": "1.4.2",
-            "test-exclude": "4.1.1",
-            "yargs": "10.0.3",
-            "yargs-parser": "8.0.0"
-          },
-          "dependencies": {
-            "align-text": {
-              "version": "0.1.4",
-              "bundled": true,
-              "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
-              }
-            },
-            "amdefine": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "append-transform": {
-              "version": "0.4.0",
-              "bundled": true,
-              "requires": {
-                "default-require-extensions": "1.0.0"
-              }
-            },
-            "archy": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "arr-diff": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "arr-flatten": "1.1.0"
-              }
-            },
-            "arr-flatten": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "array-unique": {
-              "version": "0.2.1",
-              "bundled": true
-            },
-            "arrify": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "async": {
-              "version": "1.5.2",
-              "bundled": true
-            },
-            "babel-code-frame": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
-              }
-            },
-            "babel-generator": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "detect-indent": "4.0.0",
-                "jsesc": "1.3.0",
-                "lodash": "4.17.4",
-                "source-map": "0.5.7",
-                "trim-right": "1.0.1"
-              }
-            },
-            "babel-messages": {
-              "version": "6.23.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0"
-              }
-            },
-            "babel-runtime": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "core-js": "2.5.3",
-                "regenerator-runtime": "0.11.1"
-              }
-            },
-            "babel-template": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "lodash": "4.17.4"
-              }
-            },
-            "babel-traverse": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "debug": "2.6.9",
-                "globals": "9.18.0",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4"
-              }
-            },
-            "babel-types": {
-              "version": "6.26.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.26.0",
-                "esutils": "2.0.2",
-                "lodash": "4.17.4",
-                "to-fast-properties": "1.0.3"
-              }
-            },
-            "babylon": {
-              "version": "6.18.0",
-              "bundled": true
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "bundled": true,
-              "requires": {
-                "balanced-match": "1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "braces": {
-              "version": "1.8.5",
-              "bundled": true,
-              "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
-              }
-            },
-            "builtin-modules": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "caching-transform": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "md5-hex": "1.3.0",
-                "mkdirp": "0.5.1",
-                "write-file-atomic": "1.3.4"
-              }
-            },
-            "camelcase": {
-              "version": "1.2.1",
-              "bundled": true,
-              "optional": true
-            },
-            "center-align": {
-              "version": "0.1.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
-              }
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              }
-            },
-            "cliui": {
-              "version": "2.1.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
-                "wordwrap": "0.0.2"
-              },
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.2",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "commondir": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "convert-source-map": {
-              "version": "1.5.1",
-              "bundled": true
-            },
-            "core-js": {
-              "version": "2.5.3",
-              "bundled": true
-            },
-            "cross-spawn": {
-              "version": "4.0.2",
-              "bundled": true,
-              "requires": {
-                "lru-cache": "4.1.1",
-                "which": "1.3.0"
-              }
-            },
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "debug-log": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "decamelize": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "default-require-extensions": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "strip-bom": "2.0.0"
-              }
-            },
-            "detect-indent": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "repeating": "2.0.1"
-              }
-            },
-            "error-ex": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "is-arrayish": "0.2.1"
-              }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "execa": {
-              "version": "0.7.0",
-              "bundled": true,
-              "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
-              },
-              "dependencies": {
-                "cross-spawn": {
-                  "version": "5.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "lru-cache": "4.1.1",
-                    "shebang-command": "1.2.0",
-                    "which": "1.3.0"
-                  }
-                }
-              }
-            },
-            "expand-brackets": {
-              "version": "0.1.5",
-              "bundled": true,
-              "requires": {
-                "is-posix-bracket": "0.1.1"
-              }
-            },
-            "expand-range": {
-              "version": "1.8.2",
-              "bundled": true,
-              "requires": {
-                "fill-range": "2.2.3"
-              }
-            },
-            "extglob": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "1.0.0"
-              }
-            },
-            "filename-regex": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "fill-range": {
-              "version": "2.2.3",
-              "bundled": true,
-              "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.7",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
-              }
-            },
-            "find-cache-dir": {
-              "version": "0.1.1",
-              "bundled": true,
-              "requires": {
-                "commondir": "1.0.1",
-                "mkdirp": "0.5.1",
-                "pkg-dir": "1.0.0"
-              }
-            },
-            "find-up": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "locate-path": "2.0.0"
-              }
-            },
-            "for-in": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "for-own": {
-              "version": "0.1.5",
-              "bundled": true,
-              "requires": {
-                "for-in": "1.0.2"
-              }
-            },
-            "foreground-child": {
-              "version": "1.5.6",
-              "bundled": true,
-              "requires": {
-                "cross-spawn": "4.0.2",
-                "signal-exit": "3.0.2"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "get-caller-file": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "get-stream": {
-              "version": "3.0.0",
-              "bundled": true
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            },
-            "glob-base": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
-              }
-            },
-            "glob-parent": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "is-glob": "2.0.1"
-              }
-            },
-            "globals": {
-              "version": "9.18.0",
-              "bundled": true
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true
-            },
-            "handlebars": {
-              "version": "4.0.11",
-              "bundled": true,
-              "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.8.29"
-              },
-              "dependencies": {
-                "source-map": {
-                  "version": "0.4.4",
-                  "bundled": true,
-                  "requires": {
-                    "amdefine": "1.0.1"
-                  }
-                }
-              }
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "has-flag": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "hosted-git-info": {
-              "version": "2.5.0",
-              "bundled": true
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "bundled": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "1.3.1"
-              }
-            },
-            "invert-kv": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "is-arrayish": {
-              "version": "0.2.1",
-              "bundled": true
-            },
-            "is-buffer": {
-              "version": "1.1.6",
-              "bundled": true
-            },
-            "is-builtin-module": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "builtin-modules": "1.1.1"
-              }
-            },
-            "is-dotfile": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "is-equal-shallow": {
-              "version": "0.1.3",
-              "bundled": true,
-              "requires": {
-                "is-primitive": "2.0.0"
-              }
-            },
-            "is-extendable": {
-              "version": "0.1.1",
-              "bundled": true
-            },
-            "is-extglob": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "is-finite": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "1.0.1"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "1.0.1"
-              }
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "1.0.0"
-              }
-            },
-            "is-number": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              }
-            },
-            "is-posix-bracket": {
-              "version": "0.1.1",
-              "bundled": true
-            },
-            "is-primitive": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "is-utf8": {
-              "version": "0.2.1",
-              "bundled": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isexe": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "isobject": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "isarray": "1.0.0"
-              }
-            },
-            "istanbul-lib-coverage": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "istanbul-lib-hook": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "append-transform": "0.4.0"
-              }
-            },
-            "istanbul-lib-instrument": {
-              "version": "1.9.1",
-              "bundled": true,
-              "requires": {
-                "babel-generator": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "istanbul-lib-coverage": "1.1.1",
-                "semver": "5.4.1"
-              }
-            },
-            "istanbul-lib-report": {
-              "version": "1.1.2",
-              "bundled": true,
-              "requires": {
-                "istanbul-lib-coverage": "1.1.1",
-                "mkdirp": "0.5.1",
-                "path-parse": "1.0.5",
-                "supports-color": "3.2.3"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "3.2.3",
-                  "bundled": true,
-                  "requires": {
-                    "has-flag": "1.0.0"
-                  }
-                }
-              }
-            },
-            "istanbul-lib-source-maps": {
-              "version": "1.2.2",
-              "bundled": true,
-              "requires": {
-                "debug": "3.1.0",
-                "istanbul-lib-coverage": "1.1.1",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "source-map": "0.5.7"
-              },
-              "dependencies": {
-                "debug": {
-                  "version": "3.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "ms": "2.0.0"
-                  }
-                }
-              }
-            },
-            "istanbul-reports": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "handlebars": "4.0.11"
-              }
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "jsesc": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "kind-of": {
-              "version": "3.2.2",
-              "bundled": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            },
-            "lazy-cache": {
-              "version": "1.0.4",
-              "bundled": true,
-              "optional": true
-            },
-            "lcid": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "invert-kv": "1.0.0"
-              }
-            },
-            "load-json-file": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
-              },
-              "dependencies": {
-                "path-exists": {
-                  "version": "3.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "longest": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "3.0.2"
-              }
-            },
-            "lru-cache": {
-              "version": "4.1.1",
-              "bundled": true,
-              "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
-              }
-            },
-            "md5-hex": {
-              "version": "1.3.0",
-              "bundled": true,
-              "requires": {
-                "md5-o-matic": "0.1.1"
-              }
-            },
-            "md5-o-matic": {
-              "version": "0.1.1",
-              "bundled": true
-            },
-            "mem": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "mimic-fn": "1.1.0"
-              }
-            },
-            "merge-source-map": {
-              "version": "1.0.4",
-              "bundled": true,
-              "requires": {
-                "source-map": "0.5.7"
-              }
-            },
-            "micromatch": {
-              "version": "2.3.11",
-              "bundled": true,
-              "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
-              }
-            },
-            "mimic-fn": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "normalize-package-data": {
-              "version": "2.4.0",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "2.5.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.4.1",
-                "validate-npm-package-license": "3.0.1"
-              }
-            },
-            "normalize-path": {
-              "version": "2.1.1",
-              "bundled": true,
-              "requires": {
-                "remove-trailing-separator": "1.1.0"
-              }
-            },
-            "npm-run-path": {
-              "version": "2.0.2",
-              "bundled": true,
-              "requires": {
-                "path-key": "2.0.1"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "object.omit": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              }
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "bundled": true,
-              "requires": {
-                "minimist": "0.0.8",
-                "wordwrap": "0.0.3"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "os-locale": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "execa": "0.7.0",
-                "lcid": "1.0.0",
-                "mem": "1.1.0"
-              }
-            },
-            "p-finally": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "p-limit": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "p-locate": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "p-limit": "1.1.0"
-              }
-            },
-            "parse-glob": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
-              }
-            },
-            "parse-json": {
-              "version": "2.2.0",
-              "bundled": true,
-              "requires": {
-                "error-ex": "1.3.1"
-              }
-            },
-            "path-exists": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "pinkie-promise": "2.0.1"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "path-key": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "path-parse": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "path-type": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
-              }
-            },
-            "pify": {
-              "version": "2.3.0",
-              "bundled": true
-            },
-            "pinkie": {
-              "version": "2.0.4",
-              "bundled": true
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "pinkie": "2.0.4"
-              }
-            },
-            "pkg-dir": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "find-up": "1.1.2"
-              },
-              "dependencies": {
-                "find-up": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "path-exists": "2.1.0",
-                    "pinkie-promise": "2.0.1"
-                  }
-                }
-              }
-            },
-            "preserve": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "pseudomap": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "randomatic": {
-              "version": "1.1.7",
-              "bundled": true,
-              "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
-              },
-              "dependencies": {
-                "is-number": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "kind-of": "3.2.2"
-                  },
-                  "dependencies": {
-                    "kind-of": {
-                      "version": "3.2.2",
-                      "bundled": true,
-                      "requires": {
-                        "is-buffer": "1.1.6"
-                      }
-                    }
-                  }
-                },
-                "kind-of": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "read-pkg": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
-              }
-            },
-            "read-pkg-up": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
-              },
-              "dependencies": {
-                "find-up": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "path-exists": "2.1.0",
-                    "pinkie-promise": "2.0.1"
-                  }
-                }
-              }
-            },
-            "regenerator-runtime": {
-              "version": "0.11.1",
-              "bundled": true
-            },
-            "regex-cache": {
-              "version": "0.4.4",
-              "bundled": true,
-              "requires": {
-                "is-equal-shallow": "0.1.3"
-              }
-            },
-            "remove-trailing-separator": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "repeat-element": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "repeat-string": {
-              "version": "1.6.1",
-              "bundled": true
-            },
-            "repeating": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-finite": "1.0.2"
-              }
-            },
-            "require-directory": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "require-main-filename": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "resolve-from": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "right-align": {
-              "version": "0.1.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "align-text": "0.1.4"
-              }
-            },
-            "rimraf": {
-              "version": "2.6.2",
-              "bundled": true,
-              "requires": {
-                "glob": "7.1.2"
-              }
-            },
-            "semver": {
-              "version": "5.4.1",
-              "bundled": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "shebang-command": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "shebang-regex": "1.0.0"
-              }
-            },
-            "shebang-regex": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "slide": {
-              "version": "1.1.6",
-              "bundled": true
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true
-            },
-            "spawn-wrap": {
-              "version": "1.4.2",
-              "bundled": true,
-              "requires": {
-                "foreground-child": "1.5.6",
-                "mkdirp": "0.5.1",
-                "os-homedir": "1.0.2",
-                "rimraf": "2.6.2",
-                "signal-exit": "3.0.2",
-                "which": "1.3.0"
-              }
-            },
-            "spdx-correct": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "spdx-license-ids": "1.2.2"
-              }
-            },
-            "spdx-expression-parse": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "spdx-license-ids": {
-              "version": "1.2.2",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "2.1.1",
-              "bundled": true,
-              "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "3.0.0",
-                  "bundled": true
-                },
-                "is-fullwidth-code-point": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "strip-ansi": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "3.0.0"
-                  }
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "strip-bom": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "is-utf8": "0.2.1"
-              }
-            },
-            "strip-eof": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "test-exclude": {
-              "version": "4.1.1",
-              "bundled": true,
-              "requires": {
-                "arrify": "1.0.1",
-                "micromatch": "2.3.11",
-                "object-assign": "4.1.1",
-                "read-pkg-up": "1.0.1",
-                "require-main-filename": "1.0.1"
-              }
-            },
-            "to-fast-properties": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "trim-right": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "uglify-js": {
-              "version": "2.8.29",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "source-map": "0.5.7",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
-              },
-              "dependencies": {
-                "yargs": {
-                  "version": "3.10.0",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "camelcase": "1.2.1",
-                    "cliui": "2.1.0",
-                    "decamelize": "1.2.0",
-                    "window-size": "0.1.0"
-                  }
-                }
-              }
-            },
-            "uglify-to-browserify": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "validate-npm-package-license": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "spdx-correct": "1.0.2",
-                "spdx-expression-parse": "1.0.4"
-              }
-            },
-            "which": {
-              "version": "1.3.0",
-              "bundled": true,
-              "requires": {
-                "isexe": "2.0.0"
-              }
-            },
-            "which-module": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "window-size": {
-              "version": "0.1.0",
-              "bundled": true,
-              "optional": true
-            },
-            "wordwrap": {
-              "version": "0.0.3",
-              "bundled": true
-            },
-            "wrap-ansi": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
-              },
-              "dependencies": {
-                "string-width": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  }
-                }
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "write-file-atomic": {
-              "version": "1.3.4",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "imurmurhash": "0.1.4",
-                "slide": "1.1.6"
-              }
-            },
-            "y18n": {
-              "version": "3.2.1",
-              "bundled": true
-            },
-            "yallist": {
-              "version": "2.1.2",
-              "bundled": true
-            },
-            "yargs": {
-              "version": "10.0.3",
-              "bundled": true,
-              "requires": {
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "find-up": "2.1.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.1.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "8.0.0"
-              },
-              "dependencies": {
-                "cliui": {
-                  "version": "3.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1",
-                    "wrap-ansi": "2.1.0"
-                  },
-                  "dependencies": {
-                    "string-width": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "yargs-parser": {
-              "version": "8.0.0",
-              "bundled": true,
-              "requires": {
-                "camelcase": "4.1.0"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "4.1.0",
-                  "bundled": true
-                }
-              }
-            }
-          }
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "optionator": {
-          "version": "0.8.2",
-          "bundled": true,
-          "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.6",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
-          }
-        },
-        "parse5": {
-          "version": "3.0.3",
-          "bundled": true,
-          "requires": {
-            "@types/node": "8.0.57"
-          }
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "pn": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "bundled": true,
-          "requires": {
-            "asap": "2.0.6"
-          }
-        },
-        "prop-types": {
-          "version": "15.6.0",
-          "bundled": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
-          }
-        },
-        "punycode": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.5.1",
-          "bundled": true
-        },
-        "react-dom": {
-          "version": "16.2.0",
-          "bundled": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "redux": {
-          "version": "3.7.2",
-          "bundled": true,
-          "requires": {
-            "lodash": "4.17.4",
-            "lodash-es": "4.17.4",
-            "loose-envify": "1.3.1",
-            "symbol-observable": "1.0.4"
-          }
-        },
-        "redux-mock-store": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "lodash.isplainobject": "4.0.6"
-          }
-        },
-        "request": {
-          "version": "2.83.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
-          }
-        },
-        "request-promise-core": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "request-promise-native": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "request-promise-core": "1.1.1",
-            "stealthy-require": "1.1.1",
-            "tough-cookie": "2.3.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true,
-          "optional": true
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "stealthy-require": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
-        "symbol-observable": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "symbol-tree": {
-          "version": "3.2.2",
-          "bundled": true
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "bundled": true,
-          "requires": {
-            "punycode": "1.4.1"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            }
-          }
-        },
-        "tr46": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "punycode": "2.1.0"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2"
-          }
-        },
-        "ua-parser-js": {
-          "version": "0.7.12",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
-        },
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "bundled": true
-        },
-        "whatwg-encoding": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "0.4.19"
-          }
-        },
-        "whatwg-fetch": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "whatwg-url": {
-          "version": "6.4.0",
-          "bundled": true,
-          "requires": {
-            "lodash.sortby": "4.7.0",
-            "tr46": "1.0.1",
-            "webidl-conversions": "4.0.2"
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "xml-name-validator": {
-          "version": "2.0.1",
-          "bundled": true
-        }
-      }
-    },
-    "@jsonforms/react": {
-      "version": "2.0.0-rc.3",
-      "requires": {
-        "@jsonforms/core": "2.0.0-rc.3",
-        "lodash": "4.17.4",
-        "react": "16.2.0",
-        "react-redux": "5.0.6"
-      },
-      "dependencies": {
-        "@jsonforms/core": {
-          "version": "2.0.0-rc.3",
-          "bundled": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "lodash": "4.17.4",
-            "redux": "3.7.2",
-            "uuid": "3.1.0"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "8.0.57",
-              "bundled": true
-            },
-            "abab": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "acorn": {
-              "version": "5.2.1",
-              "bundled": true
-            },
-            "acorn-globals": {
-              "version": "4.1.0",
-              "bundled": true,
-              "requires": {
-                "acorn": "5.2.1"
-              }
-            },
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
-              }
-            },
-            "array-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asap": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "boom": {
-              "version": "4.3.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "browser-process-hrtime": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "content-type-parser": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "boom": "5.2.0"
-              },
-              "dependencies": {}
-            },
-            "cssom": {
-              "version": "0.3.2",
-              "bundled": true
-            },
-            "cssstyle": {
-              "version": "0.2.37",
-              "bundled": true,
-              "requires": {
-                "cssom": "0.3.2"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "deep-is": {
-              "version": "0.1.3",
-              "bundled": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "document-register-element": {
-              "version": "1.7.0",
-              "bundled": true
-            },
-            "domexception": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "escodegen": {
-              "version": "1.9.0",
-              "bundled": true,
-              "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.5.7"
-              },
-              "dependencies": {}
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "fast-deep-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "fast-levenshtein": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "fbjs": {
-              "version": "0.8.16",
-              "bundled": true,
-              "requires": {
-                "core-js": "1.2.7",
-                "isomorphic-fetch": "2.2.1",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "promise": "7.3.1",
-                "setimmediate": "1.0.5",
-                "ua-parser-js": "0.7.12"
-              },
-              "dependencies": {}
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.1",
-              "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "har-schema": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "5.5.1",
-                "har-schema": "2.0.0"
-              },
-              "dependencies": {}
-            },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.1.0"
-              }
-            },
-            "hoek": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "html-encoding-sniffer": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "whatwg-encoding": "1.0.3"
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.19",
-              "bundled": true
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "node-fetch": "1.7.3",
-                "whatwg-fetch": "2.0.3"
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "jsdom": {
-              "version": "11.5.1",
-              "bundled": true,
-              "requires": {
-                "abab": "1.0.4",
-                "acorn": "5.2.1",
-                "acorn-globals": "4.1.0",
-                "array-equal": "1.0.0",
-                "browser-process-hrtime": "0.1.2",
-                "content-type-parser": "1.0.2",
-                "cssom": "0.3.2",
-                "cssstyle": "0.2.37",
-                "domexception": "1.0.0",
-                "escodegen": "1.9.0",
-                "html-encoding-sniffer": "1.0.2",
-                "left-pad": "1.2.0",
-                "nwmatcher": "1.4.3",
-                "parse5": "3.0.3",
-                "pn": "1.0.0",
-                "request": "2.83.0",
-                "request-promise-native": "1.0.5",
-                "sax": "1.2.4",
-                "symbol-tree": "3.2.2",
-                "tough-cookie": "2.3.3",
-                "webidl-conversions": "4.0.2",
-                "whatwg-encoding": "1.0.3",
-                "whatwg-url": "6.4.0",
-                "xml-name-validator": "2.0.1"
-              }
-            },
-            "jsdom-global": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "bundled": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              }
-            },
-            "left-pad": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "levn": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
-              }
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash-es": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash.isplainobject": {
-              "version": "4.0.6",
-              "bundled": true
-            },
-            "lodash.sortby": {
-              "version": "4.7.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "3.0.2"
-              }
-            },
-            "mime-db": {
-              "version": "1.30.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              }
-            },
-            "node-fetch": {
-              "version": "1.7.3",
-              "bundled": true,
-              "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
-              }
-            },
-            "nwmatcher": {
-              "version": "1.4.3",
-              "bundled": true
-            },
-            "nyc": {
-              "version": "11.4.1",
-              "bundled": true,
-              "requires": {
-                "archy": "1.0.0",
-                "arrify": "1.0.1",
-                "caching-transform": "1.0.1",
-                "convert-source-map": "1.5.1",
-                "debug-log": "1.0.1",
-                "default-require-extensions": "1.0.0",
-                "find-cache-dir": "0.1.1",
-                "find-up": "2.1.0",
-                "foreground-child": "1.5.6",
-                "glob": "7.1.2",
-                "istanbul-lib-coverage": "1.1.1",
-                "istanbul-lib-hook": "1.1.0",
-                "istanbul-lib-instrument": "1.9.1",
-                "istanbul-lib-report": "1.1.2",
-                "istanbul-lib-source-maps": "1.2.2",
-                "istanbul-reports": "1.1.3",
-                "md5-hex": "1.3.0",
-                "merge-source-map": "1.0.4",
-                "micromatch": "2.3.11",
-                "mkdirp": "0.5.1",
-                "resolve-from": "2.0.0",
-                "rimraf": "2.6.2",
-                "signal-exit": "3.0.2",
-                "spawn-wrap": "1.4.2",
-                "test-exclude": "4.1.1",
-                "yargs": "10.0.3",
-                "yargs-parser": "8.0.0"
-              },
-              "dependencies": {}
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "bundled": true,
-              "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
-              }
-            },
-            "parse5": {
-              "version": "3.0.3",
-              "bundled": true,
-              "requires": {
-                "@types/node": "8.0.57"
-              }
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "pn": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "prelude-ls": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "promise": {
-              "version": "7.3.1",
-              "bundled": true,
-              "requires": {
-                "asap": "2.0.6"
-              }
-            },
-            "prop-types": {
-              "version": "15.6.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1"
-              }
-            },
-            "punycode": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
-            "react-dom": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "redux": {
-              "version": "3.7.2",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "symbol-observable": "1.0.4"
-              }
-            },
-            "redux-mock-store": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.isplainobject": "4.0.6"
-              }
-            },
-            "request": {
-              "version": "2.83.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
-              }
-            },
-            "request-promise-core": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4"
-              }
-            },
-            "request-promise-native": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "bundled": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "sntp": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true,
-              "optional": true
-            },
-            "sshpk": {
-              "version": "1.13.1",
-              "bundled": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "stealthy-require": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "symbol-observable": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "symbol-tree": {
-              "version": "3.2.2",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              },
-              "dependencies": {}
-            },
-            "tr46": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "punycode": "2.1.0"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2"
-              }
-            },
-            "ua-parser-js": {
-              "version": "0.7.12",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "bundled": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              }
-            },
-            "webidl-conversions": {
-              "version": "4.0.2",
-              "bundled": true
-            },
-            "whatwg-encoding": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "whatwg-fetch": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "whatwg-url": {
-              "version": "6.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.sortby": "4.7.0",
-                "tr46": "1.0.1",
-                "webidl-conversions": "4.0.2"
-              }
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "xml-name-validator": {
-              "version": "2.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "abab": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "acorn": {
-          "version": "5.4.1",
-          "bundled": true
-        },
-        "acorn-globals": {
-          "version": "4.1.0",
-          "bundled": true,
-          "requires": {
-            "acorn": "5.4.1"
-          }
-        },
-        "ajv": {
-          "version": "5.5.2",
-          "bundled": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
-        },
-        "array-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asap": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "async-limiter": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "boom": {
-          "version": "4.3.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "browser-process-hrtime": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "content-type-parser": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "cssom": {
-          "version": "0.3.2",
-          "bundled": true
-        },
-        "cssstyle": {
-          "version": "0.2.37",
-          "bundled": true,
-          "requires": {
-            "cssom": "0.3.2"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "deep-is": {
-          "version": "0.1.3",
-          "bundled": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "document-register-element": {
-          "version": "1.7.2",
-          "bundled": true,
-          "requires": {
-            "lightercollective": "0.0.0"
-          }
-        },
-        "domexception": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "webidl-conversions": "4.0.2"
-          }
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "0.4.19"
-          }
-        },
-        "escodegen": {
-          "version": "1.9.0",
-          "bundled": true,
-          "requires": {
-            "esprima": "3.1.3",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.5.7"
-          }
-        },
-        "esprima": {
-          "version": "3.1.3",
-          "bundled": true
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "fast-deep-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "fbjs": {
-          "version": "0.8.16",
-          "bundled": true,
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.17"
-          }
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "bundled": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "bundled": true,
-          "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "bundled": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.1.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "hoist-non-react-statics": {
-          "version": "2.3.1",
-          "bundled": true
-        },
-        "html-encoding-sniffer": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "whatwg-encoding": "1.0.3"
-          }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "bundled": true
-        },
-        "invariant": {
-          "version": "2.2.2",
-          "bundled": true,
-          "requires": {
-            "loose-envify": "1.3.1"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "node-fetch": "1.7.3",
-            "whatwg-fetch": "2.0.3"
-          }
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "jsdom": {
-          "version": "11.6.2",
-          "bundled": true,
-          "requires": {
-            "abab": "1.0.4",
-            "acorn": "5.4.1",
-            "acorn-globals": "4.1.0",
-            "array-equal": "1.0.0",
-            "browser-process-hrtime": "0.1.2",
-            "content-type-parser": "1.0.2",
-            "cssom": "0.3.2",
-            "cssstyle": "0.2.37",
-            "domexception": "1.0.1",
-            "escodegen": "1.9.0",
-            "html-encoding-sniffer": "1.0.2",
-            "left-pad": "1.2.0",
-            "nwmatcher": "1.4.3",
-            "parse5": "4.0.0",
-            "pn": "1.1.0",
-            "request": "2.83.0",
-            "request-promise-native": "1.0.5",
-            "sax": "1.2.4",
-            "symbol-tree": "3.2.2",
-            "tough-cookie": "2.3.3",
-            "w3c-hr-time": "1.0.1",
-            "webidl-conversions": "4.0.2",
-            "whatwg-encoding": "1.0.3",
-            "whatwg-url": "6.4.0",
-            "ws": "4.0.0",
-            "xml-name-validator": "3.0.0"
-          }
-        },
-        "jsdom-global": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "bundled": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "left-pad": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "levn": {
-          "version": "0.3.0",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
-          }
-        },
-        "lightercollective": {
-          "version": "0.0.0",
-          "bundled": true
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash-es": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash.isplainobject": {
-          "version": "4.0.6",
-          "bundled": true
-        },
-        "lodash.sortby": {
-          "version": "4.7.0",
-          "bundled": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "js-tokens": "3.0.2"
-          }
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "bundled": true,
-          "requires": {
-            "encoding": "0.1.12",
-            "is-stream": "1.1.0"
-          }
-        },
-        "nwmatcher": {
-          "version": "1.4.3",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "optionator": {
-          "version": "0.8.2",
-          "bundled": true,
-          "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.6",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
-          }
-        },
-        "parse5": {
-          "version": "4.0.0",
-          "bundled": true
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "pn": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "bundled": true,
-          "requires": {
-            "asap": "2.0.6"
-          }
-        },
-        "prop-types": {
-          "version": "15.6.0",
-          "bundled": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
-          }
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.5.1",
-          "bundled": true
-        },
-        "react": {
-          "version": "16.2.0",
-          "bundled": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "react-dom": {
-          "version": "16.2.0",
-          "bundled": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "react-redux": {
-          "version": "5.0.6",
-          "bundled": true,
-          "requires": {
-            "hoist-non-react-statics": "2.3.1",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4",
-            "lodash-es": "4.17.4",
-            "loose-envify": "1.3.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "redux": {
-          "version": "3.7.2",
-          "bundled": true,
-          "requires": {
-            "lodash": "4.17.4",
-            "lodash-es": "4.17.4",
-            "loose-envify": "1.3.1",
-            "symbol-observable": "1.2.0"
-          }
-        },
-        "redux-mock-store": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "lodash.isplainobject": "4.0.6"
-          }
-        },
-        "request": {
-          "version": "2.83.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
-          }
-        },
-        "request-promise-core": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "request-promise-native": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "request-promise-core": "1.1.1",
-            "stealthy-require": "1.1.1",
-            "tough-cookie": "2.3.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true,
-          "optional": true
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "stealthy-require": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
-        "symbol-observable": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "symbol-tree": {
-          "version": "3.2.2",
-          "bundled": true
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "bundled": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tr46": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "punycode": "2.1.0"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "2.1.0",
-              "bundled": true
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2"
-          }
-        },
-        "ua-parser-js": {
-          "version": "0.7.17",
-          "bundled": true
-        },
-        "ultron": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.2.1",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
-        },
-        "w3c-hr-time": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "browser-process-hrtime": "0.1.2"
-          }
-        },
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "bundled": true
-        },
-        "whatwg-encoding": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "0.4.19"
-          }
-        },
-        "whatwg-fetch": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "whatwg-url": {
-          "version": "6.4.0",
-          "bundled": true,
-          "requires": {
-            "lodash.sortby": "4.7.0",
-            "tr46": "1.0.1",
-            "webidl-conversions": "4.0.2"
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "ws": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "async-limiter": "1.0.0",
-            "safe-buffer": "5.1.1",
-            "ultron": "1.1.1"
-          }
-        },
-        "xml-name-validator": {
-          "version": "3.0.0",
-          "bundled": true
-        }
-      }
-    },
-    "@jsonforms/test": {
-      "version": "2.0.0-rc.3",
-      "dev": true,
-      "dependencies": {
-        "@jsonforms/core": {
-          "bundled": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "lodash": "4.17.4",
-            "redux": "3.7.2",
-            "uuid": "3.1.0"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "8.0.57",
-              "bundled": true
-            },
-            "abab": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "acorn": {
-              "version": "5.2.1",
-              "bundled": true
-            },
-            "acorn-globals": {
-              "version": "4.1.0",
-              "bundled": true,
-              "requires": {
-                "acorn": "5.2.1"
-              }
-            },
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
-              }
-            },
-            "array-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asap": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "boom": {
-              "version": "4.3.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "browser-process-hrtime": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "content-type-parser": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "boom": "5.2.0"
-              },
-              "dependencies": {}
-            },
-            "cssom": {
-              "version": "0.3.2",
-              "bundled": true
-            },
-            "cssstyle": {
-              "version": "0.2.37",
-              "bundled": true,
-              "requires": {
-                "cssom": "0.3.2"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "deep-is": {
-              "version": "0.1.3",
-              "bundled": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "document-register-element": {
-              "version": "1.7.0",
-              "bundled": true
-            },
-            "domexception": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "escodegen": {
-              "version": "1.9.0",
-              "bundled": true,
-              "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.5.7"
-              },
-              "dependencies": {}
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "fast-deep-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "fast-levenshtein": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "fbjs": {
-              "version": "0.8.16",
-              "bundled": true,
-              "requires": {
-                "core-js": "1.2.7",
-                "isomorphic-fetch": "2.2.1",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "promise": "7.3.1",
-                "setimmediate": "1.0.5",
-                "ua-parser-js": "0.7.12"
-              },
-              "dependencies": {}
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.1",
-              "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "har-schema": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "5.5.1",
-                "har-schema": "2.0.0"
-              },
-              "dependencies": {}
-            },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.1.0"
-              }
-            },
-            "hoek": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "html-encoding-sniffer": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "whatwg-encoding": "1.0.3"
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.19",
-              "bundled": true
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "node-fetch": "1.7.3",
-                "whatwg-fetch": "2.0.3"
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "jsdom": {
-              "version": "11.5.1",
-              "bundled": true,
-              "requires": {
-                "abab": "1.0.4",
-                "acorn": "5.2.1",
-                "acorn-globals": "4.1.0",
-                "array-equal": "1.0.0",
-                "browser-process-hrtime": "0.1.2",
-                "content-type-parser": "1.0.2",
-                "cssom": "0.3.2",
-                "cssstyle": "0.2.37",
-                "domexception": "1.0.0",
-                "escodegen": "1.9.0",
-                "html-encoding-sniffer": "1.0.2",
-                "left-pad": "1.2.0",
-                "nwmatcher": "1.4.3",
-                "parse5": "3.0.3",
-                "pn": "1.0.0",
-                "request": "2.83.0",
-                "request-promise-native": "1.0.5",
-                "sax": "1.2.4",
-                "symbol-tree": "3.2.2",
-                "tough-cookie": "2.3.3",
-                "webidl-conversions": "4.0.2",
-                "whatwg-encoding": "1.0.3",
-                "whatwg-url": "6.4.0",
-                "xml-name-validator": "2.0.1"
-              }
-            },
-            "jsdom-global": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "bundled": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              }
-            },
-            "left-pad": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "levn": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
-              }
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash-es": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash.isplainobject": {
-              "version": "4.0.6",
-              "bundled": true
-            },
-            "lodash.sortby": {
-              "version": "4.7.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "3.0.2"
-              }
-            },
-            "mime-db": {
-              "version": "1.30.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              }
-            },
-            "node-fetch": {
-              "version": "1.7.3",
-              "bundled": true,
-              "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
-              }
-            },
-            "nwmatcher": {
-              "version": "1.4.3",
-              "bundled": true
-            },
-            "nyc": {
-              "version": "11.4.1",
-              "bundled": true,
-              "requires": {
-                "archy": "1.0.0",
-                "arrify": "1.0.1",
-                "caching-transform": "1.0.1",
-                "convert-source-map": "1.5.1",
-                "debug-log": "1.0.1",
-                "default-require-extensions": "1.0.0",
-                "find-cache-dir": "0.1.1",
-                "find-up": "2.1.0",
-                "foreground-child": "1.5.6",
-                "glob": "7.1.2",
-                "istanbul-lib-coverage": "1.1.1",
-                "istanbul-lib-hook": "1.1.0",
-                "istanbul-lib-instrument": "1.9.1",
-                "istanbul-lib-report": "1.1.2",
-                "istanbul-lib-source-maps": "1.2.2",
-                "istanbul-reports": "1.1.3",
-                "md5-hex": "1.3.0",
-                "merge-source-map": "1.0.4",
-                "micromatch": "2.3.11",
-                "mkdirp": "0.5.1",
-                "resolve-from": "2.0.0",
-                "rimraf": "2.6.2",
-                "signal-exit": "3.0.2",
-                "spawn-wrap": "1.4.2",
-                "test-exclude": "4.1.1",
-                "yargs": "10.0.3",
-                "yargs-parser": "8.0.0"
-              },
-              "dependencies": {}
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "bundled": true,
-              "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
-              }
-            },
-            "parse5": {
-              "version": "3.0.3",
-              "bundled": true,
-              "requires": {
-                "@types/node": "8.0.57"
-              }
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "pn": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "prelude-ls": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "promise": {
-              "version": "7.3.1",
-              "bundled": true,
-              "requires": {
-                "asap": "2.0.6"
-              }
-            },
-            "prop-types": {
-              "version": "15.6.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1"
-              }
-            },
-            "punycode": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
-            "react-dom": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "redux": {
-              "version": "3.7.2",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "symbol-observable": "1.0.4"
-              }
-            },
-            "redux-mock-store": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.isplainobject": "4.0.6"
-              }
-            },
-            "request": {
-              "version": "2.83.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
-              }
-            },
-            "request-promise-core": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4"
-              }
-            },
-            "request-promise-native": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "bundled": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "sntp": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true,
-              "optional": true
-            },
-            "sshpk": {
-              "version": "1.13.1",
-              "bundled": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "stealthy-require": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "symbol-observable": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "symbol-tree": {
-              "version": "3.2.2",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              },
-              "dependencies": {}
-            },
-            "tr46": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "punycode": "2.1.0"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2"
-              }
-            },
-            "ua-parser-js": {
-              "version": "0.7.12",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "bundled": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              }
-            },
-            "webidl-conversions": {
-              "version": "4.0.2",
-              "bundled": true
-            },
-            "whatwg-encoding": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "whatwg-fetch": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "whatwg-url": {
-              "version": "6.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.sortby": "4.7.0",
-                "tr46": "1.0.1",
-                "webidl-conversions": "4.0.2"
-              }
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "xml-name-validator": {
-              "version": "2.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "@jsonforms/react": {
-          "bundled": true,
-          "requires": {
-            "@jsonforms/core": "2.0.0-rc.3",
-            "lodash": "4.17.4",
-            "react": "16.2.0",
-            "react-redux": "5.0.6"
-          },
-          "dependencies": {
-            "@jsonforms/core": {
-              "version": "2.0.0-rc.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "4.11.8",
-                "lodash": "4.17.4",
-                "redux": "3.7.2",
-                "uuid": "3.1.0"
-              },
-              "dependencies": {}
-            },
-            "abab": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "acorn": {
-              "version": "5.4.1",
-              "bundled": true
-            },
-            "acorn-globals": {
-              "version": "4.1.0",
-              "bundled": true,
-              "requires": {
-                "acorn": "5.4.1"
-              }
-            },
-            "ajv": {
-              "version": "5.5.2",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
-              }
-            },
-            "array-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asap": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "async-limiter": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "boom": {
-              "version": "4.3.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "browser-process-hrtime": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "content-type-parser": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "core-js": {
-              "version": "1.2.7",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "boom": "5.2.0"
-              },
-              "dependencies": {}
-            },
-            "cssom": {
-              "version": "0.3.2",
-              "bundled": true
-            },
-            "cssstyle": {
-              "version": "0.2.37",
-              "bundled": true,
-              "requires": {
-                "cssom": "0.3.2"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "deep-is": {
-              "version": "0.1.3",
-              "bundled": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "document-register-element": {
-              "version": "1.7.2",
-              "bundled": true,
-              "requires": {
-                "lightercollective": "0.0.0"
-              }
-            },
-            "domexception": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "webidl-conversions": "4.0.2"
-              }
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "escodegen": {
-              "version": "1.9.0",
-              "bundled": true,
-              "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.5.7"
-              }
-            },
-            "esprima": {
-              "version": "3.1.3",
-              "bundled": true
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "fast-deep-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "fast-levenshtein": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "fbjs": {
-              "version": "0.8.16",
-              "bundled": true,
-              "requires": {
-                "core-js": "1.2.7",
-                "isomorphic-fetch": "2.2.1",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "promise": "7.3.1",
-                "setimmediate": "1.0.5",
-                "ua-parser-js": "0.7.17"
-              }
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.1",
-              "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "har-schema": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
-              }
-            },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.1.0"
-              }
-            },
-            "hoek": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "hoist-non-react-statics": {
-              "version": "2.3.1",
-              "bundled": true
-            },
-            "html-encoding-sniffer": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "whatwg-encoding": "1.0.3"
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.19",
-              "bundled": true
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "1.3.1"
-              }
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "node-fetch": "1.7.3",
-                "whatwg-fetch": "2.0.3"
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "jsdom": {
-              "version": "11.6.2",
-              "bundled": true,
-              "requires": {
-                "abab": "1.0.4",
-                "acorn": "5.4.1",
-                "acorn-globals": "4.1.0",
-                "array-equal": "1.0.0",
-                "browser-process-hrtime": "0.1.2",
-                "content-type-parser": "1.0.2",
-                "cssom": "0.3.2",
-                "cssstyle": "0.2.37",
-                "domexception": "1.0.1",
-                "escodegen": "1.9.0",
-                "html-encoding-sniffer": "1.0.2",
-                "left-pad": "1.2.0",
-                "nwmatcher": "1.4.3",
-                "parse5": "4.0.0",
-                "pn": "1.1.0",
-                "request": "2.83.0",
-                "request-promise-native": "1.0.5",
-                "sax": "1.2.4",
-                "symbol-tree": "3.2.2",
-                "tough-cookie": "2.3.3",
-                "w3c-hr-time": "1.0.1",
-                "webidl-conversions": "4.0.2",
-                "whatwg-encoding": "1.0.3",
-                "whatwg-url": "6.4.0",
-                "ws": "4.0.0",
-                "xml-name-validator": "3.0.0"
-              }
-            },
-            "jsdom-global": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "bundled": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              }
-            },
-            "left-pad": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "levn": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
-              }
-            },
-            "lightercollective": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash-es": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash.isplainobject": {
-              "version": "4.0.6",
-              "bundled": true
-            },
-            "lodash.sortby": {
-              "version": "4.7.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "3.0.2"
-              }
-            },
-            "mime-db": {
-              "version": "1.30.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              }
-            },
-            "node-fetch": {
-              "version": "1.7.3",
-              "bundled": true,
-              "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
-              }
-            },
-            "nwmatcher": {
-              "version": "1.4.3",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "bundled": true,
-              "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
-              }
-            },
-            "parse5": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "pn": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "prelude-ls": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "promise": {
-              "version": "7.3.1",
-              "bundled": true,
-              "requires": {
-                "asap": "2.0.6"
-              }
-            },
-            "prop-types": {
-              "version": "15.6.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1"
-              }
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
-            "react": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-dom": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-redux": {
-              "version": "5.0.6",
-              "bundled": true,
-              "requires": {
-                "hoist-non-react-statics": "2.3.1",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "redux": {
-              "version": "3.7.2",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "symbol-observable": "1.2.0"
-              }
-            },
-            "redux-mock-store": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.isplainobject": "4.0.6"
-              }
-            },
-            "request": {
-              "version": "2.83.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
-              }
-            },
-            "request-promise-core": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4"
-              }
-            },
-            "request-promise-native": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "bundled": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "sntp": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true,
-              "optional": true
-            },
-            "sshpk": {
-              "version": "1.13.1",
-              "bundled": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "stealthy-require": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "symbol-observable": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "symbol-tree": {
-              "version": "3.2.2",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              }
-            },
-            "tr46": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "punycode": "2.1.0"
-              },
-              "dependencies": {}
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2"
-              }
-            },
-            "ua-parser-js": {
-              "version": "0.7.17",
-              "bundled": true
-            },
-            "ultron": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.2.1",
-              "bundled": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              }
-            },
-            "w3c-hr-time": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "browser-process-hrtime": "0.1.2"
-              }
-            },
-            "webidl-conversions": {
-              "version": "4.0.2",
-              "bundled": true
-            },
-            "whatwg-encoding": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "whatwg-fetch": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "whatwg-url": {
-              "version": "6.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.sortby": "4.7.0",
-                "tr46": "1.0.1",
-                "webidl-conversions": "4.0.2"
-              }
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "ws": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "async-limiter": "1.0.0",
-                "safe-buffer": "5.1.1",
-                "ultron": "1.1.1"
-              }
-            },
-            "xml-name-validator": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "@types/node": {
-          "version": "8.5.7",
-          "bundled": true
-        },
-        "abab": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "acorn": {
-          "version": "5.3.0",
-          "bundled": true
-        },
-        "acorn-globals": {
-          "version": "4.1.0",
-          "bundled": true,
-          "requires": {
-            "acorn": "5.3.0"
-          }
-        },
-        "ajv": {
-          "version": "5.5.2",
-          "bundled": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
-        },
-        "array-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asap": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "boom": {
-          "version": "4.3.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "browser-process-hrtime": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "content-type-parser": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "cssom": {
-          "version": "0.3.2",
-          "bundled": true
-        },
-        "cssstyle": {
-          "version": "0.2.37",
-          "bundled": true,
-          "requires": {
-            "cssom": "0.3.2"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "deep-is": {
-          "version": "0.1.3",
-          "bundled": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "document-register-element": {
-          "version": "1.7.0",
-          "bundled": true
-        },
-        "domexception": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "0.4.19"
-          }
-        },
-        "escodegen": {
-          "version": "1.9.0",
-          "bundled": true,
-          "requires": {
-            "esprima": "3.1.3",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.5.7"
-          }
-        },
-        "esprima": {
-          "version": "3.1.3",
-          "bundled": true
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "fast-deep-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "fbjs": {
-          "version": "0.8.16",
-          "bundled": true,
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.17"
-          }
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "bundled": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "bundled": true,
-          "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "bundled": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.1.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "hoist-non-react-statics": {
-          "version": "2.3.1",
-          "bundled": true
-        },
-        "html-encoding-sniffer": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "whatwg-encoding": "1.0.3"
-          }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "bundled": true
-        },
-        "invariant": {
-          "version": "2.2.2",
-          "bundled": true,
-          "requires": {
-            "loose-envify": "1.3.1"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "node-fetch": "1.7.3",
-            "whatwg-fetch": "2.0.3"
-          }
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "jsdom": {
-          "version": "11.5.1",
-          "bundled": true,
-          "requires": {
-            "abab": "1.0.4",
-            "acorn": "5.3.0",
-            "acorn-globals": "4.1.0",
-            "array-equal": "1.0.0",
-            "browser-process-hrtime": "0.1.2",
-            "content-type-parser": "1.0.2",
-            "cssom": "0.3.2",
-            "cssstyle": "0.2.37",
-            "domexception": "1.0.0",
-            "escodegen": "1.9.0",
-            "html-encoding-sniffer": "1.0.2",
-            "left-pad": "1.2.0",
-            "nwmatcher": "1.4.3",
-            "parse5": "3.0.3",
-            "pn": "1.1.0",
-            "request": "2.83.0",
-            "request-promise-native": "1.0.5",
-            "sax": "1.2.4",
-            "symbol-tree": "3.2.2",
-            "tough-cookie": "2.3.3",
-            "webidl-conversions": "4.0.2",
-            "whatwg-encoding": "1.0.3",
-            "whatwg-url": "6.4.0",
-            "xml-name-validator": "2.0.1"
-          }
-        },
-        "jsdom-global": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "bundled": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "left-pad": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "levn": {
-          "version": "0.3.0",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash-es": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash.sortby": {
-          "version": "4.7.0",
-          "bundled": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "js-tokens": "3.0.2"
-          }
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "bundled": true,
-          "requires": {
-            "encoding": "0.1.12",
-            "is-stream": "1.1.0"
-          }
-        },
-        "nwmatcher": {
-          "version": "1.4.3",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "optionator": {
-          "version": "0.8.2",
-          "bundled": true,
-          "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.6",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
-          }
-        },
-        "parse5": {
-          "version": "3.0.3",
-          "bundled": true,
-          "requires": {
-            "@types/node": "8.5.7"
-          }
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "pn": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "bundled": true,
-          "requires": {
-            "asap": "2.0.6"
-          }
-        },
-        "prop-types": {
-          "version": "15.6.0",
-          "bundled": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
-          }
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.5.1",
-          "bundled": true
-        },
-        "react": {
-          "version": "16.2.0",
-          "bundled": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "react-dom": {
-          "version": "16.2.0",
-          "bundled": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "react-redux": {
-          "version": "5.0.6",
-          "bundled": true,
-          "requires": {
-            "hoist-non-react-statics": "2.3.1",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4",
-            "lodash-es": "4.17.4",
-            "loose-envify": "1.3.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "redux": {
-          "version": "3.7.2",
-          "bundled": true,
-          "requires": {
-            "lodash": "4.17.4",
-            "lodash-es": "4.17.4",
-            "loose-envify": "1.3.1",
-            "symbol-observable": "1.1.0"
-          }
-        },
-        "request": {
-          "version": "2.83.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
-          }
-        },
-        "request-promise-core": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "request-promise-native": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "request-promise-core": "1.1.1",
-            "stealthy-require": "1.1.1",
-            "tough-cookie": "2.3.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true,
-          "optional": true
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "stealthy-require": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
-        "symbol-observable": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "symbol-tree": {
-          "version": "3.2.2",
-          "bundled": true
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "bundled": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tr46": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "punycode": "2.1.0"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "2.1.0",
-              "bundled": true
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2"
-          }
-        },
-        "ua-parser-js": {
-          "version": "0.7.17",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
-        },
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "bundled": true
-        },
-        "whatwg-encoding": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "0.4.19"
-          }
-        },
-        "whatwg-fetch": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "whatwg-url": {
-          "version": "6.4.0",
-          "bundled": true,
-          "requires": {
-            "lodash.sortby": "4.7.0",
-            "tr46": "1.0.1",
-            "webidl-conversions": "4.0.2"
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "xml-name-validator": {
-          "version": "2.0.1",
-          "bundled": true
-        }
-      }
-    },
-    "@jsonforms/webcomponent": {
-      "version": "2.0.0-rc.3",
-      "dev": true,
-      "requires": {
-        "@jsonforms/core": "2.0.0-rc.3",
-        "@jsonforms/react": "2.0.0-rc.3",
-        "@webcomponents/webcomponentsjs": "1.0.22",
-        "es6-shim": "0.35.3",
-        "json-refs": "2.1.7",
-        "react": "16.2.0",
-        "react-dom": "16.2.0",
-        "react-redux": "5.0.6",
-        "redux": "3.7.2"
-      },
-      "dependencies": {
-        "@jsonforms/core": {
-          "version": "2.0.0-rc.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "lodash": "4.17.4",
-            "redux": "3.7.2",
-            "uuid": "3.1.0"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "8.0.57",
-              "bundled": true
-            },
-            "abab": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "acorn": {
-              "version": "5.2.1",
-              "bundled": true
-            },
-            "acorn-globals": {
-              "version": "4.1.0",
-              "bundled": true,
-              "requires": {
-                "acorn": "5.2.1"
-              }
-            },
-            "ajv": {
-              "version": "4.11.8",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
-              }
-            },
-            "array-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asap": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "boom": {
-              "version": "4.3.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "browser-process-hrtime": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "content-type-parser": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "boom": "5.2.0"
-              },
-              "dependencies": {}
-            },
-            "cssom": {
-              "version": "0.3.2",
-              "bundled": true
-            },
-            "cssstyle": {
-              "version": "0.2.37",
-              "bundled": true,
-              "requires": {
-                "cssom": "0.3.2"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "deep-is": {
-              "version": "0.1.3",
-              "bundled": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "document-register-element": {
-              "version": "1.7.0",
-              "bundled": true
-            },
-            "domexception": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "escodegen": {
-              "version": "1.9.0",
-              "bundled": true,
-              "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.5.7"
-              },
-              "dependencies": {}
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "fast-deep-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "fast-levenshtein": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "fbjs": {
-              "version": "0.8.16",
-              "bundled": true,
-              "requires": {
-                "core-js": "1.2.7",
-                "isomorphic-fetch": "2.2.1",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "promise": "7.3.1",
-                "setimmediate": "1.0.5",
-                "ua-parser-js": "0.7.12"
-              },
-              "dependencies": {}
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.1",
-              "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "har-schema": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "5.5.1",
-                "har-schema": "2.0.0"
-              },
-              "dependencies": {}
-            },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.1.0"
-              }
-            },
-            "hoek": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "html-encoding-sniffer": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "whatwg-encoding": "1.0.3"
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.19",
-              "bundled": true
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "node-fetch": "1.7.3",
-                "whatwg-fetch": "2.0.3"
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "jsdom": {
-              "version": "11.5.1",
-              "bundled": true,
-              "requires": {
-                "abab": "1.0.4",
-                "acorn": "5.2.1",
-                "acorn-globals": "4.1.0",
-                "array-equal": "1.0.0",
-                "browser-process-hrtime": "0.1.2",
-                "content-type-parser": "1.0.2",
-                "cssom": "0.3.2",
-                "cssstyle": "0.2.37",
-                "domexception": "1.0.0",
-                "escodegen": "1.9.0",
-                "html-encoding-sniffer": "1.0.2",
-                "left-pad": "1.2.0",
-                "nwmatcher": "1.4.3",
-                "parse5": "3.0.3",
-                "pn": "1.0.0",
-                "request": "2.83.0",
-                "request-promise-native": "1.0.5",
-                "sax": "1.2.4",
-                "symbol-tree": "3.2.2",
-                "tough-cookie": "2.3.3",
-                "webidl-conversions": "4.0.2",
-                "whatwg-encoding": "1.0.3",
-                "whatwg-url": "6.4.0",
-                "xml-name-validator": "2.0.1"
-              }
-            },
-            "jsdom-global": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "bundled": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              }
-            },
-            "left-pad": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "levn": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
-              }
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash-es": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash.isplainobject": {
-              "version": "4.0.6",
-              "bundled": true
-            },
-            "lodash.sortby": {
-              "version": "4.7.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "3.0.2"
-              }
-            },
-            "mime-db": {
-              "version": "1.30.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              }
-            },
-            "node-fetch": {
-              "version": "1.7.3",
-              "bundled": true,
-              "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
-              }
-            },
-            "nwmatcher": {
-              "version": "1.4.3",
-              "bundled": true
-            },
-            "nyc": {
-              "version": "11.4.1",
-              "bundled": true,
-              "requires": {
-                "archy": "1.0.0",
-                "arrify": "1.0.1",
-                "caching-transform": "1.0.1",
-                "convert-source-map": "1.5.1",
-                "debug-log": "1.0.1",
-                "default-require-extensions": "1.0.0",
-                "find-cache-dir": "0.1.1",
-                "find-up": "2.1.0",
-                "foreground-child": "1.5.6",
-                "glob": "7.1.2",
-                "istanbul-lib-coverage": "1.1.1",
-                "istanbul-lib-hook": "1.1.0",
-                "istanbul-lib-instrument": "1.9.1",
-                "istanbul-lib-report": "1.1.2",
-                "istanbul-lib-source-maps": "1.2.2",
-                "istanbul-reports": "1.1.3",
-                "md5-hex": "1.3.0",
-                "merge-source-map": "1.0.4",
-                "micromatch": "2.3.11",
-                "mkdirp": "0.5.1",
-                "resolve-from": "2.0.0",
-                "rimraf": "2.6.2",
-                "signal-exit": "3.0.2",
-                "spawn-wrap": "1.4.2",
-                "test-exclude": "4.1.1",
-                "yargs": "10.0.3",
-                "yargs-parser": "8.0.0"
-              },
-              "dependencies": {}
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "bundled": true,
-              "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
-              }
-            },
-            "parse5": {
-              "version": "3.0.3",
-              "bundled": true,
-              "requires": {
-                "@types/node": "8.0.57"
-              }
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "pn": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "prelude-ls": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "promise": {
-              "version": "7.3.1",
-              "bundled": true,
-              "requires": {
-                "asap": "2.0.6"
-              }
-            },
-            "prop-types": {
-              "version": "15.6.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1"
-              }
-            },
-            "punycode": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
-            "react-dom": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "redux": {
-              "version": "3.7.2",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "symbol-observable": "1.0.4"
-              }
-            },
-            "redux-mock-store": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.isplainobject": "4.0.6"
-              }
-            },
-            "request": {
-              "version": "2.83.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
-              }
-            },
-            "request-promise-core": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4"
-              }
-            },
-            "request-promise-native": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "bundled": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "sntp": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true,
-              "optional": true
-            },
-            "sshpk": {
-              "version": "1.13.1",
-              "bundled": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "stealthy-require": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "symbol-observable": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "symbol-tree": {
-              "version": "3.2.2",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              },
-              "dependencies": {}
-            },
-            "tr46": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "punycode": "2.1.0"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2"
-              }
-            },
-            "ua-parser-js": {
-              "version": "0.7.12",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "bundled": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              }
-            },
-            "webidl-conversions": {
-              "version": "4.0.2",
-              "bundled": true
-            },
-            "whatwg-encoding": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "whatwg-fetch": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "whatwg-url": {
-              "version": "6.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.sortby": "4.7.0",
-                "tr46": "1.0.1",
-                "webidl-conversions": "4.0.2"
-              }
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "xml-name-validator": {
-              "version": "2.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "@jsonforms/react": {
-          "version": "2.0.0-rc.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@jsonforms/core": "2.0.0-rc.3",
-            "lodash": "4.17.4",
-            "react": "16.2.0",
-            "react-redux": "5.0.6"
-          },
-          "dependencies": {
-            "@jsonforms/core": {
-              "version": "2.0.0-rc.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "4.11.8",
-                "lodash": "4.17.4",
-                "redux": "3.7.2",
-                "uuid": "3.1.0"
-              },
-              "dependencies": {}
-            },
-            "abab": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "acorn": {
-              "version": "5.4.1",
-              "bundled": true
-            },
-            "acorn-globals": {
-              "version": "4.1.0",
-              "bundled": true,
-              "requires": {
-                "acorn": "5.4.1"
-              }
-            },
-            "ajv": {
-              "version": "5.5.2",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
-              }
-            },
-            "array-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asap": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "async-limiter": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "boom": {
-              "version": "4.3.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "browser-process-hrtime": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "content-type-parser": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "core-js": {
-              "version": "1.2.7",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "boom": "5.2.0"
-              },
-              "dependencies": {}
-            },
-            "cssom": {
-              "version": "0.3.2",
-              "bundled": true
-            },
-            "cssstyle": {
-              "version": "0.2.37",
-              "bundled": true,
-              "requires": {
-                "cssom": "0.3.2"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "deep-is": {
-              "version": "0.1.3",
-              "bundled": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "document-register-element": {
-              "version": "1.7.2",
-              "bundled": true,
-              "requires": {
-                "lightercollective": "0.0.0"
-              }
-            },
-            "domexception": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "webidl-conversions": "4.0.2"
-              }
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "escodegen": {
-              "version": "1.9.0",
-              "bundled": true,
-              "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.5.7"
-              }
-            },
-            "esprima": {
-              "version": "3.1.3",
-              "bundled": true
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "fast-deep-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "fast-levenshtein": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "fbjs": {
-              "version": "0.8.16",
-              "bundled": true,
-              "requires": {
-                "core-js": "1.2.7",
-                "isomorphic-fetch": "2.2.1",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "promise": "7.3.1",
-                "setimmediate": "1.0.5",
-                "ua-parser-js": "0.7.17"
-              }
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.1",
-              "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "har-schema": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
-              }
-            },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.1.0"
-              }
-            },
-            "hoek": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "hoist-non-react-statics": {
-              "version": "2.3.1",
-              "bundled": true
-            },
-            "html-encoding-sniffer": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "whatwg-encoding": "1.0.3"
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.19",
-              "bundled": true
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "1.3.1"
-              }
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "node-fetch": "1.7.3",
-                "whatwg-fetch": "2.0.3"
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "jsdom": {
-              "version": "11.6.2",
-              "bundled": true,
-              "requires": {
-                "abab": "1.0.4",
-                "acorn": "5.4.1",
-                "acorn-globals": "4.1.0",
-                "array-equal": "1.0.0",
-                "browser-process-hrtime": "0.1.2",
-                "content-type-parser": "1.0.2",
-                "cssom": "0.3.2",
-                "cssstyle": "0.2.37",
-                "domexception": "1.0.1",
-                "escodegen": "1.9.0",
-                "html-encoding-sniffer": "1.0.2",
-                "left-pad": "1.2.0",
-                "nwmatcher": "1.4.3",
-                "parse5": "4.0.0",
-                "pn": "1.1.0",
-                "request": "2.83.0",
-                "request-promise-native": "1.0.5",
-                "sax": "1.2.4",
-                "symbol-tree": "3.2.2",
-                "tough-cookie": "2.3.3",
-                "w3c-hr-time": "1.0.1",
-                "webidl-conversions": "4.0.2",
-                "whatwg-encoding": "1.0.3",
-                "whatwg-url": "6.4.0",
-                "ws": "4.0.0",
-                "xml-name-validator": "3.0.0"
-              }
-            },
-            "jsdom-global": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "bundled": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              }
-            },
-            "left-pad": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "levn": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
-              }
-            },
-            "lightercollective": {
-              "version": "0.0.0",
-              "bundled": true
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash-es": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash.isplainobject": {
-              "version": "4.0.6",
-              "bundled": true
-            },
-            "lodash.sortby": {
-              "version": "4.7.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "3.0.2"
-              }
-            },
-            "mime-db": {
-              "version": "1.30.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              }
-            },
-            "node-fetch": {
-              "version": "1.7.3",
-              "bundled": true,
-              "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
-              }
-            },
-            "nwmatcher": {
-              "version": "1.4.3",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "bundled": true,
-              "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
-              }
-            },
-            "parse5": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "pn": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "prelude-ls": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "promise": {
-              "version": "7.3.1",
-              "bundled": true,
-              "requires": {
-                "asap": "2.0.6"
-              }
-            },
-            "prop-types": {
-              "version": "15.6.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1"
-              }
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
-            "react": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-dom": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-redux": {
-              "version": "5.0.6",
-              "bundled": true,
-              "requires": {
-                "hoist-non-react-statics": "2.3.1",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "redux": {
-              "version": "3.7.2",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "symbol-observable": "1.2.0"
-              }
-            },
-            "redux-mock-store": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.isplainobject": "4.0.6"
-              }
-            },
-            "request": {
-              "version": "2.83.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
-              }
-            },
-            "request-promise-core": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4"
-              }
-            },
-            "request-promise-native": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "bundled": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "sntp": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true,
-              "optional": true
-            },
-            "sshpk": {
-              "version": "1.13.1",
-              "bundled": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "stealthy-require": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "symbol-observable": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "symbol-tree": {
-              "version": "3.2.2",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              }
-            },
-            "tr46": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "punycode": "2.1.0"
-              },
-              "dependencies": {}
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2"
-              }
-            },
-            "ua-parser-js": {
-              "version": "0.7.17",
-              "bundled": true
-            },
-            "ultron": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.2.1",
-              "bundled": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              }
-            },
-            "w3c-hr-time": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "browser-process-hrtime": "0.1.2"
-              }
-            },
-            "webidl-conversions": {
-              "version": "4.0.2",
-              "bundled": true
-            },
-            "whatwg-encoding": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "whatwg-fetch": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "whatwg-url": {
-              "version": "6.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.sortby": "4.7.0",
-                "tr46": "1.0.1",
-                "webidl-conversions": "4.0.2"
-              }
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "ws": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "async-limiter": "1.0.0",
-                "safe-buffer": "5.1.1",
-                "ultron": "1.1.1"
-              }
-            },
-            "xml-name-validator": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "@jsonforms/test": {
-          "bundled": true,
-          "dependencies": {
-            "@jsonforms/core": {
-              "bundled": true,
-              "requires": {
-                "ajv": "4.11.8",
-                "lodash": "4.17.4",
-                "redux": "3.7.2",
-                "uuid": "3.1.0"
-              },
-              "dependencies": {}
-            },
-            "@jsonforms/react": {
-              "bundled": true,
-              "requires": {
-                "@jsonforms/core": "2.0.0-rc.3",
-                "lodash": "4.17.4",
-                "react": "16.2.0",
-                "react-redux": "5.0.6"
-              },
-              "dependencies": {}
-            },
-            "@types/node": {
-              "version": "8.5.7",
-              "bundled": true
-            },
-            "abab": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "acorn": {
-              "version": "5.3.0",
-              "bundled": true
-            },
-            "acorn-globals": {
-              "version": "4.1.0",
-              "bundled": true,
-              "requires": {
-                "acorn": "5.3.0"
-              }
-            },
-            "ajv": {
-              "version": "5.5.2",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
-              }
-            },
-            "array-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asap": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "boom": {
-              "version": "4.3.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "browser-process-hrtime": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "co": {
-              "version": "4.6.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
-            },
-            "content-type-parser": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "core-js": {
-              "version": "1.2.7",
-              "bundled": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "cryptiles": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "boom": "5.2.0"
-              },
-              "dependencies": {}
-            },
-            "cssom": {
-              "version": "0.3.2",
-              "bundled": true
-            },
-            "cssstyle": {
-              "version": "0.2.37",
-              "bundled": true,
-              "requires": {
-                "cssom": "0.3.2"
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "deep-is": {
-              "version": "0.1.3",
-              "bundled": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "document-register-element": {
-              "version": "1.7.0",
-              "bundled": true
-            },
-            "domexception": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "encoding": {
-              "version": "0.1.12",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "escodegen": {
-              "version": "1.9.0",
-              "bundled": true,
-              "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.5.7"
-              }
-            },
-            "esprima": {
-              "version": "3.1.3",
-              "bundled": true
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "fast-deep-equal": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "fast-levenshtein": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "fbjs": {
-              "version": "0.8.16",
-              "bundled": true,
-              "requires": {
-                "core-js": "1.2.7",
-                "isomorphic-fetch": "2.2.1",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "promise": "7.3.1",
-                "setimmediate": "1.0.5",
-                "ua-parser-js": "0.7.17"
-              }
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.1",
-              "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              }
-            },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
-            "har-schema": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
-              }
-            },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.1.0"
-              }
-            },
-            "hoek": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "hoist-non-react-statics": {
-              "version": "2.3.1",
-              "bundled": true
-            },
-            "html-encoding-sniffer": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "whatwg-encoding": "1.0.3"
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.19",
-              "bundled": true
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "1.3.1"
-              }
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "node-fetch": "1.7.3",
-                "whatwg-fetch": "2.0.3"
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "jsdom": {
-              "version": "11.5.1",
-              "bundled": true,
-              "requires": {
-                "abab": "1.0.4",
-                "acorn": "5.3.0",
-                "acorn-globals": "4.1.0",
-                "array-equal": "1.0.0",
-                "browser-process-hrtime": "0.1.2",
-                "content-type-parser": "1.0.2",
-                "cssom": "0.3.2",
-                "cssstyle": "0.2.37",
-                "domexception": "1.0.0",
-                "escodegen": "1.9.0",
-                "html-encoding-sniffer": "1.0.2",
-                "left-pad": "1.2.0",
-                "nwmatcher": "1.4.3",
-                "parse5": "3.0.3",
-                "pn": "1.1.0",
-                "request": "2.83.0",
-                "request-promise-native": "1.0.5",
-                "sax": "1.2.4",
-                "symbol-tree": "3.2.2",
-                "tough-cookie": "2.3.3",
-                "webidl-conversions": "4.0.2",
-                "whatwg-encoding": "1.0.3",
-                "whatwg-url": "6.4.0",
-                "xml-name-validator": "2.0.1"
-              }
-            },
-            "jsdom-global": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "bundled": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              }
-            },
-            "left-pad": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "levn": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
-              }
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash-es": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "lodash.sortby": {
-              "version": "4.7.0",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "3.0.2"
-              }
-            },
-            "mime-db": {
-              "version": "1.30.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              }
-            },
-            "node-fetch": {
-              "version": "1.7.3",
-              "bundled": true,
-              "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
-              }
-            },
-            "nwmatcher": {
-              "version": "1.4.3",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "bundled": true,
-              "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
-              }
-            },
-            "parse5": {
-              "version": "3.0.3",
-              "bundled": true,
-              "requires": {
-                "@types/node": "8.5.7"
-              }
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "pn": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "prelude-ls": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "promise": {
-              "version": "7.3.1",
-              "bundled": true,
-              "requires": {
-                "asap": "2.0.6"
-              }
-            },
-            "prop-types": {
-              "version": "15.6.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1"
-              }
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
-            "react": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-dom": {
-              "version": "16.2.0",
-              "bundled": true,
-              "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "react-redux": {
-              "version": "5.0.6",
-              "bundled": true,
-              "requires": {
-                "hoist-non-react-statics": "2.3.1",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "prop-types": "15.6.0"
-              }
-            },
-            "redux": {
-              "version": "3.7.2",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4",
-                "lodash-es": "4.17.4",
-                "loose-envify": "1.3.1",
-                "symbol-observable": "1.1.0"
-              }
-            },
-            "request": {
-              "version": "2.83.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
-              }
-            },
-            "request-promise-core": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "lodash": "4.17.4"
-              }
-            },
-            "request-promise-native": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "bundled": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "sntp": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            },
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true,
-              "optional": true
-            },
-            "sshpk": {
-              "version": "1.13.1",
-              "bundled": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "stealthy-require": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "symbol-observable": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "symbol-tree": {
-              "version": "3.2.2",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              }
-            },
-            "tr46": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "punycode": "2.1.0"
-              },
-              "dependencies": {}
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "prelude-ls": "1.1.2"
-              }
-            },
-            "ua-parser-js": {
-              "version": "0.7.17",
-              "bundled": true
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "bundled": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              }
-            },
-            "webidl-conversions": {
-              "version": "4.0.2",
-              "bundled": true
-            },
-            "whatwg-encoding": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "iconv-lite": "0.4.19"
-              }
-            },
-            "whatwg-fetch": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "whatwg-url": {
-              "version": "6.4.0",
-              "bundled": true,
-              "requires": {
-                "lodash.sortby": "4.7.0",
-                "tr46": "1.0.1",
-                "webidl-conversions": "4.0.2"
-              }
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "xml-name-validator": {
-              "version": "2.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "@types/node": {
-          "version": "9.3.0",
-          "bundled": true
-        },
-        "@webcomponents/webcomponentsjs": {
-          "version": "1.0.22",
-          "bundled": true,
-          "dev": true
-        },
-        "abab": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "acorn": {
-          "version": "5.3.0",
-          "bundled": true
-        },
-        "acorn-globals": {
-          "version": "4.1.0",
-          "bundled": true,
-          "requires": {
-            "acorn": "5.3.0"
-          }
-        },
-        "argparse": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "sprintf-js": "1.0.3"
-          }
-        },
-        "array-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asap": {
-          "version": "2.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "boom": {
-          "version": "4.3.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "browser-process-hrtime": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "commander": {
-          "version": "2.13.0",
-          "bundled": true,
-          "dev": true
-        },
-        "component-emitter": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "content-type-parser": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cookiejar": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "core-js": {
-          "version": "1.2.7",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "cssom": {
-          "version": "0.3.2",
-          "bundled": true
-        },
-        "cssstyle": {
-          "version": "0.2.37",
-          "bundled": true,
-          "requires": {
-            "cssom": "0.3.2"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-is": {
-          "version": "0.1.3",
-          "bundled": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "document-register-element": {
-          "version": "1.7.0",
-          "bundled": true
-        },
-        "domexception": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "iconv-lite": "0.4.19"
-          }
-        },
-        "es6-shim": {
-          "version": "0.35.3",
-          "bundled": true,
-          "dev": true
-        },
-        "escodegen": {
-          "version": "1.9.0",
-          "bundled": true,
-          "requires": {
-            "esprima": "3.1.3",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.5.7"
-          }
-        },
-        "esprima": {
-          "version": "3.1.3",
-          "bundled": true
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "fast-deep-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "fbjs": {
-          "version": "0.8.16",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.17"
-          }
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "bundled": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "formidable": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "graphlib": {
-          "version": "2.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "bundled": true,
-          "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
-          },
-          "dependencies": {
-            "ajv": {
-              "version": "5.5.2",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
-              }
-            }
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "bundled": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.1.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "hoist-non-react-statics": {
-          "version": "2.3.1",
-          "bundled": true,
-          "dev": true
-        },
-        "html-encoding-sniffer": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "whatwg-encoding": "1.0.3"
-          }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "bundled": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "invariant": {
-          "version": "2.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "1.3.1"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "node-fetch": "1.7.3",
-            "whatwg-fetch": "2.0.3"
-          }
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.10.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
-          },
-          "dependencies": {
-            "esprima": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "jsdom": {
-          "version": "11.5.1",
-          "bundled": true,
-          "requires": {
-            "abab": "1.0.4",
-            "acorn": "5.3.0",
-            "acorn-globals": "4.1.0",
-            "array-equal": "1.0.0",
-            "browser-process-hrtime": "0.1.2",
-            "content-type-parser": "1.0.2",
-            "cssom": "0.3.2",
-            "cssstyle": "0.2.37",
-            "domexception": "1.0.0",
-            "escodegen": "1.9.0",
-            "html-encoding-sniffer": "1.0.2",
-            "left-pad": "1.2.0",
-            "nwmatcher": "1.4.3",
-            "parse5": "3.0.3",
-            "pn": "1.1.0",
-            "request": "2.83.0",
-            "request-promise-native": "1.0.5",
-            "sax": "1.2.4",
-            "symbol-tree": "3.2.2",
-            "tough-cookie": "2.3.3",
-            "webidl-conversions": "4.0.2",
-            "whatwg-encoding": "1.0.3",
-            "whatwg-url": "6.4.0",
-            "xml-name-validator": "2.0.1"
-          }
-        },
-        "jsdom-global": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "json-refs": {
-          "version": "2.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "commander": "2.13.0",
-            "graphlib": "2.1.5",
-            "js-yaml": "3.10.0",
-            "native-promise-only": "0.8.1",
-            "path-loader": "1.0.4",
-            "slash": "1.0.0",
-            "uri-js": "3.0.2"
-          }
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "bundled": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "left-pad": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "levn": {
-          "version": "0.3.0",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash-es": {
-          "version": "4.17.4",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.sortby": {
-          "version": "4.7.0",
-          "bundled": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "3.0.2"
-          }
-        },
-        "methods": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "mime": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "native-promise-only": {
-          "version": "0.8.1",
-          "bundled": true,
-          "dev": true
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "encoding": "0.1.12",
-            "is-stream": "1.1.0"
-          }
-        },
-        "nwmatcher": {
-          "version": "1.4.3",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "optionator": {
-          "version": "0.8.2",
-          "bundled": true,
-          "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.6",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
-          }
-        },
-        "parse5": {
-          "version": "3.0.3",
-          "bundled": true,
-          "requires": {
-            "@types/node": "9.3.0"
-          }
-        },
-        "path-loader": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "native-promise-only": "0.8.1",
-            "superagent": "3.8.2"
-          }
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "pn": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "asap": "2.0.6"
-          }
-        },
-        "prop-types": {
-          "version": "15.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
-          }
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.5.1",
-          "bundled": true
-        },
-        "react": {
-          "version": "16.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "react-dom": {
-          "version": "16.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "react-redux": {
-          "version": "5.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoist-non-react-statics": "2.3.1",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4",
-            "lodash-es": "4.17.4",
-            "loose-envify": "1.3.1",
-            "prop-types": "15.6.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "redux": {
-          "version": "3.7.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4",
-            "lodash-es": "4.17.4",
-            "loose-envify": "1.3.1",
-            "symbol-observable": "1.1.0"
-          }
-        },
-        "request": {
-          "version": "2.83.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
-          }
-        },
-        "request-promise-core": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "request-promise-native": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "request-promise-core": "1.1.1",
-            "stealthy-require": "1.1.1",
-            "tough-cookie": "2.3.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "slash": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true,
-          "optional": true
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "stealthy-require": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
-        "superagent": {
-          "version": "3.8.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "component-emitter": "1.2.1",
-            "cookiejar": "2.1.1",
-            "debug": "3.1.0",
-            "extend": "3.0.1",
-            "form-data": "2.3.1",
-            "formidable": "1.1.1",
-            "methods": "1.1.2",
-            "mime": "1.6.0",
-            "qs": "6.5.1",
-            "readable-stream": "2.3.3"
-          }
-        },
-        "symbol-observable": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "symbol-tree": {
-          "version": "3.2.2",
-          "bundled": true
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "bundled": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tr46": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "punycode": "2.1.0"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "2.1.0",
-              "bundled": true
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2"
-          }
-        },
-        "ua-parser-js": {
-          "version": "0.7.17",
-          "bundled": true,
-          "dev": true
-        },
-        "uri-js": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "punycode": "2.1.0"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.2.1",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
-        },
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "bundled": true
-        },
-        "whatwg-encoding": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "0.4.19"
-          }
-        },
-        "whatwg-fetch": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "whatwg-url": {
-          "version": "6.4.0",
-          "bundled": true,
-          "requires": {
-            "lodash.sortby": "4.7.0",
-            "tr46": "1.0.1",
-            "webidl-conversions": "4.0.2"
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "xml-name-validator": {
-          "version": "2.0.1",
-          "bundled": true
-        }
-      }
-    },
-    "@types/node": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.5.tgz",
-      "integrity": "sha512-JRnfoh0Ll4ElmIXKxbUfcOodkGvcNHljct6mO1X9hE/mlrMzAx0hYCLAD7sgT53YAY1HdlpzUcV0CkmDqUqTuA==",
-      "dev": true
-    },
-    "abab": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
-      "dev": true
-    },
-    "accepts": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
-      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
-      "dev": true,
-      "requires": {
-        "mime-types": "2.1.17",
-        "negotiator": "0.6.1"
-      }
-    },
-    "acorn": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
-      "dev": true
-    },
-    "acorn-globals": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
-      "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
-      "dev": true,
-      "requires": {
-        "acorn": "5.3.0"
-      }
-    },
-    "ansi-align": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-      "dev": true,
-      "requires": {
-        "string-width": "2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
-      }
-    },
-    "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
-      "dev": true
-    },
-    "ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
-      "dev": true
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
-    },
-    "ansi-styles": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-      "dev": true,
-      "requires": {
-        "color-convert": "1.9.1"
-      }
-    },
-    "anymatch": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-      "dev": true,
-      "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
-      }
-    },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true
-    },
-    "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "1.0.3"
-      }
-    },
-    "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
-      "requires": {
-        "arr-flatten": "1.1.0"
-      }
-    },
-    "arr-exclude": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/arr-exclude/-/arr-exclude-1.0.0.tgz",
-      "integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE=",
-      "dev": true
-    },
-    "arr-flatten": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
-    },
-    "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-      "dev": true
-    },
-    "array-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-      "dev": true
-    },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true
-    },
-    "array-flatten": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-      "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
-      "dev": true
-    },
-    "array-includes": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0"
-      }
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "1.0.3"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
-    "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-      "dev": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
-    "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
-    },
-    "async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4"
-      }
-    },
-    "async-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-      "dev": true
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
-    },
-    "auto-bind": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-1.1.0.tgz",
-      "integrity": "sha1-k7hk3H7gGjJigXddXHXKCnUeWWE=",
-      "dev": true
-    },
-    "ava": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/ava/-/ava-0.24.0.tgz",
-      "integrity": "sha512-o/ykNzsWB5qgh1cR9jzVw0E1y4E219aXl9njNFGSamSCsD7VhPd3aoZabNZuG1PSVMZmQ8RuwKnTuz/loNhKnw==",
-      "dev": true,
-      "requires": {
-        "@ava/babel-preset-stage-4": "1.1.0",
-        "@ava/babel-preset-transform-test-files": "3.0.0",
-        "@ava/write-file-atomic": "2.2.0",
-        "@concordance/react": "1.0.0",
-        "ansi-escapes": "3.0.0",
-        "ansi-styles": "3.2.0",
-        "arr-flatten": "1.1.0",
-        "array-union": "1.0.2",
-        "array-uniq": "1.0.3",
-        "arrify": "1.0.1",
-        "auto-bind": "1.1.0",
-        "ava-init": "0.2.1",
-        "babel-core": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "bluebird": "3.5.1",
-        "caching-transform": "1.0.1",
-        "chalk": "2.3.0",
-        "chokidar": "1.7.0",
-        "clean-stack": "1.3.0",
-        "clean-yaml-object": "0.1.0",
-        "cli-cursor": "2.1.0",
-        "cli-spinners": "1.1.0",
-        "cli-truncate": "1.1.0",
-        "co-with-promise": "4.6.0",
-        "code-excerpt": "2.1.0",
-        "common-path-prefix": "1.0.0",
-        "concordance": "3.0.0",
-        "convert-source-map": "1.5.1",
-        "core-assert": "0.2.1",
-        "currently-unhandled": "0.4.1",
-        "debug": "3.1.0",
-        "dot-prop": "4.2.0",
-        "empower-core": "0.6.2",
-        "equal-length": "1.0.1",
-        "figures": "2.0.0",
-        "find-cache-dir": "1.0.0",
-        "fn-name": "2.0.1",
-        "get-port": "3.2.0",
-        "globby": "6.1.0",
-        "has-flag": "2.0.0",
-        "hullabaloo-config-manager": "1.1.1",
-        "ignore-by-default": "1.0.1",
-        "import-local": "0.1.1",
-        "indent-string": "3.2.0",
-        "is-ci": "1.1.0",
-        "is-generator-fn": "1.0.0",
-        "is-obj": "1.0.1",
-        "is-observable": "1.1.0",
-        "is-promise": "2.1.0",
-        "js-yaml": "3.10.0",
-        "last-line-stream": "1.0.0",
-        "lodash.clonedeepwith": "4.5.0",
-        "lodash.debounce": "4.0.8",
-        "lodash.difference": "4.5.0",
-        "lodash.flatten": "4.4.0",
-        "loud-rejection": "1.6.0",
-        "make-dir": "1.1.0",
-        "matcher": "1.0.0",
-        "md5-hex": "2.0.0",
-        "meow": "3.7.0",
-        "ms": "2.0.0",
-        "multimatch": "2.1.0",
-        "observable-to-promise": "0.5.0",
-        "option-chain": "1.0.0",
-        "package-hash": "2.0.0",
-        "pkg-conf": "2.1.0",
-        "plur": "2.1.2",
-        "pretty-ms": "3.1.0",
-        "require-precompiled": "0.1.0",
-        "resolve-cwd": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "semver": "5.4.1",
-        "slash": "1.0.0",
-        "source-map-support": "0.5.0",
-        "stack-utils": "1.0.1",
-        "strip-ansi": "4.0.0",
-        "strip-bom-buf": "1.0.0",
-        "supports-color": "5.1.0",
-        "time-require": "0.1.2",
-        "trim-off-newlines": "1.0.1",
-        "unique-temp-dir": "1.0.0",
-        "update-notifier": "2.3.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "dev": true,
-          "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "indent-string": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-          "dev": true
-        },
-        "is-observable": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-          "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-          "dev": true,
-          "requires": {
-            "symbol-observable": "1.1.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
-      }
-    },
-    "ava-init": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ava-init/-/ava-init-0.2.1.tgz",
-      "integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
-      "dev": true,
-      "requires": {
-        "arr-exclude": "1.0.0",
-        "execa": "0.7.0",
-        "has-yarn": "1.0.0",
-        "read-pkg-up": "2.0.0",
-        "write-pkg": "3.1.0"
-      },
-      "dependencies": {
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "2.3.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        }
-      }
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
-    },
-    "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-      "dev": true
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
-    "babel-core": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
-      }
-    },
-    "babel-generator": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-      "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
-      "dev": true,
-      "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
-      }
-    },
-    "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "dev": true,
-      "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-call-delegate": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-explode-assignable-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true,
-      "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-get-function-arity": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-hoist-variables": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-regex": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-helper-remap-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helpers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-check-es2015-constants": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-espower": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-2.3.2.tgz",
-      "integrity": "sha1-VRa4/NsmyfDh2BYHSfbkxl5xJx4=",
-      "dev": true,
-      "requires": {
-        "babel-generator": "6.26.0",
-        "babylon": "6.18.0",
-        "call-matcher": "1.0.1",
-        "core-js": "2.5.3",
-        "espower-location-detector": "1.0.0",
-        "espurify": "1.7.0",
-        "estraverse": "4.2.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-          "dev": true
-        }
-      }
-    },
-    "babel-plugin-syntax-async-functions": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-      "dev": true
-    },
-    "babel-plugin-syntax-exponentiation-operator": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-      "dev": true
-    },
-    "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-      "dev": true
-    },
-    "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-      "dev": true
-    },
-    "babel-plugin-transform-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "dev": true,
-      "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-parameters": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true,
-      "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-spread": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
-      }
-    },
-    "babel-plugin-transform-exponentiation-operator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "dev": true,
-      "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-strict-mode": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-register": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "dev": true,
-      "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.7"
-          }
-        }
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.11.1"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
-        }
-      }
-    },
-    "babel-template": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
-    },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "batch": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
-      "dev": true
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "big.js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-      "dev": true
-    },
-    "binary-extensions": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
-      "dev": true
-    },
-    "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-      "dev": true
-    },
-    "body-parser": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-      "dev": true,
-      "requires": {
-        "bytes": "3.0.0",
-        "content-type": "1.0.4",
-        "debug": "2.6.9",
-        "depd": "1.1.1",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
-        "qs": "6.5.1",
-        "raw-body": "2.3.2",
-        "type-is": "1.6.15"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "bonjour": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
-      "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
-      "dev": true,
-      "requires": {
-        "array-flatten": "2.1.1",
-        "deep-equal": "1.0.1",
-        "dns-equal": "1.0.0",
-        "dns-txt": "2.0.2",
-        "multicast-dns": "6.2.1",
-        "multicast-dns-service-types": "1.1.0"
-      }
-    },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
-    "boxen": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-      "dev": true,
-      "requires": {
-        "ansi-align": "2.0.0",
-        "camelcase": "4.1.0",
-        "chalk": "2.3.0",
-        "cli-boxes": "1.0.0",
-        "string-width": "2.1.1",
-        "term-size": "1.2.0",
-        "widest-line": "2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
-      }
-    },
-    "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
-      "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true,
-      "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
-      }
-    },
-    "brcast": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
-      "integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg=="
-    },
-    "browser-process-hrtime": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
-      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
-      "dev": true
-    },
-    "buf-compare": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
-      "integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=",
-      "dev": true
-    },
-    "buffer-indexof": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
-      "dev": true
-    },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
-    },
-    "bytes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-      "dev": true
-    },
-    "cacache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.1.tgz",
-      "integrity": "sha512-dRHYcs9LvG9cHgdPzjiI+/eS7e1xRhULrcyOx04RZQsszNJXU2SL9CyG60yLnge282Qq5nwTv+ieK2fH+WPZmA==",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.5.1",
-        "chownr": "1.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "lru-cache": "4.1.1",
-        "mississippi": "1.3.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "promise-inflight": "1.0.1",
-        "rimraf": "2.6.2",
-        "ssri": "5.0.0",
-        "unique-filename": "1.1.0",
-        "y18n": "3.2.1"
-      }
-    },
-    "caching-transform": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-      "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
-      "dev": true,
-      "requires": {
-        "md5-hex": "1.3.0",
-        "mkdirp": "0.5.1",
-        "write-file-atomic": "1.3.4"
-      },
-      "dependencies": {
-        "md5-hex": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-          "dev": true,
-          "requires": {
-            "md5-o-matic": "0.1.1"
-          }
-        },
-        "write-file-atomic": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
-          }
-        }
-      }
-    },
-    "call-matcher": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.0.1.tgz",
-      "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.3",
-        "deep-equal": "1.0.1",
-        "espurify": "1.7.0",
-        "estraverse": "4.2.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-          "dev": true
-        }
-      }
-    },
-    "call-signature": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
-      "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
-      "dev": true
-    },
-    "camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-      "dev": true
-    },
-    "camelcase-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true,
-      "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
-      }
-    },
-    "capture-stack-trace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-      "dev": true
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
-    },
-    "chain-function": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
-      "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
-    },
-    "chalk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "4.5.0"
-      }
-    },
-    "change-emitter": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
-    },
-    "chokidar": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "dev": true,
-      "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        }
-      }
-    },
-    "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-      "dev": true
-    },
-    "ci-info": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
-      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
-      "dev": true
-    },
-    "classnames": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
-      "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
-    },
-    "clean-stack": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
-      "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE=",
-      "dev": true
-    },
-    "clean-yaml-object": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
-      "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
-      "dev": true
-    },
-    "cli-boxes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-      "dev": true
-    },
-    "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "2.0.0"
-      }
-    },
-    "cli-spinners": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
-      "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
-      "dev": true
-    },
-    "cli-truncate": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
-      "integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
-      "dev": true,
-      "requires": {
-        "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
-      }
-    },
-    "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "dev": true,
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
-      }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
-    },
-    "co-with-promise": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co-with-promise/-/co-with-promise-4.6.0.tgz",
-      "integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "1.0.0"
-      },
-      "dependencies": {
-        "pinkie": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-          "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-          "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
-          "dev": true,
-          "requires": {
-            "pinkie": "1.0.0"
-          }
-        }
-      }
-    },
-    "code-excerpt": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.0.tgz",
-      "integrity": "sha1-XcwIHoj0p+O1VOnjXX7yMtR/gUc=",
-      "dev": true,
-      "requires": {
-        "convert-to-spaces": "1.0.2"
-      }
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
-    },
-    "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
-    },
-    "common-path-prefix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
-      "integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA=",
-      "dev": true
-    },
-    "commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true
-    },
-    "compressible": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
-      "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
-      "dev": true,
-      "requires": {
-        "mime-db": "1.30.0"
-      }
-    },
-    "compression": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
-      "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
-      "dev": true,
-      "requires": {
-        "accepts": "1.3.4",
-        "bytes": "3.0.0",
-        "compressible": "2.0.12",
-        "debug": "2.6.9",
-        "on-headers": "1.0.1",
-        "safe-buffer": "5.1.1",
-        "vary": "1.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
-      }
-    },
-    "concordance": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/concordance/-/concordance-3.0.0.tgz",
-      "integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
-      "dev": true,
-      "requires": {
-        "date-time": "2.1.0",
-        "esutils": "2.0.2",
-        "fast-diff": "1.1.2",
-        "function-name-support": "0.2.0",
-        "js-string-escape": "1.0.1",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.flattendeep": "4.4.0",
-        "lodash.merge": "4.6.0",
-        "md5-hex": "2.0.0",
-        "semver": "5.4.1",
-        "well-known-symbols": "1.0.0"
-      }
-    },
-    "configstore": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
-      "dev": true,
-      "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
-      }
-    },
-    "connect-history-api-fallback": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-      "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
-      "dev": true
-    },
-    "content-disposition": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-      "dev": true
-    },
-    "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-      "dev": true
-    },
-    "content-type-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
-      "dev": true
-    },
-    "convert-source-map": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-      "dev": true
-    },
-    "convert-to-spaces": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
-      "integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU=",
-      "dev": true
-    },
-    "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-      "dev": true
-    },
-    "cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-      "dev": true
-    },
-    "copy-concurrently": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
-      "dev": true,
-      "requires": {
-        "aproba": "1.2.0",
-        "fs-write-stream-atomic": "1.0.10",
-        "iferr": "0.1.5",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
-      }
-    },
-    "copy-webpack-plugin": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.3.0.tgz",
-      "integrity": "sha512-5o1/xyWm8OYDmLFKAWMuPU3A/jZ4Z6kZSZGh36KD2XmtxnRa8lQyLx7bCNQm08BPaR/oqUdtJOr9jWfnYINp9g==",
-      "dev": true,
-      "requires": {
-        "cacache": "10.0.1",
-        "find-cache-dir": "1.0.0",
-        "globby": "7.1.1",
-        "is-glob": "4.0.0",
-        "loader-utils": "0.2.17",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "p-limit": "1.1.0",
-        "pify": "3.0.0",
-        "serialize-javascript": "1.4.0"
-      }
-    },
-    "core-assert": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
-      "integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
-      "dev": true,
-      "requires": {
-        "buf-compare": "1.0.1",
-        "is-error": "2.2.1"
-      }
-    },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
-    },
-    "create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
-      "requires": {
-        "capture-stack-trace": "1.0.0"
-      }
-    },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
-      }
-    },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "dev": true,
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
-      }
-    },
-    "crypto-random-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-      "dev": true
-    },
-    "css-vendor": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-0.3.8.tgz",
-      "integrity": "sha1-ZCHP0wNM5mT+dnOXL9ARn8KJQfo=",
-      "requires": {
-        "is-in-browser": "1.1.3"
-      }
-    },
-    "cssom": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
-      "dev": true
-    },
-    "cssstyle": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-      "dev": true,
-      "requires": {
-        "cssom": "0.3.2"
-      }
-    },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true,
-      "requires": {
-        "array-find-index": "1.0.2"
-      }
-    },
-    "cyclist": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
-      "dev": true
-    },
-    "d": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "requires": {
-        "es5-ext": "0.10.38"
-      }
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
-    },
-    "date-time": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
-      "integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
-      "dev": true,
-      "requires": {
-        "time-zone": "1.0.0"
-      }
-    },
-    "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
-      "requires": {
-        "ms": "2.0.0"
-      }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
-    },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
-    },
-    "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-      "dev": true
-    },
-    "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
-    },
-    "deepmerge": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.0.1.tgz",
-      "integrity": "sha512-VIPwiMJqJ13ZQfaCsIFnp5Me9tnjURiaIFxfz7EH0Ci0dTSQpZtSLrqOicXqEd/z2r+z+Klk9GzmnRsgpgbOsQ=="
-    },
-    "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true,
-      "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
-      }
-    },
-    "del": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
-      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
-      "dev": true,
-      "requires": {
-        "globby": "6.1.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "p-map": "1.2.0",
-        "pify": "3.0.0",
-        "rimraf": "2.6.2"
-      },
-      "dependencies": {
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "dev": true,
-          "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-              "dev": true
-            }
-          }
-        }
-      }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
-    },
-    "depd": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-      "dev": true
-    },
-    "destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "dev": true
-    },
-    "detect-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
-      "requires": {
-        "repeating": "2.0.1"
-      }
-    },
-    "detect-node": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
-      "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=",
-      "dev": true
-    },
-    "dir-glob": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
-      "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
-      "dev": true,
-      "requires": {
-        "arrify": "1.0.1",
-        "path-type": "3.0.0"
-      }
-    },
-    "dns-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
-      "dev": true
-    },
-    "dns-packet": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.2.2.tgz",
-      "integrity": "sha512-kN+DjfGF7dJGUL7nWRktL9Z18t1rWP3aQlyZdY8XlpvU3Nc6GeFTQApftcjtWKxAZfiggZSGrCEoszNgvnpwDg==",
-      "dev": true,
-      "requires": {
-        "ip": "1.1.5",
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "dns-txt": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
-      "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
-      "dev": true,
-      "requires": {
-        "buffer-indexof": "1.1.1"
-      }
-    },
-    "document-register-element": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.7.0.tgz",
-      "integrity": "sha512-qAoWcNm1zW3LVO0KSblYISM0oLQzlNtns2gd1O/YS3QvFYFidG6lF73fC98fIbfPQkws698L0/URrtmN8+ADbQ==",
-      "dev": true
-    },
-    "dom-helpers": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
-      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
-    },
-    "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
-    },
-    "domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.0.tgz",
-      "integrity": "sha512-WpwuBlZ2lQRFa4H/4w49deb9rJLot9KmqrKKjMc9qBl7CID+DdC2swoa34ccRl+anL2B6bLp6TjFdIdnzekMBQ==",
-      "dev": true
-    },
-    "dot-prop": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-      "dev": true,
-      "requires": {
-        "is-obj": "1.0.1"
-      }
-    },
-    "duplexer3": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-      "dev": true
-    },
-    "duplexify": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
-      "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "1.4.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
-      }
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
-    },
-    "ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
-    },
-    "emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true
-    },
-    "empower-core": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
-      "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
-      "dev": true,
-      "requires": {
-        "call-signature": "0.0.2",
-        "core-js": "2.5.3"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-          "dev": true
-        }
-      }
-    },
-    "encodeurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
-      "dev": true
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.19"
-      }
-    },
-    "end-of-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0"
-      }
-    },
-    "enhanced-resolve": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
-      "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.8"
-      }
-    },
-    "equal-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/equal-length/-/equal-length-1.0.1.tgz",
-      "integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w=",
-      "dev": true
-    },
-    "errno": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
-      "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
-      "dev": true,
-      "requires": {
-        "prr": "1.0.1"
-      }
-    },
-    "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "0.2.1"
-      }
-    },
-    "es-abstract": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
-      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true,
-      "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
-      }
-    },
-    "es5-ext": {
-      "version": "0.10.38",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
-      "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
-      "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
-      }
-    },
-    "es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38",
-        "es6-symbol": "3.1.1"
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38"
-      }
-    },
-    "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
-    },
-    "escodegen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
-      "dev": true,
-      "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
-    "espower-location-detector": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
-      "integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
-      "dev": true,
-      "requires": {
-        "is-url": "1.2.2",
-        "path-is-absolute": "1.0.1",
-        "source-map": "0.5.7",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
-      }
-    },
-    "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
-    },
-    "espurify": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
-      "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.3"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-          "dev": true
-        }
-      }
-    },
-    "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-      "dev": true
-    },
-    "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
-    },
-    "etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "dev": true
-    },
-    "eventemitter3": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
-      "dev": true
-    },
-    "eventsource": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
-      "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
-      "dev": true,
-      "requires": {
-        "original": "1.0.0"
-      }
-    },
-    "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
-      }
-    },
-    "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true,
-      "requires": {
-        "is-posix-bracket": "0.1.1"
-      }
-    },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
-      "requires": {
-        "fill-range": "2.2.3"
-      }
-    },
-    "express": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
-      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
-      "dev": true,
-      "requires": {
-        "accepts": "1.3.4",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.18.2",
-        "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
-        "cookie": "0.3.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "1.1.1",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
-        "finalhandler": "1.1.0",
-        "fresh": "0.5.2",
-        "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.2",
-        "qs": "6.5.1",
-        "range-parser": "1.2.0",
-        "safe-buffer": "5.1.1",
-        "send": "0.16.1",
-        "serve-static": "1.13.1",
-        "setprototypeof": "1.1.0",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15",
-        "utils-merge": "1.0.1",
-        "vary": "1.1.2"
-      },
-      "dependencies": {
-        "array-flatten": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
-    },
-    "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "1.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        }
-      }
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
-    },
-    "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
-      "dev": true
-    },
-    "fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
-      "dev": true
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
-    },
-    "faye-websocket": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-      "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-      "dev": true,
-      "requires": {
-        "websocket-driver": "0.7.0"
-      }
-    },
-    "fbjs": {
-      "version": "0.8.16",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
-      "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.17"
-      }
-    },
-    "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5"
-      }
-    },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "dev": true
-    },
-    "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true,
-      "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
-      }
-    },
-    "finalhandler": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
-      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "find-cache-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-      "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-      "dev": true,
-      "requires": {
-        "commondir": "1.0.1",
-        "make-dir": "1.1.0",
-        "pkg-dir": "2.0.0"
-      }
-    },
-    "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-      "dev": true,
-      "requires": {
-        "locate-path": "2.0.0"
-      }
-    },
-    "flush-write-stream": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
-      "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
-      }
-    },
-    "fn-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
-      "dev": true
-    },
-    "for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
-      "requires": {
-        "for-in": "1.0.2"
-      }
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
-    },
-    "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-      "dev": true,
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
-      }
-    },
-    "forwarded": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-      "dev": true
-    },
-    "fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "dev": true
-    },
-    "from2": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
-      }
-    },
-    "fs-write-stream-atomic": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "2.3.3"
-      }
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "fsevents": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "2.9.2",
-        "node-pre-gyp": "0.6.39"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true,
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.39",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "1.0.2",
-            "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
-    "function-name-support": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/function-name-support/-/function-name-support-0.2.0.tgz",
-      "integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE=",
-      "dev": true
-    },
-    "get-caller-file": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-      "dev": true
-    },
-    "get-port": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
-      "dev": true
-    },
-    "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-      "dev": true
-    },
-    "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
-    },
-    "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
-    },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        }
-      }
-    },
-    "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true,
-      "requires": {
-        "is-glob": "2.0.1"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        }
-      }
-    },
-    "global": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
-      }
-    },
-    "global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-      "dev": true,
-      "requires": {
-        "ini": "1.3.5"
-      }
-    },
-    "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
-    },
-    "globby": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-      "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-      "dev": true,
-      "requires": {
-        "array-union": "1.0.2",
-        "dir-glob": "2.0.0",
-        "glob": "7.1.2",
-        "ignore": "3.3.7",
-        "pify": "3.0.0",
-        "slash": "1.0.0"
-      }
-    },
-    "got": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-      "dev": true,
-      "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
-        "url-parse-lax": "1.0.0"
-      }
-    },
-    "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
-    },
-    "handle-thing": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
-      "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
-      "dev": true
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
-    },
-    "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "dev": true,
-      "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
-        }
-      }
-    },
-    "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true,
-      "requires": {
-        "function-bind": "1.1.1"
-      }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
-    },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-      "dev": true
-    },
-    "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-      "dev": true
-    },
-    "has-yarn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
-      "integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
-      "dev": true
-    },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "dev": true,
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
-      }
-    },
-    "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-      "dev": true
-    },
-    "hoist-non-react-statics": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
-      "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
-    },
-    "home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
-    },
-    "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-      "dev": true
-    },
-    "hpack.js": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "obuf": "1.1.1",
-        "readable-stream": "2.3.3",
-        "wbuf": "1.7.2"
-      }
-    },
-    "html-encoding-sniffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-      "dev": true,
-      "requires": {
-        "whatwg-encoding": "1.0.3"
-      }
-    },
-    "html-entities": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
-      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
-      "dev": true
-    },
-    "http-deceiver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
-      "dev": true
-    },
-    "http-errors": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-      "dev": true,
-      "requires": {
-        "depd": "1.1.1",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
-      },
-      "dependencies": {
-        "setprototypeof": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-          "dev": true
-        }
-      }
-    },
-    "http-parser-js": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz",
-      "integrity": "sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE=",
-      "dev": true
-    },
-    "http-proxy": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
-      "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
-      "dev": true,
-      "requires": {
-        "eventemitter3": "1.2.0",
-        "requires-port": "1.0.0"
-      }
-    },
-    "http-proxy-middleware": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
-      "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
-      "dev": true,
-      "requires": {
-        "http-proxy": "1.16.2",
-        "is-glob": "3.1.0",
-        "lodash": "4.17.4",
-        "micromatch": "2.3.11"
-      },
-      "dependencies": {
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "2.1.1"
-          }
-        }
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
-      }
-    },
-    "hullabaloo-config-manager": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.1.1.tgz",
-      "integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
-      "dev": true,
-      "requires": {
-        "dot-prop": "4.2.0",
-        "es6-error": "4.1.1",
-        "graceful-fs": "4.1.11",
-        "indent-string": "3.2.0",
-        "json5": "0.5.1",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.clonedeepwith": "4.5.0",
-        "lodash.isequal": "4.5.0",
-        "lodash.merge": "4.6.0",
-        "md5-hex": "2.0.0",
-        "package-hash": "2.0.0",
-        "pkg-dir": "2.0.0",
-        "resolve-from": "3.0.0",
-        "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "indent-string": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-          "dev": true
-        }
-      }
-    },
-    "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-    },
-    "iferr": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-      "dev": true
-    },
-    "ignore": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
-      "dev": true
-    },
-    "ignore-by-default": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
-      "dev": true
-    },
-    "import-lazy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-      "dev": true
-    },
-    "import-local": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
-      "integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
-      "dev": true,
-      "requires": {
-        "pkg-dir": "2.0.0",
-        "resolve-cwd": "2.0.0"
-      }
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
-    },
-    "indent-string": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true,
-      "requires": {
-        "repeating": "2.0.1"
-      }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
-    "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
-    },
-    "internal-ip": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
-      "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
-      "dev": true,
-      "requires": {
-        "meow": "3.7.0"
-      }
-    },
-    "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true,
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
-    },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true
-    },
-    "ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-      "dev": true
-    },
-    "ipaddr.js": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
-      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
-      "dev": true
-    },
-    "irregular-plurals": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
-      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
-      "dev": true
-    },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
-    "is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true,
-      "requires": {
-        "binary-extensions": "1.11.0"
-      }
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "1.1.1"
-      }
-    },
-    "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-      "dev": true
-    },
-    "is-ci": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
-      "dev": true,
-      "requires": {
-        "ci-info": "1.1.2"
-      }
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
-    },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
-      "requires": {
-        "is-primitive": "2.0.0"
-      }
-    },
-    "is-error": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz",
-      "integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw=",
-      "dev": true
-    },
-    "is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
-    },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
-    },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
-    },
-    "is-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
-    },
-    "is-generator-fn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-      "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
-      "dev": true
-    },
-    "is-glob": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "2.1.1"
-      }
-    },
-    "is-in-browser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
-    },
-    "is-installed-globally": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-      "dev": true,
-      "requires": {
-        "global-dirs": "0.1.1",
-        "is-path-inside": "1.0.1"
-      }
-    },
-    "is-npm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-      "dev": true
-    },
-    "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2"
-      }
-    },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
-    },
-    "is-observable": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
-      "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
-      "dev": true,
-      "requires": {
-        "symbol-observable": "0.2.4"
-      },
-      "dependencies": {
-        "symbol-observable": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
-          "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
-          "dev": true
-        }
-      }
-    },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "1.0.1"
-      }
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "1.0.2"
-      }
-    },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
-    },
-    "is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "requires": {
-        "isobject": "3.0.1"
-      }
-    },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "dev": true
-    },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.1"
-      }
-    },
-    "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-      "dev": true
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-      "dev": true
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
-    },
-    "is-url": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
-      "integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY=",
-      "dev": true
-    },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
-    },
-    "is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-      "dev": true
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
-      }
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
-    },
-    "js-string-escape": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
-      "dev": true
-    },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-    },
-    "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-      "dev": true,
-      "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
-      }
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
-      "optional": true
-    },
-    "jsdom": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.5.1.tgz",
-      "integrity": "sha512-89ztIZ03aYK9f1uUrLXLsZndRge/JnZjzjpaN+lrse3coqz+8PR/dX4WLHpbF5fIKTXhDjFODOJw2328lPJ90g==",
-      "dev": true,
-      "requires": {
-        "abab": "1.0.4",
-        "acorn": "5.3.0",
-        "acorn-globals": "4.1.0",
-        "array-equal": "1.0.0",
-        "browser-process-hrtime": "0.1.2",
-        "content-type-parser": "1.0.2",
-        "cssom": "0.3.2",
-        "cssstyle": "0.2.37",
-        "domexception": "1.0.0",
-        "escodegen": "1.9.0",
-        "html-encoding-sniffer": "1.0.2",
-        "left-pad": "1.2.0",
-        "nwmatcher": "1.4.3",
-        "parse5": "3.0.3",
-        "pn": "1.1.0",
-        "request": "2.83.0",
-        "request-promise-native": "1.0.5",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.3",
-        "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.3",
-        "whatwg-url": "6.4.0",
-        "xml-name-validator": "2.0.1"
-      }
-    },
-    "jsdom-global": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
-      "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
-      "dev": true
-    },
-    "jsesc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-      "dev": true
-    },
-    "json-parse-better-errors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
-      "dev": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
-    },
-    "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
-    },
-    "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-      "dev": true
-    },
-    "json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
-    "jss": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/jss/-/jss-9.6.0.tgz",
-      "integrity": "sha512-fnj0UV//VdgxwH0h9pOZljAwFlJMZTAeaDD6u9G0VFMSDwTgdRYxV7+/RZohZYMEVITkgXedHiQHW5ETRVAXkA==",
-      "requires": {
-        "is-in-browser": "1.1.3",
-        "symbol-observable": "1.1.0",
-        "warning": "3.0.0"
-      }
-    },
-    "jss-camel-case": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/jss-camel-case/-/jss-camel-case-6.0.0.tgz",
-      "integrity": "sha512-XAYa7JpGkLdlLgEfuzSQSVONRzSVvv4Tvyv5H8hLmJuHeFHTWwVrJrW1Cg/buED3izXKwTU2KBGpeXjIR5Eaew=="
-    },
-    "jss-compose": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/jss-compose/-/jss-compose-5.0.0.tgz",
-      "integrity": "sha512-YofRYuiA0+VbeOw0VjgkyO380sA4+TWDrW52nSluD9n+1FWOlDzNbgpZ/Sb3Y46+DcAbOS21W5jo6SAqUEiuwA==",
-      "requires": {
-        "warning": "3.0.0"
-      }
-    },
-    "jss-default-unit": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
-      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg=="
-    },
-    "jss-expand": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/jss-expand/-/jss-expand-5.1.0.tgz",
-      "integrity": "sha512-WTxmNipgj0V8kr8gc8Gc6Et7uQZH60H7FFNG9zZHjR6TPJoj7TDK+/EBxwRHtCRQD4B8RTwoa7MyEKD4ReKfXw=="
-    },
-    "jss-extend": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jss-extend/-/jss-extend-6.1.0.tgz",
-      "integrity": "sha512-bSNwLDOZnMxABsUqvq2lwLJ/MMFs8ThligiLZBOUeyoZCoHqAbcTghvunk2QDVxiOhRTDS57VvhXVJZETW58Bw==",
-      "requires": {
-        "warning": "3.0.0"
-      }
-    },
-    "jss-global": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
-      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q=="
-    },
-    "jss-nested": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/jss-nested/-/jss-nested-6.0.1.tgz",
-      "integrity": "sha512-rn964TralHOZxoyEgeq3hXY8hyuCElnvQoVrQwKHVmu55VRDd6IqExAx9be5HgK0yN/+hQdgAXQl/GUrBbbSTA==",
-      "requires": {
-        "warning": "3.0.0"
-      }
-    },
-    "jss-preset-default": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jss-preset-default/-/jss-preset-default-4.1.0.tgz",
-      "integrity": "sha512-C6SyfDg99EFrt0bv0lsg2OEN3e72Fry9/hMPW2sO6MSVsx+vc/Og6TJJY3F2MY5Z/V2/wlARHVmCb3TYMr0zFA==",
-      "requires": {
-        "jss-camel-case": "6.0.0",
-        "jss-compose": "5.0.0",
-        "jss-default-unit": "8.0.2",
-        "jss-expand": "5.1.0",
-        "jss-extend": "6.1.0",
-        "jss-global": "3.0.0",
-        "jss-nested": "6.0.1",
-        "jss-props-sort": "6.0.0",
-        "jss-template": "1.0.1",
-        "jss-vendor-prefixer": "7.0.0"
-      }
-    },
-    "jss-props-sort": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
-      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g=="
-    },
-    "jss-template": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/jss-template/-/jss-template-1.0.1.tgz",
-      "integrity": "sha512-m5BqEWha17fmIVXm1z8xbJhY6GFJxNB9H68GVnCWPyGYfxiAgY9WTQyvDAVj+pYRgrXSOfN5V1T4+SzN1sJTeg==",
-      "requires": {
-        "warning": "3.0.0"
-      }
-    },
-    "jss-vendor-prefixer": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz",
-      "integrity": "sha512-Agd+FKmvsI0HLcYXkvy8GYOw3AAASBUpsmIRvVQheps+JWaN892uFOInTr0DRydwaD91vSSUCU4NssschvF7MA==",
-      "requires": {
-        "css-vendor": "0.3.8"
-      }
-    },
-    "keycode": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.1.9.tgz",
-      "integrity": "sha1-lkojxU5IiUBbSGGlyfBIDUUUHfo="
-    },
-    "killable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz",
-      "integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms=",
-      "dev": true
-    },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "1.1.6"
-      }
-    },
-    "last-line-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/last-line-stream/-/last-line-stream-1.0.0.tgz",
-      "integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
-      "dev": true,
-      "requires": {
-        "through2": "2.0.3"
-      }
-    },
-    "latest-version": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-      "dev": true,
-      "requires": {
-        "package-json": "4.0.1"
-      }
-    },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
-      "requires": {
-        "invert-kv": "1.0.0"
-      }
-    },
-    "left-pad": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
-      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
-      "dev": true
-    },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
-      }
-    },
-    "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
-      }
-    },
-    "loader-utils": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-      "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-      "dev": true,
-      "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1",
-        "object-assign": "4.1.1"
-      }
-    },
-    "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true,
-      "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
-      }
-    },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-    },
-    "lodash-es": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
-    },
-    "lodash.clonedeepwith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
-      "integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ=",
-      "dev": true
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
-    },
-    "lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-      "dev": true
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-      "dev": true
-    },
-    "lodash.flattendeep": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-      "dev": true
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-      "dev": true
-    },
-    "lodash.merge": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
-      "dev": true
-    },
-    "lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
-    },
-    "loglevel": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.0.tgz",
-      "integrity": "sha1-rgyqVhERSYxboTcj1vtjHSQAOTQ=",
-      "dev": true
-    },
-    "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "requires": {
-        "js-tokens": "3.0.2"
-      }
-    },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true,
-      "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
-      }
-    },
-    "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-      "dev": true
-    },
-    "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true,
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
-    },
-    "make-dir": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
-      "dev": true,
-      "requires": {
-        "pify": "3.0.0"
-      }
-    },
-    "map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true
-    },
-    "matcher": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.0.0.tgz",
-      "integrity": "sha1-qvDEgW62m5IJRnQXViXzRmsOPhk=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5"
-      }
-    },
-    "material-ui": {
-      "version": "1.0.0-beta.25",
-      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.25.tgz",
-      "integrity": "sha512-c31uPg4h9VP1Udn//wSqSRwrWryCT9kaUlOdpVvHCL0i5dNqD1eU9dYQNUihwO3P//DXEzOYwmbEHFR8ZeYjbw==",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "brcast": "3.0.1",
-        "classnames": "2.2.5",
-        "deepmerge": "2.0.1",
-        "dom-helpers": "3.3.1",
-        "hoist-non-react-statics": "2.3.1",
-        "jss": "9.6.0",
-        "jss-preset-default": "4.1.0",
-        "keycode": "2.1.9",
-        "lodash": "4.17.4",
-        "normalize-scroll-left": "0.1.2",
-        "prop-types": "15.6.0",
-        "react-event-listener": "0.5.3",
-        "react-jss": "8.2.1",
-        "react-popper": "0.7.5",
-        "react-scrollbar-size": "2.1.0",
-        "react-transition-group": "2.2.1",
-        "recompose": "0.26.0",
-        "scroll": "2.0.1",
-        "warning": "3.0.0"
-      }
-    },
-    "material-ui-icons": {
-      "version": "1.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/material-ui-icons/-/material-ui-icons-1.0.0-beta.17.tgz",
-      "integrity": "sha1-XxmvVKLZnu7zR6VUFKaFPhyFDcM=",
-      "requires": {
-        "recompose": "0.26.0"
-      }
-    },
-    "material-ui-pickers": {
-      "version": "1.0.0-beta.12",
-      "resolved": "https://registry.npmjs.org/material-ui-pickers/-/material-ui-pickers-1.0.0-beta.12.tgz",
-      "integrity": "sha512-eNRy183HRJ7xahxCv+eOhDG5uRAGxMjQxK15zkG8ZtgNmDQhJS8MlZ/ZJPljDelypozKxRJUIq1DRVwO5ux+FA==",
-      "requires": {
-        "moment-range": "3.1.1",
-        "react-text-mask": "5.1.0"
-      }
-    },
-    "md5-hex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
-      "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
-      "dev": true,
-      "requires": {
-        "md5-o-matic": "0.1.1"
-      }
-    },
-    "md5-o-matic": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-      "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
-      "dev": true
-    },
-    "media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-      "dev": true
-    },
-    "memory-fs": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-      "dev": true,
-      "requires": {
-        "errno": "0.1.6",
-        "readable-stream": "2.3.3"
-      }
-    },
-    "meow": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "dev": true,
-      "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
-    "merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
-    },
-    "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true
-    },
-    "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true,
-      "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        }
-      }
-    },
-    "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-      "dev": true
-    },
-    "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-      "dev": true
-    },
-    "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-      "dev": true,
-      "requires": {
-        "mime-db": "1.30.0"
-      }
-    },
-    "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-      "dev": true
-    },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "requires": {
-        "dom-walk": "0.1.1"
-      }
-    },
-    "minimalistic-assert": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
-      "dev": true
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "1.1.8"
-      }
-    },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
-    },
-    "mississippi": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
-      "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "1.6.0",
-        "duplexify": "3.5.1",
-        "end-of-stream": "1.4.0",
-        "flush-write-stream": "1.0.2",
-        "from2": "2.3.0",
-        "parallel-transform": "1.1.0",
-        "pump": "1.0.3",
-        "pumpify": "1.3.5",
-        "stream-each": "1.2.2",
-        "through2": "2.0.3"
-      }
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      }
-    },
-    "moment": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
-    },
-    "moment-range": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/moment-range/-/moment-range-3.1.1.tgz",
-      "integrity": "sha1-XFLPn6sp253ZvNhtN+UrBKenJxo=",
-      "requires": {
-        "es6-symbol": "3.1.1"
-      }
-    },
-    "move-concurrently": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
-      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-      "dev": true,
-      "requires": {
-        "aproba": "1.2.0",
-        "copy-concurrently": "1.0.5",
-        "fs-write-stream-atomic": "1.0.10",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
-      }
-    },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
-    },
-    "multicast-dns": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.1.tgz",
-      "integrity": "sha512-uV3/ckdsffHx9IrGQrx613mturMdMqQ06WTq+C09NsStJ9iNG6RcUWgPKs1Rfjy+idZT6tfQoXEusGNnEZhT3w==",
-      "dev": true,
-      "requires": {
-        "dns-packet": "1.2.2",
-        "thunky": "0.1.0"
-      }
-    },
-    "multicast-dns-service-types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
-      "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
-      "dev": true
-    },
-    "multimatch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-      "dev": true,
-      "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
-      }
-    },
-    "nan": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
-      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
-      "dev": true,
-      "optional": true
-    },
-    "negotiator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-      "dev": true
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
-    },
-    "node-forge": {
-      "version": "0.6.33",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.33.tgz",
-      "integrity": "sha1-RjgRh59XPUUVWtap9D3ClujoXrw=",
-      "dev": true
-    },
-    "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
-      }
-    },
-    "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "requires": {
-        "remove-trailing-separator": "1.1.0"
-      }
-    },
-    "normalize-scroll-left": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz",
-      "integrity": "sha512-F9YMRls0zCF6BFIE2YnXDRpHPpfd91nOIaNdDgrx5YMoPLo8Wqj+6jNXHQsYBavJeXP4ww8HCt0xQAKc5qk2Fg=="
-    },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
-      "requires": {
-        "path-key": "2.0.1"
-      }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
-    "nwmatcher": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
-      "dev": true
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-      "dev": true
-    },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
-      "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
-      }
-    },
-    "observable-to-promise": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-0.5.0.tgz",
-      "integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
-      "dev": true,
-      "requires": {
-        "is-observable": "0.2.0",
-        "symbol-observable": "1.1.0"
-      }
-    },
-    "obuf": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
-      "integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4=",
-      "dev": true
-    },
-    "on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
-      "requires": {
-        "ee-first": "1.1.1"
-      }
-    },
-    "on-headers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
-      "dev": true
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1.0.2"
-      }
-    },
-    "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "1.1.0"
-      }
-    },
-    "opn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
-      "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
-      "dev": true,
-      "requires": {
-        "is-wsl": "1.1.0"
-      }
-    },
-    "option-chain": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/option-chain/-/option-chain-1.0.0.tgz",
-      "integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI=",
-      "dev": true
-    },
-    "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
-      "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
-      }
-    },
-    "original": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
-      "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
-      "dev": true,
-      "requires": {
-        "url-parse": "1.0.5"
-      },
-      "dependencies": {
-        "url-parse": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
-          "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
-          "dev": true,
-          "requires": {
-            "querystringify": "0.0.4",
-            "requires-port": "1.0.0"
-          }
-        }
-      }
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
-    },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true,
-      "requires": {
-        "lcid": "1.0.0"
-      }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
-    },
-    "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
-    },
-    "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
-      "requires": {
-        "p-limit": "1.1.0"
-      }
-    },
-    "p-map": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
-      "dev": true
-    },
-    "package-hash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
-      "integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "lodash.flattendeep": "4.4.0",
-        "md5-hex": "2.0.0",
-        "release-zalgo": "1.0.0"
-      }
-    },
-    "package-json": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-      "dev": true,
-      "requires": {
-        "got": "6.7.1",
-        "registry-auth-token": "3.3.1",
-        "registry-url": "3.1.0",
-        "semver": "5.4.1"
-      }
-    },
-    "parallel-transform": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
-      "dev": true,
-      "requires": {
-        "cyclist": "0.2.2",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
-      }
-    },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
-      "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        }
-      }
-    },
-    "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
-      "requires": {
-        "error-ex": "1.3.1"
-      }
-    },
-    "parse-ms": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
-      "dev": true
-    },
-    "parse5": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "8.5.5"
-      }
-    },
-    "parseurl": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
-      "dev": true
-    },
-    "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
-    },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
-    },
-    "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-      "dev": true
-    },
-    "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "dev": true,
-      "requires": {
-        "pify": "3.0.0"
-      }
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
-    },
-    "pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "dev": true
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "2.0.4"
-      }
-    },
-    "pkg-conf": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
-      "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
-      "dev": true,
-      "requires": {
-        "find-up": "2.1.0",
-        "load-json-file": "4.0.0"
-      },
-      "dependencies": {
-        "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.1"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        }
-      }
-    },
-    "pkg-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-      "dev": true,
-      "requires": {
-        "find-up": "2.1.0"
-      }
-    },
-    "plur": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
-      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
-      "dev": true,
-      "requires": {
-        "irregular-plurals": "1.4.0"
-      }
-    },
-    "pn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-      "dev": true
-    },
-    "popper.js": {
-      "version": "1.12.9",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.12.9.tgz",
-      "integrity": "sha1-DfvC3/lsRRuzMu3Pz6r1ZtMx1bM="
-    },
-    "portfinder": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
-      "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
-      "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
-    },
-    "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true
-    },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "dev": true
-    },
-    "pretty-ms": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
-      "integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
-      "dev": true,
-      "requires": {
-        "parse-ms": "1.0.1",
-        "plur": "2.1.2"
-      }
-    },
-    "private": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-      "dev": true
-    },
-    "process": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
-    },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
-    },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "2.0.6"
-      }
-    },
-    "promise-inflight": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
-      "dev": true
-    },
-    "prop-types": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
-    },
-    "proxy-addr": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
-      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
-      "dev": true,
-      "requires": {
-        "forwarded": "0.1.2",
-        "ipaddr.js": "1.5.2"
-      }
-    },
-    "prr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
-    },
-    "pump": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "1.4.0",
-        "once": "1.4.0"
-      }
-    },
-    "pumpify": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
-      "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
-      "dev": true,
-      "requires": {
-        "duplexify": "3.5.1",
-        "inherits": "2.0.3",
-        "pump": "1.0.3"
-      }
-    },
-    "punycode": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
-      "dev": true
-    },
-    "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-      "dev": true
-    },
-    "querystringify": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
-      "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw=",
-      "dev": true
-    },
-    "rafl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rafl/-/rafl-1.2.2.tgz",
-      "integrity": "sha1-/pMPdYIRAg1H44gV9Rlqi+QVB0A=",
-      "requires": {
-        "global": "4.3.2"
-      }
-    },
-    "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-      "dev": true,
-      "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        }
-      }
-    },
-    "range-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-      "dev": true
-    },
-    "raw-body": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-      "dev": true,
-      "requires": {
-        "bytes": "3.0.0",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
-        "unpipe": "1.0.0"
-      }
-    },
-    "rc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
-      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
-      "dev": true,
-      "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
-    "react": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
-      "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
-      }
-    },
-    "react-dom": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
-      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
-      "dev": true,
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
-      }
-    },
-    "react-event-listener": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.5.3.tgz",
-      "integrity": "sha512-fTGYvhe7eTsqq0m664Km0rxKQcqLIGZWZINmy1LU0fu312tay8Mt3Twq2P5Xj1dfDVvvzT1Ql3/FDkiMPJ1MOg==",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "fbjs": "0.8.16",
-        "prop-types": "15.6.0",
-        "warning": "3.0.0"
-      }
-    },
-    "react-jss": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/react-jss/-/react-jss-8.2.1.tgz",
-      "integrity": "sha512-H1fm32xG8pi4LMHkXjqpLyFOvSDsravd0HI6Dtlb/iyma1tfi7qqqSH2bf0kKyTAJV5hvYL0ls0qvRJWKfDPcA==",
-      "requires": {
-        "hoist-non-react-statics": "2.3.1",
-        "jss": "9.6.0",
-        "jss-preset-default": "4.1.0",
-        "prop-types": "15.6.0",
-        "theming": "1.3.0"
-      }
-    },
-    "react-popper": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.7.5.tgz",
-      "integrity": "sha512-ya9dhhGCf74JTOB2uyksEHhIGw7w9tNZRUJF73lEq2h4H5JT6MBa4PdT4G+sx6fZwq+xKZAL/sVNAIuojPn7Dg==",
-      "requires": {
-        "popper.js": "1.12.9",
-        "prop-types": "15.6.0"
-      }
-    },
-    "react-redux": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz",
-      "integrity": "sha512-8taaaGu+J7PMJQDJrk/xiWEYQmdo3mkXw6wPr3K3LxvXis3Fymiq7c13S+Tpls/AyNUAsoONkU81AP0RA6y6Vw==",
-      "dev": true,
-      "requires": {
-        "hoist-non-react-statics": "2.3.1",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
-        "loose-envify": "1.3.1",
-        "prop-types": "15.6.0"
-      }
-    },
-    "react-scrollbar-size": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/react-scrollbar-size/-/react-scrollbar-size-2.1.0.tgz",
-      "integrity": "sha512-9dDUJvk7S48r0TRKjlKJ9e/LkLLYgc9LdQR6W21I8ZqtSrEsedPOoMji4nU3DHy7fx2l8YMScJS/N7qiloYzXQ==",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "prop-types": "15.6.0",
-        "react-event-listener": "0.5.3",
-        "stifle": "1.0.4"
-      }
-    },
-    "react-text-mask": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/react-text-mask/-/react-text-mask-5.1.0.tgz",
-      "integrity": "sha512-9YTPppMq06sbKj7WXX/pt5PE0Ck5OdckSVa7OaekH1jerW5pbfCZDzCi5bWczNKYhq7fBBDFOsfrFGSp+ufShQ==",
-      "requires": {
-        "prop-types": "15.6.0"
-      }
-    },
-    "react-transition-group": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.2.1.tgz",
-      "integrity": "sha512-q54UBM22bs/CekG8r3+vi9TugSqh0t7qcEVycaRc9M0p0aCEu+h6rp/RFiW7fHfgd1IKpd9oILFTl5QK+FpiPA==",
-      "requires": {
-        "chain-function": "1.0.0",
-        "classnames": "2.2.5",
-        "dom-helpers": "3.3.1",
-        "loose-envify": "1.3.1",
-        "prop-types": "15.6.0",
-        "warning": "3.0.0"
-      }
-    },
-    "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
-      },
-      "dependencies": {
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
-      }
-    },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
-      "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        }
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
-      }
-    },
-    "readdirp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
-      }
-    },
-    "recompose": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
-      "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
-      "requires": {
-        "change-emitter": "0.1.6",
-        "fbjs": "0.8.16",
-        "hoist-non-react-statics": "2.3.1",
-        "symbol-observable": "1.1.0"
-      }
-    },
-    "redent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true,
-      "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
-      }
-    },
-    "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
-      "requires": {
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
-        "loose-envify": "1.3.1",
-        "symbol-observable": "1.1.0"
-      }
-    },
-    "regenerate": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
-      "dev": true
-    },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-    },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "dev": true,
-      "requires": {
-        "is-equal-shallow": "0.1.3"
-      }
-    },
-    "regexpu-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true,
-      "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      }
-    },
-    "registry-auth-token": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
-      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
-      "dev": true,
-      "requires": {
-        "rc": "1.2.2",
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "registry-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "dev": true,
-      "requires": {
-        "rc": "1.2.2"
-      }
-    },
-    "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-      "dev": true
-    },
-    "regjsparser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true,
-      "requires": {
-        "jsesc": "0.5.0"
-      }
-    },
-    "release-zalgo": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
-      "dev": true,
-      "requires": {
-        "es6-error": "4.1.1"
-      }
-    },
-    "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
-    },
-    "repeat-element": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
-    },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "1.0.2"
-      }
-    },
-    "request": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-          "dev": true
-        }
-      }
-    },
-    "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4"
-      }
-    },
-    "request-promise-native": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
-      "dev": true,
-      "requires": {
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.3"
-      }
-    },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
-    },
-    "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-      "dev": true
-    },
-    "require-precompiled": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
-      "integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo=",
-      "dev": true
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
-    },
-    "resolve-cwd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-      "dev": true,
-      "requires": {
-        "resolve-from": "3.0.0"
-      }
-    },
-    "resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-      "dev": true
-    },
-    "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
-      "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
-      }
-    },
-    "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2"
-      }
-    },
-    "run-queue": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
-      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
-      "dev": true,
-      "requires": {
-        "aproba": "1.2.0"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
-    },
-    "scroll": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/scroll/-/scroll-2.0.1.tgz",
-      "integrity": "sha1-tMfSfovPOuiligQvJyaK4/VfnM0=",
-      "requires": {
-        "rafl": "1.2.2"
-      }
-    },
-    "select-hose": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
-      "dev": true
-    },
-    "selfsigned": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.1.tgz",
-      "integrity": "sha1-v4y3uDJWxFUeMTR8YxF3jbme7FI=",
-      "dev": true,
-      "requires": {
-        "node-forge": "0.6.33"
-      }
-    },
-    "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true
-    },
-    "semver-diff": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "dev": true,
-      "requires": {
-        "semver": "5.4.1"
-      }
-    },
-    "send": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
-      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "depd": "1.1.1",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "1.6.2",
-        "mime": "1.4.1",
-        "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "serialize-javascript": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
-      "integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU=",
-      "dev": true
-    },
-    "serve-index": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
-      "dev": true,
-      "requires": {
-        "accepts": "1.3.4",
-        "batch": "0.6.1",
-        "debug": "2.6.9",
-        "escape-html": "1.0.3",
-        "http-errors": "1.6.2",
-        "mime-types": "2.1.17",
-        "parseurl": "1.3.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "serve-static": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
-      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
-      "dev": true,
-      "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
-        "send": "0.16.1"
-      }
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
-    },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-    },
-    "setprototypeof": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-      "dev": true
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
-    },
-    "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
-    },
-    "slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
-    },
-    "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        }
-      }
-    },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-      "dev": true
-    },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
-    "sockjs": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
-      "integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
-      "dev": true,
-      "requires": {
-        "faye-websocket": "0.10.0",
-        "uuid": "2.0.3"
-      }
-    },
-    "sockjs-client": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
-      "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "eventsource": "0.1.6",
-        "faye-websocket": "0.11.1",
-        "inherits": "2.0.3",
-        "json3": "3.3.2",
-        "url-parse": "1.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "faye-websocket": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
-          "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
-          "dev": true,
-          "requires": {
-            "websocket-driver": "0.7.0"
-          }
-        }
-      }
-    },
-    "sort-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-      "dev": true,
-      "requires": {
-        "is-plain-obj": "1.1.0"
-      }
-    },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
-    },
-    "source-map-loader": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.3.tgz",
-      "integrity": "sha512-MYbFX9DYxmTQFfy2v8FC1XZwpwHKYxg3SK8Wb7VPBKuhDjz8gi9re2819MsG4p49HDyiOSUKlmZ+nQBArW5CGw==",
-      "dev": true,
-      "requires": {
-        "async": "2.6.0",
-        "loader-utils": "0.2.17",
-        "source-map": "0.6.1"
-      }
-    },
-    "source-map-support": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
-      "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
-      "dev": true,
-      "requires": {
-        "source-map": "0.6.1"
-      }
-    },
-    "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true,
-      "requires": {
-        "spdx-license-ids": "1.2.2"
-      }
-    },
-    "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-      "dev": true
-    },
-    "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-      "dev": true
-    },
-    "spdy": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
-      "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "handle-thing": "1.2.5",
-        "http-deceiver": "1.2.7",
-        "safe-buffer": "5.1.1",
-        "select-hose": "2.0.0",
-        "spdy-transport": "2.0.20"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "spdy-transport": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
-      "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "detect-node": "2.0.3",
-        "hpack.js": "2.1.6",
-        "obuf": "1.1.1",
-        "readable-stream": "2.3.3",
-        "safe-buffer": "5.1.1",
-        "wbuf": "1.7.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
-    },
-    "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "dev": true,
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "ssri": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz",
-      "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "stack-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-      "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
-      "dev": true
-    },
-    "statuses": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-      "dev": true
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "dev": true
-    },
-    "stifle": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/stifle/-/stifle-1.0.4.tgz",
-      "integrity": "sha1-izvN9SQZsKnHnjWtrc5QEjwdjpk="
-    },
-    "stream-each": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
-      "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "1.4.0",
-        "stream-shift": "1.0.0"
-      }
-    },
-    "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-      "dev": true
-    },
-    "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
-    },
-    "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
-      "requires": {
-        "is-utf8": "0.2.1"
-      }
-    },
-    "strip-bom-buf": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
-      "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
-      "dev": true,
-      "requires": {
-        "is-utf8": "0.2.1"
-      }
-    },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
-    },
-    "strip-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true,
-      "requires": {
-        "get-stdin": "4.0.1"
-      }
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
-    },
-    "supports-color": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-      "dev": true,
-      "requires": {
-        "has-flag": "2.0.0"
-      }
-    },
-    "symbol-observable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
-      "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw=="
-    },
-    "symbol-tree": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
-      "dev": true
-    },
-    "tapable": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
-      "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
-      "dev": true
-    },
-    "term-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "dev": true,
-      "requires": {
-        "execa": "0.7.0"
-      }
-    },
-    "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
-    "theming": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/theming/-/theming-1.3.0.tgz",
-      "integrity": "sha512-ya5Ef7XDGbTPBv5ENTwrwkPUexrlPeiAg/EI9kdlUAZhNlRbCdhMKRgjNX1IcmsmiPcqDQZE6BpSaH+cr31FKw==",
-      "requires": {
-        "brcast": "3.0.1",
-        "is-function": "1.0.1",
-        "is-plain-object": "2.0.4",
-        "prop-types": "15.6.0"
-      }
-    },
-    "through2": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
-      }
-    },
-    "thunky": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
-      "integrity": "sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4=",
-      "dev": true
-    },
-    "time-require": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/time-require/-/time-require-0.1.2.tgz",
-      "integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
-      "dev": true,
-      "requires": {
-        "chalk": "0.4.0",
-        "date-time": "0.1.1",
-        "pretty-ms": "0.2.2",
-        "text-table": "0.2.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
-          }
-        },
-        "date-time": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
-          "integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
-          "dev": true
-        },
-        "parse-ms": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
-          "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
-          "dev": true
-        },
-        "pretty-ms": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
-          "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
-          "dev": true,
-          "requires": {
-            "parse-ms": "0.1.2"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-          "dev": true
-        }
-      }
-    },
-    "time-stamp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
-      "integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=",
-      "dev": true
-    },
-    "time-zone": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
-      "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
-      "dev": true
-    },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true
-    },
-    "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
-    },
-    "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-      "dev": true,
-      "requires": {
-        "punycode": "1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        }
-      }
-    },
-    "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "requires": {
-        "punycode": "2.1.0"
-      }
-    },
-    "trim-newlines": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-      "dev": true
-    },
-    "trim-off-newlines": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
-      "dev": true
-    },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
-    },
-    "ts-loader": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-3.2.0.tgz",
-      "integrity": "sha512-4g8BF3gKWBHeM1jAFmMPHofuJlwTUU4iHJ0i3mwXRHwy74RU6VBOgl9kDVMGpapvGcMlVqV5G6v9XmV66Qqd7w==",
-      "dev": true,
-      "requires": {
-        "chalk": "2.3.0",
-        "enhanced-resolve": "3.4.1",
-        "loader-utils": "1.1.0",
-        "semver": "5.4.1"
-      },
-      "dependencies": {
-        "loader-utils": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true,
-          "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1"
-          }
-        }
-      }
-    },
-    "tslint-loader": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/tslint-loader/-/tslint-loader-3.5.3.tgz",
-      "integrity": "sha1-ND90Ei2U81a2iUV9P1n2SmmrYG8=",
-      "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1",
-        "rimraf": "2.6.2",
-        "semver": "5.4.1"
-      },
-      "dependencies": {
-        "loader-utils": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true,
-          "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1"
-          }
-        }
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
-      "optional": true
-    },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2"
-      }
-    },
-    "type-is": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "dev": true,
-      "requires": {
-        "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
-      }
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
-    "ua-parser-js": {
-      "version": "0.7.17",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
-    },
-    "uid2": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
-      "dev": true
-    },
-    "unique-filename": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
-      "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
-      "dev": true,
-      "requires": {
-        "unique-slug": "2.0.0"
-      }
-    },
-    "unique-slug": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
-      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-      "dev": true,
-      "requires": {
-        "imurmurhash": "0.1.4"
-      }
-    },
-    "unique-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "dev": true,
-      "requires": {
-        "crypto-random-string": "1.0.0"
-      }
-    },
-    "unique-temp-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
-      "integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1",
-        "os-tmpdir": "1.0.2",
-        "uid2": "0.0.3"
-      }
-    },
-    "unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "dev": true
-    },
-    "unzip-response": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-      "dev": true
-    },
-    "update-notifier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
-      "dev": true,
-      "requires": {
-        "boxen": "1.3.0",
-        "chalk": "2.3.0",
-        "configstore": "3.1.1",
-        "import-lazy": "2.1.0",
-        "is-installed-globally": "0.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "3.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "3.0.0"
-      }
-    },
-    "url-parse": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
-      "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
-      "dev": true,
-      "requires": {
-        "querystringify": "1.0.0",
-        "requires-port": "1.0.0"
-      },
-      "dependencies": {
-        "querystringify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
-          "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
-          "dev": true
-        }
-      }
-    },
-    "url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true,
-      "requires": {
-        "prepend-http": "1.0.4"
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
-    "utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-      "dev": true
-    },
-    "uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-      "dev": true
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true,
-      "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
-      }
-    },
-    "vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-      "dev": true
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      }
-    },
-    "warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
-    },
-    "wbuf": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
-      "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
-      "dev": true,
-      "requires": {
-        "minimalistic-assert": "1.0.0"
-      }
-    },
-    "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
-    },
-    "webpack-dev-middleware": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
-      "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
-      "dev": true,
-      "requires": {
-        "memory-fs": "0.4.1",
-        "mime": "1.6.0",
-        "path-is-absolute": "1.0.1",
-        "range-parser": "1.2.0",
-        "time-stamp": "2.0.0"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-          "dev": true
-        }
-      }
-    },
-    "webpack-dev-server": {
-      "version": "2.9.7",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.7.tgz",
-      "integrity": "sha512-Pu7uoQFgQj5RE5wmlfkpYSzihMKxulwEuO2xCsaMnAnyRSApwoVi3B8WCm9XbigyWTHaIMzYGkB90Vr6leAeTQ==",
-      "dev": true,
-      "requires": {
-        "ansi-html": "0.0.7",
-        "array-includes": "3.0.3",
-        "bonjour": "3.5.0",
-        "chokidar": "1.7.0",
-        "compression": "1.7.1",
-        "connect-history-api-fallback": "1.5.0",
-        "debug": "3.1.0",
-        "del": "3.0.0",
-        "express": "4.16.2",
-        "html-entities": "1.2.1",
-        "http-proxy-middleware": "0.17.4",
-        "import-local": "0.1.1",
-        "internal-ip": "1.2.0",
-        "ip": "1.1.5",
-        "killable": "1.0.0",
-        "loglevel": "1.6.0",
-        "opn": "5.1.0",
-        "portfinder": "1.0.13",
-        "selfsigned": "1.10.1",
-        "serve-index": "1.9.1",
-        "sockjs": "0.3.18",
-        "sockjs-client": "1.1.4",
-        "spdy": "3.4.7",
-        "strip-ansi": "3.0.1",
-        "supports-color": "4.5.0",
-        "webpack-dev-middleware": "1.12.2",
-        "yargs": "6.6.0"
-      }
-    },
-    "websocket-driver": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
-      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
-      "dev": true,
-      "requires": {
-        "http-parser-js": "0.4.9",
-        "websocket-extensions": "0.1.3"
-      }
-    },
-    "websocket-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
-      "dev": true
-    },
-    "well-known-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-1.0.0.tgz",
-      "integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg=",
-      "dev": true
-    },
-    "whatwg-encoding": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-      "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "0.4.19"
-      }
-    },
-    "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
-    },
-    "whatwg-url": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
-      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
-      "dev": true,
-      "requires": {
-        "lodash.sortby": "4.7.0",
-        "tr46": "1.0.1",
-        "webidl-conversions": "4.0.2"
-      }
-    },
-    "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "dev": true,
-      "requires": {
-        "isexe": "2.0.0"
-      }
-    },
-    "which-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-      "dev": true
-    },
-    "widest-line": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
-      "dev": true,
-      "requires": {
-        "string-width": "2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
-      }
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
-    },
-    "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true,
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
-    },
-    "write-file-atomic": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
-      }
-    },
-    "write-json-file": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
-      "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
-      "dev": true,
-      "requires": {
-        "detect-indent": "5.0.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
-        "pify": "3.0.0",
-        "sort-keys": "2.0.0",
-        "write-file-atomic": "2.3.0"
-      },
-      "dependencies": {
-        "detect-indent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-          "dev": true
-        }
-      }
-    },
-    "write-pkg": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.1.0.tgz",
-      "integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
-      "dev": true,
-      "requires": {
-        "sort-keys": "2.0.0",
-        "write-json-file": "2.3.0"
-      }
-    },
-    "xdg-basedir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-      "dev": true
-    },
-    "xml-name-validator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
-      "dev": true
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
-    },
-    "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-      "dev": true
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
-    },
-    "yargs": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-      "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-      "dev": true,
-      "requires": {
-        "camelcase": "3.0.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "4.2.1"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-      "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-      "dev": true,
-      "requires": {
-        "camelcase": "3.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        }
-      }
-    }
-  }
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"@ava/babel-plugin-throws-helper": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-2.0.0.tgz",
+			"integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw="
+		},
+		"@ava/babel-preset-stage-4": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-1.1.0.tgz",
+			"integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
+			"requires": {
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-async-to-generator": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "6.24.1",
+				"package-hash": "1.2.0"
+			},
+			"dependencies": {
+				"md5-hex": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+					"requires": {
+						"md5-o-matic": "0.1.1"
+					}
+				},
+				"package-hash": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-1.2.0.tgz",
+					"integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
+					"requires": {
+						"md5-hex": "1.3.0"
+					}
+				}
+			}
+		},
+		"@ava/babel-preset-transform-test-files": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-3.0.0.tgz",
+			"integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
+			"requires": {
+				"@ava/babel-plugin-throws-helper": "2.0.0",
+				"babel-plugin-espower": "2.4.0"
+			}
+		},
+		"@ava/write-file-atomic": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@ava/write-file-atomic/-/write-file-atomic-2.2.0.tgz",
+			"integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"slide": "1.1.6"
+			}
+		},
+		"@babel/code-frame": {
+			"version": "7.0.0-beta.40",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
+			"integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
+			"requires": {
+				"@babel/highlight": "7.0.0-beta.40"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0-beta.40",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
+			"integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
+			"requires": {
+				"chalk": "2.3.2",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			}
+		},
+		"@concordance/react": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz",
+			"integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
+			"requires": {
+				"arrify": "1.0.1"
+			}
+		},
+		"abab": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+		},
+		"accepts": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+			"requires": {
+				"mime-types": "2.1.18",
+				"negotiator": "0.6.1"
+			}
+		},
+		"acorn": {
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
+		},
+		"acorn-globals": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+			"requires": {
+				"acorn": "5.5.3"
+			}
+		},
+		"ajv": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"requires": {
+				"co": "4.6.0",
+				"fast-deep-equal": "1.1.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
+			}
+		},
+		"align-text": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"requires": {
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+		},
+		"ansi-align": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+			"requires": {
+				"string-width": "2.1.1"
+			}
+		},
+		"ansi-escapes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+		},
+		"ansi-html": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "1.9.1"
+			}
+		},
+		"anymatch": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"requires": {
+				"micromatch": "2.3.11",
+				"normalize-path": "2.1.1"
+			}
+		},
+		"append-transform": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+			"requires": {
+				"default-require-extensions": "1.0.0"
+			}
+		},
+		"aproba": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"requires": {
+				"sprintf-js": "1.0.3"
+			}
+		},
+		"arr-diff": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"requires": {
+				"arr-flatten": "1.1.0"
+			}
+		},
+		"arr-exclude": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/arr-exclude/-/arr-exclude-1.0.0.tgz",
+			"integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE="
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+		},
+		"array-differ": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+		},
+		"array-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+		},
+		"array-filter": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
+		},
+		"array-find-index": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+		},
+		"array-flatten": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
+			"integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
+		},
+		"array-includes": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+			"requires": {
+				"define-properties": "1.1.2",
+				"es-abstract": "1.10.0"
+			}
+		},
+		"array-map": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+		},
+		"array-reduce": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
+		},
+		"array-union": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"requires": {
+				"array-uniq": "1.0.3"
+			}
+		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+		},
+		"array-unique": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+		},
+		"astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+		},
+		"async": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"async-each": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"atob": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
+			"integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10="
+		},
+		"auto-bind": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-1.2.0.tgz",
+			"integrity": "sha512-Zw7pZp7tztvKnWWtoII4AmqH5a2PV3ZN5F0BPRTGcc1kpRm4b6QXQnPU7Znbl6BfPfqOVOV29g4JeMqZQaqqOA=="
+		},
+		"ava": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-0.24.0.tgz",
+			"integrity": "sha512-o/ykNzsWB5qgh1cR9jzVw0E1y4E219aXl9njNFGSamSCsD7VhPd3aoZabNZuG1PSVMZmQ8RuwKnTuz/loNhKnw==",
+			"requires": {
+				"@ava/babel-preset-stage-4": "1.1.0",
+				"@ava/babel-preset-transform-test-files": "3.0.0",
+				"@ava/write-file-atomic": "2.2.0",
+				"@concordance/react": "1.0.0",
+				"ansi-escapes": "3.0.0",
+				"ansi-styles": "3.2.1",
+				"arr-flatten": "1.1.0",
+				"array-union": "1.0.2",
+				"array-uniq": "1.0.3",
+				"arrify": "1.0.1",
+				"auto-bind": "1.2.0",
+				"ava-init": "0.2.1",
+				"babel-core": "6.26.0",
+				"babel-generator": "6.26.1",
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"bluebird": "3.5.1",
+				"caching-transform": "1.0.1",
+				"chalk": "2.3.2",
+				"chokidar": "1.7.0",
+				"clean-stack": "1.3.0",
+				"clean-yaml-object": "0.1.0",
+				"cli-cursor": "2.1.0",
+				"cli-spinners": "1.1.0",
+				"cli-truncate": "1.1.0",
+				"co-with-promise": "4.6.0",
+				"code-excerpt": "2.1.1",
+				"common-path-prefix": "1.0.0",
+				"concordance": "3.0.0",
+				"convert-source-map": "1.5.1",
+				"core-assert": "0.2.1",
+				"currently-unhandled": "0.4.1",
+				"debug": "3.1.0",
+				"dot-prop": "4.2.0",
+				"empower-core": "0.6.2",
+				"equal-length": "1.0.1",
+				"figures": "2.0.0",
+				"find-cache-dir": "1.0.0",
+				"fn-name": "2.0.1",
+				"get-port": "3.2.0",
+				"globby": "6.1.0",
+				"has-flag": "2.0.0",
+				"hullabaloo-config-manager": "1.1.1",
+				"ignore-by-default": "1.0.1",
+				"import-local": "0.1.1",
+				"indent-string": "3.2.0",
+				"is-ci": "1.1.0",
+				"is-generator-fn": "1.0.0",
+				"is-obj": "1.0.1",
+				"is-observable": "1.1.0",
+				"is-promise": "2.1.0",
+				"js-yaml": "3.11.0",
+				"last-line-stream": "1.0.0",
+				"lodash.clonedeepwith": "4.5.0",
+				"lodash.debounce": "4.0.8",
+				"lodash.difference": "4.5.0",
+				"lodash.flatten": "4.4.0",
+				"loud-rejection": "1.6.0",
+				"make-dir": "1.2.0",
+				"matcher": "1.1.0",
+				"md5-hex": "2.0.0",
+				"meow": "3.7.0",
+				"ms": "2.1.1",
+				"multimatch": "2.1.0",
+				"observable-to-promise": "0.5.0",
+				"option-chain": "1.0.0",
+				"package-hash": "2.0.0",
+				"pkg-conf": "2.1.0",
+				"plur": "2.1.2",
+				"pretty-ms": "3.1.0",
+				"require-precompiled": "0.1.0",
+				"resolve-cwd": "2.0.0",
+				"safe-buffer": "5.1.1",
+				"semver": "5.5.0",
+				"slash": "1.0.0",
+				"source-map-support": "0.5.3",
+				"stack-utils": "1.0.1",
+				"strip-ansi": "4.0.0",
+				"strip-bom-buf": "1.0.0",
+				"supports-color": "5.3.0",
+				"time-require": "0.1.2",
+				"trim-off-newlines": "1.0.1",
+				"unique-temp-dir": "1.0.0",
+				"update-notifier": "2.3.0"
+			}
+		},
+		"ava-init": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/ava-init/-/ava-init-0.2.1.tgz",
+			"integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
+			"requires": {
+				"arr-exclude": "1.0.0",
+				"execa": "0.7.0",
+				"has-yarn": "1.0.0",
+				"read-pkg-up": "2.0.0",
+				"write-pkg": "3.1.0"
+			}
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+		},
+		"aws4": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"requires": {
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
+			}
+		},
+		"babel-core": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.1",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"convert-source-map": "1.5.1",
+				"debug": "2.6.9",
+				"json5": "0.5.1",
+				"lodash": "4.17.5",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.8",
+				"slash": "1.0.0",
+				"source-map": "0.5.7"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"babel-generator": {
+			"version": "6.26.1",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"requires": {
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.5",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+				}
+			}
+		},
+		"babel-helper-builder-binary-assignment-operator-visitor": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"requires": {
+				"babel-helper-explode-assignable-expression": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-call-delegate": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"requires": {
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-explode-assignable-expression": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-function-name": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"requires": {
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-get-function-arity": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-hoist-variables": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-regex": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.5"
+			}
+		},
+		"babel-helper-remap-async-to-generator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helpers": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
+			}
+		},
+		"babel-jest": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.1.tgz",
+			"integrity": "sha512-rEdN/jevSuX0IQKcUqwqOGa0gDNis4jGY52Rq53aizfDGPwQYNJq+f9NCMT1HUhtUZhYSjvfGUfHQWBRT1/icA==",
+			"requires": {
+				"babel-plugin-istanbul": "4.1.5",
+				"babel-preset-jest": "22.4.1"
+			}
+		},
+		"babel-messages": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-check-es2015-constants": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-espower": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-2.4.0.tgz",
+			"integrity": "sha512-/+SRpy7pKgTI28oEHfn1wkuM5QFAdRq8WNsOOih1dVrdV6A/WbNbRZyl0eX5eyDgtb0lOE27PeDFuCX2j8OxVg==",
+			"requires": {
+				"babel-generator": "6.26.1",
+				"babylon": "6.18.0",
+				"call-matcher": "1.0.1",
+				"core-js": "2.5.3",
+				"espower-location-detector": "1.0.0",
+				"espurify": "1.7.0",
+				"estraverse": "4.2.0"
+			}
+		},
+		"babel-plugin-istanbul": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
+			"integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
+			"requires": {
+				"find-up": "2.1.0",
+				"istanbul-lib-instrument": "1.9.2",
+				"test-exclude": "4.2.0"
+			}
+		},
+		"babel-plugin-jest-hoist": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.1.tgz",
+			"integrity": "sha512-gmj5FvFflXSnRapWmF/jDjx5Lof1kX0OwXibCxMOx38V3CFMOnTxLTUrAFfLkhCey3FJvv0ACvv/+h4nzFRxhg=="
+		},
+		"babel-plugin-syntax-async-functions": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+		},
+		"babel-plugin-syntax-exponentiation-operator": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+		},
+		"babel-plugin-syntax-object-rest-spread": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+		},
+		"babel-plugin-syntax-trailing-function-commas": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+		},
+		"babel-plugin-transform-async-to-generator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"requires": {
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-functions": "6.13.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-destructuring": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-function-name": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-modules-commonjs": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+			"requires": {
+				"babel-plugin-transform-strict-mode": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-parameters": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"requires": {
+				"babel-helper-call-delegate": "6.24.1",
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-spread": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-sticky-regex": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"requires": {
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-unicode-regex": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"requires": {
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"regexpu-core": "2.0.0"
+			}
+		},
+		"babel-plugin-transform-exponentiation-operator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"requires": {
+				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-strict-mode": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-preset-jest": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.1.tgz",
+			"integrity": "sha512-gW3+spyB8fkSAI9fX+41BQMwar5LjR+nyKa2QRvK22snxnI29+jJVAMfId+osucFJzJJvhlvzKWnfwX8Omodvg==",
+			"requires": {
+				"babel-plugin-jest-hoist": "22.4.1",
+				"babel-plugin-syntax-object-rest-spread": "6.13.0"
+			}
+		},
+		"babel-register": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"requires": {
+				"babel-core": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.3",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.5",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.18"
+			},
+			"dependencies": {
+				"source-map-support": {
+					"version": "0.4.18",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+					"requires": {
+						"source-map": "0.5.7"
+					}
+				}
+			}
+		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"requires": {
+				"core-js": "2.5.3",
+				"regenerator-runtime": "0.11.1"
+			}
+		},
+		"babel-template": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.5"
+			}
+		},
+		"babel-traverse": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.9",
+				"globals": "9.18.0",
+				"invariant": "2.2.3",
+				"lodash": "4.17.5"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.5",
+				"to-fast-properties": "1.0.3"
+			}
+		},
+		"babylon": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"requires": {
+				"cache-base": "1.0.1",
+				"class-utils": "0.3.6",
+				"component-emitter": "1.2.1",
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"mixin-deep": "1.3.1",
+				"pascalcase": "0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"batch": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"optional": true,
+			"requires": {
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"big.js": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+		},
+		"binary-extensions": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+		},
+		"bluebird": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+		},
+		"body-parser": {
+			"version": "1.18.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+			"requires": {
+				"bytes": "3.0.0",
+				"content-type": "1.0.4",
+				"debug": "2.6.9",
+				"depd": "1.1.2",
+				"http-errors": "1.6.2",
+				"iconv-lite": "0.4.19",
+				"on-finished": "2.3.0",
+				"qs": "6.5.1",
+				"raw-body": "2.3.2",
+				"type-is": "1.6.16"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"bonjour": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+			"integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+			"requires": {
+				"array-flatten": "2.1.1",
+				"deep-equal": "1.0.1",
+				"dns-equal": "1.0.0",
+				"dns-txt": "2.0.2",
+				"multicast-dns": "6.2.3",
+				"multicast-dns-service-types": "1.1.0"
+			}
+		},
+		"boom": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+			"requires": {
+				"hoek": "4.2.1"
+			}
+		},
+		"boxen": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+			"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+			"requires": {
+				"ansi-align": "2.0.0",
+				"camelcase": "4.1.0",
+				"chalk": "2.3.2",
+				"cli-boxes": "1.0.0",
+				"string-width": "2.1.1",
+				"term-size": "1.2.0",
+				"widest-line": "2.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				}
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"requires": {
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
+			}
+		},
+		"brcast": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
+			"integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg=="
+		},
+		"browser-process-hrtime": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
+		},
+		"browser-resolve": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+			"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+			"requires": {
+				"resolve": "1.1.7"
+			}
+		},
+		"bser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"requires": {
+				"node-int64": "0.4.0"
+			}
+		},
+		"buf-compare": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
+			"integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o="
+		},
+		"buffer-indexof": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+			"integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+		},
+		"bytes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+		},
+		"cacache": {
+			"version": "10.0.4",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+			"requires": {
+				"bluebird": "3.5.1",
+				"chownr": "1.0.1",
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"lru-cache": "4.1.1",
+				"mississippi": "2.0.0",
+				"mkdirp": "0.5.1",
+				"move-concurrently": "1.0.1",
+				"promise-inflight": "1.0.1",
+				"rimraf": "2.6.2",
+				"ssri": "5.2.4",
+				"unique-filename": "1.1.0",
+				"y18n": "4.0.0"
+			}
+		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"requires": {
+				"collection-visit": "1.0.0",
+				"component-emitter": "1.2.1",
+				"get-value": "2.0.6",
+				"has-value": "1.0.0",
+				"isobject": "3.0.1",
+				"set-value": "2.0.0",
+				"to-object-path": "0.3.0",
+				"union-value": "1.0.0",
+				"unset-value": "1.0.0"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"caching-transform": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+			"integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+			"requires": {
+				"md5-hex": "1.3.0",
+				"mkdirp": "0.5.1",
+				"write-file-atomic": "1.3.4"
+			},
+			"dependencies": {
+				"md5-hex": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+					"requires": {
+						"md5-o-matic": "0.1.1"
+					}
+				},
+				"write-file-atomic": {
+					"version": "1.3.4",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
+					}
+				}
+			}
+		},
+		"call-matcher": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.0.1.tgz",
+			"integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
+			"requires": {
+				"core-js": "2.5.3",
+				"deep-equal": "1.0.1",
+				"espurify": "1.7.0",
+				"estraverse": "4.2.0"
+			}
+		},
+		"call-signature": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
+			"integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY="
+		},
+		"callsites": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+		},
+		"camelcase": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+		},
+		"camelcase-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+			"requires": {
+				"camelcase": "2.1.1",
+				"map-obj": "1.0.1"
+			}
+		},
+		"capture-stack-trace": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+		},
+		"center-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"optional": true,
+			"requires": {
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
+			}
+		},
+		"chain-function": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
+			"integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
+		},
+		"chalk": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+			"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+			"requires": {
+				"ansi-styles": "3.2.1",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "5.3.0"
+			}
+		},
+		"change-emitter": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+			"integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
+		},
+		"chokidar": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"requires": {
+				"anymatch": "1.3.2",
+				"async-each": "1.0.1",
+				"fsevents": "1.1.3",
+				"glob-parent": "2.0.0",
+				"inherits": "2.0.3",
+				"is-binary-path": "1.0.1",
+				"is-glob": "2.0.1",
+				"path-is-absolute": "1.0.1",
+				"readdirp": "2.1.0"
+			}
+		},
+		"chownr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+		},
+		"ci-info": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+			"integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA=="
+		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"requires": {
+				"arr-union": "3.1.0",
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"static-extend": "0.1.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				}
+			}
+		},
+		"classnames": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+			"integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+		},
+		"clean-stack": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
+			"integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
+		},
+		"clean-yaml-object": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
+			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g="
+		},
+		"cli-boxes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+		},
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"requires": {
+				"restore-cursor": "2.0.0"
+			}
+		},
+		"cli-spinners": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
+			"integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY="
+		},
+		"cli-truncate": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
+			"integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
+			"requires": {
+				"slice-ansi": "1.0.0",
+				"string-width": "2.1.1"
+			}
+		},
+		"cliui": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"optional": true,
+			"requires": {
+				"center-align": "0.1.3",
+				"right-align": "0.1.3",
+				"wordwrap": "0.0.2"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+					"optional": true
+				}
+			}
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+		},
+		"co-with-promise": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co-with-promise/-/co-with-promise-4.6.0.tgz",
+			"integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
+			"requires": {
+				"pinkie-promise": "1.0.0"
+			}
+		},
+		"code-excerpt": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.1.tgz",
+			"integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
+			"requires": {
+				"convert-to-spaces": "1.0.2"
+			}
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"requires": {
+				"map-visit": "1.0.0",
+				"object-visit": "1.0.1"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"combined-stream": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"requires": {
+				"delayed-stream": "1.0.0"
+			}
+		},
+		"common-path-prefix": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
+			"integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA="
+		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+		},
+		"compressible": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
+			"integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
+			"requires": {
+				"mime-db": "1.33.0"
+			}
+		},
+		"compression": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+			"integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
+			"requires": {
+				"accepts": "1.3.5",
+				"bytes": "3.0.0",
+				"compressible": "2.0.13",
+				"debug": "2.6.9",
+				"on-headers": "1.0.1",
+				"safe-buffer": "5.1.1",
+				"vary": "1.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"concat-stream": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
+			"integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5",
+				"typedarray": "0.0.6"
+			}
+		},
+		"concordance": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/concordance/-/concordance-3.0.0.tgz",
+			"integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
+			"requires": {
+				"date-time": "2.1.0",
+				"esutils": "2.0.2",
+				"fast-diff": "1.1.2",
+				"function-name-support": "0.2.0",
+				"js-string-escape": "1.0.1",
+				"lodash.clonedeep": "4.5.0",
+				"lodash.flattendeep": "4.4.0",
+				"lodash.merge": "4.6.1",
+				"md5-hex": "2.0.0",
+				"semver": "5.5.0",
+				"well-known-symbols": "1.0.0"
+			}
+		},
+		"configstore": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
+			"integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+			"requires": {
+				"dot-prop": "4.2.0",
+				"graceful-fs": "4.1.11",
+				"make-dir": "1.2.0",
+				"unique-string": "1.0.0",
+				"write-file-atomic": "2.3.0",
+				"xdg-basedir": "3.0.0"
+			}
+		},
+		"connect-history-api-fallback": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
+			"integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
+		},
+		"content-disposition": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+		},
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+		},
+		"content-type-parser": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
+		},
+		"convert-source-map": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+		},
+		"convert-to-spaces": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
+			"integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU="
+		},
+		"cookie": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+		},
+		"cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+		},
+		"copy-concurrently": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+			"requires": {
+				"aproba": "1.2.0",
+				"fs-write-stream-atomic": "1.0.10",
+				"iferr": "0.1.5",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"run-queue": "1.0.3"
+			}
+		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+		},
+		"copy-webpack-plugin": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.5.0.tgz",
+			"integrity": "sha512-ROQ85fWKuhJfUkBTdHvfV+Zv6Ltm3G/vPVFdLPFwzWzd9RUY1yLw3rt6FmKK2PaeNQCNvmwgFhuarkjuV4PVDQ==",
+			"requires": {
+				"cacache": "10.0.4",
+				"find-cache-dir": "1.0.0",
+				"globby": "7.1.1",
+				"is-glob": "4.0.0",
+				"loader-utils": "1.1.0",
+				"minimatch": "3.0.4",
+				"p-limit": "1.2.0",
+				"serialize-javascript": "1.4.0"
+			},
+			"dependencies": {
+				"globby": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+					"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+					"requires": {
+						"array-union": "1.0.2",
+						"dir-glob": "2.0.0",
+						"glob": "7.1.2",
+						"ignore": "3.3.7",
+						"pify": "3.0.0",
+						"slash": "1.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+				},
+				"is-glob": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"requires": {
+						"is-extglob": "2.1.1"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"core-assert": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
+			"integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
+			"requires": {
+				"buf-compare": "1.0.1",
+				"is-error": "2.2.1"
+			}
+		},
+		"core-js": {
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"cpx": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/cpx/-/cpx-1.5.0.tgz",
+			"integrity": "sha1-GFvgGFEdhycN7czCkxceN2VauI8=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"chokidar": "1.7.0",
+				"duplexer": "0.1.1",
+				"glob": "7.1.2",
+				"glob2base": "0.0.12",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"resolve": "1.1.7",
+				"safe-buffer": "5.1.1",
+				"shell-quote": "1.6.1",
+				"subarg": "1.0.0"
+			}
+		},
+		"create-error-class": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+			"requires": {
+				"capture-stack-trace": "1.0.0"
+			}
+		},
+		"cross-spawn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"requires": {
+				"lru-cache": "4.1.1",
+				"shebang-command": "1.2.0",
+				"which": "1.3.0"
+			}
+		},
+		"cryptiles": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+			"requires": {
+				"boom": "5.2.0"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+					"requires": {
+						"hoek": "4.2.1"
+					}
+				}
+			}
+		},
+		"crypto-random-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+		},
+		"css-vendor": {
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-0.3.8.tgz",
+			"integrity": "sha1-ZCHP0wNM5mT+dnOXL9ARn8KJQfo=",
+			"requires": {
+				"is-in-browser": "1.1.3"
+			}
+		},
+		"cssom": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+		},
+		"cssstyle": {
+			"version": "0.2.37",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"requires": {
+				"cssom": "0.3.2"
+			}
+		},
+		"currently-unhandled": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+			"requires": {
+				"array-find-index": "1.0.2"
+			}
+		},
+		"cyclist": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
+		},
+		"d": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+			"requires": {
+				"es5-ext": "0.10.39"
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			}
+		},
+		"date-time": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
+			"integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
+			"requires": {
+				"time-zone": "1.0.0"
+			}
+		},
+		"debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"requires": {
+				"ms": "2.0.0"
+			},
+			"dependencies": {
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+		},
+		"deep-equal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+		},
+		"deep-extend": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+		},
+		"deepmerge": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.1.0.tgz",
+			"integrity": "sha512-Q89Z26KAfA3lpPGhbF6XMfYAm3jIV3avViy6KOJ2JLzFbeWHOvPQUu5aSJIWXap3gDZC2y1eF5HXEPI2wGqgvw=="
+		},
+		"default-require-extensions": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+			"requires": {
+				"strip-bom": "2.0.0"
+			},
+			"dependencies": {
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				}
+			}
+		},
+		"define-properties": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"requires": {
+				"foreach": "2.0.5",
+				"object-keys": "1.0.11"
+			}
+		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"requires": {
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"del": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+			"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+			"requires": {
+				"globby": "6.1.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.0",
+				"p-map": "1.2.0",
+				"pify": "3.0.0",
+				"rimraf": "2.6.2"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
+		"depd": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+		},
+		"destroy": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+		},
+		"detect-indent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"requires": {
+				"repeating": "2.0.1"
+			}
+		},
+		"detect-newline": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+		},
+		"detect-node": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
+			"integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
+		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+		},
+		"dir-glob": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+			"requires": {
+				"arrify": "1.0.1",
+				"path-type": "3.0.0"
+			},
+			"dependencies": {
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"requires": {
+						"pify": "3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"dns-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+			"integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
+		},
+		"dns-packet": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
+			"integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+			"requires": {
+				"ip": "1.1.5",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"dns-txt": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+			"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+			"requires": {
+				"buffer-indexof": "1.1.1"
+			}
+		},
+		"document-register-element": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.7.2.tgz",
+			"integrity": "sha512-E+y3qJgckbXK/Ev+jPIF+ussxJRaFRIxYCAkxeYcTdccuQoPw5emVWXkox6JnMejFryjlCs/sw2cokMO2lHxjQ==",
+			"requires": {
+				"lightercollective": "0.0.0"
+			}
+		},
+		"dom-helpers": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
+			"integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
+		},
+		"dom-walk": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+		},
+		"domexception": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"requires": {
+				"webidl-conversions": "4.0.2"
+			}
+		},
+		"dot-prop": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+			"requires": {
+				"is-obj": "1.0.1"
+			}
+		},
+		"duplexer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+		},
+		"duplexer3": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+		},
+		"duplexify": {
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
+			"integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5",
+				"stream-shift": "1.0.0"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"optional": true,
+			"requires": {
+				"jsbn": "0.1.1"
+			}
+		},
+		"ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+		},
+		"emojis-list": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+		},
+		"empower-core": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
+			"integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
+			"requires": {
+				"call-signature": "0.0.2",
+				"core-js": "2.5.3"
+			}
+		},
+		"encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"requires": {
+				"once": "1.4.0"
+			}
+		},
+		"enhanced-resolve": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"memory-fs": "0.4.1",
+				"object-assign": "4.1.1",
+				"tapable": "0.2.8"
+			}
+		},
+		"equal-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/equal-length/-/equal-length-1.0.1.tgz",
+			"integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w="
+		},
+		"errno": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+			"requires": {
+				"prr": "1.0.1"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"requires": {
+				"is-arrayish": "0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+			"integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+			"requires": {
+				"es-to-primitive": "1.1.1",
+				"function-bind": "1.1.1",
+				"has": "1.0.1",
+				"is-callable": "1.1.3",
+				"is-regex": "1.0.4"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"requires": {
+				"is-callable": "1.1.3",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.1"
+			}
+		},
+		"es5-ext": {
+			"version": "0.10.39",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz",
+			"integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
+			"requires": {
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"es6-error": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+		},
+		"es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.39",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"es6-symbol": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.39"
+			}
+		},
+		"escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"escodegen": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+			"requires": {
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"optional": true
+				}
+			}
+		},
+		"espower-location-detector": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
+			"integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
+			"requires": {
+				"is-url": "1.2.2",
+				"path-is-absolute": "1.0.1",
+				"source-map": "0.5.7",
+				"xtend": "4.0.1"
+			}
+		},
+		"esprima": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+		},
+		"espurify": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
+			"integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
+			"requires": {
+				"core-js": "2.5.3"
+			}
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
+		"etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+		},
+		"eventemitter3": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+			"integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+		},
+		"eventsource": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+			"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+			"requires": {
+				"original": "1.0.0"
+			}
+		},
+		"exec-sh": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+			"requires": {
+				"merge": "1.2.0"
+			}
+		},
+		"execa": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"requires": {
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
+			}
+		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+		},
+		"expand-brackets": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"requires": {
+				"is-posix-bracket": "0.1.1"
+			}
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"requires": {
+				"fill-range": "2.2.3"
+			}
+		},
+		"expect": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-22.4.0.tgz",
+			"integrity": "sha512-Fiy862jT3qc70hwIHwwCBNISmaqBrfWKKrtqyMJ6iwZr+6KXtcnHojZFtd63TPRvRl8EQTJ+YXYy2lK6/6u+Hw==",
+			"requires": {
+				"ansi-styles": "3.2.1",
+				"jest-diff": "22.4.0",
+				"jest-get-type": "22.1.0",
+				"jest-matcher-utils": "22.4.0",
+				"jest-message-util": "22.4.0",
+				"jest-regex-util": "22.1.0"
+			}
+		},
+		"express": {
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+			"integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+			"requires": {
+				"accepts": "1.3.5",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.18.2",
+				"content-disposition": "0.5.2",
+				"content-type": "1.0.4",
+				"cookie": "0.3.1",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "1.1.2",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
+				"finalhandler": "1.1.0",
+				"fresh": "0.5.2",
+				"merge-descriptors": "1.0.1",
+				"methods": "1.1.2",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "2.0.3",
+				"qs": "6.5.1",
+				"range-parser": "1.2.0",
+				"safe-buffer": "5.1.1",
+				"send": "0.16.1",
+				"serve-static": "1.13.1",
+				"setprototypeof": "1.1.0",
+				"statuses": "1.3.1",
+				"type-is": "1.6.16",
+				"utils-merge": "1.0.1",
+				"vary": "1.1.2"
+			},
+			"dependencies": {
+				"array-flatten": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"requires": {
+				"assign-symbols": "1.0.0",
+				"is-extendable": "1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "2.0.4"
+					}
+				}
+			}
+		},
+		"extglob": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"requires": {
+				"is-extglob": "1.0.0"
+			}
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"fast-deep-equal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+		},
+		"fast-diff": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+			"integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+		},
+		"faye-websocket": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+			"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+			"requires": {
+				"websocket-driver": "0.7.0"
+			}
+		},
+		"fb-watchman": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"requires": {
+				"bser": "2.0.0"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.16",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"requires": {
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.17"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				}
+			}
+		},
+		"figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"requires": {
+				"escape-string-regexp": "1.0.5"
+			}
+		},
+		"filename-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+		},
+		"fileset": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+			"requires": {
+				"glob": "7.1.2",
+				"minimatch": "3.0.4"
+			}
+		},
+		"fill-range": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"requires": {
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "1.1.7",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"finalhandler": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+			"integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+			"requires": {
+				"debug": "2.6.9",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"statuses": "1.3.1",
+				"unpipe": "1.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"find-cache-dir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+			"requires": {
+				"commondir": "1.0.1",
+				"make-dir": "1.2.0",
+				"pkg-dir": "2.0.0"
+			}
+		},
+		"find-index": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+			"integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ="
+		},
+		"find-up": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"requires": {
+				"locate-path": "2.0.0"
+			}
+		},
+		"flush-write-stream": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+			"integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
+			}
+		},
+		"fn-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
+			"integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc="
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"requires": {
+				"for-in": "1.0.2"
+			}
+		},
+		"foreach": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+		},
+		"form-data": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"requires": {
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.6",
+				"mime-types": "2.1.18"
+			}
+		},
+		"forwarded": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"requires": {
+				"map-cache": "0.2.2"
+			}
+		},
+		"fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+		},
+		"from2": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
+			}
+		},
+		"fs-extra": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"jsonfile": "4.0.0",
+				"universalify": "0.1.1"
+			}
+		},
+		"fs-write-stream-atomic": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"iferr": "0.1.5",
+				"imurmurhash": "0.1.4",
+				"readable-stream": "2.3.5"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"fsevents": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"optional": true,
+			"requires": {
+				"nan": "2.9.2",
+				"node-pre-gyp": "0.6.39"
+			},
+			"dependencies": {
+				"abbrev": {
+					"version": "1.1.0",
+					"bundled": true,
+					"optional": true
+				},
+				"ajv": {
+					"version": "4.11.8",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"aproba": {
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"delegates": "1.0.0",
+						"readable-stream": "2.2.9"
+					}
+				},
+				"asn1": {
+					"version": "0.2.3",
+					"bundled": true,
+					"optional": true
+				},
+				"assert-plus": {
+					"version": "0.2.0",
+					"bundled": true,
+					"optional": true
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"bundled": true,
+					"optional": true
+				},
+				"aws-sign2": {
+					"version": "0.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"aws4": {
+					"version": "1.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"balanced-match": {
+					"version": "0.4.2",
+					"bundled": true
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"tweetnacl": "0.14.5"
+					}
+				},
+				"block-stream": {
+					"version": "0.0.9",
+					"bundled": true,
+					"requires": {
+						"inherits": "2.0.3"
+					}
+				},
+				"boom": {
+					"version": "2.10.1",
+					"bundled": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.7",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "0.4.2",
+						"concat-map": "0.0.1"
+					}
+				},
+				"buffer-shims": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"bundled": true,
+					"optional": true
+				},
+				"co": {
+					"version": "4.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"combined-stream": {
+					"version": "1.0.5",
+					"bundled": true,
+					"requires": {
+						"delayed-stream": "1.0.0"
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"cryptiles": {
+					"version": "2.0.5",
+					"bundled": true,
+					"requires": {
+						"boom": "2.10.1"
+					}
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.8",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"deep-extend": {
+					"version": "0.4.2",
+					"bundled": true,
+					"optional": true
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"ecc-jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"extend": {
+					"version": "3.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"extsprintf": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"bundled": true,
+					"optional": true
+				},
+				"form-data": {
+					"version": "2.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.15"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"fstream": {
+					"version": "1.0.11",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"inherits": "2.0.3",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.1"
+					}
+				},
+				"fstream-ignore": {
+					"version": "1.0.5",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"fstream": "1.0.11",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4"
+					}
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"aproba": "1.1.1",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
+					}
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true
+				},
+				"har-schema": {
+					"version": "1.0.5",
+					"bundled": true,
+					"optional": true
+				},
+				"har-validator": {
+					"version": "4.2.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ajv": "4.11.8",
+						"har-schema": "1.0.5"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"hawk": {
+					"version": "3.1.3",
+					"bundled": true,
+					"requires": {
+						"boom": "2.10.1",
+						"cryptiles": "2.0.5",
+						"hoek": "2.16.3",
+						"sntp": "1.0.9"
+					}
+				},
+				"hoek": {
+					"version": "2.16.3",
+					"bundled": true
+				},
+				"http-signature": {
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "0.2.0",
+						"jsprim": "1.4.0",
+						"sshpk": "1.13.0"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"ini": {
+					"version": "1.3.4",
+					"bundled": true,
+					"optional": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"bundled": true,
+					"optional": true
+				},
+				"jodid25519": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"bundled": true,
+					"optional": true
+				},
+				"json-stable-stringify": {
+					"version": "1.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsonify": "0.0.0"
+					}
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"jsonify": {
+					"version": "0.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"jsprim": {
+					"version": "1.4.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.0.2",
+						"json-schema": "0.2.3",
+						"verror": "1.3.6"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"mime-db": {
+					"version": "1.27.0",
+					"bundled": true
+				},
+				"mime-types": {
+					"version": "2.1.15",
+					"bundled": true,
+					"requires": {
+						"mime-db": "1.27.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"node-pre-gyp": {
+					"version": "0.6.39",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"detect-libc": "1.0.2",
+						"hawk": "3.1.3",
+						"mkdirp": "0.5.1",
+						"nopt": "4.0.1",
+						"npmlog": "4.1.0",
+						"rc": "1.2.1",
+						"request": "2.81.0",
+						"rimraf": "2.6.1",
+						"semver": "5.3.0",
+						"tar": "2.2.1",
+						"tar-pack": "3.4.0"
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"abbrev": "1.1.0",
+						"osenv": "0.1.4"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"oauth-sign": {
+					"version": "0.8.2",
+					"bundled": true,
+					"optional": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"osenv": {
+					"version": "0.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"performance-now": {
+					"version": "0.2.0",
+					"bundled": true,
+					"optional": true
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"bundled": true
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"bundled": true,
+					"optional": true
+				},
+				"qs": {
+					"version": "6.4.0",
+					"bundled": true,
+					"optional": true
+				},
+				"rc": {
+					"version": "1.2.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"deep-extend": "0.4.2",
+						"ini": "1.3.4",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.2.9",
+					"bundled": true,
+					"requires": {
+						"buffer-shims": "1.0.0",
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "1.0.1",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"request": {
+					"version": "2.81.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "4.2.1",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.15",
+						"oauth-sign": "0.8.2",
+						"performance-now": "0.2.0",
+						"qs": "6.4.0",
+						"safe-buffer": "5.0.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.2",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.1",
+					"bundled": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.0.1",
+					"bundled": true
+				},
+				"semver": {
+					"version": "5.3.0",
+					"bundled": true,
+					"optional": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"sntp": {
+					"version": "1.0.9",
+					"bundled": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"sshpk": {
+					"version": "1.13.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"asn1": "0.2.3",
+						"assert-plus": "1.0.0",
+						"bcrypt-pbkdf": "1.0.1",
+						"dashdash": "1.14.1",
+						"ecc-jsbn": "0.1.1",
+						"getpass": "0.1.7",
+						"jodid25519": "1.0.2",
+						"jsbn": "0.1.1",
+						"tweetnacl": "0.14.5"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"stringstream": {
+					"version": "0.0.5",
+					"bundled": true,
+					"optional": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"tar": {
+					"version": "2.2.1",
+					"bundled": true,
+					"requires": {
+						"block-stream": "0.0.9",
+						"fstream": "1.0.11",
+						"inherits": "2.0.3"
+					}
+				},
+				"tar-pack": {
+					"version": "3.4.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"debug": "2.6.8",
+						"fstream": "1.0.11",
+						"fstream-ignore": "1.0.5",
+						"once": "1.4.0",
+						"readable-stream": "2.2.9",
+						"rimraf": "2.6.1",
+						"tar": "2.2.1",
+						"uid-number": "0.0.6"
+					}
+				},
+				"tough-cookie": {
+					"version": "2.3.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"punycode": "1.4.1"
+					}
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"bundled": true,
+					"optional": true
+				},
+				"uid-number": {
+					"version": "0.0.6",
+					"bundled": true,
+					"optional": true
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"uuid": {
+					"version": "3.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"verror": {
+					"version": "1.3.6",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"extsprintf": "1.0.2"
+					}
+				},
+				"wide-align": {
+					"version": "1.1.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"string-width": "1.0.2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				}
+			}
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		},
+		"function-name-support": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/function-name-support/-/function-name-support-0.2.0.tgz",
+			"integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE="
+		},
+		"get-caller-file": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+		},
+		"get-port": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
+		},
+		"get-stdin": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+		},
+		"get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			}
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"requires": {
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
+			}
+		},
+		"glob-base": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"requires": {
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
+			}
+		},
+		"glob-parent": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"requires": {
+				"is-glob": "2.0.1"
+			}
+		},
+		"glob2base": {
+			"version": "0.0.12",
+			"resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+			"integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
+			"requires": {
+				"find-index": "0.1.1"
+			}
+		},
+		"global": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+			"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+			"requires": {
+				"min-document": "2.19.0",
+				"process": "0.5.2"
+			}
+		},
+		"global-dirs": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+			"requires": {
+				"ini": "1.3.5"
+			}
+		},
+		"globals": {
+			"version": "9.18.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+		},
+		"globby": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+			"requires": {
+				"array-union": "1.0.2",
+				"glob": "7.1.2",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
+			},
+			"dependencies": {
+				"pinkie": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+					"requires": {
+						"pinkie": "2.0.4"
+					}
+				}
+			}
+		},
+		"got": {
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+			"requires": {
+				"create-error-class": "3.0.2",
+				"duplexer3": "0.1.4",
+				"get-stream": "3.0.0",
+				"is-redirect": "1.0.0",
+				"is-retry-allowed": "1.1.0",
+				"is-stream": "1.1.0",
+				"lowercase-keys": "1.0.0",
+				"safe-buffer": "5.1.1",
+				"timed-out": "4.0.1",
+				"unzip-response": "2.0.1",
+				"url-parse-lax": "1.0.0"
+			}
+		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+		},
+		"growly": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+		},
+		"handle-thing": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
+		},
+		"handlebars": {
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+			"requires": {
+				"async": "1.5.2",
+				"optimist": "0.6.1",
+				"source-map": "0.4.4",
+				"uglify-js": "2.8.29"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				},
+				"source-map": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"requires": {
+						"amdefine": "1.0.1"
+					}
+				}
+			}
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+		},
+		"har-validator": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"requires": {
+				"ajv": "5.5.2",
+				"har-schema": "2.0.0"
+			}
+		},
+		"has": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"requires": {
+				"function-bind": "1.1.1"
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"has-color": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+		},
+		"has-flag": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+		},
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"requires": {
+				"get-value": "2.0.6",
+				"has-values": "1.0.0",
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
+		"has-yarn": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
+			"integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac="
+		},
+		"hawk": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+			"requires": {
+				"boom": "4.3.1",
+				"cryptiles": "3.1.2",
+				"hoek": "4.2.1",
+				"sntp": "2.1.0"
+			}
+		},
+		"hoek": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+		},
+		"hoist-non-react-statics": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
+			"integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
+		},
+		"home-or-tmp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"requires": {
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
+			}
+		},
+		"hosted-git-info": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+		},
+		"hpack.js": {
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+			"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+			"requires": {
+				"inherits": "2.0.3",
+				"obuf": "1.1.1",
+				"readable-stream": "2.3.5",
+				"wbuf": "1.7.2"
+			}
+		},
+		"html-encoding-sniffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"requires": {
+				"whatwg-encoding": "1.0.3"
+			}
+		},
+		"html-entities": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+		},
+		"http-deceiver": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+			"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
+		},
+		"http-errors": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+			"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+			"requires": {
+				"depd": "1.1.1",
+				"inherits": "2.0.3",
+				"setprototypeof": "1.0.3",
+				"statuses": "1.3.1"
+			},
+			"dependencies": {
+				"depd": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+				},
+				"setprototypeof": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+				}
+			}
+		},
+		"http-parser-js": {
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.11.tgz",
+			"integrity": "sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA=="
+		},
+		"http-proxy": {
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+			"integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
+			"requires": {
+				"eventemitter3": "1.2.0",
+				"requires-port": "1.0.0"
+			}
+		},
+		"http-proxy-middleware": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+			"integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+			"requires": {
+				"http-proxy": "1.16.2",
+				"is-glob": "3.1.0",
+				"lodash": "4.17.5",
+				"micromatch": "2.3.11"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+				},
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"requires": {
+						"is-extglob": "2.1.1"
+					}
+				}
+			}
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.13.1"
+			}
+		},
+		"hullabaloo-config-manager": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.1.1.tgz",
+			"integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
+			"requires": {
+				"dot-prop": "4.2.0",
+				"es6-error": "4.1.1",
+				"graceful-fs": "4.1.11",
+				"indent-string": "3.2.0",
+				"json5": "0.5.1",
+				"lodash.clonedeep": "4.5.0",
+				"lodash.clonedeepwith": "4.5.0",
+				"lodash.isequal": "4.5.0",
+				"lodash.merge": "4.6.1",
+				"md5-hex": "2.0.0",
+				"package-hash": "2.0.0",
+				"pkg-dir": "2.0.0",
+				"resolve-from": "3.0.0",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"hyphenate-style-name": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
+			"integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+		},
+		"iferr": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+		},
+		"ignore": {
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+		},
+		"ignore-by-default": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk="
+		},
+		"import-lazy": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+		},
+		"import-local": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
+			"integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
+			"requires": {
+				"pkg-dir": "2.0.0",
+				"resolve-cwd": "2.0.0"
+			}
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+		},
+		"indent-string": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+		},
+		"internal-ip": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
+			"integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
+			"requires": {
+				"meow": "3.7.0"
+			}
+		},
+		"invariant": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
+			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+			"requires": {
+				"loose-envify": "1.3.1"
+			}
+		},
+		"invert-kv": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+		},
+		"ip": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+		},
+		"ipaddr.js": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+			"integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
+		},
+		"irregular-plurals": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+			"integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
+		},
+		"is-accessor-descriptor": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+			"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+			"requires": {
+				"kind-of": "6.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+		},
+		"is-binary-path": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"requires": {
+				"binary-extensions": "1.11.0"
+			}
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+		},
+		"is-builtin-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"requires": {
+				"builtin-modules": "1.1.1"
+			}
+		},
+		"is-callable": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+		},
+		"is-ci": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+			"requires": {
+				"ci-info": "1.1.2"
+			}
+		},
+		"is-data-descriptor": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+			"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+			"requires": {
+				"kind-of": "6.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+		},
+		"is-descriptor": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+			"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+			"requires": {
+				"is-accessor-descriptor": "1.0.0",
+				"is-data-descriptor": "1.0.0",
+				"kind-of": "6.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
+		"is-dotfile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+		},
+		"is-equal-shallow": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"requires": {
+				"is-primitive": "2.0.0"
+			}
+		},
+		"is-error": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz",
+			"integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw="
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+		},
+		"is-extglob": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+		},
+		"is-finite": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"requires": {
+				"number-is-nan": "1.0.1"
+			}
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+		},
+		"is-function": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+		},
+		"is-generator-fn": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
+		},
+		"is-glob": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"requires": {
+				"is-extglob": "1.0.0"
+			}
+		},
+		"is-in-browser": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+			"integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
+		},
+		"is-installed-globally": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+			"requires": {
+				"global-dirs": "0.1.1",
+				"is-path-inside": "1.0.1"
+			}
+		},
+		"is-npm": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+		},
+		"is-number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+		},
+		"is-observable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+			"requires": {
+				"symbol-observable": "1.2.0"
+			}
+		},
+		"is-odd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+			"requires": {
+				"is-number": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+				}
+			}
+		},
+		"is-path-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+		},
+		"is-path-in-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"requires": {
+				"is-path-inside": "1.0.1"
+			}
+		},
+		"is-path-inside": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"requires": {
+				"path-is-inside": "1.0.2"
+			}
+		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"requires": {
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"is-posix-bracket": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+		},
+		"is-primitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+		},
+		"is-redirect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"requires": {
+				"has": "1.0.1"
+			}
+		},
+		"is-retry-allowed": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-symbol": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"is-url": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
+			"integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY="
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+		},
+		"is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"requires": {
+				"isarray": "1.0.0"
+			}
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.3"
+			}
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"istanbul-api": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.2.tgz",
+			"integrity": "sha512-kH5YRdqdbs5hiH4/Rr1Q0cSAGgjh3jTtg8vu9NLebBAoK3adVO4jk81J+TYOkTr2+Q4NLeb1ACvmEt65iG/Vbw==",
+			"requires": {
+				"async": "2.6.0",
+				"fileset": "2.0.3",
+				"istanbul-lib-coverage": "1.1.2",
+				"istanbul-lib-hook": "1.1.0",
+				"istanbul-lib-instrument": "1.9.2",
+				"istanbul-lib-report": "1.1.3",
+				"istanbul-lib-source-maps": "1.2.3",
+				"istanbul-reports": "1.1.4",
+				"js-yaml": "3.11.0",
+				"mkdirp": "0.5.1",
+				"once": "1.4.0"
+			}
+		},
+		"istanbul-lib-coverage": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.2.tgz",
+			"integrity": "sha512-tZYA0v5A7qBSsOzcebJJ/z3lk3oSzH62puG78DbBA1+zupipX2CakDyiPV3pOb8He+jBwVimuwB0dTnh38hX0w=="
+		},
+		"istanbul-lib-hook": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
+			"integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
+			"requires": {
+				"append-transform": "0.4.0"
+			}
+		},
+		"istanbul-lib-instrument": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.2.tgz",
+			"integrity": "sha512-nz8t4HQ2206a/3AXi+NHFWEa844DMpPsgbcUteJbt1j8LX1xg56H9rOMnhvcvVvPbW60qAIyrSk44H8ZDqaSSA==",
+			"requires": {
+				"babel-generator": "6.26.1",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"istanbul-lib-coverage": "1.1.2",
+				"semver": "5.5.0"
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
+			"integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
+			"requires": {
+				"istanbul-lib-coverage": "1.1.2",
+				"mkdirp": "0.5.1",
+				"path-parse": "1.0.5",
+				"supports-color": "3.2.3"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
+			"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+			"requires": {
+				"debug": "3.1.0",
+				"istanbul-lib-coverage": "1.1.2",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"source-map": "0.5.7"
+			}
+		},
+		"istanbul-reports": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.4.tgz",
+			"integrity": "sha512-DfSTVOTkuO+kRmbO8Gk650Wqm1WRGr6lrdi2EwDK1vxpS71vdlLd613EpzOKdIFioB5f/scJTjeWBnvd1FWejg==",
+			"requires": {
+				"handlebars": "4.0.11"
+			}
+		},
+		"jest": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-22.4.2.tgz",
+			"integrity": "sha512-wD7dXWtfaQAgbNVsjFqzmuhg6nzwGsTRVea3FpSJ7GURhG+J536fw4mdoLB01DgiEozDDeF1ZMR/UlUszTsCrg==",
+			"requires": {
+				"import-local": "1.0.0",
+				"jest-cli": "22.4.2"
+			},
+			"dependencies": {
+				"import-local": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+					"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+					"requires": {
+						"pkg-dir": "2.0.0",
+						"resolve-cwd": "2.0.0"
+					}
+				},
+				"jest-cli": {
+					"version": "22.4.2",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.2.tgz",
+					"integrity": "sha512-ebo6ZWK2xDSs7LGnLvM16SZOIJ2dj0B6/oERmGcal32NHkks450nNfGrGTyOSPgJDgH8DFhVdBXgSamN7mtZ0Q==",
+					"requires": {
+						"ansi-escapes": "3.0.0",
+						"chalk": "2.3.2",
+						"exit": "0.1.2",
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"import-local": "1.0.0",
+						"is-ci": "1.1.0",
+						"istanbul-api": "1.2.2",
+						"istanbul-lib-coverage": "1.1.2",
+						"istanbul-lib-instrument": "1.9.2",
+						"istanbul-lib-source-maps": "1.2.3",
+						"jest-changed-files": "22.2.0",
+						"jest-config": "22.4.2",
+						"jest-environment-jsdom": "22.4.1",
+						"jest-get-type": "22.1.0",
+						"jest-haste-map": "22.4.2",
+						"jest-message-util": "22.4.0",
+						"jest-regex-util": "22.1.0",
+						"jest-resolve-dependencies": "22.1.0",
+						"jest-runner": "22.4.2",
+						"jest-runtime": "22.4.2",
+						"jest-snapshot": "22.4.0",
+						"jest-util": "22.4.1",
+						"jest-validate": "22.4.2",
+						"jest-worker": "22.2.2",
+						"micromatch": "2.3.11",
+						"node-notifier": "5.2.1",
+						"realpath-native": "1.0.0",
+						"rimraf": "2.6.2",
+						"slash": "1.0.0",
+						"string-length": "2.0.0",
+						"strip-ansi": "4.0.0",
+						"which": "1.3.0",
+						"yargs": "10.1.2"
+					}
+				}
+			}
+		},
+		"jest-changed-files": {
+			"version": "22.2.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.2.0.tgz",
+			"integrity": "sha512-SzqOvoPMrXB0NPvDrSPeKETpoUNCtNDOsFbCzAGWxqWVvNyrIMLpUjVExT3u3LfdVrENlrNGCfh5YoFd8+ZeXg==",
+			"requires": {
+				"throat": "4.1.0"
+			}
+		},
+		"jest-config": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.2.tgz",
+			"integrity": "sha512-oG31qYO73/3vj/Q8aM2RgzmHndTkz9nRk8ISybfuJqqbf0RW7OUjHVOZPLOUiwLWtz52Yq2HkjIblsyhbA7vrg==",
+			"requires": {
+				"chalk": "2.3.2",
+				"glob": "7.1.2",
+				"jest-environment-jsdom": "22.4.1",
+				"jest-environment-node": "22.4.1",
+				"jest-get-type": "22.1.0",
+				"jest-jasmine2": "22.4.2",
+				"jest-regex-util": "22.1.0",
+				"jest-resolve": "22.4.2",
+				"jest-util": "22.4.1",
+				"jest-validate": "22.4.2",
+				"pretty-format": "22.4.0"
+			}
+		},
+		"jest-diff": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.0.tgz",
+			"integrity": "sha512-+/t20WmnkOkB8MOaGaPziI8zWKxquMvYw4Ub+wOzi7AUhmpFXz43buWSxVoZo4J5RnCozpGbX3/FssjJ5KV9Nw==",
+			"requires": {
+				"chalk": "2.3.2",
+				"diff": "3.5.0",
+				"jest-get-type": "22.1.0",
+				"pretty-format": "22.4.0"
+			}
+		},
+		"jest-docblock": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.0.tgz",
+			"integrity": "sha512-lDY7GZ+/CJb02oULYLBDj7Hs5shBhVpDYpIm8LUyqw9X2J22QRsM19gmGQwIFqGSJmpc/LRrSYudeSrG510xlQ==",
+			"requires": {
+				"detect-newline": "2.1.0"
+			}
+		},
+		"jest-environment-jsdom": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.1.tgz",
+			"integrity": "sha512-x/JzAoH+dWPBnIMv5OQKiIR0TYf6UvbRjsIuDZ11yDFXkHKGJZg6jNnLAsokAm3cq9kUa2hH5BPUC9XU4n1ELQ==",
+			"requires": {
+				"jest-mock": "22.2.0",
+				"jest-util": "22.4.1",
+				"jsdom": "11.6.2"
+			}
+		},
+		"jest-environment-node": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.1.tgz",
+			"integrity": "sha512-wj9+zzfRgnUbm5VwFOCGgG1QmbucUyrjPKBKUJdLW8K5Ss5zrNc1k+v6feZhFg6sS3ZGnjgtIyklaxEARxu+LQ==",
+			"requires": {
+				"jest-mock": "22.2.0",
+				"jest-util": "22.4.1"
+			}
+		},
+		"jest-get-type": {
+			"version": "22.1.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.1.0.tgz",
+			"integrity": "sha512-nD97IVOlNP6fjIN5i7j5XRH+hFsHL7VlauBbzRvueaaUe70uohrkz7pL/N8lx/IAwZRTJ//wOdVgh85OgM7g3w=="
+		},
+		"jest-haste-map": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.2.tgz",
+			"integrity": "sha512-EdQADHGXRqHJYAr7q9B9YYHZnrlcMwhx1+DnIgc9uN05nCW3RvGCxJ91MqWXcC1AzatLoSv7SNd0qXMp2jKBDA==",
+			"requires": {
+				"fb-watchman": "2.0.0",
+				"graceful-fs": "4.1.11",
+				"jest-docblock": "22.4.0",
+				"jest-serializer": "22.4.0",
+				"jest-worker": "22.2.2",
+				"micromatch": "2.3.11",
+				"sane": "2.4.1"
+			}
+		},
+		"jest-jasmine2": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.2.tgz",
+			"integrity": "sha512-KZaIHpXQ0AIlvQJFCU0uoXxtz5GG47X14r9upMe7VXE55UazoMZBFnQb9TX2HoYX2/AxJYnjHuvwKVCFqOrEtw==",
+			"requires": {
+				"chalk": "2.3.2",
+				"co": "4.6.0",
+				"expect": "22.4.0",
+				"graceful-fs": "4.1.11",
+				"is-generator-fn": "1.0.0",
+				"jest-diff": "22.4.0",
+				"jest-matcher-utils": "22.4.0",
+				"jest-message-util": "22.4.0",
+				"jest-snapshot": "22.4.0",
+				"jest-util": "22.4.1",
+				"source-map-support": "0.5.3"
+			}
+		},
+		"jest-leak-detector": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.0.tgz",
+			"integrity": "sha512-r3NEIVNh4X3fEeJtUIrKXWKhNokwUM2ILp5LD8w1KrEanPsFtZmYjmyZYjDTX2dXYr33TW65OvbRE3hWFAyq6g==",
+			"requires": {
+				"pretty-format": "22.4.0"
+			}
+		},
+		"jest-matcher-utils": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.0.tgz",
+			"integrity": "sha512-03m3issxUXpWMwDYTfmL8hRNewUB0yCRTeXPm+eq058rZxLHD9f5NtSSO98CWHqe4UyISIxd9Ao9iDVjHWd2qg==",
+			"requires": {
+				"chalk": "2.3.2",
+				"jest-get-type": "22.1.0",
+				"pretty-format": "22.4.0"
+			}
+		},
+		"jest-message-util": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.0.tgz",
+			"integrity": "sha512-eyCJB0T3hrlpFF2FqQoIB093OulP+1qvATQmD3IOgJgMGqPL6eYw8TbC5P/VCWPqKhGL51xvjIIhow5eZ2wHFw==",
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.40",
+				"chalk": "2.3.2",
+				"micromatch": "2.3.11",
+				"slash": "1.0.0",
+				"stack-utils": "1.0.1"
+			}
+		},
+		"jest-mock": {
+			"version": "22.2.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.2.0.tgz",
+			"integrity": "sha512-eOfoUYLOB/JlxChOFkh/bzpWGqUXb9I+oOpkprHHs9L7nUNfL8Rk28h1ycWrqzWCEQ/jZBg/xIv7VdQkfAkOhw=="
+		},
+		"jest-regex-util": {
+			"version": "22.1.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.1.0.tgz",
+			"integrity": "sha512-on0LqVS6Xeh69sw3d1RukVnur+lVOl3zkmb0Q54FHj9wHoq6dbtWqb3TSlnVUyx36hqjJhjgs/QLqs07Bzu72Q=="
+		},
+		"jest-resolve": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.2.tgz",
+			"integrity": "sha512-P1hSfcc2HJYT5t+WPu/11OfFMa7m8pBb2Gf2vm6W9OVs7YTXQ5RCC3nDqaYZQaTqxEM1ZZaTcQGcE6U2xMOsqQ==",
+			"requires": {
+				"browser-resolve": "1.11.2",
+				"chalk": "2.3.2"
+			}
+		},
+		"jest-resolve-dependencies": {
+			"version": "22.1.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.1.0.tgz",
+			"integrity": "sha512-76Ll61bD/Sus8wK8d+lw891EtiBJGJkWG8OuVDTEX0z3z2+jPujvQqSB2eQ+kCHyCsRwJ2PSjhn3UHqae/oEtA==",
+			"requires": {
+				"jest-regex-util": "22.1.0"
+			}
+		},
+		"jest-runner": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.2.tgz",
+			"integrity": "sha512-W4vwgiVQS0NyXt8hgpw7i0YUtsfoChiQcoHWBJeq2ocV4VF2osEZx8HYgpH5HfNe1Cb5LZeZWxX8Dr3hesbGFg==",
+			"requires": {
+				"exit": "0.1.2",
+				"jest-config": "22.4.2",
+				"jest-docblock": "22.4.0",
+				"jest-haste-map": "22.4.2",
+				"jest-jasmine2": "22.4.2",
+				"jest-leak-detector": "22.4.0",
+				"jest-message-util": "22.4.0",
+				"jest-runtime": "22.4.2",
+				"jest-util": "22.4.1",
+				"jest-worker": "22.2.2",
+				"throat": "4.1.0"
+			}
+		},
+		"jest-runtime": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.2.tgz",
+			"integrity": "sha512-9/Fxbj99cqxI7o2nTNzevnI38eDBstkwve8ZeaAD/Kz0fbU3i3eRv2QPEmzbmyCyBvUWxCT7BzNLTzTqH1+pyA==",
+			"requires": {
+				"babel-core": "6.26.0",
+				"babel-jest": "22.4.1",
+				"babel-plugin-istanbul": "4.1.5",
+				"chalk": "2.3.2",
+				"convert-source-map": "1.5.1",
+				"exit": "0.1.2",
+				"graceful-fs": "4.1.11",
+				"jest-config": "22.4.2",
+				"jest-haste-map": "22.4.2",
+				"jest-regex-util": "22.1.0",
+				"jest-resolve": "22.4.2",
+				"jest-util": "22.4.1",
+				"jest-validate": "22.4.2",
+				"json-stable-stringify": "1.0.1",
+				"micromatch": "2.3.11",
+				"realpath-native": "1.0.0",
+				"slash": "1.0.0",
+				"strip-bom": "3.0.0",
+				"write-file-atomic": "2.3.0",
+				"yargs": "10.1.2"
+			}
+		},
+		"jest-serializer": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.0.tgz",
+			"integrity": "sha512-dnqde95MiYfdc1ZJpjEiHCRvRGGJHPsZQARJFucEGIaOzxqqS9/tt2WzD/OUSGT6kxaEGLQE92faVJGdoCu+Rw=="
+		},
+		"jest-snapshot": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.0.tgz",
+			"integrity": "sha512-6Zz4F9G1Nbr93kfm5h3A2+OkE+WGpgJlskYE4iSNN2uYfoTL5b9W6aB9Orpx+ueReHyqmy7HET7Z3EmYlL3hKw==",
+			"requires": {
+				"chalk": "2.3.2",
+				"jest-diff": "22.4.0",
+				"jest-matcher-utils": "22.4.0",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"pretty-format": "22.4.0"
+			}
+		},
+		"jest-util": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.1.tgz",
+			"integrity": "sha512-9ySBdJY2qVWpg0OvZbGcFXE2NgwccpZVj384E9bx7brKFc7l5anpqah15mseWcz7FLDk7/N+LyYgqFme7Rez2Q==",
+			"requires": {
+				"callsites": "2.0.0",
+				"chalk": "2.3.2",
+				"graceful-fs": "4.1.11",
+				"is-ci": "1.1.0",
+				"jest-message-util": "22.4.0",
+				"mkdirp": "0.5.1",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"jest-validate": {
+			"version": "22.4.2",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.2.tgz",
+			"integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
+			"requires": {
+				"chalk": "2.3.2",
+				"jest-config": "22.4.2",
+				"jest-get-type": "22.1.0",
+				"leven": "2.1.0",
+				"pretty-format": "22.4.0"
+			}
+		},
+		"jest-worker": {
+			"version": "22.2.2",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.2.2.tgz",
+			"integrity": "sha512-ZylDXjrFNt/OP6cUxwJFWwDgazP7hRjtCQbocFHyiwov+04Wm1x5PYzMGNJT53s4nwr0oo9ocYTImS09xOlUnw==",
+			"requires": {
+				"merge-stream": "1.0.1"
+			}
+		},
+		"js-string-escape": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"js-yaml": {
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+			"requires": {
+				"argparse": "1.0.10",
+				"esprima": "4.0.0"
+			}
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"optional": true
+		},
+		"jsdom": {
+			"version": "11.6.2",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
+			"integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
+			"requires": {
+				"abab": "1.0.4",
+				"acorn": "5.5.3",
+				"acorn-globals": "4.1.0",
+				"array-equal": "1.0.0",
+				"browser-process-hrtime": "0.1.2",
+				"content-type-parser": "1.0.2",
+				"cssom": "0.3.2",
+				"cssstyle": "0.2.37",
+				"domexception": "1.0.1",
+				"escodegen": "1.9.1",
+				"html-encoding-sniffer": "1.0.2",
+				"left-pad": "1.2.0",
+				"nwmatcher": "1.4.3",
+				"parse5": "4.0.0",
+				"pn": "1.1.0",
+				"request": "2.83.0",
+				"request-promise-native": "1.0.5",
+				"sax": "1.2.4",
+				"symbol-tree": "3.2.2",
+				"tough-cookie": "2.3.4",
+				"w3c-hr-time": "1.0.1",
+				"webidl-conversions": "4.0.2",
+				"whatwg-encoding": "1.0.3",
+				"whatwg-url": "6.4.0",
+				"ws": "4.1.0",
+				"xml-name-validator": "3.0.0"
+			}
+		},
+		"jsdom-global": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
+			"integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk="
+		},
+		"jsesc": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+			"integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"requires": {
+				"jsonify": "0.0.0"
+			}
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
+		"json3": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+		},
+		"json5": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+		},
+		"jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"requires": {
+				"graceful-fs": "4.1.11"
+			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			}
+		},
+		"jss": {
+			"version": "9.8.0",
+			"resolved": "https://registry.npmjs.org/jss/-/jss-9.8.0.tgz",
+			"integrity": "sha512-1E9pn6k1Qd1BxKz845supoedukHuwMeBiqybCQV9l60v8JE7owkZSvVJfjw3wm50SjG1C/ABPtQ8PrGfhfrzLw==",
+			"requires": {
+				"is-in-browser": "1.1.3",
+				"symbol-observable": "1.2.0",
+				"warning": "3.0.0"
+			}
+		},
+		"jss-camel-case": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jss-camel-case/-/jss-camel-case-6.1.0.tgz",
+			"integrity": "sha512-HPF2Q7wmNW1t79mCqSeU2vdd/vFFGpkazwvfHMOhPlMgXrJDzdj9viA2SaHk9ZbD5pfL63a8ylp4++irYbbzMQ==",
+			"requires": {
+				"hyphenate-style-name": "1.0.2"
+			}
+		},
+		"jss-compose": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/jss-compose/-/jss-compose-5.0.0.tgz",
+			"integrity": "sha512-YofRYuiA0+VbeOw0VjgkyO380sA4+TWDrW52nSluD9n+1FWOlDzNbgpZ/Sb3Y46+DcAbOS21W5jo6SAqUEiuwA==",
+			"requires": {
+				"warning": "3.0.0"
+			}
+		},
+		"jss-default-unit": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
+			"integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg=="
+		},
+		"jss-expand": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/jss-expand/-/jss-expand-5.1.0.tgz",
+			"integrity": "sha512-WTxmNipgj0V8kr8gc8Gc6Et7uQZH60H7FFNG9zZHjR6TPJoj7TDK+/EBxwRHtCRQD4B8RTwoa7MyEKD4ReKfXw=="
+		},
+		"jss-extend": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/jss-extend/-/jss-extend-6.2.0.tgz",
+			"integrity": "sha512-YszrmcB6o9HOsKPszK7NeDBNNjVyiW864jfoiHoMlgMIg2qlxKw70axZHqgczXHDcoyi/0/ikP1XaHDPRvYtEA==",
+			"requires": {
+				"warning": "3.0.0"
+			}
+		},
+		"jss-global": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
+			"integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q=="
+		},
+		"jss-nested": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/jss-nested/-/jss-nested-6.0.1.tgz",
+			"integrity": "sha512-rn964TralHOZxoyEgeq3hXY8hyuCElnvQoVrQwKHVmu55VRDd6IqExAx9be5HgK0yN/+hQdgAXQl/GUrBbbSTA==",
+			"requires": {
+				"warning": "3.0.0"
+			}
+		},
+		"jss-preset-default": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/jss-preset-default/-/jss-preset-default-4.3.0.tgz",
+			"integrity": "sha512-3VqMmR07OkiGyVPHfke/sjR33kSyRVjIE/3+bGgJ9Pp1jMIAPIDDY3h3wfEwa97DFV25SncTrNjjIgBFVCb4BA==",
+			"requires": {
+				"jss-camel-case": "6.1.0",
+				"jss-compose": "5.0.0",
+				"jss-default-unit": "8.0.2",
+				"jss-expand": "5.1.0",
+				"jss-extend": "6.2.0",
+				"jss-global": "3.0.0",
+				"jss-nested": "6.0.1",
+				"jss-props-sort": "6.0.0",
+				"jss-template": "1.0.1",
+				"jss-vendor-prefixer": "7.0.0"
+			}
+		},
+		"jss-props-sort": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
+			"integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g=="
+		},
+		"jss-template": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/jss-template/-/jss-template-1.0.1.tgz",
+			"integrity": "sha512-m5BqEWha17fmIVXm1z8xbJhY6GFJxNB9H68GVnCWPyGYfxiAgY9WTQyvDAVj+pYRgrXSOfN5V1T4+SzN1sJTeg==",
+			"requires": {
+				"warning": "3.0.0"
+			}
+		},
+		"jss-vendor-prefixer": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz",
+			"integrity": "sha512-Agd+FKmvsI0HLcYXkvy8GYOw3AAASBUpsmIRvVQheps+JWaN892uFOInTr0DRydwaD91vSSUCU4NssschvF7MA==",
+			"requires": {
+				"css-vendor": "0.3.8"
+			}
+		},
+		"keycode": {
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/keycode/-/keycode-2.1.9.tgz",
+			"integrity": "sha1-lkojxU5IiUBbSGGlyfBIDUUUHfo="
+		},
+		"killable": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz",
+			"integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms="
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"requires": {
+				"is-buffer": "1.1.6"
+			}
+		},
+		"last-line-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/last-line-stream/-/last-line-stream-1.0.0.tgz",
+			"integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
+			"requires": {
+				"through2": "2.0.3"
+			}
+		},
+		"latest-version": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+			"requires": {
+				"package-json": "4.0.1"
+			}
+		},
+		"lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"optional": true
+		},
+		"lcid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"requires": {
+				"invert-kv": "1.0.0"
+			}
+		},
+		"left-pad": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
+			"integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
+		},
+		"leven": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"requires": {
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
+			}
+		},
+		"lightercollective": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/lightercollective/-/lightercollective-0.0.0.tgz",
+			"integrity": "sha512-4SdGgHgQjlqhk90QxAYsltGEI6HHt30xy9fOIPKi+c3vcGRcpPDtzm6+kxr1N9ixkrx/ngMhTCe/VpBc/HmNBQ=="
+		},
+		"load-json-file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"strip-bom": "3.0.0"
+			}
+		},
+		"loader-utils": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+			"requires": {
+				"big.js": "3.2.0",
+				"emojis-list": "2.1.0",
+				"json5": "0.5.1"
+			}
+		},
+		"locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"requires": {
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+		},
+		"lodash-es": {
+			"version": "4.17.7",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.7.tgz",
+			"integrity": "sha512-jzqTi3vk4J5Dxq43cNjB0ekfCjPLHixoY2Sc0WHTo+0r928taLqe/VCt02vY5uQBvg0rdXgL3xWkK4X0MCmZcw=="
+		},
+		"lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+		},
+		"lodash.clonedeepwith": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
+			"integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ="
+		},
+		"lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+		},
+		"lodash.difference": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+		},
+		"lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+		},
+		"lodash.flattendeep": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+		},
+		"lodash.merge": {
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+		},
+		"loglevel": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
+			"integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
+		},
+		"longest": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"requires": {
+				"js-tokens": "3.0.2"
+			}
+		},
+		"loud-rejection": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+			"requires": {
+				"currently-unhandled": "0.4.1",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"lowercase-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+			"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+		},
+		"lru-cache": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"requires": {
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
+			}
+		},
+		"make-dir": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
+			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+			"requires": {
+				"pify": "3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"makeerror": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"requires": {
+				"tmpl": "1.0.4"
+			}
+		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+		},
+		"map-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"requires": {
+				"object-visit": "1.0.1"
+			}
+		},
+		"matcher": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.0.tgz",
+			"integrity": "sha512-aZGv6JBTHqfqAd09jmAlbKnAICTfIvb5Z8gXVxPB5WZtFfHMaAMdACL7tQflD2V+6/8KNcY8s6DYtWLgpJP5lA==",
+			"requires": {
+				"escape-string-regexp": "1.0.5"
+			}
+		},
+		"material-ui": {
+			"version": "1.0.0-beta.25",
+			"resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.25.tgz",
+			"integrity": "sha512-c31uPg4h9VP1Udn//wSqSRwrWryCT9kaUlOdpVvHCL0i5dNqD1eU9dYQNUihwO3P//DXEzOYwmbEHFR8ZeYjbw==",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"brcast": "3.0.1",
+				"classnames": "2.2.5",
+				"deepmerge": "2.1.0",
+				"dom-helpers": "3.3.1",
+				"hoist-non-react-statics": "2.5.0",
+				"jss": "9.8.0",
+				"jss-preset-default": "4.3.0",
+				"keycode": "2.1.9",
+				"lodash": "4.17.5",
+				"normalize-scroll-left": "0.1.2",
+				"prop-types": "15.6.1",
+				"react-event-listener": "0.5.3",
+				"react-jss": "8.3.3",
+				"react-popper": "0.7.5",
+				"react-scrollbar-size": "2.1.0",
+				"react-transition-group": "2.2.1",
+				"recompose": "0.26.0",
+				"scroll": "2.0.3",
+				"warning": "3.0.0"
+			}
+		},
+		"material-ui-icons": {
+			"version": "1.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/material-ui-icons/-/material-ui-icons-1.0.0-beta.36.tgz",
+			"integrity": "sha512-7rS6b2EV5QXCB/gTi/Ac9Wbxd+h9EZv1Td3rLLJe4IER8mVHRgdqZccB3EsjW2DrJ7opdY1+8X3/vyrS7CQNpg==",
+			"requires": {
+				"recompose": "0.26.0"
+			}
+		},
+		"material-ui-pickers": {
+			"version": "1.0.0-beta.12",
+			"resolved": "https://registry.npmjs.org/material-ui-pickers/-/material-ui-pickers-1.0.0-beta.12.tgz",
+			"integrity": "sha512-eNRy183HRJ7xahxCv+eOhDG5uRAGxMjQxK15zkG8ZtgNmDQhJS8MlZ/ZJPljDelypozKxRJUIq1DRVwO5ux+FA==",
+			"requires": {
+				"moment-range": "3.1.1",
+				"react-text-mask": "5.1.0"
+			}
+		},
+		"md5-hex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
+			"integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
+			"requires": {
+				"md5-o-matic": "0.1.1"
+			}
+		},
+		"md5-o-matic": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
+		},
+		"media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+		},
+		"mem": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"requires": {
+				"mimic-fn": "1.2.0"
+			}
+		},
+		"memory-fs": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+			"requires": {
+				"errno": "0.1.7",
+				"readable-stream": "2.3.5"
+			}
+		},
+		"meow": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+			"requires": {
+				"camelcase-keys": "2.1.0",
+				"decamelize": "1.2.0",
+				"loud-rejection": "1.6.0",
+				"map-obj": "1.0.1",
+				"minimist": "1.2.0",
+				"normalize-package-data": "2.4.0",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"redent": "1.0.0",
+				"trim-newlines": "1.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+					"requires": {
+						"pinkie": "2.0.4"
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"requires": {
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"requires": {
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				}
+			}
+		},
+		"merge": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"requires": {
+				"readable-stream": "2.3.5"
+			}
+		},
+		"methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+		},
+		"micromatch": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"requires": {
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.4"
+			}
+		},
+		"mime": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+		},
+		"mime-db": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+		},
+		"mime-types": {
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+			"requires": {
+				"mime-db": "1.33.0"
+			}
+		},
+		"mimic-fn": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+		},
+		"min-document": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+			"requires": {
+				"dom-walk": "0.1.1"
+			}
+		},
+		"minimalistic-assert": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+			"integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "1.1.11"
+			}
+		},
+		"minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"mississippi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+			"requires": {
+				"concat-stream": "1.6.1",
+				"duplexify": "3.5.4",
+				"end-of-stream": "1.4.1",
+				"flush-write-stream": "1.0.2",
+				"from2": "2.3.0",
+				"parallel-transform": "1.1.0",
+				"pump": "2.0.1",
+				"pumpify": "1.4.0",
+				"stream-each": "1.2.2",
+				"through2": "2.0.3"
+			}
+		},
+		"mixin-deep": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"requires": {
+				"for-in": "1.0.2",
+				"is-extendable": "1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "2.0.4"
+					}
+				}
+			}
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"requires": {
+				"minimist": "0.0.8"
+			}
+		},
+		"moment": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+			"integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
+		},
+		"moment-range": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/moment-range/-/moment-range-3.1.1.tgz",
+			"integrity": "sha1-XFLPn6sp253ZvNhtN+UrBKenJxo=",
+			"requires": {
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"move-concurrently": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+			"requires": {
+				"aproba": "1.2.0",
+				"copy-concurrently": "1.0.5",
+				"fs-write-stream-atomic": "1.0.10",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"run-queue": "1.0.3"
+			}
+		},
+		"ms": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+		},
+		"multicast-dns": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
+			"integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+			"requires": {
+				"dns-packet": "1.3.1",
+				"thunky": "1.0.2"
+			}
+		},
+		"multicast-dns-service-types": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+		},
+		"multimatch": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+			"requires": {
+				"array-differ": "1.0.0",
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"minimatch": "3.0.4"
+			}
+		},
+		"nan": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+			"integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+			"optional": true
+		},
+		"nanomatch": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+			"requires": {
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"fragment-cache": "0.2.1",
+				"is-odd": "2.0.0",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.1",
+				"to-regex": "3.0.2"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+		},
+		"negotiator": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
+			}
+		},
+		"node-forge": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
+			"integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA="
+		},
+		"node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+		},
+		"node-notifier": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+			"requires": {
+				"growly": "1.3.0",
+				"semver": "5.5.0",
+				"shellwords": "0.1.1",
+				"which": "1.3.0"
+			}
+		},
+		"normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"requires": {
+				"hosted-git-info": "2.6.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.5.0",
+				"validate-npm-package-license": "3.0.3"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"requires": {
+				"remove-trailing-separator": "1.1.0"
+			}
+		},
+		"normalize-scroll-left": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz",
+			"integrity": "sha512-F9YMRls0zCF6BFIE2YnXDRpHPpfd91nOIaNdDgrx5YMoPLo8Wqj+6jNXHQsYBavJeXP4ww8HCt0xQAKc5qk2Fg=="
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"requires": {
+				"path-key": "2.0.1"
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+		},
+		"nwmatcher": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
+			"integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw=="
+		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"requires": {
+				"copy-descriptor": "0.1.1",
+				"define-property": "0.2.5",
+				"kind-of": "3.2.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				}
+			}
+		},
+		"object-keys": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"requires": {
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"requires": {
+				"define-properties": "1.1.2",
+				"es-abstract": "1.10.0"
+			}
+		},
+		"object.omit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"requires": {
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"requires": {
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"observable-to-promise": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-0.5.0.tgz",
+			"integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
+			"requires": {
+				"is-observable": "0.2.0",
+				"symbol-observable": "1.2.0"
+			},
+			"dependencies": {
+				"is-observable": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+					"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+					"requires": {
+						"symbol-observable": "0.2.4"
+					},
+					"dependencies": {
+						"symbol-observable": {
+							"version": "0.2.4",
+							"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+							"integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A="
+						}
+					}
+				}
+			}
+		},
+		"obuf": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
+			"integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4="
+		},
+		"on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"requires": {
+				"ee-first": "1.1.1"
+			}
+		},
+		"on-headers": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1.0.2"
+			}
+		},
+		"onetime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"requires": {
+				"mimic-fn": "1.2.0"
+			}
+		},
+		"opn": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/opn/-/opn-5.2.0.tgz",
+			"integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
+			"requires": {
+				"is-wsl": "1.1.0"
+			}
+		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"requires": {
+				"minimist": "0.0.8",
+				"wordwrap": "0.0.3"
+			}
+		},
+		"option-chain": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/option-chain/-/option-chain-1.0.0.tgz",
+			"integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI="
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"requires": {
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+				}
+			}
+		},
+		"original": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
+			"integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
+			"requires": {
+				"url-parse": "1.0.5"
+			},
+			"dependencies": {
+				"url-parse": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
+					"integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
+					"requires": {
+						"querystringify": "0.0.4",
+						"requires-port": "1.0.0"
+					}
+				}
+			}
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+		},
+		"os-locale": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"requires": {
+				"execa": "0.7.0",
+				"lcid": "1.0.0",
+				"mem": "1.1.0"
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+		},
+		"p-limit": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+			"requires": {
+				"p-try": "1.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"requires": {
+				"p-limit": "1.2.0"
+			}
+		},
+		"p-map": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
+		},
+		"p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+		},
+		"package-hash": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
+			"integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"lodash.flattendeep": "4.4.0",
+				"md5-hex": "2.0.0",
+				"release-zalgo": "1.0.0"
+			}
+		},
+		"package-json": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+			"requires": {
+				"got": "6.7.1",
+				"registry-auth-token": "3.3.2",
+				"registry-url": "3.1.0",
+				"semver": "5.5.0"
+			}
+		},
+		"parallel-transform": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+			"requires": {
+				"cyclist": "0.2.2",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
+			}
+		},
+		"parse-glob": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"requires": {
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
+			}
+		},
+		"parse-json": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"requires": {
+				"error-ex": "1.3.1"
+			}
+		},
+		"parse-ms": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
+			"integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0="
+		},
+		"parse5": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+		},
+		"parseurl": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+		},
+		"path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+		},
+		"path-parse": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+		},
+		"path-to-regexp": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+		},
+		"path-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"requires": {
+				"pify": "2.3.0"
+			}
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+		},
+		"pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+		},
+		"pinkie": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+			"integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q="
+		},
+		"pinkie-promise": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+			"integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+			"requires": {
+				"pinkie": "1.0.0"
+			}
+		},
+		"pkg-conf": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+			"integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+			"requires": {
+				"find-up": "2.1.0",
+				"load-json-file": "4.0.0"
+			},
+			"dependencies": {
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "4.0.0",
+						"pify": "3.0.0",
+						"strip-bom": "3.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"requires": {
+						"error-ex": "1.3.1",
+						"json-parse-better-errors": "1.0.1"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"pkg-dir": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"requires": {
+				"find-up": "2.1.0"
+			}
+		},
+		"plur": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+			"integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+			"requires": {
+				"irregular-plurals": "1.4.0"
+			}
+		},
+		"pn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+		},
+		"popper.js": {
+			"version": "1.12.9",
+			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.12.9.tgz",
+			"integrity": "sha1-DfvC3/lsRRuzMu3Pz6r1ZtMx1bM="
+		},
+		"portfinder": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
+			"integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+			"requires": {
+				"async": "1.5.2",
+				"debug": "2.6.9",
+				"mkdirp": "0.5.1"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+		},
+		"prepend-http": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+		},
+		"preserve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+		},
+		"pretty-format": {
+			"version": "22.4.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.0.tgz",
+			"integrity": "sha512-pvCxP2iODIIk9adXlo4S3GRj0BrJiil68kByAa1PrgG97c1tClh9dLMgp3Z6cHFZrclaABt0UH8PIhwHuFLqYA==",
+			"requires": {
+				"ansi-regex": "3.0.0",
+				"ansi-styles": "3.2.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				}
+			}
+		},
+		"pretty-ms": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
+			"integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
+			"requires": {
+				"parse-ms": "1.0.1",
+				"plur": "2.1.2"
+			}
+		},
+		"private": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+		},
+		"process": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+			"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+		},
+		"process-nextick-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "2.0.6"
+			}
+		},
+		"promise-inflight": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+		},
+		"prop-types": {
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			}
+		},
+		"proxy-addr": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+			"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+			"requires": {
+				"forwarded": "0.1.2",
+				"ipaddr.js": "1.6.0"
+			}
+		},
+		"prr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		},
+		"pump": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"once": "1.4.0"
+			}
+		},
+		"pumpify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
+			"integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+			"requires": {
+				"duplexify": "3.5.4",
+				"inherits": "2.0.3",
+				"pump": "2.0.1"
+			}
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+		},
+		"qs": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+		},
+		"querystringify": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+			"integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw="
+		},
+		"rafl": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/rafl/-/rafl-1.2.2.tgz",
+			"integrity": "sha1-/pMPdYIRAg1H44gV9Rlqi+QVB0A=",
+			"requires": {
+				"global": "4.3.2"
+			}
+		},
+		"randomatic": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
+		"range-parser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+		},
+		"raw-body": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+			"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+			"requires": {
+				"bytes": "3.0.0",
+				"http-errors": "1.6.2",
+				"iconv-lite": "0.4.19",
+				"unpipe": "1.0.0"
+			}
+		},
+		"rc": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
+			"integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
+			"requires": {
+				"deep-extend": "0.4.2",
+				"ini": "1.3.5",
+				"minimist": "1.2.0",
+				"strip-json-comments": "2.0.1"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"react": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
+			"integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
+			}
+		},
+		"react-dom": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
+			"integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
+			}
+		},
+		"react-event-listener": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.5.3.tgz",
+			"integrity": "sha512-fTGYvhe7eTsqq0m664Km0rxKQcqLIGZWZINmy1LU0fu312tay8Mt3Twq2P5Xj1dfDVvvzT1Ql3/FDkiMPJ1MOg==",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"fbjs": "0.8.16",
+				"prop-types": "15.6.1",
+				"warning": "3.0.0"
+			}
+		},
+		"react-jss": {
+			"version": "8.3.3",
+			"resolved": "https://registry.npmjs.org/react-jss/-/react-jss-8.3.3.tgz",
+			"integrity": "sha512-4ZIDMjmC5NOREb2gWI9R14gignNiDRDy/sMwtNRXKeCv26C703Y++aYe0kqn22PGiBredaXXOsgWTVuKFhxfig==",
+			"requires": {
+				"hoist-non-react-statics": "2.5.0",
+				"jss": "9.8.0",
+				"jss-preset-default": "4.3.0",
+				"prop-types": "15.6.1",
+				"theming": "1.3.0"
+			}
+		},
+		"react-popper": {
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.7.5.tgz",
+			"integrity": "sha512-ya9dhhGCf74JTOB2uyksEHhIGw7w9tNZRUJF73lEq2h4H5JT6MBa4PdT4G+sx6fZwq+xKZAL/sVNAIuojPn7Dg==",
+			"requires": {
+				"popper.js": "1.12.9",
+				"prop-types": "15.6.1"
+			}
+		},
+		"react-redux": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+			"integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+			"requires": {
+				"hoist-non-react-statics": "2.5.0",
+				"invariant": "2.2.3",
+				"lodash": "4.17.5",
+				"lodash-es": "4.17.7",
+				"loose-envify": "1.3.1",
+				"prop-types": "15.6.1"
+			}
+		},
+		"react-scrollbar-size": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/react-scrollbar-size/-/react-scrollbar-size-2.1.0.tgz",
+			"integrity": "sha512-9dDUJvk7S48r0TRKjlKJ9e/LkLLYgc9LdQR6W21I8ZqtSrEsedPOoMji4nU3DHy7fx2l8YMScJS/N7qiloYzXQ==",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"prop-types": "15.6.1",
+				"react-event-listener": "0.5.3",
+				"stifle": "1.0.4"
+			}
+		},
+		"react-text-mask": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/react-text-mask/-/react-text-mask-5.1.0.tgz",
+			"integrity": "sha512-9YTPppMq06sbKj7WXX/pt5PE0Ck5OdckSVa7OaekH1jerW5pbfCZDzCi5bWczNKYhq7fBBDFOsfrFGSp+ufShQ==",
+			"requires": {
+				"prop-types": "15.6.1"
+			}
+		},
+		"react-transition-group": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.2.1.tgz",
+			"integrity": "sha512-q54UBM22bs/CekG8r3+vi9TugSqh0t7qcEVycaRc9M0p0aCEu+h6rp/RFiW7fHfgd1IKpd9oILFTl5QK+FpiPA==",
+			"requires": {
+				"chain-function": "1.0.0",
+				"classnames": "2.2.5",
+				"dom-helpers": "3.3.1",
+				"loose-envify": "1.3.1",
+				"prop-types": "15.6.1",
+				"warning": "3.0.0"
+			}
+		},
+		"read-pkg": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"requires": {
+				"load-json-file": "2.0.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "2.0.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"requires": {
+				"find-up": "2.1.0",
+				"read-pkg": "2.0.0"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+			"requires": {
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.0",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.0.3",
+				"util-deprecate": "1.0.2"
+			}
+		},
+		"readdirp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"minimatch": "3.0.4",
+				"readable-stream": "2.3.5",
+				"set-immediate-shim": "1.0.1"
+			}
+		},
+		"realpath-native": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
+			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+			"requires": {
+				"util.promisify": "1.0.0"
+			}
+		},
+		"recompose": {
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
+			"integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
+			"requires": {
+				"change-emitter": "0.1.6",
+				"fbjs": "0.8.16",
+				"hoist-non-react-statics": "2.5.0",
+				"symbol-observable": "1.2.0"
+			}
+		},
+		"redent": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+			"requires": {
+				"indent-string": "2.1.0",
+				"strip-indent": "1.0.1"
+			},
+			"dependencies": {
+				"indent-string": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+					"requires": {
+						"repeating": "2.0.1"
+					}
+				}
+			}
+		},
+		"redux": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"requires": {
+				"lodash": "4.17.5",
+				"lodash-es": "4.17.7",
+				"loose-envify": "1.3.1",
+				"symbol-observable": "1.2.0"
+			}
+		},
+		"redux-mock-store": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.1.tgz",
+			"integrity": "sha512-B+iZ98ESHw4EAWVLKUknQlop1OdLKOayGRmd6KavNtC0zoSsycD8hTt0hEr1eUTw2gmYJOdfBY5QAgZweTUcLQ==",
+			"requires": {
+				"lodash.isplainobject": "4.0.6"
+			}
+		},
+		"regenerate": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+		},
+		"regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+		},
+		"regex-cache": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"requires": {
+				"is-equal-shallow": "0.1.3"
+			}
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"requires": {
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
+			}
+		},
+		"regexpu-core": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"requires": {
+				"regenerate": "1.3.3",
+				"regjsgen": "0.2.0",
+				"regjsparser": "0.1.5"
+			}
+		},
+		"registry-auth-token": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+			"requires": {
+				"rc": "1.2.5",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"registry-url": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+			"requires": {
+				"rc": "1.2.5"
+			}
+		},
+		"regjsgen": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+		},
+		"regjsparser": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"requires": {
+				"jsesc": "0.5.0"
+			}
+		},
+		"release-zalgo": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+			"integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+			"requires": {
+				"es6-error": "4.1.1"
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+		},
+		"repeat-element": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+		},
+		"repeating": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"requires": {
+				"is-finite": "1.0.2"
+			}
+		},
+		"request": {
+			"version": "2.83.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+			"requires": {
+				"aws-sign2": "0.7.0",
+				"aws4": "1.6.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.6",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.2",
+				"har-validator": "5.0.3",
+				"hawk": "6.0.2",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.18",
+				"oauth-sign": "0.8.2",
+				"performance-now": "2.1.0",
+				"qs": "6.5.1",
+				"safe-buffer": "5.1.1",
+				"stringstream": "0.0.5",
+				"tough-cookie": "2.3.4",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.2.1"
+			}
+		},
+		"request-promise-core": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"requires": {
+				"request-promise-core": "1.1.1",
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.3.4"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+		},
+		"require-main-filename": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+		},
+		"require-precompiled": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
+			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo="
+		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+		},
+		"resolve": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+		},
+		"resolve-cwd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"requires": {
+				"resolve-from": "3.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"requires": {
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+		},
+		"right-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"optional": true,
+			"requires": {
+				"align-text": "0.1.4"
+			}
+		},
+		"rimraf": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"requires": {
+				"glob": "7.1.2"
+			}
+		},
+		"run-queue": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+			"requires": {
+				"aproba": "1.2.0"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"requires": {
+				"ret": "0.1.15"
+			}
+		},
+		"sane": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-2.4.1.tgz",
+			"integrity": "sha512-fW9svvNd81XzHDZyis9/tEY1bZikDGryy8Hi1BErPyNPYv47CdLseUN+tI5FBHWXEENRtj1SWtX/jBnggLaP0w==",
+			"requires": {
+				"anymatch": "1.3.2",
+				"exec-sh": "0.2.1",
+				"fb-watchman": "2.0.0",
+				"fsevents": "1.1.3",
+				"minimatch": "3.0.4",
+				"minimist": "1.2.0",
+				"walker": "1.0.7",
+				"watch": "0.18.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
+		"scroll": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/scroll/-/scroll-2.0.3.tgz",
+			"integrity": "sha512-3ncZzf8gUW739h3LeS68nSssO60O+GGjT3SxzgofQmT8PIoyHzebql9HHPJopZX8iT6TKOdwaWFMqL6LzUN3DQ==",
+			"requires": {
+				"rafl": "1.2.2"
+			}
+		},
+		"select-hose": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
+		},
+		"selfsigned": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.2.tgz",
+			"integrity": "sha1-tESVgNmZKbZbEKSDiTAaZZIIh1g=",
+			"requires": {
+				"node-forge": "0.7.1"
+			}
+		},
+		"semver": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+		},
+		"semver-diff": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+			"requires": {
+				"semver": "5.5.0"
+			}
+		},
+		"send": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+			"integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+			"requires": {
+				"debug": "2.6.9",
+				"depd": "1.1.2",
+				"destroy": "1.0.4",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "1.6.2",
+				"mime": "1.4.1",
+				"ms": "2.0.0",
+				"on-finished": "2.3.0",
+				"range-parser": "1.2.0",
+				"statuses": "1.3.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"serialize-javascript": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
+			"integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU="
+		},
+		"serve-index": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+			"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+			"requires": {
+				"accepts": "1.3.5",
+				"batch": "0.6.1",
+				"debug": "2.6.9",
+				"escape-html": "1.0.3",
+				"http-errors": "1.6.2",
+				"mime-types": "2.1.18",
+				"parseurl": "1.3.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"serve-static": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+			"integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+			"requires": {
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"parseurl": "1.3.2",
+				"send": "0.16.1"
+			}
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+		},
+		"set-getter": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+			"integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+			"requires": {
+				"to-object-path": "0.3.0"
+			}
+		},
+		"set-immediate-shim": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+		},
+		"set-value": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"requires": {
+				"extend-shallow": "2.0.1",
+				"is-extendable": "0.1.1",
+				"is-plain-object": "2.0.4",
+				"split-string": "3.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				}
+			}
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+		},
+		"setprototypeof": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"requires": {
+				"shebang-regex": "1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+		},
+		"shell-quote": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+			"requires": {
+				"array-filter": "0.0.1",
+				"array-map": "0.0.0",
+				"array-reduce": "0.0.0",
+				"jsonify": "0.0.0"
+			}
+		},
+		"shellwords": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
+		"slash": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+		},
+		"slice-ansi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0"
+			}
+		},
+		"slide": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+		},
+		"snapdragon": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
+			"integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
+			"requires": {
+				"base": "0.11.2",
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"map-cache": "0.2.2",
+				"source-map": "0.5.7",
+				"source-map-resolve": "0.5.1",
+				"use": "2.0.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"requires": {
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"snapdragon-util": "3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"sntp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+			"requires": {
+				"hoek": "4.2.1"
+			}
+		},
+		"sockjs": {
+			"version": "0.3.19",
+			"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
+			"integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
+			"requires": {
+				"faye-websocket": "0.10.0",
+				"uuid": "3.2.1"
+			}
+		},
+		"sockjs-client": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+			"integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+			"requires": {
+				"debug": "2.6.9",
+				"eventsource": "0.1.6",
+				"faye-websocket": "0.11.1",
+				"inherits": "2.0.3",
+				"json3": "3.3.2",
+				"url-parse": "1.2.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"faye-websocket": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+					"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+					"requires": {
+						"websocket-driver": "0.7.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"sort-keys": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+			"requires": {
+				"is-plain-obj": "1.1.0"
+			}
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"source-map-loader": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.3.tgz",
+			"integrity": "sha512-MYbFX9DYxmTQFfy2v8FC1XZwpwHKYxg3SK8Wb7VPBKuhDjz8gi9re2819MsG4p49HDyiOSUKlmZ+nQBArW5CGw==",
+			"requires": {
+				"async": "2.6.0",
+				"loader-utils": "0.2.17",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"loader-utils": {
+					"version": "0.2.17",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+					"requires": {
+						"big.js": "3.2.0",
+						"emojis-list": "2.1.0",
+						"json5": "0.5.1",
+						"object-assign": "4.1.1"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"source-map-resolve": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+			"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+			"requires": {
+				"atob": "2.0.3",
+				"decode-uri-component": "0.2.0",
+				"resolve-url": "0.2.1",
+				"source-map-url": "0.4.0",
+				"urix": "0.1.0"
+			}
+		},
+		"source-map-support": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
+			"integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
+			"requires": {
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+		},
+		"spdx-correct": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+			"requires": {
+				"spdx-expression-parse": "3.0.0",
+				"spdx-license-ids": "3.0.0"
+			}
+		},
+		"spdx-exceptions": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"requires": {
+				"spdx-exceptions": "2.1.0",
+				"spdx-license-ids": "3.0.0"
+			}
+		},
+		"spdx-license-ids": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+		},
+		"spdy": {
+			"version": "3.4.7",
+			"resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
+			"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+			"requires": {
+				"debug": "2.6.9",
+				"handle-thing": "1.2.5",
+				"http-deceiver": "1.2.7",
+				"safe-buffer": "5.1.1",
+				"select-hose": "2.0.0",
+				"spdy-transport": "2.0.20"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"spdy-transport": {
+			"version": "2.0.20",
+			"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
+			"integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
+			"requires": {
+				"debug": "2.6.9",
+				"detect-node": "2.0.3",
+				"hpack.js": "2.1.6",
+				"obuf": "1.1.1",
+				"readable-stream": "2.3.5",
+				"safe-buffer": "5.1.1",
+				"wbuf": "1.7.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"requires": {
+				"extend-shallow": "3.0.2"
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"sshpk": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"requires": {
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"ssri": {
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.2.4.tgz",
+			"integrity": "sha512-UnEAgMZa15973iH7cUi0AHjJn1ACDIkaMyZILoqwN6yzt+4P81I8tBc5Hl+qwi5auMplZtPQsHrPBR5vJLcQtQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"stack-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
+		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"requires": {
+				"define-property": "0.2.5",
+				"object-copy": "0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				}
+			}
+		},
+		"statuses": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+			"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+		},
+		"stifle": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/stifle/-/stifle-1.0.4.tgz",
+			"integrity": "sha1-izvN9SQZsKnHnjWtrc5QEjwdjpk="
+		},
+		"stream-each": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+			"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"stream-shift": "1.0.0"
+			}
+		},
+		"stream-shift": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+		},
+		"string-length": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+			"requires": {
+				"astral-regex": "1.0.0",
+				"strip-ansi": "4.0.0"
+			}
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
+			}
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"stringstream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+		},
+		"strip-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"requires": {
+				"ansi-regex": "3.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				}
+			}
+		},
+		"strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+		},
+		"strip-bom-buf": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
+			"integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+			"requires": {
+				"is-utf8": "0.2.1"
+			}
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+		},
+		"strip-indent": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+			"requires": {
+				"get-stdin": "4.0.1"
+			}
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+		},
+		"subarg": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+			"integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+			"requires": {
+				"minimist": "1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"supports-color": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+			"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+			"requires": {
+				"has-flag": "3.0.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				}
+			}
+		},
+		"symbol-observable": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+		},
+		"symbol-tree": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+		},
+		"tapable": {
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
+			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
+		},
+		"term-size": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+			"requires": {
+				"execa": "0.7.0"
+			}
+		},
+		"test-exclude": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.0.tgz",
+			"integrity": "sha512-8hMFzjxbPv6xSlwGhXSvOMJ/vTy3bkng+2pxmf6E1z6VF7I9nIyNfvHtaw+NBPgvz647gADBbMSbwLfZYppT/w==",
+			"requires": {
+				"arrify": "1.0.1",
+				"micromatch": "2.3.11",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"require-main-filename": "1.0.1"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+					"requires": {
+						"pinkie": "2.0.4"
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"requires": {
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"requires": {
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				}
+			}
+		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+		},
+		"theming": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/theming/-/theming-1.3.0.tgz",
+			"integrity": "sha512-ya5Ef7XDGbTPBv5ENTwrwkPUexrlPeiAg/EI9kdlUAZhNlRbCdhMKRgjNX1IcmsmiPcqDQZE6BpSaH+cr31FKw==",
+			"requires": {
+				"brcast": "3.0.1",
+				"is-function": "1.0.1",
+				"is-plain-object": "2.0.4",
+				"prop-types": "15.6.1"
+			}
+		},
+		"throat": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
+		},
+		"through2": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+			"requires": {
+				"readable-stream": "2.3.5",
+				"xtend": "4.0.1"
+			}
+		},
+		"thunky": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz",
+			"integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E="
+		},
+		"time-require": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/time-require/-/time-require-0.1.2.tgz",
+			"integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
+			"requires": {
+				"chalk": "0.4.0",
+				"date-time": "0.1.1",
+				"pretty-ms": "0.2.2",
+				"text-table": "0.2.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
+				},
+				"chalk": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+					"requires": {
+						"ansi-styles": "1.0.0",
+						"has-color": "0.1.7",
+						"strip-ansi": "0.1.1"
+					}
+				},
+				"date-time": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
+					"integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc="
+				},
+				"parse-ms": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
+					"integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4="
+				},
+				"pretty-ms": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
+					"integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
+					"requires": {
+						"parse-ms": "0.1.2"
+					}
+				},
+				"strip-ansi": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
+				}
+			}
+		},
+		"time-stamp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
+			"integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c="
+		},
+		"time-zone": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
+			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0="
+		},
+		"timed-out": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+		},
+		"tmpl": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+		},
+		"to-fast-properties": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"requires": {
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"requires": {
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				}
+			}
+		},
+		"tough-cookie": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+			"requires": {
+				"punycode": "1.4.1"
+			}
+		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"requires": {
+				"punycode": "2.1.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+				}
+			}
+		},
+		"trim-newlines": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+		},
+		"trim-off-newlines": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+		},
+		"ts-jest": {
+			"version": "22.4.1",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-22.4.1.tgz",
+			"integrity": "sha512-6D3rWDiIuuRmtnoxDK0s69VK8Zw+JTdOkG9KeqQJF1U4ODlvAXg7ZLHfjZTmRFEshitFFeSmJ/reKzufYeibWA==",
+			"requires": {
+				"babel-core": "6.26.0",
+				"babel-plugin-istanbul": "4.1.5",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-preset-jest": "22.4.1",
+				"cpx": "1.5.0",
+				"fs-extra": "4.0.3",
+				"jest-config": "22.4.2",
+				"pkg-dir": "2.0.0",
+				"yargs": "11.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"cliui": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+					"requires": {
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+				},
+				"yargs": {
+					"version": "11.0.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+					"requires": {
+						"cliui": "4.0.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "9.0.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "9.0.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+					"requires": {
+						"camelcase": "4.1.0"
+					}
+				}
+			}
+		},
+		"ts-loader": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-3.5.0.tgz",
+			"integrity": "sha512-JTia3kObhTk36wPFgy0RnkZReiusYx7Le9IhcUWRrCTcFcr6Dy1zGsFd3x8DG4gevlbN65knI8W50FfoykXcng==",
+			"requires": {
+				"chalk": "2.3.2",
+				"enhanced-resolve": "3.4.1",
+				"loader-utils": "1.1.0",
+				"micromatch": "3.1.9",
+				"semver": "5.5.0"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"braces": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
+					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+					"requires": {
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"kind-of": "6.0.2",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.1",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.1",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.1",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"micromatch": {
+					"version": "3.1.9",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
+					"integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
+					"requires": {
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.1",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.1",
+						"to-regex": "3.0.2"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"tslint-loader": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/tslint-loader/-/tslint-loader-3.6.0.tgz",
+			"integrity": "sha512-Me9Qf/87BOfCY8uJJw+J7VMF4U8WiMXKLhKKKugMydF0xMhMOt9wo2mjYTNhwbF9H7SHh8PAIwRG8roisTNekQ==",
+			"requires": {
+				"loader-utils": "1.1.0",
+				"mkdirp": "0.5.1",
+				"object-assign": "4.1.1",
+				"rimraf": "2.6.2",
+				"semver": "5.5.0"
+			}
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"optional": true
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"requires": {
+				"prelude-ls": "1.1.2"
+			}
+		},
+		"type-is": {
+			"version": "1.6.16",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+			"requires": {
+				"media-typer": "0.3.0",
+				"mime-types": "2.1.18"
+			}
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+		},
+		"ua-parser-js": {
+			"version": "0.7.17",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+		},
+		"uglify-js": {
+			"version": "2.8.29",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"optional": true,
+			"requires": {
+				"source-map": "0.5.7",
+				"uglify-to-browserify": "1.0.2",
+				"yargs": "3.10.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+					"optional": true
+				},
+				"yargs": {
+					"version": "3.10.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+					"optional": true,
+					"requires": {
+						"camelcase": "1.2.1",
+						"cliui": "2.1.0",
+						"decamelize": "1.2.0",
+						"window-size": "0.1.0"
+					}
+				}
+			}
+		},
+		"uglify-to-browserify": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"optional": true
+		},
+		"uid2": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
+		},
+		"union-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"requires": {
+				"arr-union": "3.1.0",
+				"get-value": "2.0.6",
+				"is-extendable": "0.1.1",
+				"set-value": "0.4.3"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				},
+				"set-value": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"to-object-path": "0.3.0"
+					}
+				}
+			}
+		},
+		"unique-filename": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+			"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+			"requires": {
+				"unique-slug": "2.0.0"
+			}
+		},
+		"unique-slug": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+			"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+			"requires": {
+				"imurmurhash": "0.1.4"
+			}
+		},
+		"unique-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+			"requires": {
+				"crypto-random-string": "1.0.0"
+			}
+		},
+		"unique-temp-dir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
+			"integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
+			"requires": {
+				"mkdirp": "0.5.1",
+				"os-tmpdir": "1.0.2",
+				"uid2": "0.0.3"
+			}
+		},
+		"universalify": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+		},
+		"unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+		},
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"requires": {
+				"has-value": "0.3.1",
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"requires": {
+						"get-value": "2.0.6",
+						"has-values": "0.1.4",
+						"isobject": "2.1.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"unzip-response": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+		},
+		"upath": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
+			"integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw=="
+		},
+		"update-notifier": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
+			"integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+			"requires": {
+				"boxen": "1.3.0",
+				"chalk": "2.3.2",
+				"configstore": "3.1.1",
+				"import-lazy": "2.1.0",
+				"is-installed-globally": "0.1.0",
+				"is-npm": "1.0.0",
+				"latest-version": "3.1.0",
+				"semver-diff": "2.1.0",
+				"xdg-basedir": "3.0.0"
+			}
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+		},
+		"url-parse": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
+			"integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
+			"requires": {
+				"querystringify": "1.0.0",
+				"requires-port": "1.0.0"
+			},
+			"dependencies": {
+				"querystringify": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+					"integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
+				}
+			}
+		},
+		"url-parse-lax": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+			"requires": {
+				"prepend-http": "1.0.4"
+			}
+		},
+		"use": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
+			"integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
+			"requires": {
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"lazy-cache": "2.0.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				},
+				"lazy-cache": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+					"integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+					"requires": {
+						"set-getter": "0.1.0"
+					}
+				}
+			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"util.promisify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"requires": {
+				"define-properties": "1.1.2",
+				"object.getownpropertydescriptors": "2.0.3"
+			}
+		},
+		"utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+		},
+		"uuid": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+			"requires": {
+				"spdx-correct": "3.0.0",
+				"spdx-expression-parse": "3.0.0"
+			}
+		},
+		"vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "1.3.0"
+			}
+		},
+		"w3c-hr-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"requires": {
+				"browser-process-hrtime": "0.1.2"
+			}
+		},
+		"walker": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"requires": {
+				"makeerror": "1.0.11"
+			}
+		},
+		"warning": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+			"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+			"requires": {
+				"loose-envify": "1.3.1"
+			}
+		},
+		"watch": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+			"requires": {
+				"exec-sh": "0.2.1",
+				"minimist": "1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"wbuf": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
+			"integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
+			"requires": {
+				"minimalistic-assert": "1.0.0"
+			}
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+		},
+		"webpack-dev-middleware": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
+			"integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
+			"requires": {
+				"memory-fs": "0.4.1",
+				"mime": "1.6.0",
+				"path-is-absolute": "1.0.1",
+				"range-parser": "1.2.0",
+				"time-stamp": "2.0.0"
+			},
+			"dependencies": {
+				"mime": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+				}
+			}
+		},
+		"webpack-dev-server": {
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz",
+			"integrity": "sha512-zrPoX97bx47vZiAXfDrkw8pe9QjJ+lunQl3dypojyWwWr1M5I2h0VSrMPfTjopHQPRNn+NqfjcMmhoLcUJe2gA==",
+			"requires": {
+				"ansi-html": "0.0.7",
+				"array-includes": "3.0.3",
+				"bonjour": "3.5.0",
+				"chokidar": "2.0.2",
+				"compression": "1.7.2",
+				"connect-history-api-fallback": "1.5.0",
+				"debug": "3.1.0",
+				"del": "3.0.0",
+				"express": "4.16.2",
+				"html-entities": "1.2.1",
+				"http-proxy-middleware": "0.17.4",
+				"import-local": "1.0.0",
+				"internal-ip": "1.2.0",
+				"ip": "1.1.5",
+				"killable": "1.0.0",
+				"loglevel": "1.6.1",
+				"opn": "5.2.0",
+				"portfinder": "1.0.13",
+				"selfsigned": "1.10.2",
+				"serve-index": "1.9.1",
+				"sockjs": "0.3.19",
+				"sockjs-client": "1.1.4",
+				"spdy": "3.4.7",
+				"strip-ansi": "3.0.1",
+				"supports-color": "5.3.0",
+				"webpack-dev-middleware": "1.12.2",
+				"yargs": "6.6.0"
+			},
+			"dependencies": {
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"requires": {
+						"micromatch": "3.1.9",
+						"normalize-path": "2.1.1"
+					}
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"braces": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
+					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+					"requires": {
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"kind-of": "6.0.2",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.1",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+				},
+				"chokidar": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.2.tgz",
+					"integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
+					"requires": {
+						"anymatch": "2.0.0",
+						"async-each": "1.0.1",
+						"braces": "2.3.1",
+						"fsevents": "1.1.3",
+						"glob-parent": "3.1.0",
+						"inherits": "2.0.3",
+						"is-binary-path": "1.0.1",
+						"is-glob": "4.0.0",
+						"normalize-path": "2.1.1",
+						"path-is-absolute": "1.0.1",
+						"readdirp": "2.1.0",
+						"upath": "1.0.4"
+					}
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.1",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.1",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"glob-parent": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+					"requires": {
+						"is-glob": "3.1.0",
+						"path-dirname": "1.0.2"
+					},
+					"dependencies": {
+						"is-glob": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+							"requires": {
+								"is-extglob": "2.1.1"
+							}
+						}
+					}
+				},
+				"import-local": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+					"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+					"requires": {
+						"pkg-dir": "2.0.0",
+						"resolve-cwd": "2.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-glob": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"requires": {
+						"is-extglob": "2.1.1"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "3.1.9",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
+					"integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
+					"requires": {
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.1",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.1",
+						"to-regex": "3.0.2"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"os-locale": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+					"requires": {
+						"lcid": "1.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+					"requires": {
+						"pinkie": "2.0.4"
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"requires": {
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"requires": {
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"which-module": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+				},
+				"yargs": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+					"requires": {
+						"camelcase": "3.0.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "1.4.0",
+						"read-pkg-up": "1.0.1",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "1.0.2",
+						"which-module": "1.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "4.2.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+					"requires": {
+						"camelcase": "3.0.0"
+					}
+				}
+			}
+		},
+		"websocket-driver": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+			"integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+			"requires": {
+				"http-parser-js": "0.4.11",
+				"websocket-extensions": "0.1.3"
+			}
+		},
+		"websocket-extensions": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
+		},
+		"well-known-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-1.0.0.tgz",
+			"integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg="
+		},
+		"whatwg-encoding": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"whatwg-fetch": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+		},
+		"whatwg-url": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+			"integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+			"requires": {
+				"lodash.sortby": "4.7.0",
+				"tr46": "1.0.1",
+				"webidl-conversions": "4.0.2"
+			}
+		},
+		"which": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"requires": {
+				"isexe": "2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+		},
+		"widest-line": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+			"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+			"requires": {
+				"string-width": "2.1.1"
+			}
+		},
+		"window-size": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+			"optional": true
+		},
+		"wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"requires": {
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"write-file-atomic": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"write-json-file": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
+			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
+			"requires": {
+				"detect-indent": "5.0.0",
+				"graceful-fs": "4.1.11",
+				"make-dir": "1.2.0",
+				"pify": "3.0.0",
+				"sort-keys": "2.0.0",
+				"write-file-atomic": "2.3.0"
+			},
+			"dependencies": {
+				"detect-indent": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"write-pkg": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.1.0.tgz",
+			"integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
+			"requires": {
+				"sort-keys": "2.0.0",
+				"write-json-file": "2.3.0"
+			}
+		},
+		"ws": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+			"requires": {
+				"async-limiter": "1.0.0",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"xdg-basedir": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+		},
+		"xml-name-validator": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"y18n": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+		},
+		"yargs": {
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+			"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+			"requires": {
+				"cliui": "4.0.0",
+				"decamelize": "1.2.0",
+				"find-up": "2.1.0",
+				"get-caller-file": "1.0.2",
+				"os-locale": "2.1.0",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "2.1.1",
+				"which-module": "2.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "8.1.0"
+			},
+			"dependencies": {
+				"cliui": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+					"requires": {
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+				}
+			}
+		},
+		"yargs-parser": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+			"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+			"requires": {
+				"camelcase": "4.1.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				}
+			}
+		}
+	}
 }

--- a/packages/material/package-lock.json
+++ b/packages/material/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonforms/material-renderers",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -71,6 +71,26 @@
         "slide": "1.1.6"
       }
     },
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.40",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
+      "integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "7.0.0-beta.40"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0-beta.40",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
+      "integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
     "@concordance/react": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz",
@@ -78,6 +98,7813 @@
       "dev": true,
       "requires": {
         "arrify": "1.0.1"
+      }
+    },
+    "@jsonforms/core": {
+      "version": "2.0.0-rc.3",
+      "requires": {
+        "ajv": "4.11.8",
+        "lodash": "4.17.4",
+        "redux": "3.7.2",
+        "uuid": "3.1.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.0.57",
+          "bundled": true
+        },
+        "abab": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "acorn": {
+          "version": "5.2.1",
+          "bundled": true
+        },
+        "acorn-globals": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "5.2.1"
+          }
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "array-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "boom": {
+          "version": "4.3.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "browser-process-hrtime": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "content-type-parser": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "boom": "5.2.0"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            }
+          }
+        },
+        "cssom": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "cssstyle": {
+          "version": "0.2.37",
+          "bundled": true,
+          "requires": {
+            "cssom": "0.3.2"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          }
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "document-register-element": {
+          "version": "1.7.0",
+          "bundled": true
+        },
+        "domexception": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "0.4.19"
+          }
+        },
+        "escodegen": {
+          "version": "1.9.0",
+          "bundled": true,
+          "requires": {
+            "esprima": "3.1.3",
+            "estraverse": "4.2.0",
+            "esutils": "2.0.2",
+            "optionator": "0.8.2",
+            "source-map": "0.5.7"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "3.1.3",
+              "bundled": true
+            }
+          }
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "fbjs": {
+          "version": "0.8.16",
+          "bundled": true,
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.12"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "1.2.7",
+              "bundled": true
+            }
+          }
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.3.1",
+          "bundled": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "5.5.1",
+            "har-schema": "2.0.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "5.5.1",
+              "bundled": true,
+              "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+              }
+            }
+          }
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "bundled": true,
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.0",
+            "sntp": "2.1.0"
+          }
+        },
+        "hoek": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "hoist-non-react-statics": {
+          "version": "2.3.1",
+          "bundled": true
+        },
+        "html-encoding-sniffer": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "whatwg-encoding": "1.0.3"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "bundled": true
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "node-fetch": "1.7.3",
+            "whatwg-fetch": "2.0.3"
+          }
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsdom": {
+          "version": "11.5.1",
+          "bundled": true,
+          "requires": {
+            "abab": "1.0.4",
+            "acorn": "5.2.1",
+            "acorn-globals": "4.1.0",
+            "array-equal": "1.0.0",
+            "browser-process-hrtime": "0.1.2",
+            "content-type-parser": "1.0.2",
+            "cssom": "0.3.2",
+            "cssstyle": "0.2.37",
+            "domexception": "1.0.0",
+            "escodegen": "1.9.0",
+            "html-encoding-sniffer": "1.0.2",
+            "left-pad": "1.2.0",
+            "nwmatcher": "1.4.3",
+            "parse5": "3.0.3",
+            "pn": "1.0.0",
+            "request": "2.83.0",
+            "request-promise-native": "1.0.5",
+            "sax": "1.2.4",
+            "symbol-tree": "3.2.2",
+            "tough-cookie": "2.3.3",
+            "webidl-conversions": "4.0.2",
+            "whatwg-encoding": "1.0.3",
+            "whatwg-url": "6.4.0",
+            "xml-name-validator": "2.0.1"
+          }
+        },
+        "jsdom-global": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "left-pad": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "bundled": true
+        },
+        "lodash-es": {
+          "version": "4.17.4",
+          "bundled": true
+        },
+        "lodash.isplainobject": {
+          "version": "4.0.6",
+          "bundled": true
+        },
+        "lodash.sortby": {
+          "version": "4.7.0",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "mime-db": {
+          "version": "1.30.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.30.0"
+          }
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "bundled": true,
+          "requires": {
+            "encoding": "0.1.12",
+            "is-stream": "1.1.0"
+          }
+        },
+        "nwmatcher": {
+          "version": "1.4.3",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "2.0.6",
+            "levn": "0.3.0",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "1.0.0"
+          }
+        },
+        "parse5": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "@types/node": "8.0.57"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "pn": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "promise": {
+          "version": "7.3.1",
+          "bundled": true,
+          "requires": {
+            "asap": "2.0.6"
+          }
+        },
+        "prop-types": {
+          "version": "15.6.0",
+          "bundled": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        },
+        "punycode": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "bundled": true
+        },
+        "react": {
+          "version": "16.2.0",
+          "bundled": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "react-dom": {
+          "version": "16.2.0",
+          "bundled": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "react-redux": {
+          "version": "5.0.6",
+          "bundled": true,
+          "requires": {
+            "hoist-non-react-statics": "2.3.1",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4",
+            "lodash-es": "4.17.4",
+            "loose-envify": "1.3.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "redux": {
+          "version": "3.7.2",
+          "bundled": true,
+          "requires": {
+            "lodash": "4.17.4",
+            "lodash-es": "4.17.4",
+            "loose-envify": "1.3.1",
+            "symbol-observable": "1.0.4"
+          }
+        },
+        "redux-mock-store": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "lodash.isplainobject": "4.0.6"
+          }
+        },
+        "request": {
+          "version": "2.83.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.1",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          }
+        },
+        "request-promise-core": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "request-promise-native": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "request-promise-core": "1.1.1",
+            "stealthy-require": "1.1.1",
+            "tough-cookie": "2.3.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "sntp": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true,
+          "optional": true
+        },
+        "sshpk": {
+          "version": "1.13.1",
+          "bundled": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "stealthy-require": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true
+        },
+        "symbol-observable": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "symbol-tree": {
+          "version": "3.2.2",
+          "bundled": true
+        },
+        "tough-cookie": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.4.1"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "1.4.1",
+              "bundled": true
+            }
+          }
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "punycode": "2.1.0"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "1.1.2"
+          }
+        },
+        "ua-parser-js": {
+          "version": "0.7.12",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "1.3.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "whatwg-encoding": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "0.4.19"
+          }
+        },
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "whatwg-url": {
+          "version": "6.4.0",
+          "bundled": true,
+          "requires": {
+            "lodash.sortby": "4.7.0",
+            "tr46": "1.0.1",
+            "webidl-conversions": "4.0.2"
+          }
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "xml-name-validator": {
+          "version": "2.0.1",
+          "bundled": true
+        }
+      }
+    },
+    "@jsonforms/react": {
+      "version": "2.0.0-rc.3",
+      "requires": {
+        "@jsonforms/core": "2.0.0-rc.3",
+        "lodash": "4.17.4",
+        "react": "16.2.0",
+        "react-redux": "5.0.6"
+      },
+      "dependencies": {
+        "@jsonforms/core": {
+          "version": "2.0.0-rc.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "lodash": "4.17.4",
+            "redux": "3.7.2",
+            "uuid": "3.1.0"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "8.0.57",
+              "bundled": true
+            },
+            "abab": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "acorn": {
+              "version": "5.2.1",
+              "bundled": true
+            },
+            "acorn-globals": {
+              "version": "4.1.0",
+              "bundled": true,
+              "requires": {
+                "acorn": "5.2.1"
+              }
+            },
+            "ajv": {
+              "version": "4.11.8",
+              "bundled": true,
+              "requires": {
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
+              }
+            },
+            "array-equal": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "asap": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "bundled": true
+            },
+            "aws-sign2": {
+              "version": "0.7.0",
+              "bundled": true
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "bundled": true
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "boom": {
+              "version": "4.3.1",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            },
+            "browser-process-hrtime": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true
+            },
+            "co": {
+              "version": "4.6.0",
+              "bundled": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            },
+            "content-type-parser": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "cryptiles": {
+              "version": "3.1.2",
+              "bundled": true,
+              "requires": {
+                "boom": "5.2.0"
+              },
+              "dependencies": {}
+            },
+            "cssom": {
+              "version": "0.3.2",
+              "bundled": true
+            },
+            "cssstyle": {
+              "version": "0.2.37",
+              "bundled": true,
+              "requires": {
+                "cssom": "0.3.2"
+              }
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              }
+            },
+            "deep-is": {
+              "version": "0.1.3",
+              "bundled": true
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "document-register-element": {
+              "version": "1.7.0",
+              "bundled": true
+            },
+            "domexception": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "encoding": {
+              "version": "0.1.12",
+              "bundled": true,
+              "requires": {
+                "iconv-lite": "0.4.19"
+              }
+            },
+            "escodegen": {
+              "version": "1.9.0",
+              "bundled": true,
+              "requires": {
+                "esprima": "3.1.3",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.5.7"
+              },
+              "dependencies": {}
+            },
+            "estraverse": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "bundled": true
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "extsprintf": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "fast-deep-equal": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "fast-json-stable-stringify": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "fast-levenshtein": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "fbjs": {
+              "version": "0.8.16",
+              "bundled": true,
+              "requires": {
+                "core-js": "1.2.7",
+                "isomorphic-fetch": "2.2.1",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "promise": "7.3.1",
+                "setimmediate": "1.0.5",
+                "ua-parser-js": "0.7.12"
+              },
+              "dependencies": {}
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "form-data": {
+              "version": "2.3.1",
+              "bundled": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
+              }
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              }
+            },
+            "har-schema": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "har-validator": {
+              "version": "5.0.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "5.5.1",
+                "har-schema": "2.0.0"
+              },
+              "dependencies": {}
+            },
+            "hawk": {
+              "version": "6.0.2",
+              "bundled": true,
+              "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.0",
+                "sntp": "2.1.0"
+              }
+            },
+            "hoek": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "hoist-non-react-statics": {
+              "version": "2.3.1",
+              "bundled": true
+            },
+            "html-encoding-sniffer": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "whatwg-encoding": "1.0.3"
+              }
+            },
+            "http-signature": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
+              }
+            },
+            "iconv-lite": {
+              "version": "0.4.19",
+              "bundled": true
+            },
+            "invariant": {
+              "version": "2.2.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "1.3.1"
+              }
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isomorphic-fetch": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "node-fetch": "1.7.3",
+                "whatwg-fetch": "2.0.3"
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "jsdom": {
+              "version": "11.5.1",
+              "bundled": true,
+              "requires": {
+                "abab": "1.0.4",
+                "acorn": "5.2.1",
+                "acorn-globals": "4.1.0",
+                "array-equal": "1.0.0",
+                "browser-process-hrtime": "0.1.2",
+                "content-type-parser": "1.0.2",
+                "cssom": "0.3.2",
+                "cssstyle": "0.2.37",
+                "domexception": "1.0.0",
+                "escodegen": "1.9.0",
+                "html-encoding-sniffer": "1.0.2",
+                "left-pad": "1.2.0",
+                "nwmatcher": "1.4.3",
+                "parse5": "3.0.3",
+                "pn": "1.0.0",
+                "request": "2.83.0",
+                "request-promise-native": "1.0.5",
+                "sax": "1.2.4",
+                "symbol-tree": "3.2.2",
+                "tough-cookie": "2.3.3",
+                "webidl-conversions": "4.0.2",
+                "whatwg-encoding": "1.0.3",
+                "whatwg-url": "6.4.0",
+                "xml-name-validator": "2.0.1"
+              }
+            },
+            "jsdom-global": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.3.1",
+              "bundled": true
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "jsonify": "0.0.0"
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "jsonify": {
+              "version": "0.0.0",
+              "bundled": true
+            },
+            "jsprim": {
+              "version": "1.4.1",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+              }
+            },
+            "left-pad": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "levn": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+              }
+            },
+            "lodash": {
+              "version": "4.17.4",
+              "bundled": true
+            },
+            "lodash-es": {
+              "version": "4.17.4",
+              "bundled": true
+            },
+            "lodash.isplainobject": {
+              "version": "4.0.6",
+              "bundled": true
+            },
+            "lodash.sortby": {
+              "version": "4.7.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "3.0.2"
+              }
+            },
+            "mime-db": {
+              "version": "1.30.0",
+              "bundled": true
+            },
+            "mime-types": {
+              "version": "2.1.17",
+              "bundled": true,
+              "requires": {
+                "mime-db": "1.30.0"
+              }
+            },
+            "node-fetch": {
+              "version": "1.7.3",
+              "bundled": true,
+              "requires": {
+                "encoding": "0.1.12",
+                "is-stream": "1.1.0"
+              }
+            },
+            "nwmatcher": {
+              "version": "1.4.3",
+              "bundled": true
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "optionator": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
+              }
+            },
+            "parse5": {
+              "version": "3.0.3",
+              "bundled": true,
+              "requires": {
+                "@types/node": "8.0.57"
+              }
+            },
+            "performance-now": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "pn": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "promise": {
+              "version": "7.3.1",
+              "bundled": true,
+              "requires": {
+                "asap": "2.0.6"
+              }
+            },
+            "prop-types": {
+              "version": "15.6.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1"
+              }
+            },
+            "punycode": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "qs": {
+              "version": "6.5.1",
+              "bundled": true
+            },
+            "react": {
+              "version": "16.2.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "react-dom": {
+              "version": "16.2.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "react-redux": {
+              "version": "5.0.6",
+              "bundled": true,
+              "requires": {
+                "hoist-non-react-statics": "2.3.1",
+                "invariant": "2.2.2",
+                "lodash": "4.17.4",
+                "lodash-es": "4.17.4",
+                "loose-envify": "1.3.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "redux": {
+              "version": "3.7.2",
+              "bundled": true,
+              "requires": {
+                "lodash": "4.17.4",
+                "lodash-es": "4.17.4",
+                "loose-envify": "1.3.1",
+                "symbol-observable": "1.0.4"
+              }
+            },
+            "redux-mock-store": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "lodash.isplainobject": "4.0.6"
+              }
+            },
+            "request": {
+              "version": "2.83.0",
+              "bundled": true,
+              "requires": {
+                "aws-sign2": "0.7.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.1",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.1.0"
+              }
+            },
+            "request-promise-core": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "lodash": "4.17.4"
+              }
+            },
+            "request-promise-native": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "request-promise-core": "1.1.1",
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.3.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true
+            },
+            "setimmediate": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "sntp": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true,
+              "optional": true
+            },
+            "sshpk": {
+              "version": "1.13.1",
+              "bundled": true,
+              "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "stealthy-require": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true
+            },
+            "symbol-observable": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "symbol-tree": {
+              "version": "3.2.2",
+              "bundled": true
+            },
+            "tough-cookie": {
+              "version": "2.3.3",
+              "bundled": true,
+              "requires": {
+                "punycode": "1.4.1"
+              },
+              "dependencies": {}
+            },
+            "tr46": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "punycode": "2.1.0"
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "bundled": true,
+              "optional": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "1.1.2"
+              }
+            },
+            "ua-parser-js": {
+              "version": "0.7.12",
+              "bundled": true
+            },
+            "uuid": {
+              "version": "3.1.0",
+              "bundled": true
+            },
+            "verror": {
+              "version": "1.10.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+              }
+            },
+            "webidl-conversions": {
+              "version": "4.0.2",
+              "bundled": true
+            },
+            "whatwg-encoding": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "iconv-lite": "0.4.19"
+              }
+            },
+            "whatwg-fetch": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "whatwg-url": {
+              "version": "6.4.0",
+              "bundled": true,
+              "requires": {
+                "lodash.sortby": "4.7.0",
+                "tr46": "1.0.1",
+                "webidl-conversions": "4.0.2"
+              }
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "xml-name-validator": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "abab": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "acorn": {
+          "version": "5.4.1",
+          "bundled": true
+        },
+        "acorn-globals": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "5.4.1"
+          }
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "bundled": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "array-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "async-limiter": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "boom": {
+          "version": "4.3.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "browser-process-hrtime": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "content-type-parser": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "boom": "5.2.0"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            }
+          }
+        },
+        "cssom": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "cssstyle": {
+          "version": "0.2.37",
+          "bundled": true,
+          "requires": {
+            "cssom": "0.3.2"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          }
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "document-register-element": {
+          "version": "1.7.2",
+          "bundled": true,
+          "requires": {
+            "lightercollective": "0.0.0"
+          }
+        },
+        "domexception": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "webidl-conversions": "4.0.2"
+          }
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "0.4.19"
+          }
+        },
+        "escodegen": {
+          "version": "1.9.0",
+          "bundled": true,
+          "requires": {
+            "esprima": "3.1.3",
+            "estraverse": "4.2.0",
+            "esutils": "2.0.2",
+            "optionator": "0.8.2",
+            "source-map": "0.5.7"
+          }
+        },
+        "esprima": {
+          "version": "3.1.3",
+          "bundled": true
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "fbjs": {
+          "version": "0.8.16",
+          "bundled": true,
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.17"
+          }
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.3.1",
+          "bundled": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
+          }
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "bundled": true,
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.0",
+            "sntp": "2.1.0"
+          }
+        },
+        "hoek": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "hoist-non-react-statics": {
+          "version": "2.3.1",
+          "bundled": true
+        },
+        "html-encoding-sniffer": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "whatwg-encoding": "1.0.3"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "bundled": true
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "node-fetch": "1.7.3",
+            "whatwg-fetch": "2.0.3"
+          }
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsdom": {
+          "version": "11.6.2",
+          "bundled": true,
+          "requires": {
+            "abab": "1.0.4",
+            "acorn": "5.4.1",
+            "acorn-globals": "4.1.0",
+            "array-equal": "1.0.0",
+            "browser-process-hrtime": "0.1.2",
+            "content-type-parser": "1.0.2",
+            "cssom": "0.3.2",
+            "cssstyle": "0.2.37",
+            "domexception": "1.0.1",
+            "escodegen": "1.9.0",
+            "html-encoding-sniffer": "1.0.2",
+            "left-pad": "1.2.0",
+            "nwmatcher": "1.4.3",
+            "parse5": "4.0.0",
+            "pn": "1.1.0",
+            "request": "2.83.0",
+            "request-promise-native": "1.0.5",
+            "sax": "1.2.4",
+            "symbol-tree": "3.2.2",
+            "tough-cookie": "2.3.3",
+            "w3c-hr-time": "1.0.1",
+            "webidl-conversions": "4.0.2",
+            "whatwg-encoding": "1.0.3",
+            "whatwg-url": "6.4.0",
+            "ws": "4.0.0",
+            "xml-name-validator": "3.0.0"
+          }
+        },
+        "jsdom-global": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "left-pad": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2"
+          }
+        },
+        "lightercollective": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "bundled": true
+        },
+        "lodash-es": {
+          "version": "4.17.4",
+          "bundled": true
+        },
+        "lodash.isplainobject": {
+          "version": "4.0.6",
+          "bundled": true
+        },
+        "lodash.sortby": {
+          "version": "4.7.0",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "mime-db": {
+          "version": "1.30.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.30.0"
+          }
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "bundled": true,
+          "requires": {
+            "encoding": "0.1.12",
+            "is-stream": "1.1.0"
+          }
+        },
+        "nwmatcher": {
+          "version": "1.4.3",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "2.0.6",
+            "levn": "0.3.0",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "1.0.0"
+          }
+        },
+        "parse5": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "pn": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "promise": {
+          "version": "7.3.1",
+          "bundled": true,
+          "requires": {
+            "asap": "2.0.6"
+          }
+        },
+        "prop-types": {
+          "version": "15.6.0",
+          "bundled": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "bundled": true
+        },
+        "react": {
+          "version": "16.2.0",
+          "bundled": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "react-dom": {
+          "version": "16.2.0",
+          "bundled": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "react-redux": {
+          "version": "5.0.6",
+          "bundled": true,
+          "requires": {
+            "hoist-non-react-statics": "2.3.1",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4",
+            "lodash-es": "4.17.4",
+            "loose-envify": "1.3.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "redux": {
+          "version": "3.7.2",
+          "bundled": true,
+          "requires": {
+            "lodash": "4.17.4",
+            "lodash-es": "4.17.4",
+            "loose-envify": "1.3.1",
+            "symbol-observable": "1.2.0"
+          }
+        },
+        "redux-mock-store": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "lodash.isplainobject": "4.0.6"
+          }
+        },
+        "request": {
+          "version": "2.83.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.1",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
+          }
+        },
+        "request-promise-core": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "request-promise-native": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "request-promise-core": "1.1.1",
+            "stealthy-require": "1.1.1",
+            "tough-cookie": "2.3.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "sntp": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true,
+          "optional": true
+        },
+        "sshpk": {
+          "version": "1.13.1",
+          "bundled": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "stealthy-require": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true
+        },
+        "symbol-observable": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "symbol-tree": {
+          "version": "3.2.2",
+          "bundled": true
+        },
+        "tough-cookie": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "punycode": "2.1.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "2.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "1.1.2"
+          }
+        },
+        "ua-parser-js": {
+          "version": "0.7.17",
+          "bundled": true
+        },
+        "ultron": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "1.3.0"
+          }
+        },
+        "w3c-hr-time": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "browser-process-hrtime": "0.1.2"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "whatwg-encoding": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "0.4.19"
+          }
+        },
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "whatwg-url": {
+          "version": "6.4.0",
+          "bundled": true,
+          "requires": {
+            "lodash.sortby": "4.7.0",
+            "tr46": "1.0.1",
+            "webidl-conversions": "4.0.2"
+          }
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ws": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.1",
+            "ultron": "1.1.1"
+          }
+        },
+        "xml-name-validator": {
+          "version": "3.0.0",
+          "bundled": true
+        }
+      }
+    },
+    "@jsonforms/test": {
+      "version": "2.0.0-rc.3",
+      "dev": true,
+      "dependencies": {
+        "@jsonforms/core": {
+          "bundled": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "lodash": "4.17.4",
+            "redux": "3.7.2",
+            "uuid": "3.1.0"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "8.0.57",
+              "bundled": true
+            },
+            "abab": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "acorn": {
+              "version": "5.2.1",
+              "bundled": true
+            },
+            "acorn-globals": {
+              "version": "4.1.0",
+              "bundled": true,
+              "requires": {
+                "acorn": "5.2.1"
+              }
+            },
+            "ajv": {
+              "version": "4.11.8",
+              "bundled": true,
+              "requires": {
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
+              }
+            },
+            "array-equal": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "asap": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "bundled": true
+            },
+            "aws-sign2": {
+              "version": "0.7.0",
+              "bundled": true
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "bundled": true
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "boom": {
+              "version": "4.3.1",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            },
+            "browser-process-hrtime": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true
+            },
+            "co": {
+              "version": "4.6.0",
+              "bundled": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            },
+            "content-type-parser": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "cryptiles": {
+              "version": "3.1.2",
+              "bundled": true,
+              "requires": {
+                "boom": "5.2.0"
+              },
+              "dependencies": {}
+            },
+            "cssom": {
+              "version": "0.3.2",
+              "bundled": true
+            },
+            "cssstyle": {
+              "version": "0.2.37",
+              "bundled": true,
+              "requires": {
+                "cssom": "0.3.2"
+              }
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              }
+            },
+            "deep-is": {
+              "version": "0.1.3",
+              "bundled": true
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "document-register-element": {
+              "version": "1.7.0",
+              "bundled": true
+            },
+            "domexception": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "encoding": {
+              "version": "0.1.12",
+              "bundled": true,
+              "requires": {
+                "iconv-lite": "0.4.19"
+              }
+            },
+            "escodegen": {
+              "version": "1.9.0",
+              "bundled": true,
+              "requires": {
+                "esprima": "3.1.3",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.5.7"
+              },
+              "dependencies": {}
+            },
+            "estraverse": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "bundled": true
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "extsprintf": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "fast-deep-equal": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "fast-json-stable-stringify": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "fast-levenshtein": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "fbjs": {
+              "version": "0.8.16",
+              "bundled": true,
+              "requires": {
+                "core-js": "1.2.7",
+                "isomorphic-fetch": "2.2.1",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "promise": "7.3.1",
+                "setimmediate": "1.0.5",
+                "ua-parser-js": "0.7.12"
+              },
+              "dependencies": {}
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "form-data": {
+              "version": "2.3.1",
+              "bundled": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
+              }
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              }
+            },
+            "har-schema": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "har-validator": {
+              "version": "5.0.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "5.5.1",
+                "har-schema": "2.0.0"
+              },
+              "dependencies": {}
+            },
+            "hawk": {
+              "version": "6.0.2",
+              "bundled": true,
+              "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.0",
+                "sntp": "2.1.0"
+              }
+            },
+            "hoek": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "hoist-non-react-statics": {
+              "version": "2.3.1",
+              "bundled": true
+            },
+            "html-encoding-sniffer": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "whatwg-encoding": "1.0.3"
+              }
+            },
+            "http-signature": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
+              }
+            },
+            "iconv-lite": {
+              "version": "0.4.19",
+              "bundled": true
+            },
+            "invariant": {
+              "version": "2.2.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "1.3.1"
+              }
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isomorphic-fetch": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "node-fetch": "1.7.3",
+                "whatwg-fetch": "2.0.3"
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "jsdom": {
+              "version": "11.5.1",
+              "bundled": true,
+              "requires": {
+                "abab": "1.0.4",
+                "acorn": "5.2.1",
+                "acorn-globals": "4.1.0",
+                "array-equal": "1.0.0",
+                "browser-process-hrtime": "0.1.2",
+                "content-type-parser": "1.0.2",
+                "cssom": "0.3.2",
+                "cssstyle": "0.2.37",
+                "domexception": "1.0.0",
+                "escodegen": "1.9.0",
+                "html-encoding-sniffer": "1.0.2",
+                "left-pad": "1.2.0",
+                "nwmatcher": "1.4.3",
+                "parse5": "3.0.3",
+                "pn": "1.0.0",
+                "request": "2.83.0",
+                "request-promise-native": "1.0.5",
+                "sax": "1.2.4",
+                "symbol-tree": "3.2.2",
+                "tough-cookie": "2.3.3",
+                "webidl-conversions": "4.0.2",
+                "whatwg-encoding": "1.0.3",
+                "whatwg-url": "6.4.0",
+                "xml-name-validator": "2.0.1"
+              }
+            },
+            "jsdom-global": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.3.1",
+              "bundled": true
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "jsonify": "0.0.0"
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "jsonify": {
+              "version": "0.0.0",
+              "bundled": true
+            },
+            "jsprim": {
+              "version": "1.4.1",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+              }
+            },
+            "left-pad": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "levn": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+              }
+            },
+            "lodash": {
+              "version": "4.17.4",
+              "bundled": true
+            },
+            "lodash-es": {
+              "version": "4.17.4",
+              "bundled": true
+            },
+            "lodash.isplainobject": {
+              "version": "4.0.6",
+              "bundled": true
+            },
+            "lodash.sortby": {
+              "version": "4.7.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "3.0.2"
+              }
+            },
+            "mime-db": {
+              "version": "1.30.0",
+              "bundled": true
+            },
+            "mime-types": {
+              "version": "2.1.17",
+              "bundled": true,
+              "requires": {
+                "mime-db": "1.30.0"
+              }
+            },
+            "node-fetch": {
+              "version": "1.7.3",
+              "bundled": true,
+              "requires": {
+                "encoding": "0.1.12",
+                "is-stream": "1.1.0"
+              }
+            },
+            "nwmatcher": {
+              "version": "1.4.3",
+              "bundled": true
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "optionator": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
+              }
+            },
+            "parse5": {
+              "version": "3.0.3",
+              "bundled": true,
+              "requires": {
+                "@types/node": "8.0.57"
+              }
+            },
+            "performance-now": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "pn": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "promise": {
+              "version": "7.3.1",
+              "bundled": true,
+              "requires": {
+                "asap": "2.0.6"
+              }
+            },
+            "prop-types": {
+              "version": "15.6.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1"
+              }
+            },
+            "punycode": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "qs": {
+              "version": "6.5.1",
+              "bundled": true
+            },
+            "react": {
+              "version": "16.2.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "react-dom": {
+              "version": "16.2.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "react-redux": {
+              "version": "5.0.6",
+              "bundled": true,
+              "requires": {
+                "hoist-non-react-statics": "2.3.1",
+                "invariant": "2.2.2",
+                "lodash": "4.17.4",
+                "lodash-es": "4.17.4",
+                "loose-envify": "1.3.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "redux": {
+              "version": "3.7.2",
+              "bundled": true,
+              "requires": {
+                "lodash": "4.17.4",
+                "lodash-es": "4.17.4",
+                "loose-envify": "1.3.1",
+                "symbol-observable": "1.0.4"
+              }
+            },
+            "redux-mock-store": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "lodash.isplainobject": "4.0.6"
+              }
+            },
+            "request": {
+              "version": "2.83.0",
+              "bundled": true,
+              "requires": {
+                "aws-sign2": "0.7.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.1",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.1.0"
+              }
+            },
+            "request-promise-core": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "lodash": "4.17.4"
+              }
+            },
+            "request-promise-native": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "request-promise-core": "1.1.1",
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.3.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true
+            },
+            "setimmediate": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "sntp": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true,
+              "optional": true
+            },
+            "sshpk": {
+              "version": "1.13.1",
+              "bundled": true,
+              "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "stealthy-require": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true
+            },
+            "symbol-observable": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "symbol-tree": {
+              "version": "3.2.2",
+              "bundled": true
+            },
+            "tough-cookie": {
+              "version": "2.3.3",
+              "bundled": true,
+              "requires": {
+                "punycode": "1.4.1"
+              },
+              "dependencies": {}
+            },
+            "tr46": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "punycode": "2.1.0"
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "bundled": true,
+              "optional": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "1.1.2"
+              }
+            },
+            "ua-parser-js": {
+              "version": "0.7.12",
+              "bundled": true
+            },
+            "uuid": {
+              "version": "3.1.0",
+              "bundled": true
+            },
+            "verror": {
+              "version": "1.10.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+              }
+            },
+            "webidl-conversions": {
+              "version": "4.0.2",
+              "bundled": true
+            },
+            "whatwg-encoding": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "iconv-lite": "0.4.19"
+              }
+            },
+            "whatwg-fetch": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "whatwg-url": {
+              "version": "6.4.0",
+              "bundled": true,
+              "requires": {
+                "lodash.sortby": "4.7.0",
+                "tr46": "1.0.1",
+                "webidl-conversions": "4.0.2"
+              }
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "xml-name-validator": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "@jsonforms/react": {
+          "bundled": true,
+          "requires": {
+            "@jsonforms/core": "2.0.0-rc.3",
+            "lodash": "4.17.4",
+            "react": "16.2.0",
+            "react-redux": "5.0.6"
+          },
+          "dependencies": {
+            "@jsonforms/core": {
+              "version": "2.0.0-rc.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "4.11.8",
+                "lodash": "4.17.4",
+                "redux": "3.7.2",
+                "uuid": "3.1.0"
+              },
+              "dependencies": {}
+            },
+            "abab": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "acorn": {
+              "version": "5.4.1",
+              "bundled": true
+            },
+            "acorn-globals": {
+              "version": "4.1.0",
+              "bundled": true,
+              "requires": {
+                "acorn": "5.4.1"
+              }
+            },
+            "ajv": {
+              "version": "5.5.2",
+              "bundled": true,
+              "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+              }
+            },
+            "array-equal": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "asap": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "async-limiter": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "bundled": true
+            },
+            "aws-sign2": {
+              "version": "0.7.0",
+              "bundled": true
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "bundled": true
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "boom": {
+              "version": "4.3.1",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            },
+            "browser-process-hrtime": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true
+            },
+            "co": {
+              "version": "4.6.0",
+              "bundled": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            },
+            "content-type-parser": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "core-js": {
+              "version": "1.2.7",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "cryptiles": {
+              "version": "3.1.2",
+              "bundled": true,
+              "requires": {
+                "boom": "5.2.0"
+              },
+              "dependencies": {}
+            },
+            "cssom": {
+              "version": "0.3.2",
+              "bundled": true
+            },
+            "cssstyle": {
+              "version": "0.2.37",
+              "bundled": true,
+              "requires": {
+                "cssom": "0.3.2"
+              }
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              }
+            },
+            "deep-is": {
+              "version": "0.1.3",
+              "bundled": true
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "document-register-element": {
+              "version": "1.7.2",
+              "bundled": true,
+              "requires": {
+                "lightercollective": "0.0.0"
+              }
+            },
+            "domexception": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "webidl-conversions": "4.0.2"
+              }
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "encoding": {
+              "version": "0.1.12",
+              "bundled": true,
+              "requires": {
+                "iconv-lite": "0.4.19"
+              }
+            },
+            "escodegen": {
+              "version": "1.9.0",
+              "bundled": true,
+              "requires": {
+                "esprima": "3.1.3",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.5.7"
+              }
+            },
+            "esprima": {
+              "version": "3.1.3",
+              "bundled": true
+            },
+            "estraverse": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "bundled": true
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "extsprintf": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "fast-deep-equal": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "fast-json-stable-stringify": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "fast-levenshtein": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "fbjs": {
+              "version": "0.8.16",
+              "bundled": true,
+              "requires": {
+                "core-js": "1.2.7",
+                "isomorphic-fetch": "2.2.1",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "promise": "7.3.1",
+                "setimmediate": "1.0.5",
+                "ua-parser-js": "0.7.17"
+              }
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "form-data": {
+              "version": "2.3.1",
+              "bundled": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
+              }
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              }
+            },
+            "har-schema": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "har-validator": {
+              "version": "5.0.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
+              }
+            },
+            "hawk": {
+              "version": "6.0.2",
+              "bundled": true,
+              "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.0",
+                "sntp": "2.1.0"
+              }
+            },
+            "hoek": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "hoist-non-react-statics": {
+              "version": "2.3.1",
+              "bundled": true
+            },
+            "html-encoding-sniffer": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "whatwg-encoding": "1.0.3"
+              }
+            },
+            "http-signature": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
+              }
+            },
+            "iconv-lite": {
+              "version": "0.4.19",
+              "bundled": true
+            },
+            "invariant": {
+              "version": "2.2.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "1.3.1"
+              }
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isomorphic-fetch": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "node-fetch": "1.7.3",
+                "whatwg-fetch": "2.0.3"
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "jsdom": {
+              "version": "11.6.2",
+              "bundled": true,
+              "requires": {
+                "abab": "1.0.4",
+                "acorn": "5.4.1",
+                "acorn-globals": "4.1.0",
+                "array-equal": "1.0.0",
+                "browser-process-hrtime": "0.1.2",
+                "content-type-parser": "1.0.2",
+                "cssom": "0.3.2",
+                "cssstyle": "0.2.37",
+                "domexception": "1.0.1",
+                "escodegen": "1.9.0",
+                "html-encoding-sniffer": "1.0.2",
+                "left-pad": "1.2.0",
+                "nwmatcher": "1.4.3",
+                "parse5": "4.0.0",
+                "pn": "1.1.0",
+                "request": "2.83.0",
+                "request-promise-native": "1.0.5",
+                "sax": "1.2.4",
+                "symbol-tree": "3.2.2",
+                "tough-cookie": "2.3.3",
+                "w3c-hr-time": "1.0.1",
+                "webidl-conversions": "4.0.2",
+                "whatwg-encoding": "1.0.3",
+                "whatwg-url": "6.4.0",
+                "ws": "4.0.0",
+                "xml-name-validator": "3.0.0"
+              }
+            },
+            "jsdom-global": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.3.1",
+              "bundled": true
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "jsprim": {
+              "version": "1.4.1",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+              }
+            },
+            "left-pad": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "levn": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+              }
+            },
+            "lightercollective": {
+              "version": "0.0.0",
+              "bundled": true
+            },
+            "lodash": {
+              "version": "4.17.4",
+              "bundled": true
+            },
+            "lodash-es": {
+              "version": "4.17.4",
+              "bundled": true
+            },
+            "lodash.isplainobject": {
+              "version": "4.0.6",
+              "bundled": true
+            },
+            "lodash.sortby": {
+              "version": "4.7.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "3.0.2"
+              }
+            },
+            "mime-db": {
+              "version": "1.30.0",
+              "bundled": true
+            },
+            "mime-types": {
+              "version": "2.1.17",
+              "bundled": true,
+              "requires": {
+                "mime-db": "1.30.0"
+              }
+            },
+            "node-fetch": {
+              "version": "1.7.3",
+              "bundled": true,
+              "requires": {
+                "encoding": "0.1.12",
+                "is-stream": "1.1.0"
+              }
+            },
+            "nwmatcher": {
+              "version": "1.4.3",
+              "bundled": true
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "optionator": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
+              }
+            },
+            "parse5": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "performance-now": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "pn": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "promise": {
+              "version": "7.3.1",
+              "bundled": true,
+              "requires": {
+                "asap": "2.0.6"
+              }
+            },
+            "prop-types": {
+              "version": "15.6.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1"
+              }
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "bundled": true
+            },
+            "qs": {
+              "version": "6.5.1",
+              "bundled": true
+            },
+            "react": {
+              "version": "16.2.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "react-dom": {
+              "version": "16.2.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "react-redux": {
+              "version": "5.0.6",
+              "bundled": true,
+              "requires": {
+                "hoist-non-react-statics": "2.3.1",
+                "invariant": "2.2.2",
+                "lodash": "4.17.4",
+                "lodash-es": "4.17.4",
+                "loose-envify": "1.3.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "redux": {
+              "version": "3.7.2",
+              "bundled": true,
+              "requires": {
+                "lodash": "4.17.4",
+                "lodash-es": "4.17.4",
+                "loose-envify": "1.3.1",
+                "symbol-observable": "1.2.0"
+              }
+            },
+            "redux-mock-store": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "lodash.isplainobject": "4.0.6"
+              }
+            },
+            "request": {
+              "version": "2.83.0",
+              "bundled": true,
+              "requires": {
+                "aws-sign2": "0.7.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.1",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.2.1"
+              }
+            },
+            "request-promise-core": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "lodash": "4.17.4"
+              }
+            },
+            "request-promise-native": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "request-promise-core": "1.1.1",
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.3.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true
+            },
+            "setimmediate": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "sntp": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true,
+              "optional": true
+            },
+            "sshpk": {
+              "version": "1.13.1",
+              "bundled": true,
+              "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "stealthy-require": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true
+            },
+            "symbol-observable": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "symbol-tree": {
+              "version": "3.2.2",
+              "bundled": true
+            },
+            "tough-cookie": {
+              "version": "2.3.3",
+              "bundled": true,
+              "requires": {
+                "punycode": "1.4.1"
+              }
+            },
+            "tr46": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "punycode": "2.1.0"
+              },
+              "dependencies": {}
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "bundled": true,
+              "optional": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "1.1.2"
+              }
+            },
+            "ua-parser-js": {
+              "version": "0.7.17",
+              "bundled": true
+            },
+            "ultron": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "uuid": {
+              "version": "3.2.1",
+              "bundled": true
+            },
+            "verror": {
+              "version": "1.10.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+              }
+            },
+            "w3c-hr-time": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "browser-process-hrtime": "0.1.2"
+              }
+            },
+            "webidl-conversions": {
+              "version": "4.0.2",
+              "bundled": true
+            },
+            "whatwg-encoding": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "iconv-lite": "0.4.19"
+              }
+            },
+            "whatwg-fetch": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "whatwg-url": {
+              "version": "6.4.0",
+              "bundled": true,
+              "requires": {
+                "lodash.sortby": "4.7.0",
+                "tr46": "1.0.1",
+                "webidl-conversions": "4.0.2"
+              }
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "ws": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "async-limiter": "1.0.0",
+                "safe-buffer": "5.1.1",
+                "ultron": "1.1.1"
+              }
+            },
+            "xml-name-validator": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "@types/node": {
+          "version": "8.5.7",
+          "bundled": true
+        },
+        "abab": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "acorn": {
+          "version": "5.3.0",
+          "bundled": true
+        },
+        "acorn-globals": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "5.3.0"
+          }
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "bundled": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "array-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "boom": {
+          "version": "4.3.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "browser-process-hrtime": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "content-type-parser": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "boom": "5.2.0"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            }
+          }
+        },
+        "cssom": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "cssstyle": {
+          "version": "0.2.37",
+          "bundled": true,
+          "requires": {
+            "cssom": "0.3.2"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          }
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "document-register-element": {
+          "version": "1.7.0",
+          "bundled": true
+        },
+        "domexception": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "0.4.19"
+          }
+        },
+        "escodegen": {
+          "version": "1.9.0",
+          "bundled": true,
+          "requires": {
+            "esprima": "3.1.3",
+            "estraverse": "4.2.0",
+            "esutils": "2.0.2",
+            "optionator": "0.8.2",
+            "source-map": "0.5.7"
+          }
+        },
+        "esprima": {
+          "version": "3.1.3",
+          "bundled": true
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "fbjs": {
+          "version": "0.8.16",
+          "bundled": true,
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.17"
+          }
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.3.1",
+          "bundled": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
+          }
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "bundled": true,
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.0",
+            "sntp": "2.1.0"
+          }
+        },
+        "hoek": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "hoist-non-react-statics": {
+          "version": "2.3.1",
+          "bundled": true
+        },
+        "html-encoding-sniffer": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "whatwg-encoding": "1.0.3"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "bundled": true
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "node-fetch": "1.7.3",
+            "whatwg-fetch": "2.0.3"
+          }
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsdom": {
+          "version": "11.5.1",
+          "bundled": true,
+          "requires": {
+            "abab": "1.0.4",
+            "acorn": "5.3.0",
+            "acorn-globals": "4.1.0",
+            "array-equal": "1.0.0",
+            "browser-process-hrtime": "0.1.2",
+            "content-type-parser": "1.0.2",
+            "cssom": "0.3.2",
+            "cssstyle": "0.2.37",
+            "domexception": "1.0.0",
+            "escodegen": "1.9.0",
+            "html-encoding-sniffer": "1.0.2",
+            "left-pad": "1.2.0",
+            "nwmatcher": "1.4.3",
+            "parse5": "3.0.3",
+            "pn": "1.1.0",
+            "request": "2.83.0",
+            "request-promise-native": "1.0.5",
+            "sax": "1.2.4",
+            "symbol-tree": "3.2.2",
+            "tough-cookie": "2.3.3",
+            "webidl-conversions": "4.0.2",
+            "whatwg-encoding": "1.0.3",
+            "whatwg-url": "6.4.0",
+            "xml-name-validator": "2.0.1"
+          }
+        },
+        "jsdom-global": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "left-pad": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "bundled": true
+        },
+        "lodash-es": {
+          "version": "4.17.4",
+          "bundled": true
+        },
+        "lodash.sortby": {
+          "version": "4.7.0",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "mime-db": {
+          "version": "1.30.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.30.0"
+          }
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "bundled": true,
+          "requires": {
+            "encoding": "0.1.12",
+            "is-stream": "1.1.0"
+          }
+        },
+        "nwmatcher": {
+          "version": "1.4.3",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "2.0.6",
+            "levn": "0.3.0",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "1.0.0"
+          }
+        },
+        "parse5": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "@types/node": "8.5.7"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "pn": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "promise": {
+          "version": "7.3.1",
+          "bundled": true,
+          "requires": {
+            "asap": "2.0.6"
+          }
+        },
+        "prop-types": {
+          "version": "15.6.0",
+          "bundled": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "bundled": true
+        },
+        "react": {
+          "version": "16.2.0",
+          "bundled": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "react-dom": {
+          "version": "16.2.0",
+          "bundled": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "react-redux": {
+          "version": "5.0.6",
+          "bundled": true,
+          "requires": {
+            "hoist-non-react-statics": "2.3.1",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4",
+            "lodash-es": "4.17.4",
+            "loose-envify": "1.3.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "redux": {
+          "version": "3.7.2",
+          "bundled": true,
+          "requires": {
+            "lodash": "4.17.4",
+            "lodash-es": "4.17.4",
+            "loose-envify": "1.3.1",
+            "symbol-observable": "1.1.0"
+          }
+        },
+        "request": {
+          "version": "2.83.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.1",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          }
+        },
+        "request-promise-core": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "request-promise-native": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "request-promise-core": "1.1.1",
+            "stealthy-require": "1.1.1",
+            "tough-cookie": "2.3.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "sntp": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true,
+          "optional": true
+        },
+        "sshpk": {
+          "version": "1.13.1",
+          "bundled": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "stealthy-require": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true
+        },
+        "symbol-observable": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "symbol-tree": {
+          "version": "3.2.2",
+          "bundled": true
+        },
+        "tough-cookie": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "punycode": "2.1.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "2.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "1.1.2"
+          }
+        },
+        "ua-parser-js": {
+          "version": "0.7.17",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "1.3.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "whatwg-encoding": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "0.4.19"
+          }
+        },
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "whatwg-url": {
+          "version": "6.4.0",
+          "bundled": true,
+          "requires": {
+            "lodash.sortby": "4.7.0",
+            "tr46": "1.0.1",
+            "webidl-conversions": "4.0.2"
+          }
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "xml-name-validator": {
+          "version": "2.0.1",
+          "bundled": true
+        }
+      }
+    },
+    "@jsonforms/webcomponent": {
+      "version": "2.0.0-rc.3",
+      "dev": true,
+      "requires": {
+        "@jsonforms/core": "2.0.0-rc.3",
+        "@jsonforms/react": "2.0.0-rc.3",
+        "@webcomponents/webcomponentsjs": "1.0.22",
+        "es6-shim": "0.35.3",
+        "json-refs": "2.1.7",
+        "react": "16.2.0",
+        "react-dom": "16.2.0",
+        "react-redux": "5.0.6",
+        "redux": "3.7.2"
+      },
+      "dependencies": {
+        "@jsonforms/core": {
+          "version": "2.0.0-rc.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "lodash": "4.17.4",
+            "redux": "3.7.2",
+            "uuid": "3.1.0"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "8.0.57",
+              "bundled": true
+            },
+            "abab": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "acorn": {
+              "version": "5.2.1",
+              "bundled": true
+            },
+            "acorn-globals": {
+              "version": "4.1.0",
+              "bundled": true,
+              "requires": {
+                "acorn": "5.2.1"
+              }
+            },
+            "ajv": {
+              "version": "4.11.8",
+              "bundled": true,
+              "requires": {
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
+              }
+            },
+            "array-equal": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "asap": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "bundled": true
+            },
+            "aws-sign2": {
+              "version": "0.7.0",
+              "bundled": true
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "bundled": true
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "boom": {
+              "version": "4.3.1",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            },
+            "browser-process-hrtime": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true
+            },
+            "co": {
+              "version": "4.6.0",
+              "bundled": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            },
+            "content-type-parser": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "cryptiles": {
+              "version": "3.1.2",
+              "bundled": true,
+              "requires": {
+                "boom": "5.2.0"
+              },
+              "dependencies": {}
+            },
+            "cssom": {
+              "version": "0.3.2",
+              "bundled": true
+            },
+            "cssstyle": {
+              "version": "0.2.37",
+              "bundled": true,
+              "requires": {
+                "cssom": "0.3.2"
+              }
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              }
+            },
+            "deep-is": {
+              "version": "0.1.3",
+              "bundled": true
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "document-register-element": {
+              "version": "1.7.0",
+              "bundled": true
+            },
+            "domexception": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "encoding": {
+              "version": "0.1.12",
+              "bundled": true,
+              "requires": {
+                "iconv-lite": "0.4.19"
+              }
+            },
+            "escodegen": {
+              "version": "1.9.0",
+              "bundled": true,
+              "requires": {
+                "esprima": "3.1.3",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.5.7"
+              },
+              "dependencies": {}
+            },
+            "estraverse": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "bundled": true
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "extsprintf": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "fast-deep-equal": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "fast-json-stable-stringify": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "fast-levenshtein": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "fbjs": {
+              "version": "0.8.16",
+              "bundled": true,
+              "requires": {
+                "core-js": "1.2.7",
+                "isomorphic-fetch": "2.2.1",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "promise": "7.3.1",
+                "setimmediate": "1.0.5",
+                "ua-parser-js": "0.7.12"
+              },
+              "dependencies": {}
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "form-data": {
+              "version": "2.3.1",
+              "bundled": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
+              }
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              }
+            },
+            "har-schema": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "har-validator": {
+              "version": "5.0.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "5.5.1",
+                "har-schema": "2.0.0"
+              },
+              "dependencies": {}
+            },
+            "hawk": {
+              "version": "6.0.2",
+              "bundled": true,
+              "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.0",
+                "sntp": "2.1.0"
+              }
+            },
+            "hoek": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "hoist-non-react-statics": {
+              "version": "2.3.1",
+              "bundled": true
+            },
+            "html-encoding-sniffer": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "whatwg-encoding": "1.0.3"
+              }
+            },
+            "http-signature": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
+              }
+            },
+            "iconv-lite": {
+              "version": "0.4.19",
+              "bundled": true
+            },
+            "invariant": {
+              "version": "2.2.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "1.3.1"
+              }
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isomorphic-fetch": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "node-fetch": "1.7.3",
+                "whatwg-fetch": "2.0.3"
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "jsdom": {
+              "version": "11.5.1",
+              "bundled": true,
+              "requires": {
+                "abab": "1.0.4",
+                "acorn": "5.2.1",
+                "acorn-globals": "4.1.0",
+                "array-equal": "1.0.0",
+                "browser-process-hrtime": "0.1.2",
+                "content-type-parser": "1.0.2",
+                "cssom": "0.3.2",
+                "cssstyle": "0.2.37",
+                "domexception": "1.0.0",
+                "escodegen": "1.9.0",
+                "html-encoding-sniffer": "1.0.2",
+                "left-pad": "1.2.0",
+                "nwmatcher": "1.4.3",
+                "parse5": "3.0.3",
+                "pn": "1.0.0",
+                "request": "2.83.0",
+                "request-promise-native": "1.0.5",
+                "sax": "1.2.4",
+                "symbol-tree": "3.2.2",
+                "tough-cookie": "2.3.3",
+                "webidl-conversions": "4.0.2",
+                "whatwg-encoding": "1.0.3",
+                "whatwg-url": "6.4.0",
+                "xml-name-validator": "2.0.1"
+              }
+            },
+            "jsdom-global": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.3.1",
+              "bundled": true
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "jsonify": "0.0.0"
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "jsonify": {
+              "version": "0.0.0",
+              "bundled": true
+            },
+            "jsprim": {
+              "version": "1.4.1",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+              }
+            },
+            "left-pad": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "levn": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+              }
+            },
+            "lodash": {
+              "version": "4.17.4",
+              "bundled": true
+            },
+            "lodash-es": {
+              "version": "4.17.4",
+              "bundled": true
+            },
+            "lodash.isplainobject": {
+              "version": "4.0.6",
+              "bundled": true
+            },
+            "lodash.sortby": {
+              "version": "4.7.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "3.0.2"
+              }
+            },
+            "mime-db": {
+              "version": "1.30.0",
+              "bundled": true
+            },
+            "mime-types": {
+              "version": "2.1.17",
+              "bundled": true,
+              "requires": {
+                "mime-db": "1.30.0"
+              }
+            },
+            "node-fetch": {
+              "version": "1.7.3",
+              "bundled": true,
+              "requires": {
+                "encoding": "0.1.12",
+                "is-stream": "1.1.0"
+              }
+            },
+            "nwmatcher": {
+              "version": "1.4.3",
+              "bundled": true
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "optionator": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
+              }
+            },
+            "parse5": {
+              "version": "3.0.3",
+              "bundled": true,
+              "requires": {
+                "@types/node": "8.0.57"
+              }
+            },
+            "performance-now": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "pn": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "promise": {
+              "version": "7.3.1",
+              "bundled": true,
+              "requires": {
+                "asap": "2.0.6"
+              }
+            },
+            "prop-types": {
+              "version": "15.6.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1"
+              }
+            },
+            "punycode": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "qs": {
+              "version": "6.5.1",
+              "bundled": true
+            },
+            "react": {
+              "version": "16.2.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "react-dom": {
+              "version": "16.2.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "react-redux": {
+              "version": "5.0.6",
+              "bundled": true,
+              "requires": {
+                "hoist-non-react-statics": "2.3.1",
+                "invariant": "2.2.2",
+                "lodash": "4.17.4",
+                "lodash-es": "4.17.4",
+                "loose-envify": "1.3.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "redux": {
+              "version": "3.7.2",
+              "bundled": true,
+              "requires": {
+                "lodash": "4.17.4",
+                "lodash-es": "4.17.4",
+                "loose-envify": "1.3.1",
+                "symbol-observable": "1.0.4"
+              }
+            },
+            "redux-mock-store": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "lodash.isplainobject": "4.0.6"
+              }
+            },
+            "request": {
+              "version": "2.83.0",
+              "bundled": true,
+              "requires": {
+                "aws-sign2": "0.7.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.1",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.1.0"
+              }
+            },
+            "request-promise-core": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "lodash": "4.17.4"
+              }
+            },
+            "request-promise-native": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "request-promise-core": "1.1.1",
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.3.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true
+            },
+            "setimmediate": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "sntp": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true,
+              "optional": true
+            },
+            "sshpk": {
+              "version": "1.13.1",
+              "bundled": true,
+              "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "stealthy-require": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true
+            },
+            "symbol-observable": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "symbol-tree": {
+              "version": "3.2.2",
+              "bundled": true
+            },
+            "tough-cookie": {
+              "version": "2.3.3",
+              "bundled": true,
+              "requires": {
+                "punycode": "1.4.1"
+              },
+              "dependencies": {}
+            },
+            "tr46": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "punycode": "2.1.0"
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "bundled": true,
+              "optional": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "1.1.2"
+              }
+            },
+            "ua-parser-js": {
+              "version": "0.7.12",
+              "bundled": true
+            },
+            "uuid": {
+              "version": "3.1.0",
+              "bundled": true
+            },
+            "verror": {
+              "version": "1.10.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+              }
+            },
+            "webidl-conversions": {
+              "version": "4.0.2",
+              "bundled": true
+            },
+            "whatwg-encoding": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "iconv-lite": "0.4.19"
+              }
+            },
+            "whatwg-fetch": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "whatwg-url": {
+              "version": "6.4.0",
+              "bundled": true,
+              "requires": {
+                "lodash.sortby": "4.7.0",
+                "tr46": "1.0.1",
+                "webidl-conversions": "4.0.2"
+              }
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "xml-name-validator": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "@jsonforms/react": {
+          "version": "2.0.0-rc.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@jsonforms/core": "2.0.0-rc.3",
+            "lodash": "4.17.4",
+            "react": "16.2.0",
+            "react-redux": "5.0.6"
+          },
+          "dependencies": {
+            "@jsonforms/core": {
+              "version": "2.0.0-rc.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "4.11.8",
+                "lodash": "4.17.4",
+                "redux": "3.7.2",
+                "uuid": "3.1.0"
+              },
+              "dependencies": {}
+            },
+            "abab": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "acorn": {
+              "version": "5.4.1",
+              "bundled": true
+            },
+            "acorn-globals": {
+              "version": "4.1.0",
+              "bundled": true,
+              "requires": {
+                "acorn": "5.4.1"
+              }
+            },
+            "ajv": {
+              "version": "5.5.2",
+              "bundled": true,
+              "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+              }
+            },
+            "array-equal": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "asap": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "async-limiter": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "bundled": true
+            },
+            "aws-sign2": {
+              "version": "0.7.0",
+              "bundled": true
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "bundled": true
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "boom": {
+              "version": "4.3.1",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            },
+            "browser-process-hrtime": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true
+            },
+            "co": {
+              "version": "4.6.0",
+              "bundled": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            },
+            "content-type-parser": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "core-js": {
+              "version": "1.2.7",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "cryptiles": {
+              "version": "3.1.2",
+              "bundled": true,
+              "requires": {
+                "boom": "5.2.0"
+              },
+              "dependencies": {}
+            },
+            "cssom": {
+              "version": "0.3.2",
+              "bundled": true
+            },
+            "cssstyle": {
+              "version": "0.2.37",
+              "bundled": true,
+              "requires": {
+                "cssom": "0.3.2"
+              }
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              }
+            },
+            "deep-is": {
+              "version": "0.1.3",
+              "bundled": true
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "document-register-element": {
+              "version": "1.7.2",
+              "bundled": true,
+              "requires": {
+                "lightercollective": "0.0.0"
+              }
+            },
+            "domexception": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "webidl-conversions": "4.0.2"
+              }
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "encoding": {
+              "version": "0.1.12",
+              "bundled": true,
+              "requires": {
+                "iconv-lite": "0.4.19"
+              }
+            },
+            "escodegen": {
+              "version": "1.9.0",
+              "bundled": true,
+              "requires": {
+                "esprima": "3.1.3",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.5.7"
+              }
+            },
+            "esprima": {
+              "version": "3.1.3",
+              "bundled": true
+            },
+            "estraverse": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "bundled": true
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "extsprintf": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "fast-deep-equal": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "fast-json-stable-stringify": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "fast-levenshtein": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "fbjs": {
+              "version": "0.8.16",
+              "bundled": true,
+              "requires": {
+                "core-js": "1.2.7",
+                "isomorphic-fetch": "2.2.1",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "promise": "7.3.1",
+                "setimmediate": "1.0.5",
+                "ua-parser-js": "0.7.17"
+              }
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "form-data": {
+              "version": "2.3.1",
+              "bundled": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
+              }
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              }
+            },
+            "har-schema": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "har-validator": {
+              "version": "5.0.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
+              }
+            },
+            "hawk": {
+              "version": "6.0.2",
+              "bundled": true,
+              "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.0",
+                "sntp": "2.1.0"
+              }
+            },
+            "hoek": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "hoist-non-react-statics": {
+              "version": "2.3.1",
+              "bundled": true
+            },
+            "html-encoding-sniffer": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "whatwg-encoding": "1.0.3"
+              }
+            },
+            "http-signature": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
+              }
+            },
+            "iconv-lite": {
+              "version": "0.4.19",
+              "bundled": true
+            },
+            "invariant": {
+              "version": "2.2.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "1.3.1"
+              }
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isomorphic-fetch": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "node-fetch": "1.7.3",
+                "whatwg-fetch": "2.0.3"
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "jsdom": {
+              "version": "11.6.2",
+              "bundled": true,
+              "requires": {
+                "abab": "1.0.4",
+                "acorn": "5.4.1",
+                "acorn-globals": "4.1.0",
+                "array-equal": "1.0.0",
+                "browser-process-hrtime": "0.1.2",
+                "content-type-parser": "1.0.2",
+                "cssom": "0.3.2",
+                "cssstyle": "0.2.37",
+                "domexception": "1.0.1",
+                "escodegen": "1.9.0",
+                "html-encoding-sniffer": "1.0.2",
+                "left-pad": "1.2.0",
+                "nwmatcher": "1.4.3",
+                "parse5": "4.0.0",
+                "pn": "1.1.0",
+                "request": "2.83.0",
+                "request-promise-native": "1.0.5",
+                "sax": "1.2.4",
+                "symbol-tree": "3.2.2",
+                "tough-cookie": "2.3.3",
+                "w3c-hr-time": "1.0.1",
+                "webidl-conversions": "4.0.2",
+                "whatwg-encoding": "1.0.3",
+                "whatwg-url": "6.4.0",
+                "ws": "4.0.0",
+                "xml-name-validator": "3.0.0"
+              }
+            },
+            "jsdom-global": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.3.1",
+              "bundled": true
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "jsprim": {
+              "version": "1.4.1",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+              }
+            },
+            "left-pad": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "levn": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+              }
+            },
+            "lightercollective": {
+              "version": "0.0.0",
+              "bundled": true
+            },
+            "lodash": {
+              "version": "4.17.4",
+              "bundled": true
+            },
+            "lodash-es": {
+              "version": "4.17.4",
+              "bundled": true
+            },
+            "lodash.isplainobject": {
+              "version": "4.0.6",
+              "bundled": true
+            },
+            "lodash.sortby": {
+              "version": "4.7.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "3.0.2"
+              }
+            },
+            "mime-db": {
+              "version": "1.30.0",
+              "bundled": true
+            },
+            "mime-types": {
+              "version": "2.1.17",
+              "bundled": true,
+              "requires": {
+                "mime-db": "1.30.0"
+              }
+            },
+            "node-fetch": {
+              "version": "1.7.3",
+              "bundled": true,
+              "requires": {
+                "encoding": "0.1.12",
+                "is-stream": "1.1.0"
+              }
+            },
+            "nwmatcher": {
+              "version": "1.4.3",
+              "bundled": true
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "optionator": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
+              }
+            },
+            "parse5": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "performance-now": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "pn": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "promise": {
+              "version": "7.3.1",
+              "bundled": true,
+              "requires": {
+                "asap": "2.0.6"
+              }
+            },
+            "prop-types": {
+              "version": "15.6.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1"
+              }
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "bundled": true
+            },
+            "qs": {
+              "version": "6.5.1",
+              "bundled": true
+            },
+            "react": {
+              "version": "16.2.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "react-dom": {
+              "version": "16.2.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "react-redux": {
+              "version": "5.0.6",
+              "bundled": true,
+              "requires": {
+                "hoist-non-react-statics": "2.3.1",
+                "invariant": "2.2.2",
+                "lodash": "4.17.4",
+                "lodash-es": "4.17.4",
+                "loose-envify": "1.3.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "redux": {
+              "version": "3.7.2",
+              "bundled": true,
+              "requires": {
+                "lodash": "4.17.4",
+                "lodash-es": "4.17.4",
+                "loose-envify": "1.3.1",
+                "symbol-observable": "1.2.0"
+              }
+            },
+            "redux-mock-store": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "lodash.isplainobject": "4.0.6"
+              }
+            },
+            "request": {
+              "version": "2.83.0",
+              "bundled": true,
+              "requires": {
+                "aws-sign2": "0.7.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.1",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.2.1"
+              }
+            },
+            "request-promise-core": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "lodash": "4.17.4"
+              }
+            },
+            "request-promise-native": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "request-promise-core": "1.1.1",
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.3.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true
+            },
+            "setimmediate": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "sntp": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true,
+              "optional": true
+            },
+            "sshpk": {
+              "version": "1.13.1",
+              "bundled": true,
+              "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "stealthy-require": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true
+            },
+            "symbol-observable": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "symbol-tree": {
+              "version": "3.2.2",
+              "bundled": true
+            },
+            "tough-cookie": {
+              "version": "2.3.3",
+              "bundled": true,
+              "requires": {
+                "punycode": "1.4.1"
+              }
+            },
+            "tr46": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "punycode": "2.1.0"
+              },
+              "dependencies": {}
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "bundled": true,
+              "optional": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "1.1.2"
+              }
+            },
+            "ua-parser-js": {
+              "version": "0.7.17",
+              "bundled": true
+            },
+            "ultron": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "uuid": {
+              "version": "3.2.1",
+              "bundled": true
+            },
+            "verror": {
+              "version": "1.10.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+              }
+            },
+            "w3c-hr-time": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "browser-process-hrtime": "0.1.2"
+              }
+            },
+            "webidl-conversions": {
+              "version": "4.0.2",
+              "bundled": true
+            },
+            "whatwg-encoding": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "iconv-lite": "0.4.19"
+              }
+            },
+            "whatwg-fetch": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "whatwg-url": {
+              "version": "6.4.0",
+              "bundled": true,
+              "requires": {
+                "lodash.sortby": "4.7.0",
+                "tr46": "1.0.1",
+                "webidl-conversions": "4.0.2"
+              }
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "ws": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "async-limiter": "1.0.0",
+                "safe-buffer": "5.1.1",
+                "ultron": "1.1.1"
+              }
+            },
+            "xml-name-validator": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "@jsonforms/test": {
+          "bundled": true,
+          "dependencies": {
+            "@jsonforms/core": {
+              "bundled": true,
+              "requires": {
+                "ajv": "4.11.8",
+                "lodash": "4.17.4",
+                "redux": "3.7.2",
+                "uuid": "3.1.0"
+              },
+              "dependencies": {}
+            },
+            "@jsonforms/react": {
+              "bundled": true,
+              "requires": {
+                "@jsonforms/core": "2.0.0-rc.3",
+                "lodash": "4.17.4",
+                "react": "16.2.0",
+                "react-redux": "5.0.6"
+              },
+              "dependencies": {}
+            },
+            "@types/node": {
+              "version": "8.5.7",
+              "bundled": true
+            },
+            "abab": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "acorn": {
+              "version": "5.3.0",
+              "bundled": true
+            },
+            "acorn-globals": {
+              "version": "4.1.0",
+              "bundled": true,
+              "requires": {
+                "acorn": "5.3.0"
+              }
+            },
+            "ajv": {
+              "version": "5.5.2",
+              "bundled": true,
+              "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+              }
+            },
+            "array-equal": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "asap": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "bundled": true
+            },
+            "aws-sign2": {
+              "version": "0.7.0",
+              "bundled": true
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "bundled": true
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "boom": {
+              "version": "4.3.1",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            },
+            "browser-process-hrtime": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true
+            },
+            "co": {
+              "version": "4.6.0",
+              "bundled": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            },
+            "content-type-parser": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "core-js": {
+              "version": "1.2.7",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "cryptiles": {
+              "version": "3.1.2",
+              "bundled": true,
+              "requires": {
+                "boom": "5.2.0"
+              },
+              "dependencies": {}
+            },
+            "cssom": {
+              "version": "0.3.2",
+              "bundled": true
+            },
+            "cssstyle": {
+              "version": "0.2.37",
+              "bundled": true,
+              "requires": {
+                "cssom": "0.3.2"
+              }
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              }
+            },
+            "deep-is": {
+              "version": "0.1.3",
+              "bundled": true
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "document-register-element": {
+              "version": "1.7.0",
+              "bundled": true
+            },
+            "domexception": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "encoding": {
+              "version": "0.1.12",
+              "bundled": true,
+              "requires": {
+                "iconv-lite": "0.4.19"
+              }
+            },
+            "escodegen": {
+              "version": "1.9.0",
+              "bundled": true,
+              "requires": {
+                "esprima": "3.1.3",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.5.7"
+              }
+            },
+            "esprima": {
+              "version": "3.1.3",
+              "bundled": true
+            },
+            "estraverse": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "bundled": true
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "extsprintf": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "fast-deep-equal": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "fast-json-stable-stringify": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "fast-levenshtein": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "fbjs": {
+              "version": "0.8.16",
+              "bundled": true,
+              "requires": {
+                "core-js": "1.2.7",
+                "isomorphic-fetch": "2.2.1",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "promise": "7.3.1",
+                "setimmediate": "1.0.5",
+                "ua-parser-js": "0.7.17"
+              }
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "form-data": {
+              "version": "2.3.1",
+              "bundled": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
+              }
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              }
+            },
+            "har-schema": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "har-validator": {
+              "version": "5.0.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
+              }
+            },
+            "hawk": {
+              "version": "6.0.2",
+              "bundled": true,
+              "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.0",
+                "sntp": "2.1.0"
+              }
+            },
+            "hoek": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "hoist-non-react-statics": {
+              "version": "2.3.1",
+              "bundled": true
+            },
+            "html-encoding-sniffer": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "whatwg-encoding": "1.0.3"
+              }
+            },
+            "http-signature": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
+              }
+            },
+            "iconv-lite": {
+              "version": "0.4.19",
+              "bundled": true
+            },
+            "invariant": {
+              "version": "2.2.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "1.3.1"
+              }
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isomorphic-fetch": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "node-fetch": "1.7.3",
+                "whatwg-fetch": "2.0.3"
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "jsdom": {
+              "version": "11.5.1",
+              "bundled": true,
+              "requires": {
+                "abab": "1.0.4",
+                "acorn": "5.3.0",
+                "acorn-globals": "4.1.0",
+                "array-equal": "1.0.0",
+                "browser-process-hrtime": "0.1.2",
+                "content-type-parser": "1.0.2",
+                "cssom": "0.3.2",
+                "cssstyle": "0.2.37",
+                "domexception": "1.0.0",
+                "escodegen": "1.9.0",
+                "html-encoding-sniffer": "1.0.2",
+                "left-pad": "1.2.0",
+                "nwmatcher": "1.4.3",
+                "parse5": "3.0.3",
+                "pn": "1.1.0",
+                "request": "2.83.0",
+                "request-promise-native": "1.0.5",
+                "sax": "1.2.4",
+                "symbol-tree": "3.2.2",
+                "tough-cookie": "2.3.3",
+                "webidl-conversions": "4.0.2",
+                "whatwg-encoding": "1.0.3",
+                "whatwg-url": "6.4.0",
+                "xml-name-validator": "2.0.1"
+              }
+            },
+            "jsdom-global": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.3.1",
+              "bundled": true
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "jsprim": {
+              "version": "1.4.1",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+              }
+            },
+            "left-pad": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "levn": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+              }
+            },
+            "lodash": {
+              "version": "4.17.4",
+              "bundled": true
+            },
+            "lodash-es": {
+              "version": "4.17.4",
+              "bundled": true
+            },
+            "lodash.sortby": {
+              "version": "4.7.0",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "3.0.2"
+              }
+            },
+            "mime-db": {
+              "version": "1.30.0",
+              "bundled": true
+            },
+            "mime-types": {
+              "version": "2.1.17",
+              "bundled": true,
+              "requires": {
+                "mime-db": "1.30.0"
+              }
+            },
+            "node-fetch": {
+              "version": "1.7.3",
+              "bundled": true,
+              "requires": {
+                "encoding": "0.1.12",
+                "is-stream": "1.1.0"
+              }
+            },
+            "nwmatcher": {
+              "version": "1.4.3",
+              "bundled": true
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "optionator": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
+              }
+            },
+            "parse5": {
+              "version": "3.0.3",
+              "bundled": true,
+              "requires": {
+                "@types/node": "8.5.7"
+              }
+            },
+            "performance-now": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "pn": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "promise": {
+              "version": "7.3.1",
+              "bundled": true,
+              "requires": {
+                "asap": "2.0.6"
+              }
+            },
+            "prop-types": {
+              "version": "15.6.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1"
+              }
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "bundled": true
+            },
+            "qs": {
+              "version": "6.5.1",
+              "bundled": true
+            },
+            "react": {
+              "version": "16.2.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "react-dom": {
+              "version": "16.2.0",
+              "bundled": true,
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "react-redux": {
+              "version": "5.0.6",
+              "bundled": true,
+              "requires": {
+                "hoist-non-react-statics": "2.3.1",
+                "invariant": "2.2.2",
+                "lodash": "4.17.4",
+                "lodash-es": "4.17.4",
+                "loose-envify": "1.3.1",
+                "prop-types": "15.6.0"
+              }
+            },
+            "redux": {
+              "version": "3.7.2",
+              "bundled": true,
+              "requires": {
+                "lodash": "4.17.4",
+                "lodash-es": "4.17.4",
+                "loose-envify": "1.3.1",
+                "symbol-observable": "1.1.0"
+              }
+            },
+            "request": {
+              "version": "2.83.0",
+              "bundled": true,
+              "requires": {
+                "aws-sign2": "0.7.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.1",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.1.0"
+              }
+            },
+            "request-promise-core": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "lodash": "4.17.4"
+              }
+            },
+            "request-promise-native": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "request-promise-core": "1.1.1",
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.3.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true
+            },
+            "setimmediate": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "sntp": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true,
+              "optional": true
+            },
+            "sshpk": {
+              "version": "1.13.1",
+              "bundled": true,
+              "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "stealthy-require": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true
+            },
+            "symbol-observable": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "symbol-tree": {
+              "version": "3.2.2",
+              "bundled": true
+            },
+            "tough-cookie": {
+              "version": "2.3.3",
+              "bundled": true,
+              "requires": {
+                "punycode": "1.4.1"
+              }
+            },
+            "tr46": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "punycode": "2.1.0"
+              },
+              "dependencies": {}
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "bundled": true,
+              "optional": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "1.1.2"
+              }
+            },
+            "ua-parser-js": {
+              "version": "0.7.17",
+              "bundled": true
+            },
+            "uuid": {
+              "version": "3.1.0",
+              "bundled": true
+            },
+            "verror": {
+              "version": "1.10.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+              }
+            },
+            "webidl-conversions": {
+              "version": "4.0.2",
+              "bundled": true
+            },
+            "whatwg-encoding": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "iconv-lite": "0.4.19"
+              }
+            },
+            "whatwg-fetch": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "whatwg-url": {
+              "version": "6.4.0",
+              "bundled": true,
+              "requires": {
+                "lodash.sortby": "4.7.0",
+                "tr46": "1.0.1",
+                "webidl-conversions": "4.0.2"
+              }
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "xml-name-validator": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "@types/node": {
+          "version": "9.3.0",
+          "bundled": true
+        },
+        "@webcomponents/webcomponentsjs": {
+          "version": "1.0.22",
+          "bundled": true,
+          "dev": true
+        },
+        "abab": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "acorn": {
+          "version": "5.3.0",
+          "bundled": true
+        },
+        "acorn-globals": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "5.3.0"
+          }
+        },
+        "argparse": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "sprintf-js": "1.0.3"
+          }
+        },
+        "array-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "boom": {
+          "version": "4.3.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "browser-process-hrtime": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "commander": {
+          "version": "2.13.0",
+          "bundled": true,
+          "dev": true
+        },
+        "component-emitter": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "content-type-parser": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cookiejar": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "boom": "5.2.0"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            }
+          }
+        },
+        "cssom": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "cssstyle": {
+          "version": "0.2.37",
+          "bundled": true,
+          "requires": {
+            "cssom": "0.3.2"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "document-register-element": {
+          "version": "1.7.0",
+          "bundled": true
+        },
+        "domexception": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "iconv-lite": "0.4.19"
+          }
+        },
+        "es6-shim": {
+          "version": "0.35.3",
+          "bundled": true,
+          "dev": true
+        },
+        "escodegen": {
+          "version": "1.9.0",
+          "bundled": true,
+          "requires": {
+            "esprima": "3.1.3",
+            "estraverse": "4.2.0",
+            "esutils": "2.0.2",
+            "optionator": "0.8.2",
+            "source-map": "0.5.7"
+          }
+        },
+        "esprima": {
+          "version": "3.1.3",
+          "bundled": true
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "fbjs": {
+          "version": "0.8.16",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.17"
+          }
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.3.1",
+          "bundled": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "formidable": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          }
+        },
+        "graphlib": {
+          "version": "2.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "5.5.2",
+              "bundled": true,
+              "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+              }
+            }
+          }
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "bundled": true,
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.0",
+            "sntp": "2.1.0"
+          }
+        },
+        "hoek": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "hoist-non-react-statics": {
+          "version": "2.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "html-encoding-sniffer": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "whatwg-encoding": "1.0.3"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "bundled": true
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "node-fetch": "1.7.3",
+            "whatwg-fetch": "2.0.3"
+          }
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsdom": {
+          "version": "11.5.1",
+          "bundled": true,
+          "requires": {
+            "abab": "1.0.4",
+            "acorn": "5.3.0",
+            "acorn-globals": "4.1.0",
+            "array-equal": "1.0.0",
+            "browser-process-hrtime": "0.1.2",
+            "content-type-parser": "1.0.2",
+            "cssom": "0.3.2",
+            "cssstyle": "0.2.37",
+            "domexception": "1.0.0",
+            "escodegen": "1.9.0",
+            "html-encoding-sniffer": "1.0.2",
+            "left-pad": "1.2.0",
+            "nwmatcher": "1.4.3",
+            "parse5": "3.0.3",
+            "pn": "1.1.0",
+            "request": "2.83.0",
+            "request-promise-native": "1.0.5",
+            "sax": "1.2.4",
+            "symbol-tree": "3.2.2",
+            "tough-cookie": "2.3.3",
+            "webidl-conversions": "4.0.2",
+            "whatwg-encoding": "1.0.3",
+            "whatwg-url": "6.4.0",
+            "xml-name-validator": "2.0.1"
+          }
+        },
+        "jsdom-global": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "json-refs": {
+          "version": "2.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "commander": "2.13.0",
+            "graphlib": "2.1.5",
+            "js-yaml": "3.10.0",
+            "native-promise-only": "0.8.1",
+            "path-loader": "1.0.4",
+            "slash": "1.0.0",
+            "uri-js": "3.0.2"
+          }
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "left-pad": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "bundled": true
+        },
+        "lodash-es": {
+          "version": "4.17.4",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.sortby": {
+          "version": "4.7.0",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "methods": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "mime": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-db": {
+          "version": "1.30.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.30.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "native-promise-only": {
+          "version": "0.8.1",
+          "bundled": true,
+          "dev": true
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "encoding": "0.1.12",
+            "is-stream": "1.1.0"
+          }
+        },
+        "nwmatcher": {
+          "version": "1.4.3",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "2.0.6",
+            "levn": "0.3.0",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "1.0.0"
+          }
+        },
+        "parse5": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "@types/node": "9.3.0"
+          }
+        },
+        "path-loader": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "native-promise-only": "0.8.1",
+            "superagent": "3.8.2"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "pn": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "promise": {
+          "version": "7.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asap": "2.0.6"
+          }
+        },
+        "prop-types": {
+          "version": "15.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "bundled": true
+        },
+        "react": {
+          "version": "16.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "react-dom": {
+          "version": "16.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "react-redux": {
+          "version": "5.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoist-non-react-statics": "2.3.1",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4",
+            "lodash-es": "4.17.4",
+            "loose-envify": "1.3.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "redux": {
+          "version": "3.7.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4",
+            "lodash-es": "4.17.4",
+            "loose-envify": "1.3.1",
+            "symbol-observable": "1.1.0"
+          }
+        },
+        "request": {
+          "version": "2.83.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.1",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
+          }
+        },
+        "request-promise-core": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "request-promise-native": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "request-promise-core": "1.1.1",
+            "stealthy-require": "1.1.1",
+            "tough-cookie": "2.3.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "sntp": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true,
+          "optional": true
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "sshpk": {
+          "version": "1.13.1",
+          "bundled": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "stealthy-require": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true
+        },
+        "superagent": {
+          "version": "3.8.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "cookiejar": "2.1.1",
+            "debug": "3.1.0",
+            "extend": "3.0.1",
+            "form-data": "2.3.1",
+            "formidable": "1.1.1",
+            "methods": "1.1.2",
+            "mime": "1.6.0",
+            "qs": "6.5.1",
+            "readable-stream": "2.3.3"
+          }
+        },
+        "symbol-observable": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "symbol-tree": {
+          "version": "3.2.2",
+          "bundled": true
+        },
+        "tough-cookie": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "punycode": "2.1.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "2.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "1.1.2"
+          }
+        },
+        "ua-parser-js": {
+          "version": "0.7.17",
+          "bundled": true,
+          "dev": true
+        },
+        "uri-js": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "punycode": "2.1.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "1.3.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "whatwg-encoding": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "0.4.19"
+          }
+        },
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "6.4.0",
+          "bundled": true,
+          "requires": {
+            "lodash.sortby": "4.7.0",
+            "tr46": "1.0.1",
+            "webidl-conversions": "4.0.2"
+          }
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "xml-name-validator": {
+          "version": "2.0.1",
+          "bundled": true
+        }
       }
     },
     "@types/node": {
@@ -116,6 +7943,23 @@
       "requires": {
         "acorn": "5.3.0"
       }
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -196,6 +8040,15 @@
         "normalize-path": "2.1.1"
       }
     },
+    "append-transform": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+      "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "1.0.0"
+      }
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -244,6 +8097,12 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
+    "array-filter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+      "dev": true
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -265,6 +8124,18 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.10.0"
       }
+    },
+    "array-map": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+      "dev": true
+    },
+    "array-reduce": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
+      "dev": true
     },
     "array-union": {
       "version": "1.0.2",
@@ -308,6 +8179,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "async": {
@@ -782,6 +8659,16 @@
         "babel-template": "6.26.0"
       }
     },
+    "babel-jest": {
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.1.tgz",
+      "integrity": "sha512-rEdN/jevSuX0IQKcUqwqOGa0gDNis4jGY52Rq53aizfDGPwQYNJq+f9NCMT1HUhtUZhYSjvfGUfHQWBRT1/icA==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-istanbul": "4.1.5",
+        "babel-preset-jest": "22.4.1"
+      }
+    },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
@@ -822,6 +8709,23 @@
           "dev": true
         }
       }
+    },
+    "babel-plugin-istanbul": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
+      "integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "istanbul-lib-instrument": "1.9.2",
+        "test-exclude": "4.2.0"
+      }
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.1.tgz",
+      "integrity": "sha512-gmj5FvFflXSnRapWmF/jDjx5Lof1kX0OwXibCxMOx38V3CFMOnTxLTUrAFfLkhCey3FJvv0ACvv/+h4nzFRxhg==",
+      "dev": true
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
@@ -954,6 +8858,16 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
+      }
+    },
+    "babel-preset-jest": {
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.1.tgz",
+      "integrity": "sha512-gW3+spyB8fkSAI9fX+41BQMwar5LjR+nyKa2QRvK22snxnI29+jJVAMfId+osucFJzJJvhlvzKWnfwX8Omodvg==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-jest-hoist": "22.4.1",
+        "babel-plugin-syntax-object-rest-spread": "6.13.0"
       }
     },
     "babel-register": {
@@ -1247,6 +9161,24 @@
       "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
       "dev": true
     },
+    "browser-resolve": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.1.7"
+      }
+    },
+    "bser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+      "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+      "dev": true,
+      "requires": {
+        "node-int64": "0.4.0"
+      }
+    },
     "buf-compare": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
@@ -1351,6 +9283,12 @@
       "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
       "dev": true
     },
+    "callsites": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+      "dev": true
+    },
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
@@ -1378,6 +9316,17 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chain-function": {
       "version": "1.0.0",
@@ -1807,6 +9756,25 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cpx": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cpx/-/cpx-1.5.0.tgz",
+      "integrity": "sha1-GFvgGFEdhycN7czCkxceN2VauI8=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "chokidar": "1.7.0",
+        "duplexer": "0.1.1",
+        "glob": "7.1.2",
+        "glob2base": "0.0.12",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "resolve": "1.1.7",
+        "safe-buffer": "5.1.1",
+        "shell-quote": "1.6.1",
+        "subarg": "1.0.0"
+      }
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -1955,6 +9923,15 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.0.1.tgz",
       "integrity": "sha512-VIPwiMJqJ13ZQfaCsIFnp5Me9tnjURiaIFxfz7EH0Ci0dTSQpZtSLrqOicXqEd/z2r+z+Klk9GzmnRsgpgbOsQ=="
     },
+    "default-require-extensions": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+      "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+      "dev": true,
+      "requires": {
+        "strip-bom": "2.0.0"
+      }
+    },
     "define-properties": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
@@ -2029,10 +10006,22 @@
         "repeating": "2.0.1"
       }
     },
+    "detect-newline": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+      "dev": true
+    },
     "detect-node": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
       "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "dir-glob": {
@@ -2100,6 +10089,12 @@
       "requires": {
         "is-obj": "1.0.1"
       }
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -2392,6 +10387,15 @@
         "original": "1.0.0"
       }
     },
+    "exec-sh": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+      "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+      "dev": true,
+      "requires": {
+        "merge": "1.2.0"
+      }
+    },
     "execa": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
@@ -2406,6 +10410,12 @@
         "signal-exit": "3.0.2",
         "strip-eof": "1.0.0"
       }
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
@@ -2423,6 +10433,20 @@
       "dev": true,
       "requires": {
         "fill-range": "2.2.3"
+      }
+    },
+    "expect": {
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-22.4.0.tgz",
+      "integrity": "sha512-Fiy862jT3qc70hwIHwwCBNISmaqBrfWKKrtqyMJ6iwZr+6KXtcnHojZFtd63TPRvRl8EQTJ+YXYy2lK6/6u+Hw==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.0",
+        "jest-diff": "22.4.0",
+        "jest-get-type": "22.1.0",
+        "jest-matcher-utils": "22.4.0",
+        "jest-message-util": "22.4.0",
+        "jest-regex-util": "22.1.0"
       }
     },
     "express": {
@@ -2542,6 +10566,15 @@
         "websocket-driver": "0.7.0"
       }
     },
+    "fb-watchman": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+      "dev": true,
+      "requires": {
+        "bser": "2.0.0"
+      }
+    },
     "fbjs": {
       "version": "0.8.16",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
@@ -2570,6 +10603,16 @@
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
+    },
+    "fileset": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+      "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "minimatch": "3.0.4"
+      }
     },
     "fill-range": {
       "version": "2.2.3",
@@ -2631,6 +10674,12 @@
         "make-dir": "1.1.0",
         "pkg-dir": "2.0.0"
       }
+    },
+    "find-index": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+      "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
+      "dev": true
     },
     "find-up": {
       "version": "2.1.0",
@@ -2717,6 +10766,17 @@
         "readable-stream": "2.3.3"
       }
     },
+    "fs-extra": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -2739,20 +10799,23 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.8.0",
+        "nan": "2.9.2",
         "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "ajv": {
           "version": "4.11.8",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "co": "4.6.0",
@@ -2761,16 +10824,19 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "aproba": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "delegates": "1.0.0",
@@ -2780,35 +10846,42 @@
         "asn1": {
           "version": "0.2.3",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "aws4": {
           "version": "1.6.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "tweetnacl": "0.14.5"
@@ -2817,6 +10890,7 @@
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
+          "dev": true,
           "requires": {
             "inherits": "2.0.3"
           }
@@ -2824,6 +10898,7 @@
         "boom": {
           "version": "2.10.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -2831,6 +10906,7 @@
         "brace-expansion": {
           "version": "1.1.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "balanced-match": "0.4.2",
             "concat-map": "0.0.1"
@@ -2838,44 +10914,53 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "caseless": {
           "version": "0.12.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "co": {
           "version": "4.6.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "boom": "2.10.1"
           }
@@ -2883,6 +10968,7 @@
         "dashdash": {
           "version": "1.14.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
@@ -2891,6 +10977,7 @@
             "assert-plus": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "optional": true
             }
           }
@@ -2898,6 +10985,7 @@
         "debug": {
           "version": "2.6.8",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "ms": "2.0.0"
@@ -2906,25 +10994,30 @@
         "deep-extend": {
           "version": "0.4.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "jsbn": "0.1.1"
@@ -2933,20 +11026,24 @@
         "extend": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "form-data": {
           "version": "2.1.4",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "asynckit": "0.4.0",
@@ -2956,11 +11053,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "inherits": "2.0.3",
@@ -2971,6 +11070,7 @@
         "fstream-ignore": {
           "version": "1.0.5",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "fstream": "1.0.11",
@@ -2981,6 +11081,7 @@
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "aproba": "1.1.1",
@@ -2996,6 +11097,7 @@
         "getpass": {
           "version": "0.1.7",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
@@ -3004,6 +11106,7 @@
             "assert-plus": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "optional": true
             }
           }
@@ -3011,6 +11114,7 @@
         "glob": {
           "version": "7.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -3022,16 +11126,19 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "har-validator": {
           "version": "4.2.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "ajv": "4.11.8",
@@ -3041,11 +11148,13 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "hawk": {
           "version": "3.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -3055,11 +11164,13 @@
         },
         "hoek": {
           "version": "2.16.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "assert-plus": "0.2.0",
@@ -3070,6 +11181,7 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -3077,16 +11189,19 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ini": {
           "version": "1.3.4",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -3094,20 +11209,24 @@
         "is-typedarray": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isstream": {
           "version": "0.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "jsbn": "0.1.1"
@@ -3116,16 +11235,19 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "jsonify": "0.0.0"
@@ -3134,16 +11256,19 @@
         "json-stringify-safe": {
           "version": "5.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "jsonify": {
           "version": "0.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "jsprim": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "assert-plus": "1.0.0",
@@ -3155,17 +11280,20 @@
             "assert-plus": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "optional": true
             }
           }
         },
         "mime-db": {
           "version": "1.27.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
+          "dev": true,
           "requires": {
             "mime-db": "1.27.0"
           }
@@ -3173,17 +11301,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3191,11 +11322,13 @@
         "ms": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
           "version": "0.6.39",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "1.0.2",
@@ -3214,6 +11347,7 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "abbrev": "1.1.0",
@@ -3223,6 +11357,7 @@
         "npmlog": {
           "version": "4.1.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
@@ -3233,21 +11368,25 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "wrappy": "1.0.2"
           }
@@ -3255,16 +11394,19 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.4",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "os-homedir": "1.0.2",
@@ -3273,30 +11415,36 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "punycode": {
           "version": "1.4.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "qs": {
           "version": "6.4.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "deep-extend": "0.4.2",
@@ -3308,6 +11456,7 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
+              "dev": true,
               "optional": true
             }
           }
@@ -3315,6 +11464,7 @@
         "readable-stream": {
           "version": "2.2.9",
           "bundled": true,
+          "dev": true,
           "requires": {
             "buffer-shims": "1.0.0",
             "core-util-is": "1.0.2",
@@ -3328,6 +11478,7 @@
         "request": {
           "version": "2.81.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "aws-sign2": "0.6.0",
@@ -3357,32 +11508,38 @@
         "rimraf": {
           "version": "2.6.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "7.1.2"
           }
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "semver": {
           "version": "5.3.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "sntp": {
           "version": "1.0.9",
           "bundled": true,
+          "dev": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -3390,6 +11547,7 @@
         "sshpk": {
           "version": "1.13.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "asn1": "0.2.3",
@@ -3406,6 +11564,7 @@
             "assert-plus": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "optional": true
             }
           }
@@ -3413,6 +11572,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -3422,6 +11582,7 @@
         "string_decoder": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "5.0.1"
           }
@@ -3429,11 +11590,13 @@
         "stringstream": {
           "version": "0.0.5",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
@@ -3441,11 +11604,13 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "tar": {
           "version": "2.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "block-stream": "0.0.9",
             "fstream": "1.0.11",
@@ -3455,6 +11620,7 @@
         "tar-pack": {
           "version": "3.4.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "debug": "2.6.8",
@@ -3470,6 +11636,7 @@
         "tough-cookie": {
           "version": "2.3.2",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "punycode": "1.4.1"
@@ -3478,6 +11645,7 @@
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "safe-buffer": "5.0.1"
@@ -3486,25 +11654,30 @@
         "tweetnacl": {
           "version": "0.14.5",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "uuid": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "verror": {
           "version": "1.3.6",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "extsprintf": "1.0.2"
@@ -3513,6 +11686,7 @@
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "string-width": "1.0.2"
@@ -3520,796 +11694,8 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
-        }
-      }
-    },
-    "fsevents": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-      "optional": true,
-      "requires": {
-        "nan": "2.8.0",
-        "node-pre-gyp": "0.6.39"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
           "bundled": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.39",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "1.0.2",
-            "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
+          "dev": true
         }
       }
     },
@@ -4425,6 +11811,15 @@
         }
       }
     },
+    "glob2base": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+      "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
+      "dev": true,
+      "requires": {
+        "find-index": "0.1.1"
+      }
+    },
     "global": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
@@ -4488,11 +11883,46 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
+    "growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true
+    },
     "handle-thing": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
       "dev": true
+    },
+    "handlebars": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -5169,6 +12599,652 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "istanbul-api": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.2.tgz",
+      "integrity": "sha512-kH5YRdqdbs5hiH4/Rr1Q0cSAGgjh3jTtg8vu9NLebBAoK3adVO4jk81J+TYOkTr2+Q4NLeb1ACvmEt65iG/Vbw==",
+      "dev": true,
+      "requires": {
+        "async": "2.6.0",
+        "fileset": "2.0.3",
+        "istanbul-lib-coverage": "1.1.2",
+        "istanbul-lib-hook": "1.1.0",
+        "istanbul-lib-instrument": "1.9.2",
+        "istanbul-lib-report": "1.1.3",
+        "istanbul-lib-source-maps": "1.2.3",
+        "istanbul-reports": "1.1.4",
+        "js-yaml": "3.10.0",
+        "mkdirp": "0.5.1",
+        "once": "1.4.0"
+      }
+    },
+    "istanbul-lib-coverage": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.2.tgz",
+      "integrity": "sha512-tZYA0v5A7qBSsOzcebJJ/z3lk3oSzH62puG78DbBA1+zupipX2CakDyiPV3pOb8He+jBwVimuwB0dTnh38hX0w==",
+      "dev": true
+    },
+    "istanbul-lib-hook": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
+      "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
+      "dev": true,
+      "requires": {
+        "append-transform": "0.4.0"
+      }
+    },
+    "istanbul-lib-instrument": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.2.tgz",
+      "integrity": "sha512-nz8t4HQ2206a/3AXi+NHFWEa844DMpPsgbcUteJbt1j8LX1xg56H9rOMnhvcvVvPbW60qAIyrSk44H8ZDqaSSA==",
+      "dev": true,
+      "requires": {
+        "babel-generator": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "istanbul-lib-coverage": "1.1.2",
+        "semver": "5.4.1"
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
+      "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "1.1.2",
+        "mkdirp": "0.5.1",
+        "path-parse": "1.0.5",
+        "supports-color": "3.2.3"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
+      "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0",
+        "istanbul-lib-coverage": "1.1.2",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.4.tgz",
+      "integrity": "sha512-DfSTVOTkuO+kRmbO8Gk650Wqm1WRGr6lrdi2EwDK1vxpS71vdlLd613EpzOKdIFioB5f/scJTjeWBnvd1FWejg==",
+      "dev": true,
+      "requires": {
+        "handlebars": "4.0.11"
+      }
+    },
+    "jest": {
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-22.4.2.tgz",
+      "integrity": "sha512-wD7dXWtfaQAgbNVsjFqzmuhg6nzwGsTRVea3FpSJ7GURhG+J536fw4mdoLB01DgiEozDDeF1ZMR/UlUszTsCrg==",
+      "dev": true,
+      "requires": {
+        "import-local": "1.0.0",
+        "jest-cli": "22.4.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+          "dev": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "import-local": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+          "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+          "dev": true,
+          "requires": {
+            "pkg-dir": "2.0.0",
+            "resolve-cwd": "2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "jest-cli": {
+          "version": "22.4.2",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.2.tgz",
+          "integrity": "sha512-ebo6ZWK2xDSs7LGnLvM16SZOIJ2dj0B6/oERmGcal32NHkks450nNfGrGTyOSPgJDgH8DFhVdBXgSamN7mtZ0Q==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "3.0.0",
+            "chalk": "2.3.0",
+            "exit": "0.1.2",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "import-local": "1.0.0",
+            "is-ci": "1.1.0",
+            "istanbul-api": "1.2.2",
+            "istanbul-lib-coverage": "1.1.2",
+            "istanbul-lib-instrument": "1.9.2",
+            "istanbul-lib-source-maps": "1.2.3",
+            "jest-changed-files": "22.2.0",
+            "jest-config": "22.4.2",
+            "jest-environment-jsdom": "22.4.1",
+            "jest-get-type": "22.1.0",
+            "jest-haste-map": "22.4.2",
+            "jest-message-util": "22.4.0",
+            "jest-regex-util": "22.1.0",
+            "jest-resolve-dependencies": "22.1.0",
+            "jest-runner": "22.4.2",
+            "jest-runtime": "22.4.2",
+            "jest-snapshot": "22.4.0",
+            "jest-util": "22.4.1",
+            "jest-validate": "22.4.2",
+            "jest-worker": "22.2.2",
+            "micromatch": "2.3.11",
+            "node-notifier": "5.2.1",
+            "realpath-native": "1.0.0",
+            "rimraf": "2.6.2",
+            "slash": "1.0.0",
+            "string-length": "2.0.0",
+            "strip-ansi": "4.0.0",
+            "which": "1.3.0",
+            "yargs": "10.1.2"
+          }
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+          "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+          "dev": true,
+          "requires": {
+            "cliui": "4.0.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "8.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          }
+        }
+      }
+    },
+    "jest-changed-files": {
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.2.0.tgz",
+      "integrity": "sha512-SzqOvoPMrXB0NPvDrSPeKETpoUNCtNDOsFbCzAGWxqWVvNyrIMLpUjVExT3u3LfdVrENlrNGCfh5YoFd8+ZeXg==",
+      "dev": true,
+      "requires": {
+        "throat": "4.1.0"
+      }
+    },
+    "jest-config": {
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.2.tgz",
+      "integrity": "sha512-oG31qYO73/3vj/Q8aM2RgzmHndTkz9nRk8ISybfuJqqbf0RW7OUjHVOZPLOUiwLWtz52Yq2HkjIblsyhbA7vrg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "glob": "7.1.2",
+        "jest-environment-jsdom": "22.4.1",
+        "jest-environment-node": "22.4.1",
+        "jest-get-type": "22.1.0",
+        "jest-jasmine2": "22.4.2",
+        "jest-regex-util": "22.1.0",
+        "jest-resolve": "22.4.2",
+        "jest-util": "22.4.1",
+        "jest-validate": "22.4.2",
+        "pretty-format": "22.4.0"
+      }
+    },
+    "jest-diff": {
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.0.tgz",
+      "integrity": "sha512-+/t20WmnkOkB8MOaGaPziI8zWKxquMvYw4Ub+wOzi7AUhmpFXz43buWSxVoZo4J5RnCozpGbX3/FssjJ5KV9Nw==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "diff": "3.5.0",
+        "jest-get-type": "22.1.0",
+        "pretty-format": "22.4.0"
+      }
+    },
+    "jest-docblock": {
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.0.tgz",
+      "integrity": "sha512-lDY7GZ+/CJb02oULYLBDj7Hs5shBhVpDYpIm8LUyqw9X2J22QRsM19gmGQwIFqGSJmpc/LRrSYudeSrG510xlQ==",
+      "dev": true,
+      "requires": {
+        "detect-newline": "2.1.0"
+      }
+    },
+    "jest-environment-jsdom": {
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.1.tgz",
+      "integrity": "sha512-x/JzAoH+dWPBnIMv5OQKiIR0TYf6UvbRjsIuDZ11yDFXkHKGJZg6jNnLAsokAm3cq9kUa2hH5BPUC9XU4n1ELQ==",
+      "dev": true,
+      "requires": {
+        "jest-mock": "22.2.0",
+        "jest-util": "22.4.1",
+        "jsdom": "11.5.1"
+      }
+    },
+    "jest-environment-node": {
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.1.tgz",
+      "integrity": "sha512-wj9+zzfRgnUbm5VwFOCGgG1QmbucUyrjPKBKUJdLW8K5Ss5zrNc1k+v6feZhFg6sS3ZGnjgtIyklaxEARxu+LQ==",
+      "dev": true,
+      "requires": {
+        "jest-mock": "22.2.0",
+        "jest-util": "22.4.1"
+      }
+    },
+    "jest-get-type": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.1.0.tgz",
+      "integrity": "sha512-nD97IVOlNP6fjIN5i7j5XRH+hFsHL7VlauBbzRvueaaUe70uohrkz7pL/N8lx/IAwZRTJ//wOdVgh85OgM7g3w==",
+      "dev": true
+    },
+    "jest-haste-map": {
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.2.tgz",
+      "integrity": "sha512-EdQADHGXRqHJYAr7q9B9YYHZnrlcMwhx1+DnIgc9uN05nCW3RvGCxJ91MqWXcC1AzatLoSv7SNd0qXMp2jKBDA==",
+      "dev": true,
+      "requires": {
+        "fb-watchman": "2.0.0",
+        "graceful-fs": "4.1.11",
+        "jest-docblock": "22.4.0",
+        "jest-serializer": "22.4.0",
+        "jest-worker": "22.2.2",
+        "micromatch": "2.3.11",
+        "sane": "2.4.1"
+      }
+    },
+    "jest-jasmine2": {
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.2.tgz",
+      "integrity": "sha512-KZaIHpXQ0AIlvQJFCU0uoXxtz5GG47X14r9upMe7VXE55UazoMZBFnQb9TX2HoYX2/AxJYnjHuvwKVCFqOrEtw==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "co": "4.6.0",
+        "expect": "22.4.0",
+        "graceful-fs": "4.1.11",
+        "is-generator-fn": "1.0.0",
+        "jest-diff": "22.4.0",
+        "jest-matcher-utils": "22.4.0",
+        "jest-message-util": "22.4.0",
+        "jest-snapshot": "22.4.0",
+        "jest-util": "22.4.1",
+        "source-map-support": "0.5.0"
+      }
+    },
+    "jest-leak-detector": {
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.0.tgz",
+      "integrity": "sha512-r3NEIVNh4X3fEeJtUIrKXWKhNokwUM2ILp5LD8w1KrEanPsFtZmYjmyZYjDTX2dXYr33TW65OvbRE3hWFAyq6g==",
+      "dev": true,
+      "requires": {
+        "pretty-format": "22.4.0"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.0.tgz",
+      "integrity": "sha512-03m3issxUXpWMwDYTfmL8hRNewUB0yCRTeXPm+eq058rZxLHD9f5NtSSO98CWHqe4UyISIxd9Ao9iDVjHWd2qg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "jest-get-type": "22.1.0",
+        "pretty-format": "22.4.0"
+      }
+    },
+    "jest-message-util": {
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.0.tgz",
+      "integrity": "sha512-eyCJB0T3hrlpFF2FqQoIB093OulP+1qvATQmD3IOgJgMGqPL6eYw8TbC5P/VCWPqKhGL51xvjIIhow5eZ2wHFw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.40",
+        "chalk": "2.3.0",
+        "micromatch": "2.3.11",
+        "slash": "1.0.0",
+        "stack-utils": "1.0.1"
+      }
+    },
+    "jest-mock": {
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.2.0.tgz",
+      "integrity": "sha512-eOfoUYLOB/JlxChOFkh/bzpWGqUXb9I+oOpkprHHs9L7nUNfL8Rk28h1ycWrqzWCEQ/jZBg/xIv7VdQkfAkOhw==",
+      "dev": true
+    },
+    "jest-regex-util": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.1.0.tgz",
+      "integrity": "sha512-on0LqVS6Xeh69sw3d1RukVnur+lVOl3zkmb0Q54FHj9wHoq6dbtWqb3TSlnVUyx36hqjJhjgs/QLqs07Bzu72Q==",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.2.tgz",
+      "integrity": "sha512-P1hSfcc2HJYT5t+WPu/11OfFMa7m8pBb2Gf2vm6W9OVs7YTXQ5RCC3nDqaYZQaTqxEM1ZZaTcQGcE6U2xMOsqQ==",
+      "dev": true,
+      "requires": {
+        "browser-resolve": "1.11.2",
+        "chalk": "2.3.0"
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.1.0.tgz",
+      "integrity": "sha512-76Ll61bD/Sus8wK8d+lw891EtiBJGJkWG8OuVDTEX0z3z2+jPujvQqSB2eQ+kCHyCsRwJ2PSjhn3UHqae/oEtA==",
+      "dev": true,
+      "requires": {
+        "jest-regex-util": "22.1.0"
+      }
+    },
+    "jest-runner": {
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.2.tgz",
+      "integrity": "sha512-W4vwgiVQS0NyXt8hgpw7i0YUtsfoChiQcoHWBJeq2ocV4VF2osEZx8HYgpH5HfNe1Cb5LZeZWxX8Dr3hesbGFg==",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "jest-config": "22.4.2",
+        "jest-docblock": "22.4.0",
+        "jest-haste-map": "22.4.2",
+        "jest-jasmine2": "22.4.2",
+        "jest-leak-detector": "22.4.0",
+        "jest-message-util": "22.4.0",
+        "jest-runtime": "22.4.2",
+        "jest-util": "22.4.1",
+        "jest-worker": "22.2.2",
+        "throat": "4.1.0"
+      }
+    },
+    "jest-runtime": {
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.2.tgz",
+      "integrity": "sha512-9/Fxbj99cqxI7o2nTNzevnI38eDBstkwve8ZeaAD/Kz0fbU3i3eRv2QPEmzbmyCyBvUWxCT7BzNLTzTqH1+pyA==",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-jest": "22.4.1",
+        "babel-plugin-istanbul": "4.1.5",
+        "chalk": "2.3.0",
+        "convert-source-map": "1.5.1",
+        "exit": "0.1.2",
+        "graceful-fs": "4.1.11",
+        "jest-config": "22.4.2",
+        "jest-haste-map": "22.4.2",
+        "jest-regex-util": "22.1.0",
+        "jest-resolve": "22.4.2",
+        "jest-util": "22.4.1",
+        "jest-validate": "22.4.2",
+        "json-stable-stringify": "1.0.1",
+        "micromatch": "2.3.11",
+        "realpath-native": "1.0.0",
+        "slash": "1.0.0",
+        "strip-bom": "3.0.0",
+        "write-file-atomic": "2.3.0",
+        "yargs": "10.1.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+          "dev": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+          "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+          "dev": true,
+          "requires": {
+            "cliui": "4.0.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "8.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          }
+        }
+      }
+    },
+    "jest-serializer": {
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.0.tgz",
+      "integrity": "sha512-dnqde95MiYfdc1ZJpjEiHCRvRGGJHPsZQARJFucEGIaOzxqqS9/tt2WzD/OUSGT6kxaEGLQE92faVJGdoCu+Rw==",
+      "dev": true
+    },
+    "jest-snapshot": {
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.0.tgz",
+      "integrity": "sha512-6Zz4F9G1Nbr93kfm5h3A2+OkE+WGpgJlskYE4iSNN2uYfoTL5b9W6aB9Orpx+ueReHyqmy7HET7Z3EmYlL3hKw==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "jest-diff": "22.4.0",
+        "jest-matcher-utils": "22.4.0",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "pretty-format": "22.4.0"
+      }
+    },
+    "jest-util": {
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.1.tgz",
+      "integrity": "sha512-9ySBdJY2qVWpg0OvZbGcFXE2NgwccpZVj384E9bx7brKFc7l5anpqah15mseWcz7FLDk7/N+LyYgqFme7Rez2Q==",
+      "dev": true,
+      "requires": {
+        "callsites": "2.0.0",
+        "chalk": "2.3.0",
+        "graceful-fs": "4.1.11",
+        "is-ci": "1.1.0",
+        "jest-message-util": "22.4.0",
+        "mkdirp": "0.5.1",
+        "source-map": "0.6.1"
+      }
+    },
+    "jest-validate": {
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.2.tgz",
+      "integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "jest-config": "22.4.2",
+        "jest-get-type": "22.1.0",
+        "leven": "2.1.0",
+        "pretty-format": "22.4.0"
+      }
+    },
+    "jest-worker": {
+      "version": "22.2.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.2.2.tgz",
+      "integrity": "sha512-ZylDXjrFNt/OP6cUxwJFWwDgazP7hRjtCQbocFHyiwov+04Wm1x5PYzMGNJT53s4nwr0oo9ocYTImS09xOlUnw==",
+      "dev": true,
+      "requires": {
+        "merge-stream": "1.0.1"
+      }
+    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -5259,6 +13335,15 @@
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
     },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -5275,6 +13360,21 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsprim": {
@@ -5419,6 +13519,13 @@
         "package-json": "4.0.1"
       }
     },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
+    },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -5432,6 +13539,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
       "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
+      "dev": true
+    },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
       "dev": true
     },
     "levn": {
@@ -5539,6 +13652,12 @@
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
@@ -5555,6 +13674,12 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.0.tgz",
       "integrity": "sha1-rgyqVhERSYxboTcj1vtjHSQAOTQ=",
+      "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
     "loose-envify": {
@@ -5598,6 +13723,15 @@
       "dev": true,
       "requires": {
         "pify": "3.0.0"
+      }
+    },
+    "makeerror": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.4"
       }
     },
     "map-obj": {
@@ -5680,6 +13814,15 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
+    "mem": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -5716,11 +13859,26 @@
         }
       }
     },
+    "merge": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "dev": true
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
+    },
+    "merge-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
     },
     "methods": {
       "version": "1.1.2",
@@ -5911,10 +14069,17 @@
       }
     },
     "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+      "dev": true,
       "optional": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
@@ -5936,6 +14101,24 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.33.tgz",
       "integrity": "sha1-RjgRh59XPUUVWtap9D3ClujoXrw=",
       "dev": true
+    },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "dev": true
+    },
+    "node-notifier": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+      "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+      "dev": true,
+      "requires": {
+        "growly": "1.3.0",
+        "semver": "5.4.1",
+        "shellwords": "0.1.1",
+        "which": "1.3.0"
+      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -6000,6 +14183,16 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0"
+      }
     },
     "object.omit": {
       "version": "2.0.1",
@@ -6067,6 +14260,24 @@
       "dev": true,
       "requires": {
         "is-wsl": "1.1.0"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
       }
     },
     "option-chain": {
@@ -6276,6 +14487,12 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -6432,6 +14649,24 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
+    },
+    "pretty-format": {
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.0.tgz",
+      "integrity": "sha512-pvCxP2iODIIk9adXlo4S3GRj0BrJiil68kByAa1PrgG97c1tClh9dLMgp3Z6cHFZrclaABt0UH8PIhwHuFLqYA==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
+      }
     },
     "pretty-ms": {
       "version": "3.1.0",
@@ -6821,6 +15056,15 @@
         "set-immediate-shim": "1.0.1"
       }
     },
+    "realpath-native": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
+      "integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+      "dev": true,
+      "requires": {
+        "util.promisify": "1.0.0"
+      }
+    },
     "recompose": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
@@ -6851,6 +15095,15 @@
         "lodash-es": "4.17.4",
         "loose-envify": "1.3.1",
         "symbol-observable": "1.1.0"
+      }
+    },
+    "redux-mock-store": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.1.tgz",
+      "integrity": "sha512-B+iZ98ESHw4EAWVLKUknQlop1OdLKOayGRmd6KavNtC0zoSsycD8hTt0hEr1eUTw2gmYJOdfBY5QAgZweTUcLQ==",
+      "dev": true,
+      "requires": {
+        "lodash.isplainobject": "4.0.6"
       }
     },
     "regenerate": {
@@ -7036,6 +15289,12 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
     "resolve-cwd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
@@ -7061,6 +15320,16 @@
         "signal-exit": "3.0.2"
       }
     },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
+    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -7084,6 +15353,30 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
+    },
+    "sane": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-2.4.1.tgz",
+      "integrity": "sha512-fW9svvNd81XzHDZyis9/tEY1bZikDGryy8Hi1BErPyNPYv47CdLseUN+tI5FBHWXEENRtj1SWtX/jBnggLaP0w==",
+      "dev": true,
+      "requires": {
+        "anymatch": "1.3.2",
+        "exec-sh": "0.2.1",
+        "fb-watchman": "2.0.0",
+        "fsevents": "1.1.3",
+        "minimatch": "3.0.4",
+        "minimist": "1.2.0",
+        "walker": "1.0.7",
+        "watch": "0.18.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "sax": {
       "version": "1.2.4",
@@ -7241,6 +15534,24 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shell-quote": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+      "dev": true,
+      "requires": {
+        "array-filter": "0.0.1",
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
+        "jsonify": "0.0.0"
+      }
+    },
+    "shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
     "signal-exit": {
@@ -7508,6 +15819,33 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
+    "string-length": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+      "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+      "dev": true,
+      "requires": {
+        "astral-regex": "1.0.0",
+        "strip-ansi": "4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7582,6 +15920,23 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "subarg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+      "dev": true,
+      "requires": {
+        "minimist": "1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "supports-color": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
@@ -7617,6 +15972,19 @@
         "execa": "0.7.0"
       }
     },
+    "test-exclude": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.0.tgz",
+      "integrity": "sha512-8hMFzjxbPv6xSlwGhXSvOMJ/vTy3bkng+2pxmf6E1z6VF7I9nIyNfvHtaw+NBPgvz647gADBbMSbwLfZYppT/w==",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "micromatch": "2.3.11",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "require-main-filename": "1.0.1"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -7633,6 +16001,12 @@
         "is-plain-object": "2.0.4",
         "prop-types": "15.6.0"
       }
+    },
+    "throat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+      "dev": true
     },
     "through2": {
       "version": "2.0.3",
@@ -7726,6 +16100,12 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
+    "tmpl": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "dev": true
+    },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
@@ -7775,6 +16155,119 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "ts-jest": {
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-22.4.1.tgz",
+      "integrity": "sha512-6D3rWDiIuuRmtnoxDK0s69VK8Zw+JTdOkG9KeqQJF1U4ODlvAXg7ZLHfjZTmRFEshitFFeSmJ/reKzufYeibWA==",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-plugin-istanbul": "4.1.5",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-preset-jest": "22.4.1",
+        "cpx": "1.5.0",
+        "fs-extra": "4.0.3",
+        "jest-config": "22.4.2",
+        "pkg-dir": "2.0.0",
+        "yargs": "11.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+          "dev": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+          "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "4.0.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          }
+        }
+      }
     },
     "ts-loader": {
       "version": "3.2.0",
@@ -7873,6 +16366,73 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
     },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true,
+          "optional": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
+          }
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
     "uid2": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
@@ -7916,6 +16476,12 @@
         "os-tmpdir": "1.0.2",
         "uid2": "0.0.3"
       }
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -7979,6 +16545,16 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "object.getownpropertydescriptors": "2.0.3"
+      }
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -8018,12 +16594,39 @@
         "extsprintf": "1.3.0"
       }
     },
+    "walker": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.11"
+      }
+    },
     "warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
       "requires": {
         "loose-envify": "1.3.1"
+      }
+    },
+    "watch": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+      "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+      "dev": true,
+      "requires": {
+        "exec-sh": "0.2.1",
+        "minimist": "1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
       }
     },
     "wbuf": {
@@ -8200,6 +16803,13 @@
           }
         }
       }
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/packages/material/package.json
+++ b/packages/material/package.json
@@ -47,6 +47,7 @@
     "testPathIgnorePatterns": [
       "/node_modules/",
       "/dist/"
+    ]
   },
   "nyc": {
     "reporter": [

--- a/packages/material/package.json
+++ b/packages/material/package.json
@@ -20,7 +20,7 @@
     "clean": "rm -rf lib coverage dist .nyc_output 2> /dev/null",
     "lint": "../../node_modules/.bin/tslint --project ../../tslint.json --exclude src/models/jsonSchema.ts",
     "test": "jest --no-cache",
-    "test-cov": "../../node_modules/.bin/tsc --project test/tsconfig.test.json && ../../node_modules/.bin/nyc ../../node_modules/.bin/ava ",
+    "test-cov": "jest --no-cache",
     "report": "../../node_modules/.bin/nyc report --reporter=html",
     "doc": "../../node_modules/.bin/typedoc --name 'JSON Forms Material Renderers' --mode file --excludeExternals --theme ../../typedoc-jsonforms --out docs src",
     "preparePublish": "npm run doc && npm run build && npm run bundle && npm run test"

--- a/packages/material/package.json
+++ b/packages/material/package.json
@@ -19,7 +19,7 @@
     "dev": "../../node_modules/.bin/webpack --config webpack/webpack.dev.js && webpack-dev-server --config webpack/webpack.dev.js --env=dev --inline",
     "clean": "rm -rf lib coverage dist .nyc_output 2> /dev/null",
     "lint": "../../node_modules/.bin/tslint --project ../../tslint.json --exclude src/models/jsonSchema.ts",
-    "test": "../../node_modules/.bin/tsc --project test/tsconfig.test.json && ../../node_modules/.bin/ava",
+    "test": "jest --no-cache",
     "test-cov": "../../node_modules/.bin/tsc --project test/tsconfig.test.json && ../../node_modules/.bin/nyc ../../node_modules/.bin/ava ",
     "report": "../../node_modules/.bin/nyc report --reporter=html",
     "doc": "../../node_modules/.bin/typedoc --name 'JSON Forms Material Renderers' --mode file --excludeExternals --theme ../../typedoc-jsonforms --out docs src",
@@ -31,6 +31,23 @@
       "babel-register"
     ],
     "babel": "inherit"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js"
+    ],
+    "transform": {
+      "^.+\\.(js|ts|tsx)$": "ts-jest"
+    },
+    "testMatch": [
+      "**/test/**/*.test.tsx"
+    ],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/dist/"
+    ]
   },
   "dependencies": {
     "@jsonforms/core": "^2.0.0-rc.3",
@@ -48,11 +65,14 @@
     "ava": "^0.24.0",
     "copy-webpack-plugin": "^4.2.3",
     "document-register-element": "^1.7.0",
+    "jest": "^22.4.2",
     "jsdom": "^11.5.1",
     "jsdom-global": "^3.0.2",
     "react-dom": "^16.2.0",
     "react-redux": "^5.0.6",
+    "redux-mock-store": "^1.5.1",
     "source-map-loader": "^0.2.3",
+    "ts-jest": "^22.4.1",
     "ts-loader": "^3.2.0",
     "tslint-loader": "^3.5.3",
     "webpack-dev-server": "^2.9.5"

--- a/packages/material/src/complex/MaterialArrayControlRenderer.tsx
+++ b/packages/material/src/complex/MaterialArrayControlRenderer.tsx
@@ -21,7 +21,7 @@ export class MaterialArrayControlRenderer extends RendererComponent<TableControl
   constructor(props) {
     super(props);
     this.state = {
-      selected: _.fill(Array(this.props.data.length), false),
+      selected: this.createSelection(false),
       openConfirmDelete: false
     };
   }
@@ -88,10 +88,10 @@ export class MaterialArrayControlRenderer extends RendererComponent<TableControl
   }
   private selectAll = (_event, checked) => {
     if (checked) {
-      this.setState({ selected: _.fill(Array(this.props.data.length), true) });
+      this.setState({ selected: this.createSelection(true) });
       return;
     }
-    this.setState({selected: _.fill(Array(this.props.data.length), false)});
+    this.setState({selected: this.createSelection(false) });
   }
   private closeConfirmDeleteDialog = () => {
     this.setState({ openConfirmDelete: false });
@@ -112,11 +112,12 @@ export class MaterialArrayControlRenderer extends RendererComponent<TableControl
     );
     this.props.removeItems(this.props.path, toDelete)();
     this.closeConfirmDeleteDialog();
-    this.setState({selected: _.fill(new Array(this.props.data.length), false)});
+    this.setState({ selected: this.createSelection(false) });
   }
   private isSelected = index => {
     return this.state.selected[index];
   }
+  private createSelection = (selected: boolean) => _.fill(Array(this.props.data.length), selected);
 }
 
 export interface TableState {

--- a/packages/material/src/complex/MaterialTableControl.tsx
+++ b/packages/material/src/complex/MaterialTableControl.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-
+import * as _ from 'lodash';
 import Checkbox from 'material-ui/Checkbox';
 import Grid from 'material-ui/Grid';
 import Table, { TableBody, TableCell, TableHead, TableRow } from 'material-ui/Table';
@@ -33,7 +33,7 @@ const EmptyTable = () => (
 );
 
 const TableHeaderCell = ({cellProperty}) =>
-  <TableCell >{cellProperty}</TableCell>;
+  <TableCell >{_.capitalize(cellProperty)}</TableCell>;
 
 const TableContentCell = ({rowPath, cellProperty, cellPath, errors, scopedSchema}) => {
   const cellErrors = errors
@@ -66,17 +66,18 @@ const TableContentCell = ({rowPath, cellProperty, cellPath, errors, scopedSchema
 const TableWithContent = tableProps => {
   const {data, path, scopedSchema, childErrors, select, isSelected} = tableProps;
 
-  return data.map((child, index) => {
+  return data.map((_child, index) => {
     const childPath = Paths.compose(path, `${index}`);
+    const selected = isSelected(index);
 
     return (
       <TableRow
         key={childPath}
         hover
-        selected={isSelected(child)}
+        selected={selected}
       >
         <TableCell padding='checkbox'>
-          <Checkbox checked={isSelected(child)} onChange={e => select(e, child)}/>
+          <Checkbox checked={selected} onChange={e => select(e, index)}/>
         </TableCell>
         {generateCells(TableContentCell, scopedSchema, childPath, childErrors)}
       </TableRow>

--- a/packages/material/test/renderers/MaterialArrayControl.test.tsx
+++ b/packages/material/test/renderers/MaterialArrayControl.test.tsx
@@ -1,0 +1,121 @@
+import { Actions, jsonformsReducer, JsonFormsState } from '@jsonforms/core';
+import * as React from 'react';
+import * as _ from 'lodash';
+import { Provider } from 'react-redux';
+import * as TestUtils from 'react-dom/test-utils';
+
+import MaterialArrayControlRenderer from '../../src/complex/MaterialArrayControlRenderer';
+import { combineReducers, createStore, Store } from 'redux';
+import { materialFields, materialRenderers } from '../../src';
+
+export const initJsonFormsStore = (): Store<JsonFormsState> => {
+
+  const store: Store<JsonFormsState> = createStore(
+    combineReducers({ jsonforms: jsonformsReducer() }),
+    {
+      jsonforms: {
+        renderers: materialRenderers,
+        fields: materialFields,
+      }
+    }
+  );
+
+  store.dispatch(Actions.init(data, schema, uischema));
+
+  return store;
+};
+
+const data = [
+  {
+    message: 'El Barto was here',
+    done: true
+  },
+  {
+    message: 'Yolo'
+  }
+];
+const schema = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      message: {
+        type: 'string',
+        maxLength: 3
+      },
+      done: {
+        type: 'boolean'
+      }
+    }
+  }
+};
+const uischema = {
+  type: 'Control',
+  scope: '#'
+};
+
+describe('Material array control', () => {
+
+  it('should render', () => {
+    const store = initJsonFormsStore();
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialArrayControlRenderer schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+
+    const rows = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'tr');
+    // header + 2 data entries
+    expect(rows.length).toBe(3);
+  });
+
+  it('should delete an item', () => {
+    const store = initJsonFormsStore();
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialArrayControlRenderer schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+
+    const inputs: HTMLInputElement[] = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
+    const cboxes = _.filter(
+      inputs,
+      i => i.type === 'checkbox'
+    );
+    const buttons = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'button');
+    const deleteButton = buttons[1];
+    TestUtils.Simulate.change(cboxes[1], {'target': {'checked': true}});
+
+    TestUtils.Simulate.click(deleteButton);
+    const confirmButton = buttons[3];
+    TestUtils.Simulate.click(confirmButton);
+
+    const rows = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'tr');
+    expect(rows.length).toBe(2);
+    expect(store.getState().jsonforms.core.data.length).toBe(1);
+  });
+
+  it('should keep selection change', () => {
+    const store = initJsonFormsStore();
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialArrayControlRenderer schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+
+    const inputs: HTMLInputElement[] = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
+    const cboxes = _.filter(
+      inputs,
+      i => i.type === 'checkbox'
+    );
+    const currentlyChecked = _.head(_.filter(cboxes, cbox => cbox.checked));
+
+    // select all
+    TestUtils.Simulate.change(cboxes[0], {'target': {'checked': true}});
+
+    expect(_.filter(cboxes, cbox => cbox.checked).length).toBe(4);
+    TestUtils.Simulate.change(currentlyChecked, {'target': {'checked': false}});
+    // keep select all state
+    expect(_.filter(cboxes, cbox => cbox.checked).length).toBe(3);
+  });
+});

--- a/packages/material/test/renderers/MaterialBooleanField.test.tsx
+++ b/packages/material/test/renderers/MaterialBooleanField.test.tsx
@@ -1,378 +1,324 @@
-import { initJsonFormsStore } from '@jsonforms/test';
 import * as React from 'react';
-import test from 'ava';
 import {
+  Actions,
   ControlElement,
   getData,
   HorizontalLayout,
+  jsonformsReducer,
+  JsonFormsState,
   JsonSchema,
+  NOT_APPLICABLE,
   update
 } from '@jsonforms/core';
 import BooleanField, { materialBooleanFieldTester } from '../../src/fields/MaterialBooleanField';
 import HorizontalLayoutRenderer from '../../src/layouts/MaterialHorizontalLayout';
 import { Provider } from 'react-redux';
 import * as TestUtils from 'react-dom/test-utils';
+import { combineReducers, createStore, Store } from 'redux';
+import { materialFields, materialRenderers } from '../../src';
 
-test.beforeEach(t => {
-  t.context.data = { 'foo': true };
-  t.context.schema = {
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'boolean'
+export const initJsonFormsStore = (testData, testSchema, testUiSchema): Store<JsonFormsState> => {
+  const store: Store<JsonFormsState> = createStore(
+    combineReducers({ jsonforms: jsonformsReducer() }),
+    {
+      jsonforms: {
+        renderers: materialRenderers,
+        fields: materialFields,
       }
     }
-  };
-  t.context.uischema = {
-    type: 'Control',
-    scope: '#/properties/foo'
-  };
-  t.context.styles = [
-    {
-      name: 'control',
-      classNames: ['control']
-    },
-    {
-      name: 'control.validation',
-      classNames: ['validation']
-    }
-  ];
-});
-test.failing('autofocus on first element', t => {
-  const schema: JsonSchema = {
-    type: 'object',
-    properties: {
-      firstBooleanField: { type: 'boolean' },
-      secondBooleanField: { type: 'boolean' }
-    }
-  };
-  const firstControlElement: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/firstBooleanField',
-    options: {
-      focus: true
-    }
-  };
-  const secondControlElement: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/secondBooleanField',
-    options: {
-      focus: true
-    }
-  };
-  const uischema: HorizontalLayout = {
-    type: 'HorizontalLayout',
-    elements: [
-      firstControlElement,
-      secondControlElement
-    ]
-  };
-  const data = {
-    'firstBooleanField': true,
-    'secondBooleanField': false
-  };
-  const store = initJsonFormsStore({
-    data,
-    schema,
-    uischema
-  });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <HorizontalLayoutRenderer schema={schema} uischema={uischema}/>
-    </Provider>
   );
-  const inputs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
-  t.not(document.activeElement, inputs[0]);
-  t.is(document.activeElement, inputs[1]);
-});
-// seems to be broken in material-ui
-test.failing('autofocus active', t => {
-  const uischema: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/foo',
-    options: {
-      focus: true
+
+  store.dispatch(Actions.init(testData, testSchema, testUiSchema));
+  return store;
+};
+
+const data = { foo: true };
+const schema = {
+  type: 'object',
+  properties: {
+    foo: {
+      type: 'boolean'
     }
-  };
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema,
-  });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.is(document.activeElement, input);
-});
+  }
+};
+const uischema = {
+  type: 'Control',
+  scope: '#/properties/foo'
+};
 
-test('autofocus inactive', t => {
-  const uischema: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/foo',
-    options: {
-      focus: false
-    }
-  };
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema,
-  });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.false(input.autofocus);
-});
+describe('Material boolean field tester', () => {
 
-test('autofocus inactive by default', t => {
-  const uischema: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/foo',
-  };
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema,
-  });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.not(document.activeElement, input);
-});
-
-test('tester', t => {
-  t.is(materialBooleanFieldTester(undefined, undefined), -1);
-  t.is(materialBooleanFieldTester(null, undefined), -1);
-  t.is(materialBooleanFieldTester({type: 'Foo'}, undefined), -1);
-  t.is(materialBooleanFieldTester({type: 'Control'}, undefined), -1);
-});
-
-test('tester with wrong prop type', t => {
   const control: ControlElement = {
     type: 'Control',
     scope: '#/properties/foo',
   };
-  t.is(
-    materialBooleanFieldTester(
-      control,
-      {type: 'object', properties: {foo: {type: 'string'}}}
-    ),
-    -1
-  );
-});
 
-test('tester with wrong prop type, but sibling has correct one', t => {
-  const control = {
-    type: 'Control',
-    scope: '#/properties/foo'
-  };
-  t.is(
-    materialBooleanFieldTester(
-      control,
-      {
-        type: 'object',
-        properties: {
-          foo: {
-            type: 'string'
-          },
-          bar: {
-            type: 'boolean'
+  it('should fail', () => {
+    expect(materialBooleanFieldTester(undefined, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialBooleanFieldTester(null, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialBooleanFieldTester({type: 'Foo'}, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialBooleanFieldTester({type: 'Control'}, undefined)).toBe(NOT_APPLICABLE);
+    expect(
+      materialBooleanFieldTester(
+        control,
+        {type: 'object', properties: {foo: {type: 'string'}}}
+      )
+    ).toBe(NOT_APPLICABLE);
+    expect(
+      materialBooleanFieldTester(
+        control,
+        {
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'string'
+            },
+            bar: {
+              type: 'boolean'
+            }
           }
         }
-      }
-    ),
-    -1
-  );
-});
+      )
+    ).toBe(NOT_APPLICABLE);
+  });
 
-test('tester with matching prop type', t => {
-  const control = {
-    type: 'Control',
-    scope: '#/properties/foo'
-  };
-  t.is(
-    materialBooleanFieldTester(
-      control,
-      {
-        type: 'object',
-        properties: {
-          foo: {
-            type: 'boolean'
+  it('should succeed', () => {
+    expect(
+      materialBooleanFieldTester(
+        control,
+        {
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'boolean'
+            }
           }
         }
+      )
+    ).toBe(2);
+  });
+});
+
+describe('Material boolean field', () => {
+
+  test.skip('should autofocus first element', () => {
+    const jsonSchema: JsonSchema = {
+      type: 'object',
+      properties: {
+        firstBooleanField: { type: 'boolean' },
+        secondBooleanField: { type: 'boolean' }
       }
-    ),
-    2);
-});
-
-test('render', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema,
+    };
+    const firstControlElement: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/firstBooleanField',
+      options: {
+        focus: true
+      }
+    };
+    const secondControlElement: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/secondBooleanField',
+      options: {
+        focus: true
+      }
+    };
+    const layout: HorizontalLayout = {
+      type: 'HorizontalLayout',
+      elements: [
+        firstControlElement,
+        secondControlElement
+      ]
+    };
+    const store = initJsonFormsStore(
+      {
+        'firstBooleanField': true,
+        'secondBooleanField': false
+      },
+      schema,
+      layout
+    );
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <HorizontalLayoutRenderer schema={jsonSchema} uischema={layout}/>
+      </Provider>
+    );
+    const inputs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
+    expect(document.activeElement).not.toBe(inputs[0]);
+    expect(document.activeElement).toBe(inputs[1]);
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
 
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.is(input.type, 'checkbox');
-  t.is(input.checked, true);
-});
-
-test('update via input event', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema,
+  // seems to be broken in material-ui
+  test.skip('should autofocus via option', () => {
+    const control: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/foo',
+      options: {
+        focus: true
+      }
+    };
+    const store = initJsonFormsStore(data, schema, control);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <BooleanField schema={schema} uischema={control}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(document.activeElement).toBe(input);
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
 
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  input.checked = false;
-  TestUtils.Simulate.change(input);
-  t.is(getData(store.getState()).foo, false);
-});
-
-test('update via action', t => {
-  const data = { 'foo': false };
-  const store = initJsonFormsStore({
-    data,
-    schema: t.context.schema,
-    uischema: t.context.uischema,
+  it('should not autofocus via option', () => {
+    const control: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/foo',
+      options: {
+        focus: false
+      }
+    };
+    const store = initJsonFormsStore(data, schema, control);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <BooleanField schema={schema} uischema={control}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.autofocus).toBe(false);
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  store.dispatch(update('foo', () => false));
-  t.is(input.checked, false);
-  t.is(getData(store.getState()).foo, false);
-});
 
-test.failing('update with undefined value', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema,
+  it('should not autofocus by default', () => {
+    const control: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/foo',
+    };
+    const store = initJsonFormsStore(data, schema, control);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <BooleanField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(document.activeElement).not.toBe(input);
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  store.dispatch(update('foo', () => undefined));
-  t.is(input.value, '');
-});
 
-test.failing('update with null value', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema,
-  });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  store.dispatch(update('foo', () => null));
-  t.is(input.value, '');
-});
+  it('should render', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <BooleanField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
 
-test('update with wrong ref', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema,
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.type).toBe('checkbox');
+    expect(input.checked).toBeTruthy();
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  store.dispatch(update('bar', () => 11));
-  t.is(input.checked, true);
-});
 
-test('update with null ref', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema,
-  });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  store.dispatch(update(null, () => false));
-  t.is(input.checked, true);
-});
+  it('should update via input event', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <BooleanField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
 
-test('update with undefined ref', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema,
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    input.checked = false;
+    TestUtils.Simulate.change(input);
+    expect(getData(store.getState()).foo).toBeFalsy();
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  store.dispatch(update(undefined, () => false));
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.is(input.checked, true);
-});
 
-test('disable', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema,
+  it('should update via action', () => {
+    const store = initJsonFormsStore({'foo': false}, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <BooleanField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    store.dispatch(update('foo', () => false));
+    expect(input.checked).toBeFalsy();
+    expect(getData(store.getState()).foo).toBeFalsy();
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema} enabled={false}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.true(input.disabled);
-});
 
-test('enabled by default', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema,
+  test.skip('should update with undefined value', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <BooleanField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    store.dispatch(update('foo', () => undefined));
+    expect(input.value).toBe('');
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.false(input.disabled);
+
+  test.skip('should update with null value', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <BooleanField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    store.dispatch(update('foo', () => null));
+    expect(input.value).toBe('');
+  });
+
+  it('should not update with wrong ref', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <BooleanField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    store.dispatch(update('bar', () => 11));
+    expect(input.checked).toBeTruthy();
+  });
+
+  it('should not update with null ref', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <BooleanField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    store.dispatch(update(null, () => false));
+    expect(input.checked).toBeTruthy();
+  });
+
+  it('should not update with an undefined ref', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <BooleanField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    store.dispatch(update(undefined, () => false));
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.checked).toBeTruthy();
+  });
+
+  it('can be disabled', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <BooleanField schema={schema} uischema={uischema} enabled={false}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.disabled).toBeTruthy();
+  });
+
+  it('should be enabled by default', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <BooleanField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.disabled).toBeFalsy();
+  });
 });

--- a/packages/material/test/renderers/MaterialDateControl.test.tsx
+++ b/packages/material/test/renderers/MaterialDateControl.test.tsx
@@ -1,372 +1,323 @@
-import { initJsonFormsStore } from '@jsonforms/test';
-import * as React from 'react';
-import test from 'ava';
+import { Provider } from 'react-redux';
 import {
+  Actions,
   ControlElement,
   getData,
   HorizontalLayout,
+  jsonformsReducer,
+  JsonFormsState,
   JsonSchema,
-  update
+  NOT_APPLICABLE
 } from '@jsonforms/core';
 import HorizontalLayoutRenderer from '../../src/layouts/MaterialHorizontalLayout';
-import MaterialDateControl, { materialDateControlTester } from '../../src/controls/MaterialDateControl';
-import { Provider } from 'react-redux';
+import MaterialDateControl, {
+  materialDateControlTester
+} from '../../src/controls/MaterialDateControl';
+import * as React from 'react';
 import * as TestUtils from 'react-dom/test-utils';
+import { combineReducers, createStore, Store } from 'redux';
+import { materialFields, materialRenderers } from '../../src';
 
-test.beforeEach(t => {
-  t.context.data = { 'foo': '1980-06-04' };
-  t.context.schema = {
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'string',
-        format: 'date'
-      },
+const initJsonFormsStore = (testData, testSchema, testUiSchema): Store<JsonFormsState> => {
+  const store: Store<JsonFormsState> = createStore(
+    combineReducers({ jsonforms: jsonformsReducer() }),
+    {
+      jsonforms: {
+        renderers: materialRenderers,
+        fields: materialFields,
+      }
+    }
+  );
+
+  store.dispatch(Actions.init(testData, testSchema, testUiSchema));
+  return store;
+};
+
+const data = { 'foo': '1980-06-04' };
+const schema = {
+  type: 'object',
+  properties: {
+    foo: {
+      type: 'string',
+      format: 'date'
     },
-  };
-  t.context.uischema = {
-    type: 'Control',
-    scope: '#/properties/foo',
-  };
-});
-test.failing('autofocus on first element', t => {
-  const schema: JsonSchema = {
-    type: 'object',
-    properties: {
-      firstDate: { type: 'string', format: 'date' },
-      secondDate: { type: 'string', format: 'date' }
-    }
-  };
-  const firstControlElement: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/firstDate',
-    options: {
-      focus: true
-    }
-  };
-  const secondControlElement: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/secondDate',
-    options: {
-      focus: true
-    }
-  };
-  const uischema: HorizontalLayout = {
-    type: 'HorizontalLayout',
-    elements: [
-      firstControlElement,
-      secondControlElement
-    ]
-  };
-  const data = {
-    'firstDate': '1980-04-04',
-    'secondDate': '1980-04-04'
-  };
-  const store = initJsonFormsStore({
-    data,
-    schema,
-    uischema
-  });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <HorizontalLayoutRenderer schema={schema} uischema={uischema}/>
-    </Provider>
-  );
-  const inputs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
-  t.not(document.activeElement, inputs[0]);
-  t.is(document.activeElement, inputs[1]);
-});
+  },
+};
+const uischema = {
+  type: 'Control',
+  scope: '#/properties/foo',
+};
 
-test('autofocus active', t => {
-  const uischema: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/foo',
-    options: {
-      focus: true
-    }
-  };
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema
-  });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <MaterialDateControl schema={t.context.schema} uischema={uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.is(document.activeElement, input);
-});
+describe('Material date control tester', () => {
 
-test('autofocus inactive', t => {
-  const uischema: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/foo',
-    options: {
-      focus: false
-    }
-  };
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema
-  });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <MaterialDateControl schema={t.context.schema} uischema={uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.false(input.autofocus);
-});
-
-test('autofocus inactive by default', t => {
-  const uischema: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/foo'
-  };
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema
-  });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <MaterialDateControl schema={t.context.schema} uischema={uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.false(input.autofocus);
-});
-
-test('tester', t => {
-  t.is(materialDateControlTester(undefined, undefined), -1);
-  t.is(materialDateControlTester(null, undefined), -1);
-  t.is(materialDateControlTester({ type: 'Foo' }, undefined), -1);
-  t.is(materialDateControlTester({ type: 'Control' }, undefined), -1);
-});
-
-test('tester with wrong prop type', t => {
-  t.is(
-    materialDateControlTester(
-      t.context.uischmea,
-      {
-        type: 'object',
-        properties: {
-          foo: { type: 'string' },
-        },
-      },
-    ),
-    -1,
-  );
-});
-
-test('tester with wrong prop type, but sibling has correct one', t => {
-  t.is(
-    materialDateControlTester(
-      t.context.uischema,
-      {
-        type: 'object',
-        properties: {
-          foo: { type: 'string' },
-          bar: {
-            type: 'string',
-            format: 'date',
+  test('should fail', () => {
+    expect(materialDateControlTester(undefined, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialDateControlTester(null, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialDateControlTester({type: 'Foo'}, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialDateControlTester({type: 'Control'}, undefined)).toBe(NOT_APPLICABLE);
+    expect(
+      materialDateControlTester(
+        uischema,
+        {
+          type: 'object',
+          properties: {
+            foo: {type: 'string'},
           },
         },
-      },
-    ),
-    -1,
-  );
-});
-
-test('tester with correct prop type', t => {
-  t.is(
-    materialDateControlTester(
-      t.context.uischema,
-      {
-        type: 'object',
-        properties: {
-          foo: {
-            type: 'string',
-            format: 'date',
+      )
+    ).toBe(NOT_APPLICABLE);
+    expect(
+      materialDateControlTester(
+        uischema,
+        {
+          type: 'object',
+          properties: {
+            foo: {type: 'string'},
+            bar: {
+              type: 'string',
+              format: 'date',
+            },
           },
         },
+      )
+    ).toBe(NOT_APPLICABLE);
+  });
+
+  it('should succeed', () => {
+    expect(
+      materialDateControlTester(
+        uischema,
+        {
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'string',
+              format: 'date',
+            },
+          },
+        },
+      )
+    ).toBe(4);
+  });
+});
+
+describe('Material date control', () => {
+
+  test.skip('should autofocus first element', () => {
+    const jsonSchema: JsonSchema = {
+      type: 'object',
+      properties: {
+        firstDate: { type: 'string', format: 'date' },
+        secondDate: { type: 'string', format: 'date' }
+      }
+    };
+    const firstControlElement: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/firstDate',
+      options: {
+        focus: true
+      }
+    };
+    const secondControlElement: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/secondDate',
+      options: {
+        focus: true
+      }
+    };
+    const layout: HorizontalLayout = {
+      type: 'HorizontalLayout',
+      elements: [
+        firstControlElement,
+        secondControlElement
+      ]
+    };
+    const store = initJsonFormsStore(
+      {
+        firstDate: '1980-04-04',
+        secondDate: '1980-04-04'
       },
-    ),
-    4,
-  );
-});
-
-test('render', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
+      schema,
+      uischema
+    );
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <HorizontalLayoutRenderer schema={jsonSchema} uischema={layout}/>
+      </Provider>
+    );
+    const inputs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
+    expect(document.activeElement).not.toBe(inputs[0]);
+    expect(document.activeElement).toBe(inputs[1]);
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <MaterialDateControl schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
 
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.is(input.type, 'text');
-  t.is(input.value, '1980-06-04');
-});
-
-test.cb('update via event', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
+  it('should autofocus via option', () => {
+    const control: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/foo',
+      options: {
+        focus: true
+      }
+    };
+    const store = initJsonFormsStore(data, schema, control);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialDateControl schema={schema} uischema={control}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(document.activeElement).toBe(input);
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <MaterialDateControl schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  input.value = '1961-04-12';
-  TestUtils.Simulate.change(input);
-  setTimeout(
-    () => {
-      t.is(getData(store.getState()).foo, '1961-04-12');
-      t.end();
-    },
-    100
-  );
-});
 
-test.cb('update via action', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
+  it('should not autofocus via option', () => {
+    const control: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/foo',
+      options: {
+        focus: false
+      }
+    };
+    const store = initJsonFormsStore(data, schema, control);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialDateControl schema={schema} uischema={control}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.autofocus).toBeFalsy();
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <MaterialDateControl schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  store.dispatch(update('foo', () => '1961-04-12'));
-  setTimeout(
-    () => {
-      t.is(input.value, '1961-04-12');
-      t.end();
-    },
-    100
-  );
-});
 
-test('update with null value', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
+  it('should not autofocus by default', () => {
+    const control: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/foo'
+    };
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialDateControl schema={schema} uischema={control}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.autofocus).toBeFalsy();
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <MaterialDateControl schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  store.dispatch(update('foo', () => null));
-  t.is(input.value, '');
-});
 
-test('update with undefined value', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
-  });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <MaterialDateControl schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  store.dispatch(update('foo', () => undefined));
-  t.is(input.value, '');
-});
+  test('should render', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialDateControl schema={schema} uischema={uischema}/>
+      </Provider>
+    );
 
-test('update with wrong ref', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.type).toBe('text');
+    expect(input.value).toBe('1980-06-04');
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <MaterialDateControl schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  store.dispatch(update('bar', () => 'Bar'));
-  t.is(input.value, '1980-06-04');
-});
 
-test('update with null ref', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
+  it('should update via event', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialDateControl schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    input.value = '1961-04-12';
+    TestUtils.Simulate.change(input);
+    expect(getData(store.getState()).foo).toBe('1961-04-12');
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <MaterialDateControl schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  store.dispatch(update(null, () => '1961-04-12'));
-  t.is(input.value, '1980-06-04');
-});
 
-test('update with undefined ref', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
+  it('should update via action', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialDateControl schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    store.dispatch(Actions.update('foo', () => '1961-04-12'));
+    expect(input.value).toBe('1961-04-12');
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <MaterialDateControl schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  store.dispatch(update(undefined, () => '1961-04-12'));
-  t.is(input.value, '1980-06-04');
-});
 
-test('disable', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
+  it('should update with null value', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialDateControl schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    store.dispatch(Actions.update('foo', () => null));
+    expect(input.value).toBe('');
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <MaterialDateControl schema={t.context.schema} uischema={t.context.uischema} enabled={false}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.true(input.disabled);
-});
 
-test('enabled by default', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
+  test('should update with undefined value', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialDateControl schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    store.dispatch(Actions.update('foo', () => undefined));
+    expect(input.value).toBe('');
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <MaterialDateControl schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.false(input.disabled);
+
+  it('should not update with wrong ref', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialDateControl schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    store.dispatch(Actions.update('bar', () => 'Bar'));
+    expect(input.value).toBe('1980-06-04');
+  });
+
+  test('should not update with null ref', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialDateControl schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    store.dispatch(Actions.update(null, () => '1961-04-12'));
+    expect(input.value).toBe('1980-06-04');
+  });
+
+  test('should not update with undefined ref', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialDateControl schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    store.dispatch(Actions.update(undefined, () => '1961-04-12'));
+    expect(input.value).toBe('1980-06-04');
+  });
+
+  test('can be disabled', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialDateControl schema={schema} uischema={uischema} enabled={false}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.disabled).toBeTruthy();
+  });
+
+  test('should be enabled by default', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialDateControl schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.disabled).toBeFalsy();
+  });
 });

--- a/packages/material/test/renderers/MaterialNumberField.test.tsx
+++ b/packages/material/test/renderers/MaterialNumberField.test.tsx
@@ -1,386 +1,363 @@
-import { initJsonFormsStore } from '@jsonforms/test';
 import * as React from 'react';
-import test from 'ava';
 import {
+  Actions,
   ControlElement,
   getData,
   HorizontalLayout,
+  jsonformsReducer,
+  JsonFormsState,
   JsonSchema,
+  NOT_APPLICABLE,
   update
 } from '@jsonforms/core';
 import NumberField, { materialNumberFieldTester } from '../../src/fields/MaterialNumberField';
 import HorizontalLayoutRenderer from '../../src/layouts/MaterialHorizontalLayout';
 import { Provider } from 'react-redux';
 import * as TestUtils from 'react-dom/test-utils';
+import { materialFields, materialRenderers } from '../../src';
+import { combineReducers, createStore, Store } from 'redux';
 
-test.beforeEach(t => {
-  t.context.data = {'foo': 3.14};
-  t.context.schema = {
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'number',
-        minimum: 5
-      },
+const initJsonFormsStore = (testData, testSchema, testUiSchema): Store<JsonFormsState> => {
+  const store: Store<JsonFormsState> = createStore(
+    combineReducers({ jsonforms: jsonformsReducer() }),
+    {
+      jsonforms: {
+        renderers: materialRenderers,
+        fields: materialFields,
+      }
+    }
+  );
+
+  store.dispatch(Actions.init(testData, testSchema, testUiSchema));
+  return store;
+};
+
+const data = {'foo': 3.14};
+const schema = {
+  type: 'object',
+  properties: {
+    foo: {
+      type: 'number',
+      minimum: 5
     },
-  };
-  t.context.uischema = {
-    type: 'Control',
-    scope: '#/properties/foo'
-  };
-});
-test.failing('autofocus on first element', t => {
-  const schema: JsonSchema = {
-    type: 'object',
-    properties: {
-      firstNumberField: { type: 'number', minimum: 5 },
-      secondNumberField: { type: 'number', minimum: 5 }
-    }
-  };
-  const firstControlElement: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/firstNumberField',
-    options: {
-      focus: true
-    }
-  };
-  const secondControlElement: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/secondNumberField',
-    options: {
-      focus: true
-    }
-  };
-  const uischema: HorizontalLayout = {
-    type: 'HorizontalLayout',
-    elements: [
-      firstControlElement,
-      secondControlElement
-    ]
-  };
-  const data = {
-    'firstNumberField': 3.14,
-    'secondNumberField': 5.12
-  };
-  const store = initJsonFormsStore({
-    data,
-    schema,
-    uischema
+  },
+};
+const uischema = {
+  type: 'Control',
+  scope: '#/properties/foo'
+};
+
+describe('Materila number field tester', () => {
+
+  it('should fail', () => {
+    expect(materialNumberFieldTester(undefined, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialNumberFieldTester(null, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialNumberFieldTester({type: 'Foo'}, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialNumberFieldTester({type: 'Control'}, undefined)).toBe(NOT_APPLICABLE);
   });
 
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <HorizontalLayoutRenderer schema={schema} uischema={uischema}/>
-    </Provider>
-  );
-
-  const inputs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
-  t.not(document.activeElement, inputs[0]);
-  t.is(document.activeElement, inputs[1]);
-});
-
-test('autofocus active', t => {
-  const uischema: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/foo',
-    options: {
-      focus: true
-    }
-  };
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema
-  });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.is(document.activeElement, input);
-});
-
-test('autofocus inactive', t => {
-  const uischema: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/foo',
-    options: {
-      focus: false
-    }
-  };
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema
-  });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.false(input.autofocus);
-});
-
-test('autofocus inactive by default', t => {
-  const uischema: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/foo'
-  };
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema
-  });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.false(input.autofocus);
-});
-
-test('tester', t => {
-  t.is(materialNumberFieldTester(undefined, undefined), -1);
-  t.is(materialNumberFieldTester(null, undefined), -1);
-  t.is(materialNumberFieldTester({type: 'Foo'}, undefined), -1);
-  t.is(materialNumberFieldTester({type: 'Control'}, undefined), -1);
-});
-
-test('tester with wrong schema type', t => {
-  const control: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/foo'
-  };
-  t.is(
-    materialNumberFieldTester(
-      control,
-      {
-        type: 'object',
-        properties: {
-          foo: {
-            type: 'string'
+  it('should succeed with wrong schema type', () => {
+    const control: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/foo'
+    };
+    expect(
+      materialNumberFieldTester(
+        control,
+        {
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'string'
+            }
           }
         }
-      }
-    ),
-    -1
-  );
-});
+      )
+    ).toBe(NOT_APPLICABLE);
+  });
 
-test('tester with wrong schema type, but sibling has correct one', t => {
-  const control: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/foo'
-  };
-  t.is(
-    materialNumberFieldTester(
-      control,
-      {
-        type: 'object',
-        properties: {
-          foo: {
-            type: 'string'
-          },
-          bar: {
-            type: 'number'
+  it('should fail if only sibling has correct type', () => {
+    const control: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/foo'
+    };
+    expect(
+      materialNumberFieldTester(
+        control,
+        {
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'string'
+            },
+            bar: {
+              type: 'number'
+            }
           }
         }
-      }
-    ),
-    -1
-  );
-});
+      )
+    ).toBe(NOT_APPLICABLE);
+  });
 
-test('tester with machting schema type', t => {
-  const control: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/foo'
-  };
-  t.is(
-    materialNumberFieldTester(
-      control,
-      {
-        type: 'object',
-        properties: {
-          foo: {
-            type: 'number'
+  it('should succeed with matching prop type', () => {
+    const control: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/foo'
+    };
+    expect(
+      materialNumberFieldTester(
+        control,
+        {
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'number'
+            }
           }
         }
+      )
+    ).toBe(2);
+  });
+
+});
+
+describe('Material number field', () => {
+
+  test.skip('should autofocus first element', () => {
+    const jsonSchema: JsonSchema = {
+      type: 'object',
+      properties: {
+        firstNumberField: {type: 'number', minimum: 5},
+        secondNumberField: {type: 'number', minimum: 5}
       }
-    ),
-    2
-  );
-});
-
-test('render', t => {
-  const schema: JsonSchema = {
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'number'
+    };
+    const firstControlElement: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/firstNumberField',
+      options: {
+        focus: true
       }
-    }
-  };
-  const store = initJsonFormsStore({
-    data: { 'foo': 3.14 },
-    schema,
-    uischema: t.context.uischema
-  });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <NumberField schema={schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
+    };
+    const secondControlElement: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/secondNumberField',
+      options: {
+        focus: true
+      }
+    };
+    const layout: HorizontalLayout = {
+      type: 'HorizontalLayout',
+      elements: [
+        firstControlElement,
+        secondControlElement
+      ]
+    };
+    const store = initJsonFormsStore(
+      {
+        'firstNumberField': 3.14,
+        'secondNumberField': 5.12
+      },
+      schema,
+      uischema
+    );
 
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.is(input.type, 'number');
-  t.is(input.step, '0.1');
-  t.is(input.value, '3.14');
-});
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <HorizontalLayoutRenderer schema={jsonSchema} uischema={layout}/>
+      </Provider>
+    );
 
-test('update via input event', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
+    const inputs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
+    expect(document.activeElement).not.toBe(inputs[0]);
+    expect(document.activeElement).toBe(inputs[1]);
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  input.value = '2.72';
-  TestUtils.Simulate.change(input);
-  t.is(getData(store.getState()).foo, 2.72);
-});
 
-test('update via action', t => {
-  const store = initJsonFormsStore({
-    data: { 'foo': 2.72 },
-    schema: t.context.schema,
-    uischema: t.context.uischema
+  it('should autofocus via option', () => {
+    const control: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/foo',
+      options: {
+        focus: true
+      }
+    };
+    const store = initJsonFormsStore(data, schema, control);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <NumberField schema={schema} uischema={control}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(document.activeElement).toBe(input);
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.is(input.value, '2.72');
-  store.dispatch(update('foo', () => 3.14));
-  setTimeout(() => t.is(input.value, 'Bar'), 3.14);
-});
 
-test('update with undefined value', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
+  it('should not autofocus via option', () => {
+    const control: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/foo',
+      options: {
+        focus: false
+      }
+    };
+    const store = initJsonFormsStore(data, schema, control);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <NumberField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.autofocus).toBeFalsy();
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  store.dispatch(update('foo', () => undefined));
-  t.is(input.value, '');
-});
 
-test('update with null value', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
+  it('should not autofocus by default', () => {
+    const control: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/foo'
+    };
+    const store = initJsonFormsStore(data, schema, control);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <NumberField schema={schema} uischema={control}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.autofocus).toBeFalsy();
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  store.dispatch(update('foo', () => null));
-  t.is(input.value, '');
-});
 
-test('update with wrong ref', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
-  });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  store.dispatch(update('bar', () => 11));
-  t.is(input.value, '3.14');
-});
+  it('should render', () => {
+    const jsonSchema: JsonSchema = {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'number'
+        }
+      }
+    };
+    const store = initJsonFormsStore(
+      {'foo': 3.14},
+      schema,
+      uischema
+    );
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <NumberField schema={jsonSchema} uischema={uischema}/>
+      </Provider>
+    );
 
-test('update with null ref', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.type).toBe('number');
+    expect(input.step).toBe('0.1');
+    expect(input.value).toBe('3.14');
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  store.dispatch(update(null, () => 2.72));
-  t.is(input.value, '3.14');
-});
 
-test('update with undefined ref', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
+  it('should update via input event', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <NumberField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    input.value = '2.72';
+    TestUtils.Simulate.change(input);
+    expect(getData(store.getState()).foo).toBe(2.72);
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  store.dispatch(update(undefined, () => 13));
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.is(input.value, '3.14');
-});
 
-test('disable', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
+  it('should update via action', () => {
+    const store = initJsonFormsStore(
+      { 'foo': 2.72 },
+      schema,
+      uischema
+    );
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <NumberField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.value).toBe('2.72');
+    store.dispatch(update('foo', () => 3.14));
+    expect(input.value).toBe('3.14');
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={t.context.uischema} enabled={false}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.true(input.disabled);
-});
 
-test('enabled by default', t => {
-  const store = initJsonFormsStore({
-    data: t.context.data,
-    schema: t.context.schema,
-    uischema: t.context.uischema
+  it('should update with undefined value', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <NumberField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    store.dispatch(update('foo', () => undefined));
+    expect(input.value).toBe('');
   });
-  const tree = TestUtils.renderIntoDocument(
-    <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={t.context.uischema}/>
-    </Provider>
-  );
-  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-  t.false(input.disabled);
+
+  it('should not update with null value', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <NumberField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    store.dispatch(update('foo', () => null));
+    expect(input.value).toBe('');
+  });
+
+  it('should not update with wrong ref', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <NumberField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    store.dispatch(update('bar', () => 11));
+    expect(input.value).toBe('3.14');
+  });
+
+  it('should not update with null ref', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <NumberField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    store.dispatch(update(null, () => 2.72));
+    expect(input.value).toBe('3.14');
+  });
+
+  it('should not update with undefined ref', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <NumberField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    store.dispatch(update(undefined, () => 13));
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.value).toBe('3.14');
+  });
+
+  it('can be disabled', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <NumberField schema={schema} uischema={uischema} enabled={false}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.disabled).toBeTruthy();
+  });
+
+  it('should be enabled by default', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <NumberField schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.disabled).toBeFalsy();
+  });
 });

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -8,16 +8,16 @@
 			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
 		},
 		"acorn": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
-			"integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ=="
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
 		},
 		"acorn-globals": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
 			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
 			"requires": {
-				"acorn": "5.4.1"
+				"acorn": "5.5.3"
 			}
 		},
 		"ajv": {
@@ -26,7 +26,7 @@
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"requires": {
 				"co": "4.6.0",
-				"fast-deep-equal": "1.0.0",
+				"fast-deep-equal": "1.1.0",
 				"fast-json-stable-stringify": "2.0.0",
 				"json-schema-traverse": "0.3.1"
 			}
@@ -85,7 +85,7 @@
 			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
 			"requires": {
-				"hoek": "4.2.0"
+				"hoek": "4.2.1"
 			}
 		},
 		"browser-process-hrtime": {
@@ -104,9 +104,9 @@
 			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
 		},
 		"combined-stream": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"requires": {
 				"delayed-stream": "1.0.0"
 			}
@@ -139,7 +139,7 @@
 					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
 					"requires": {
-						"hoek": "4.2.0"
+						"hoek": "4.2.1"
 					}
 				}
 			}
@@ -209,15 +209,15 @@
 			}
 		},
 		"escodegen": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-			"integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
 			"requires": {
 				"esprima": "3.1.3",
 				"estraverse": "4.2.0",
 				"esutils": "2.0.2",
 				"optionator": "0.8.2",
-				"source-map": "0.5.7"
+				"source-map": "0.6.1"
 			}
 		},
 		"esprima": {
@@ -246,9 +246,9 @@
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
@@ -280,13 +280,13 @@
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-			"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
 				"asynckit": "0.4.0",
-				"combined-stream": "1.0.5",
-				"mime-types": "2.1.17"
+				"combined-stream": "1.0.6",
+				"mime-types": "2.1.18"
 			}
 		},
 		"getpass": {
@@ -318,19 +318,19 @@
 			"requires": {
 				"boom": "4.3.1",
 				"cryptiles": "3.1.2",
-				"hoek": "4.2.0",
+				"hoek": "4.2.1",
 				"sntp": "2.1.0"
 			}
 		},
 		"hoek": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-			"integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
 		},
 		"hoist-non-react-statics": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
-			"integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
+			"integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
 		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
@@ -356,9 +356,9 @@
 			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
 		},
 		"invariant": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
+			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
 			"requires": {
 				"loose-envify": "1.3.1"
 			}
@@ -404,7 +404,7 @@
 			"integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
 			"requires": {
 				"abab": "1.0.4",
-				"acorn": "5.4.1",
+				"acorn": "5.5.3",
 				"acorn-globals": "4.1.0",
 				"array-equal": "1.0.0",
 				"browser-process-hrtime": "0.1.2",
@@ -412,7 +412,7 @@
 				"cssom": "0.3.2",
 				"cssstyle": "0.2.37",
 				"domexception": "1.0.1",
-				"escodegen": "1.9.0",
+				"escodegen": "1.9.1",
 				"html-encoding-sniffer": "1.0.2",
 				"left-pad": "1.2.0",
 				"nwmatcher": "1.4.3",
@@ -422,12 +422,12 @@
 				"request-promise-native": "1.0.5",
 				"sax": "1.2.4",
 				"symbol-tree": "3.2.2",
-				"tough-cookie": "2.3.3",
+				"tough-cookie": "2.3.4",
 				"w3c-hr-time": "1.0.1",
 				"webidl-conversions": "4.0.2",
 				"whatwg-encoding": "1.0.3",
 				"whatwg-url": "6.4.0",
-				"ws": "4.0.0",
+				"ws": "4.1.0",
 				"xml-name-validator": "3.0.0"
 			}
 		},
@@ -487,9 +487,9 @@
 			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
 		},
 		"lodash-es": {
-			"version": "4.17.4",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-			"integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+			"version": "4.17.7",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.7.tgz",
+			"integrity": "sha512-jzqTi3vk4J5Dxq43cNjB0ekfCjPLHixoY2Sc0WHTo+0r928taLqe/VCt02vY5uQBvg0rdXgL3xWkK4X0MCmZcw=="
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
@@ -510,16 +510,16 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-			"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
 		},
 		"mime-types": {
-			"version": "2.1.17",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"requires": {
-				"mime-db": "1.30.0"
+				"mime-db": "1.33.0"
 			}
 		},
 		"node-fetch": {
@@ -588,9 +588,9 @@
 			}
 		},
 		"prop-types": {
-			"version": "15.6.0",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-			"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 			"requires": {
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
@@ -615,7 +615,7 @@
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
 				"object-assign": "4.1.1",
-				"prop-types": "15.6.0"
+				"prop-types": "15.6.1"
 			}
 		},
 		"react-dom": {
@@ -626,20 +626,27 @@
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
 				"object-assign": "4.1.1",
-				"prop-types": "15.6.0"
+				"prop-types": "15.6.1"
 			}
 		},
 		"react-redux": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz",
-			"integrity": "sha512-8taaaGu+J7PMJQDJrk/xiWEYQmdo3mkXw6wPr3K3LxvXis3Fymiq7c13S+Tpls/AyNUAsoONkU81AP0RA6y6Vw==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+			"integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
 			"requires": {
-				"hoist-non-react-statics": "2.3.1",
-				"invariant": "2.2.2",
-				"lodash": "4.17.4",
-				"lodash-es": "4.17.4",
+				"hoist-non-react-statics": "2.5.0",
+				"invariant": "2.2.3",
+				"lodash": "4.17.5",
+				"lodash-es": "4.17.7",
 				"loose-envify": "1.3.1",
-				"prop-types": "15.6.0"
+				"prop-types": "15.6.1"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.5",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+					"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+				}
 			}
 		},
 		"redux": {
@@ -648,7 +655,7 @@
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
 			"requires": {
 				"lodash": "4.17.4",
-				"lodash-es": "4.17.4",
+				"lodash-es": "4.17.7",
 				"loose-envify": "1.3.1",
 				"symbol-observable": "1.2.0"
 			}
@@ -669,23 +676,23 @@
 				"aws-sign2": "0.7.0",
 				"aws4": "1.6.0",
 				"caseless": "0.12.0",
-				"combined-stream": "1.0.5",
+				"combined-stream": "1.0.6",
 				"extend": "3.0.1",
 				"forever-agent": "0.6.1",
-				"form-data": "2.3.1",
+				"form-data": "2.3.2",
 				"har-validator": "5.0.3",
 				"hawk": "6.0.2",
 				"http-signature": "1.2.0",
 				"is-typedarray": "1.0.0",
 				"isstream": "0.1.2",
 				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.17",
+				"mime-types": "2.1.18",
 				"oauth-sign": "0.8.2",
 				"performance-now": "2.1.0",
 				"qs": "6.5.1",
 				"safe-buffer": "5.1.1",
 				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.3",
+				"tough-cookie": "2.3.4",
 				"tunnel-agent": "0.6.0",
 				"uuid": "3.2.1"
 			}
@@ -705,7 +712,7 @@
 			"requires": {
 				"request-promise-core": "1.1.1",
 				"stealthy-require": "1.1.1",
-				"tough-cookie": "2.3.3"
+				"tough-cookie": "2.3.4"
 			}
 		},
 		"safe-buffer": {
@@ -728,13 +735,13 @@
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
 			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
 			"requires": {
-				"hoek": "4.2.0"
+				"hoek": "4.2.1"
 			}
 		},
 		"source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"optional": true
 		},
 		"sshpk": {
@@ -773,9 +780,9 @@
 			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
 		},
 		"tough-cookie": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 			"requires": {
 				"punycode": "1.4.1"
 			}
@@ -821,11 +828,6 @@
 			"version": "0.7.17",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
 			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
-		},
-		"ultron": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-			"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
 		},
 		"uuid": {
 			"version": "3.2.1",
@@ -884,13 +886,12 @@
 			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
 		},
 		"ws": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-4.0.0.tgz",
-			"integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
 			"requires": {
 				"async-limiter": "1.0.0",
-				"safe-buffer": "5.1.1",
-				"ultron": "1.1.1"
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"xml-name-validator": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,7 +34,7 @@
     "babel": "inherit"
   },
   "dependencies": {
-    "@jsonforms/core": "^2.0.0-rc.2",
+    "@jsonforms/core": "^2.0.0-rc.3",
     "lodash": "4.17.4",
     "react": "^16.2.0",
     "react-redux": "^5.0.6"

--- a/packages/test/package-lock.json
+++ b/packages/test/package-lock.json
@@ -1,856 +1,883 @@
 {
-  "requires": true,
-  "lockfileVersion": 1,
-  "dependencies": {
-    "@types/node": {
-      "version": "8.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.7.tgz",
-      "integrity": "sha512-+1ZfzGIq8Y3EV7hPF7bs3i+Gi2mqYOiEGGRxGYPrn+hTYLMmzg+/5TkMkCHiRtLB38XSNvr/43aQ9+cUq4BbBg=="
-    },
-    "abab": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
-    },
-    "acorn": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
-    },
-    "acorn-globals": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
-      "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
-      "requires": {
-        "acorn": "5.3.0"
-      }
-    },
-    "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
-      }
-    },
-    "array-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
-    "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
-    "browser-process-hrtime": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
-      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
-    "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
-    },
-    "content-type-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
-    },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
-      }
-    },
-    "cssom": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
-    },
-    "cssstyle": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-      "requires": {
-        "cssom": "0.3.2"
-      }
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
-    },
-    "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "document-register-element": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.7.0.tgz",
-      "integrity": "sha512-qAoWcNm1zW3LVO0KSblYISM0oLQzlNtns2gd1O/YS3QvFYFidG6lF73fC98fIbfPQkws698L0/URrtmN8+ADbQ=="
-    },
-    "domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.0.tgz",
-      "integrity": "sha512-WpwuBlZ2lQRFa4H/4w49deb9rJLot9KmqrKKjMc9qBl7CID+DdC2swoa34ccRl+anL2B6bLp6TjFdIdnzekMBQ=="
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.19"
-      }
-    },
-    "escodegen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
-      "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.5.7"
-      }
-    },
-    "esprima": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-    },
-    "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
-    },
-    "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
-    },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-    },
-    "fbjs": {
-      "version": "0.8.16",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
-      "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.17"
-      }
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
-      }
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
-      }
-    },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
-      }
-    },
-    "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-    },
-    "hoist-non-react-statics": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
-      "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
-    },
-    "html-encoding-sniffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-      "requires": {
-        "whatwg-encoding": "1.0.3"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
-      }
-    },
-    "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-    },
-    "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
-      }
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
-    },
-    "jsdom": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.5.1.tgz",
-      "integrity": "sha512-89ztIZ03aYK9f1uUrLXLsZndRge/JnZjzjpaN+lrse3coqz+8PR/dX4WLHpbF5fIKTXhDjFODOJw2328lPJ90g==",
-      "requires": {
-        "abab": "1.0.4",
-        "acorn": "5.3.0",
-        "acorn-globals": "4.1.0",
-        "array-equal": "1.0.0",
-        "browser-process-hrtime": "0.1.2",
-        "content-type-parser": "1.0.2",
-        "cssom": "0.3.2",
-        "cssstyle": "0.2.37",
-        "domexception": "1.0.0",
-        "escodegen": "1.9.0",
-        "html-encoding-sniffer": "1.0.2",
-        "left-pad": "1.2.0",
-        "nwmatcher": "1.4.3",
-        "parse5": "3.0.3",
-        "pn": "1.1.0",
-        "request": "2.83.0",
-        "request-promise-native": "1.0.5",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.3",
-        "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.3",
-        "whatwg-url": "6.4.0",
-        "xml-name-validator": "2.0.1"
-      }
-    },
-    "jsdom-global": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
-      "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk="
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
-    "left-pad": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
-      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
-    },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
-      }
-    },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-    },
-    "lodash-es": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
-    },
-    "lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
-    },
-    "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "requires": {
-        "js-tokens": "3.0.2"
-      }
-    },
-    "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
-    },
-    "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-      "requires": {
-        "mime-db": "1.30.0"
-      }
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
-    },
-    "nwmatcher": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw=="
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
-      }
-    },
-    "parse5": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-      "requires": {
-        "@types/node": "8.5.7"
-      }
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
-    "pn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
-    },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-    },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "2.0.6"
-      }
-    },
-    "prop-types": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
-    },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-    },
-    "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-    },
-    "react": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
-      "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
-      }
-    },
-    "react-dom": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
-      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
-      }
-    },
-    "react-redux": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz",
-      "integrity": "sha512-8taaaGu+J7PMJQDJrk/xiWEYQmdo3mkXw6wPr3K3LxvXis3Fymiq7c13S+Tpls/AyNUAsoONkU81AP0RA6y6Vw==",
-      "requires": {
-        "hoist-non-react-statics": "2.3.1",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
-        "loose-envify": "1.3.1",
-        "prop-types": "15.6.0"
-      }
-    },
-    "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
-      "requires": {
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
-        "loose-envify": "1.3.1",
-        "symbol-observable": "1.1.0"
-      }
-    },
-    "request": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-      "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
-      }
-    },
-    "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-      "requires": {
-        "lodash": "4.17.4"
-      }
-    },
-    "request-promise-native": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
-      "requires": {
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.3"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-    },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "optional": true
-    },
-    "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-    },
-    "symbol-observable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
-      "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw=="
-    },
-    "symbol-tree": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
-    },
-    "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-      "requires": {
-        "punycode": "1.4.1"
-      }
-    },
-    "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "requires": {
-        "punycode": "2.1.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
-        }
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
-    },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "requires": {
-        "prelude-ls": "1.1.2"
-      }
-    },
-    "ua-parser-js": {
-      "version": "0.7.17",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
-    },
-    "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      }
-    },
-    "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-    },
-    "whatwg-encoding": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-      "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
-      "requires": {
-        "iconv-lite": "0.4.19"
-      }
-    },
-    "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
-    },
-    "whatwg-url": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
-      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
-      "requires": {
-        "lodash.sortby": "4.7.0",
-        "tr46": "1.0.1",
-        "webidl-conversions": "4.0.2"
-      }
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-    },
-    "xml-name-validator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
-    }
-  }
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"abab": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+		},
+		"acorn": {
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
+		},
+		"acorn-globals": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+			"requires": {
+				"acorn": "5.5.3"
+			}
+		},
+		"ajv": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"requires": {
+				"co": "4.6.0",
+				"fast-deep-equal": "1.1.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
+			}
+		},
+		"array-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+		},
+		"aws4": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"optional": true,
+			"requires": {
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"boom": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+			"requires": {
+				"hoek": "4.2.1"
+			}
+		},
+		"browser-process-hrtime": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+		},
+		"combined-stream": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"requires": {
+				"delayed-stream": "1.0.0"
+			}
+		},
+		"content-type-parser": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
+		},
+		"core-js": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"cryptiles": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+			"requires": {
+				"boom": "5.2.0"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+					"requires": {
+						"hoek": "4.2.1"
+					}
+				}
+			}
+		},
+		"cssom": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+		},
+		"cssstyle": {
+			"version": "0.2.37",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"requires": {
+				"cssom": "0.3.2"
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			}
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
+		"document-register-element": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.7.2.tgz",
+			"integrity": "sha512-E+y3qJgckbXK/Ev+jPIF+ussxJRaFRIxYCAkxeYcTdccuQoPw5emVWXkox6JnMejFryjlCs/sw2cokMO2lHxjQ==",
+			"requires": {
+				"lightercollective": "0.0.0"
+			}
+		},
+		"domexception": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"requires": {
+				"webidl-conversions": "4.0.2"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"optional": true,
+			"requires": {
+				"jsbn": "0.1.1"
+			}
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"escodegen": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+			"requires": {
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.6.1"
+			}
+		},
+		"esprima": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"fast-deep-equal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+		},
+		"fbjs": {
+			"version": "0.8.16",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"requires": {
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.17"
+			}
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+		},
+		"form-data": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"requires": {
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.6",
+				"mime-types": "2.1.18"
+			}
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			}
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+		},
+		"har-validator": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"requires": {
+				"ajv": "5.5.2",
+				"har-schema": "2.0.0"
+			}
+		},
+		"hawk": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+			"requires": {
+				"boom": "4.3.1",
+				"cryptiles": "3.1.2",
+				"hoek": "4.2.1",
+				"sntp": "2.1.0"
+			}
+		},
+		"hoek": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+		},
+		"hoist-non-react-statics": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
+			"integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
+		},
+		"html-encoding-sniffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"requires": {
+				"whatwg-encoding": "1.0.3"
+			}
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.13.1"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+		},
+		"invariant": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
+			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+			"requires": {
+				"loose-envify": "1.3.1"
+			}
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.3"
+			}
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"optional": true
+		},
+		"jsdom": {
+			"version": "11.6.2",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
+			"integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
+			"requires": {
+				"abab": "1.0.4",
+				"acorn": "5.5.3",
+				"acorn-globals": "4.1.0",
+				"array-equal": "1.0.0",
+				"browser-process-hrtime": "0.1.2",
+				"content-type-parser": "1.0.2",
+				"cssom": "0.3.2",
+				"cssstyle": "0.2.37",
+				"domexception": "1.0.1",
+				"escodegen": "1.9.1",
+				"html-encoding-sniffer": "1.0.2",
+				"left-pad": "1.2.0",
+				"nwmatcher": "1.4.3",
+				"parse5": "4.0.0",
+				"pn": "1.1.0",
+				"request": "2.83.0",
+				"request-promise-native": "1.0.5",
+				"sax": "1.2.4",
+				"symbol-tree": "3.2.2",
+				"tough-cookie": "2.3.4",
+				"w3c-hr-time": "1.0.1",
+				"webidl-conversions": "4.0.2",
+				"whatwg-encoding": "1.0.3",
+				"whatwg-url": "6.4.0",
+				"ws": "4.1.0",
+				"xml-name-validator": "3.0.0"
+			}
+		},
+		"jsdom-global": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
+			"integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk="
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			}
+		},
+		"left-pad": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
+			"integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"requires": {
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
+			}
+		},
+		"lightercollective": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/lightercollective/-/lightercollective-0.0.0.tgz",
+			"integrity": "sha512-4SdGgHgQjlqhk90QxAYsltGEI6HHt30xy9fOIPKi+c3vcGRcpPDtzm6+kxr1N9ixkrx/ngMhTCe/VpBc/HmNBQ=="
+		},
+		"lodash": {
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+		},
+		"lodash-es": {
+			"version": "4.17.7",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.7.tgz",
+			"integrity": "sha512-jzqTi3vk4J5Dxq43cNjB0ekfCjPLHixoY2Sc0WHTo+0r928taLqe/VCt02vY5uQBvg0rdXgL3xWkK4X0MCmZcw=="
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"requires": {
+				"js-tokens": "3.0.2"
+			}
+		},
+		"mime-db": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+		},
+		"mime-types": {
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+			"requires": {
+				"mime-db": "1.33.0"
+			}
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
+			}
+		},
+		"nwmatcher": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
+			"integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw=="
+		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"requires": {
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
+			}
+		},
+		"parse5": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+		},
+		"pn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "2.0.6"
+			}
+		},
+		"prop-types": {
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			}
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+		},
+		"qs": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+		},
+		"react": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
+			"integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
+			}
+		},
+		"react-dom": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
+			"integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
+			}
+		},
+		"react-redux": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+			"integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+			"requires": {
+				"hoist-non-react-statics": "2.5.0",
+				"invariant": "2.2.3",
+				"lodash": "4.17.5",
+				"lodash-es": "4.17.7",
+				"loose-envify": "1.3.1",
+				"prop-types": "15.6.1"
+			}
+		},
+		"redux": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"requires": {
+				"lodash": "4.17.5",
+				"lodash-es": "4.17.7",
+				"loose-envify": "1.3.1",
+				"symbol-observable": "1.2.0"
+			}
+		},
+		"request": {
+			"version": "2.83.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+			"requires": {
+				"aws-sign2": "0.7.0",
+				"aws4": "1.6.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.6",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.2",
+				"har-validator": "5.0.3",
+				"hawk": "6.0.2",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.18",
+				"oauth-sign": "0.8.2",
+				"performance-now": "2.1.0",
+				"qs": "6.5.1",
+				"safe-buffer": "5.1.1",
+				"stringstream": "0.0.5",
+				"tough-cookie": "2.3.4",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.2.1"
+			}
+		},
+		"request-promise-core": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"requires": {
+				"request-promise-core": "1.1.1",
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.3.4"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+		},
+		"sntp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+			"requires": {
+				"hoek": "4.2.1"
+			}
+		},
+		"source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"optional": true
+		},
+		"sshpk": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"requires": {
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+		},
+		"stringstream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+		},
+		"symbol-observable": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+		},
+		"symbol-tree": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+		},
+		"tough-cookie": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+			"requires": {
+				"punycode": "1.4.1"
+			}
+		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"requires": {
+				"punycode": "2.1.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+				}
+			}
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"optional": true
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"requires": {
+				"prelude-ls": "1.1.2"
+			}
+		},
+		"ua-parser-js": {
+			"version": "0.7.17",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+		},
+		"uuid": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "1.3.0"
+			}
+		},
+		"w3c-hr-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"requires": {
+				"browser-process-hrtime": "0.1.2"
+			}
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+		},
+		"whatwg-encoding": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"whatwg-fetch": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+		},
+		"whatwg-url": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+			"integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+			"requires": {
+				"lodash.sortby": "4.7.0",
+				"tr46": "1.0.1",
+				"webidl-conversions": "4.0.2"
+			}
+		},
+		"wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+		},
+		"ws": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+			"requires": {
+				"async-limiter": "1.0.0",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"xml-name-validator": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+		}
+	}
 }

--- a/packages/vanilla/package-lock.json
+++ b/packages/vanilla/package-lock.json
@@ -1,7666 +1,8042 @@
 {
-  "requires": true,
-  "lockfileVersion": 1,
-  "dependencies": {
-    "@ava/babel-plugin-throws-helper": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-2.0.0.tgz",
-      "integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw="
-    },
-    "@ava/babel-preset-stage-4": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-1.1.0.tgz",
-      "integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "package-hash": "1.2.0"
-      },
-      "dependencies": {
-        "md5-hex": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-          "requires": {
-            "md5-o-matic": "0.1.1"
-          }
-        },
-        "package-hash": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-1.2.0.tgz",
-          "integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
-          "requires": {
-            "md5-hex": "1.3.0"
-          }
-        }
-      }
-    },
-    "@ava/babel-preset-transform-test-files": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-3.0.0.tgz",
-      "integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
-      "requires": {
-        "@ava/babel-plugin-throws-helper": "2.0.0",
-        "babel-plugin-espower": "2.3.2"
-      }
-    },
-    "@ava/write-file-atomic": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@ava/write-file-atomic/-/write-file-atomic-2.2.0.tgz",
-      "integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
-      }
-    },
-    "@concordance/react": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz",
-      "integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
-      "requires": {
-        "arrify": "1.0.1"
-      }
-    },
-    "@types/node": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.3.0.tgz",
-      "integrity": "sha512-wNBfvNjzsJl4tswIZKXCFQY0lss9nKUyJnG6T94X/eqjRgI2jHZ4evdjhQYBSan/vGtF6XVXPApOmNH2rf0KKw=="
-    },
-    "abab": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
-    },
-    "accepts": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
-      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
-      "requires": {
-        "mime-types": "2.1.17",
-        "negotiator": "0.6.1"
-      }
-    },
-    "acorn": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
-    },
-    "acorn-globals": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
-      "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
-      "requires": {
-        "acorn": "5.3.0"
-      }
-    },
-    "ansi-align": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-      "requires": {
-        "string-width": "2.1.1"
-      }
-    },
-    "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
-    },
-    "ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
-    "ansi-styles": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-      "requires": {
-        "color-convert": "1.9.1"
-      }
-    },
-    "anymatch": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-      "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
-      }
-    },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-    },
-    "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "requires": {
-        "sprintf-js": "1.0.3"
-      }
-    },
-    "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "requires": {
-        "arr-flatten": "1.1.0"
-      }
-    },
-    "arr-exclude": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/arr-exclude/-/arr-exclude-1.0.0.tgz",
-      "integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE="
-    },
-    "arr-flatten": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
-    },
-    "arr-union": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
-    },
-    "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
-    },
-    "array-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
-    },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
-    },
-    "array-flatten": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-      "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
-    },
-    "array-includes": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0"
-      }
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "requires": {
-        "array-uniq": "1.0.3"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
-    },
-    "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
-    "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
-    "assign-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
-    },
-    "async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-      "requires": {
-        "lodash": "4.17.4"
-      }
-    },
-    "async-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "atob": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
-      "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10="
-    },
-    "auto-bind": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-1.1.0.tgz",
-      "integrity": "sha1-k7hk3H7gGjJigXddXHXKCnUeWWE="
-    },
-    "ava": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/ava/-/ava-0.24.0.tgz",
-      "integrity": "sha512-o/ykNzsWB5qgh1cR9jzVw0E1y4E219aXl9njNFGSamSCsD7VhPd3aoZabNZuG1PSVMZmQ8RuwKnTuz/loNhKnw==",
-      "requires": {
-        "@ava/babel-preset-stage-4": "1.1.0",
-        "@ava/babel-preset-transform-test-files": "3.0.0",
-        "@ava/write-file-atomic": "2.2.0",
-        "@concordance/react": "1.0.0",
-        "ansi-escapes": "3.0.0",
-        "ansi-styles": "3.2.0",
-        "arr-flatten": "1.1.0",
-        "array-union": "1.0.2",
-        "array-uniq": "1.0.3",
-        "arrify": "1.0.1",
-        "auto-bind": "1.1.0",
-        "ava-init": "0.2.1",
-        "babel-core": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "bluebird": "3.5.1",
-        "caching-transform": "1.0.1",
-        "chalk": "2.3.0",
-        "chokidar": "1.7.0",
-        "clean-stack": "1.3.0",
-        "clean-yaml-object": "0.1.0",
-        "cli-cursor": "2.1.0",
-        "cli-spinners": "1.1.0",
-        "cli-truncate": "1.1.0",
-        "co-with-promise": "4.6.0",
-        "code-excerpt": "2.1.0",
-        "common-path-prefix": "1.0.0",
-        "concordance": "3.0.0",
-        "convert-source-map": "1.5.1",
-        "core-assert": "0.2.1",
-        "currently-unhandled": "0.4.1",
-        "debug": "3.1.0",
-        "dot-prop": "4.2.0",
-        "empower-core": "0.6.2",
-        "equal-length": "1.0.1",
-        "figures": "2.0.0",
-        "find-cache-dir": "1.0.0",
-        "fn-name": "2.0.1",
-        "get-port": "3.2.0",
-        "globby": "6.1.0",
-        "has-flag": "2.0.0",
-        "hullabaloo-config-manager": "1.1.1",
-        "ignore-by-default": "1.0.1",
-        "import-local": "0.1.1",
-        "indent-string": "3.2.0",
-        "is-ci": "1.1.0",
-        "is-generator-fn": "1.0.0",
-        "is-obj": "1.0.1",
-        "is-observable": "1.1.0",
-        "is-promise": "2.1.0",
-        "js-yaml": "3.10.0",
-        "last-line-stream": "1.0.0",
-        "lodash.clonedeepwith": "4.5.0",
-        "lodash.debounce": "4.0.8",
-        "lodash.difference": "4.5.0",
-        "lodash.flatten": "4.4.0",
-        "loud-rejection": "1.6.0",
-        "make-dir": "1.1.0",
-        "matcher": "1.0.0",
-        "md5-hex": "2.0.0",
-        "meow": "3.7.0",
-        "ms": "2.0.0",
-        "multimatch": "2.1.0",
-        "observable-to-promise": "0.5.0",
-        "option-chain": "1.0.0",
-        "package-hash": "2.0.0",
-        "pkg-conf": "2.1.0",
-        "plur": "2.1.2",
-        "pretty-ms": "3.1.0",
-        "require-precompiled": "0.1.0",
-        "resolve-cwd": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "semver": "5.4.1",
-        "slash": "1.0.0",
-        "source-map-support": "0.5.0",
-        "stack-utils": "1.0.1",
-        "strip-ansi": "4.0.0",
-        "strip-bom-buf": "1.0.0",
-        "supports-color": "5.1.0",
-        "time-require": "0.1.2",
-        "trim-off-newlines": "1.0.1",
-        "unique-temp-dir": "1.0.0",
-        "update-notifier": "2.3.0"
-      }
-    },
-    "ava-init": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ava-init/-/ava-init-0.2.1.tgz",
-      "integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
-      "requires": {
-        "arr-exclude": "1.0.0",
-        "execa": "0.7.0",
-        "has-yarn": "1.0.0",
-        "read-pkg-up": "2.0.0",
-        "write-pkg": "3.1.0"
-      }
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
-    },
-    "babel-core": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "babel-generator": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-      "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
-      "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
-        }
-      }
-    },
-    "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-call-delegate": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-explode-assignable-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-get-function-arity": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-hoist-variables": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-regex": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-helper-remap-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helpers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-check-es2015-constants": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-espower": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-2.3.2.tgz",
-      "integrity": "sha1-VRa4/NsmyfDh2BYHSfbkxl5xJx4=",
-      "requires": {
-        "babel-generator": "6.26.0",
-        "babylon": "6.18.0",
-        "call-matcher": "1.0.1",
-        "core-js": "2.5.3",
-        "espower-location-detector": "1.0.0",
-        "espurify": "1.7.0",
-        "estraverse": "4.2.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
-        }
-      }
-    },
-    "babel-plugin-syntax-async-functions": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
-    },
-    "babel-plugin-syntax-exponentiation-operator": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
-    },
-    "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
-    },
-    "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
-    },
-    "babel-plugin-transform-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
-      "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-parameters": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-spread": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
-      }
-    },
-    "babel-plugin-transform-exponentiation-operator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-strict-mode": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-register": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
-        },
-        "source-map-support": {
-          "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-          "requires": {
-            "source-map": "0.5.7"
-          }
-        }
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.11.1"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
-        }
-      }
-    },
-    "babel-template": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.4"
-      }
-    },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-    },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "base": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-      "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.0",
-        "pascalcase": "0.1.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        }
-      }
-    },
-    "batch": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "big.js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
-    },
-    "binary-extensions": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
-    },
-    "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-    },
-    "body-parser": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-      "requires": {
-        "bytes": "3.0.0",
-        "content-type": "1.0.4",
-        "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
-        "qs": "6.5.1",
-        "raw-body": "2.3.2",
-        "type-is": "1.6.15"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "bonjour": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
-      "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
-      "requires": {
-        "array-flatten": "2.1.1",
-        "deep-equal": "1.0.1",
-        "dns-equal": "1.0.0",
-        "dns-txt": "2.0.2",
-        "multicast-dns": "6.2.1",
-        "multicast-dns-service-types": "1.1.0"
-      }
-    },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
-    "boxen": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-      "requires": {
-        "ansi-align": "2.0.0",
-        "camelcase": "4.1.0",
-        "chalk": "2.3.0",
-        "cli-boxes": "1.0.0",
-        "string-width": "2.1.1",
-        "term-size": "1.2.0",
-        "widest-line": "2.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-        }
-      }
-    },
-    "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
-      }
-    },
-    "browser-process-hrtime": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
-      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
-    },
-    "buf-compare": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
-      "integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o="
-    },
-    "buffer-indexof": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
-    },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-    },
-    "bytes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
-    },
-    "cacache": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.2.tgz",
-      "integrity": "sha512-dljb7dk1jqO5ogE+dRpoR9tpHYv5xz9vPSNunh1+0wRuNdYxmzp9WmsyokgW/DUF1FDRVA/TMsmxt027R8djbQ==",
-      "requires": {
-        "bluebird": "3.5.1",
-        "chownr": "1.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "lru-cache": "4.1.1",
-        "mississippi": "1.3.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "promise-inflight": "1.0.1",
-        "rimraf": "2.6.2",
-        "ssri": "5.0.0",
-        "unique-filename": "1.1.0",
-        "y18n": "3.2.1"
-      }
-    },
-    "cache-base": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-      "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        }
-      }
-    },
-    "caching-transform": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-      "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
-      "requires": {
-        "md5-hex": "1.3.0",
-        "mkdirp": "0.5.1",
-        "write-file-atomic": "1.3.4"
-      },
-      "dependencies": {
-        "md5-hex": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-          "requires": {
-            "md5-o-matic": "0.1.1"
-          }
-        },
-        "write-file-atomic": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
-          }
-        }
-      }
-    },
-    "call-matcher": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.0.1.tgz",
-      "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
-      "requires": {
-        "core-js": "2.5.3",
-        "deep-equal": "1.0.1",
-        "espurify": "1.7.0",
-        "estraverse": "4.2.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
-        }
-      }
-    },
-    "call-signature": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
-      "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY="
-    },
-    "camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-    },
-    "camelcase-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
-      }
-    },
-    "capture-stack-trace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "chalk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-      "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "4.5.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
-      }
-    },
-    "chokidar": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
-      }
-    },
-    "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
-    },
-    "ci-info": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
-      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA=="
-    },
-    "class-utils": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-      "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
-    },
-    "clean-stack": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
-      "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
-    },
-    "clean-yaml-object": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
-      "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g="
-    },
-    "cli-boxes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
-    },
-    "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "requires": {
-        "restore-cursor": "2.0.0"
-      }
-    },
-    "cli-spinners": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
-      "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY="
-    },
-    "cli-truncate": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
-      "integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
-      "requires": {
-        "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
-      }
-    },
-    "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
-      }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
-    "co-with-promise": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co-with-promise/-/co-with-promise-4.6.0.tgz",
-      "integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
-      "requires": {
-        "pinkie-promise": "1.0.0"
-      }
-    },
-    "code-excerpt": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.0.tgz",
-      "integrity": "sha1-XcwIHoj0p+O1VOnjXX7yMtR/gUc=",
-      "requires": {
-        "convert-to-spaces": "1.0.2"
-      }
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-    },
-    "collection-visit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-      "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
-      }
-    },
-    "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
-    },
-    "common-path-prefix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
-      "integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA="
-    },
-    "commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
-    },
-    "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-    },
-    "compressible": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
-      "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
-      "requires": {
-        "mime-db": "1.30.0"
-      }
-    },
-    "compression": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
-      "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
-      "requires": {
-        "accepts": "1.3.4",
-        "bytes": "3.0.0",
-        "compressible": "2.0.12",
-        "debug": "2.6.9",
-        "on-headers": "1.0.1",
-        "safe-buffer": "5.1.1",
-        "vary": "1.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
-      }
-    },
-    "concordance": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/concordance/-/concordance-3.0.0.tgz",
-      "integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
-      "requires": {
-        "date-time": "2.1.0",
-        "esutils": "2.0.2",
-        "fast-diff": "1.1.2",
-        "function-name-support": "0.2.0",
-        "js-string-escape": "1.0.1",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.flattendeep": "4.4.0",
-        "lodash.merge": "4.6.0",
-        "md5-hex": "2.0.0",
-        "semver": "5.4.1",
-        "well-known-symbols": "1.0.0"
-      }
-    },
-    "configstore": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
-      "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
-      }
-    },
-    "connect-history-api-fallback": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-      "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
-    },
-    "content-disposition": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
-    },
-    "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-    },
-    "content-type-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
-    },
-    "convert-source-map": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
-    },
-    "convert-to-spaces": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
-      "integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU="
-    },
-    "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-    },
-    "cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-    },
-    "copy-concurrently": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
-      "requires": {
-        "aproba": "1.2.0",
-        "fs-write-stream-atomic": "1.0.10",
-        "iferr": "0.1.5",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
-      }
-    },
-    "copy-descriptor": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
-    },
-    "copy-webpack-plugin": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.3.1.tgz",
-      "integrity": "sha512-xlcFiW/U7KrpS6dFuWq3r8Wb7koJx7QVc7LDFCosqkikaVSxkaYOnwDLwilbjrszZ0LYZXThDAJKcQCSrvdShQ==",
-      "requires": {
-        "cacache": "10.0.2",
-        "find-cache-dir": "1.0.0",
-        "globby": "7.1.1",
-        "is-glob": "4.0.0",
-        "loader-utils": "0.2.17",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "p-limit": "1.2.0",
-        "pify": "3.0.0",
-        "serialize-javascript": "1.4.0"
-      },
-      "dependencies": {
-        "globby": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-          "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-          "requires": {
-            "array-union": "1.0.2",
-            "dir-glob": "2.0.0",
-            "glob": "7.1.2",
-            "ignore": "3.3.7",
-            "pify": "3.0.0",
-            "slash": "1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-        },
-        "is-glob": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-          "requires": {
-            "is-extglob": "2.1.1"
-          }
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
-      }
-    },
-    "core-assert": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
-      "integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
-      "requires": {
-        "buf-compare": "1.0.1",
-        "is-error": "2.2.1"
-      }
-    },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "requires": {
-        "capture-stack-trace": "1.0.0"
-      }
-    },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
-      }
-    },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
-      }
-    },
-    "crypto-random-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
-    },
-    "cssom": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
-    },
-    "cssstyle": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-      "requires": {
-        "cssom": "0.3.2"
-      }
-    },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "requires": {
-        "array-find-index": "1.0.2"
-      }
-    },
-    "cyclist": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
-    },
-    "date-time": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
-      "integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
-      "requires": {
-        "time-zone": "1.0.0"
-      }
-    },
-    "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "requires": {
-        "ms": "2.0.0"
-      }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-    },
-    "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-    },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
-    },
-    "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-    },
-    "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
-    },
-    "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
-      }
-    },
-    "define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-      "requires": {
-        "is-descriptor": "1.0.2"
-      }
-    },
-    "del": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
-      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
-      "requires": {
-        "globby": "6.1.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "p-map": "1.2.0",
-        "pify": "3.0.0",
-        "rimraf": "2.6.2"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
-      }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-    },
-    "destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-    },
-    "detect-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "requires": {
-        "repeating": "2.0.1"
-      }
-    },
-    "detect-node": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
-      "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
-    },
-    "dir-glob": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
-      "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
-      "requires": {
-        "arrify": "1.0.1",
-        "path-type": "3.0.0"
-      },
-      "dependencies": {
-        "path-type": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "requires": {
-            "pify": "3.0.0"
-          }
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
-      }
-    },
-    "dns-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
-    },
-    "dns-packet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
-      "requires": {
-        "ip": "1.1.5",
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "dns-txt": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
-      "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
-      "requires": {
-        "buffer-indexof": "1.1.1"
-      }
-    },
-    "document-register-element": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.7.0.tgz",
-      "integrity": "sha512-qAoWcNm1zW3LVO0KSblYISM0oLQzlNtns2gd1O/YS3QvFYFidG6lF73fC98fIbfPQkws698L0/URrtmN8+ADbQ=="
-    },
-    "domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.0.tgz",
-      "integrity": "sha512-WpwuBlZ2lQRFa4H/4w49deb9rJLot9KmqrKKjMc9qBl7CID+DdC2swoa34ccRl+anL2B6bLp6TjFdIdnzekMBQ=="
-    },
-    "dot-prop": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-      "requires": {
-        "is-obj": "1.0.1"
-      }
-    },
-    "duplexer3": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-    },
-    "duplexify": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
-      "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
-      "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
-      }
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
-    },
-    "ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-    },
-    "emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
-    },
-    "empower-core": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
-      "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
-      "requires": {
-        "call-signature": "0.0.2",
-        "core-js": "2.5.3"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
-        }
-      }
-    },
-    "encodeurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.19"
-      }
-    },
-    "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "requires": {
-        "once": "1.4.0"
-      }
-    },
-    "enhanced-resolve": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
-      "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.8"
-      }
-    },
-    "equal-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/equal-length/-/equal-length-1.0.1.tgz",
-      "integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w="
-    },
-    "errno": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
-      "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
-      "requires": {
-        "prr": "1.0.1"
-      }
-    },
-    "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "requires": {
-        "is-arrayish": "0.2.1"
-      }
-    },
-    "es-abstract": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
-      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
-      "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
-      }
-    },
-    "es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
-    },
-    "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-    },
-    "escodegen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
-      "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-        }
-      }
-    },
-    "espower-location-detector": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
-      "integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
-      "requires": {
-        "is-url": "1.2.2",
-        "path-is-absolute": "1.0.1",
-        "source-map": "0.5.7",
-        "xtend": "4.0.1"
-      }
-    },
-    "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
-    },
-    "espurify": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
-      "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
-      "requires": {
-        "core-js": "2.5.3"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
-        }
-      }
-    },
-    "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
-    },
-    "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
-    },
-    "etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-    },
-    "eventemitter3": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
-    },
-    "eventsource": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
-      "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
-      "requires": {
-        "original": "1.0.0"
-      }
-    },
-    "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
-      }
-    },
-    "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "requires": {
-        "is-posix-bracket": "0.1.1"
-      }
-    },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "requires": {
-        "fill-range": "2.2.3"
-      }
-    },
-    "express": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
-      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
-      "requires": {
-        "accepts": "1.3.4",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.18.2",
-        "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
-        "cookie": "0.3.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
-        "finalhandler": "1.1.0",
-        "fresh": "0.5.2",
-        "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.2",
-        "qs": "6.5.1",
-        "range-parser": "1.2.0",
-        "safe-buffer": "5.1.1",
-        "send": "0.16.1",
-        "serve-static": "1.13.1",
-        "setprototypeof": "1.1.0",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15",
-        "utils-merge": "1.0.1",
-        "vary": "1.1.2"
-      },
-      "dependencies": {
-        "array-flatten": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-    },
-    "extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "requires": {
-        "is-extendable": "0.1.1"
-      }
-    },
-    "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
-    },
-    "fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-    },
-    "faye-websocket": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-      "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-      "requires": {
-        "websocket-driver": "0.7.0"
-      }
-    },
-    "fbjs": {
-      "version": "0.8.16",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
-      "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.17"
-      }
-    },
-    "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "requires": {
-        "escape-string-regexp": "1.0.5"
-      }
-    },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
-    },
-    "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
-      }
-    },
-    "finalhandler": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
-      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
-      "requires": {
-        "debug": "2.6.9",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "find-cache-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-      "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-      "requires": {
-        "commondir": "1.0.1",
-        "make-dir": "1.1.0",
-        "pkg-dir": "2.0.0"
-      }
-    },
-    "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-      "requires": {
-        "locate-path": "2.0.0"
-      }
-    },
-    "flush-write-stream": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
-      "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
-      }
-    },
-    "fn-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc="
-    },
-    "for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "requires": {
-        "for-in": "1.0.2"
-      }
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
-      }
-    },
-    "forwarded": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
-    },
-    "fragment-cache": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-      "requires": {
-        "map-cache": "0.2.2"
-      }
-    },
-    "fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-    },
-    "from2": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
-      }
-    },
-    "fs-write-stream-atomic": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "2.3.3"
-      }
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fsevents": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-      "optional": true,
-      "requires": {
-        "nan": "2.8.0",
-        "node-pre-gyp": "0.6.39"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.39",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "1.0.2",
-            "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        }
-      }
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "function-name-support": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/function-name-support/-/function-name-support-0.2.0.tgz",
-      "integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE="
-    },
-    "get-caller-file": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
-    },
-    "get-port": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
-    },
-    "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
-    },
-    "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-    },
-    "get-value": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
-    },
-    "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
-    },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
-      }
-    },
-    "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "requires": {
-        "is-glob": "2.0.1"
-      }
-    },
-    "global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-      "requires": {
-        "ini": "1.3.5"
-      }
-    },
-    "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-    },
-    "globby": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-      "requires": {
-        "array-union": "1.0.2",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      },
-      "dependencies": {
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        }
-      }
-    },
-    "got": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-      "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
-        "url-parse-lax": "1.0.0"
-      }
-    },
-    "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-    },
-    "handle-thing": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
-      "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
-        }
-      }
-    },
-    "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "requires": {
-        "function-bind": "1.1.1"
-      }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
-    },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
-    },
-    "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-    },
-    "has-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-      "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        }
-      }
-    },
-    "has-values": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-      "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        }
-      }
-    },
-    "has-yarn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
-      "integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac="
-    },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
-      }
-    },
-    "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-    },
-    "hoist-non-react-statics": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
-      "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
-    },
-    "home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
-    },
-    "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
-    },
-    "hpack.js": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
-      "requires": {
-        "inherits": "2.0.3",
-        "obuf": "1.1.1",
-        "readable-stream": "2.3.3",
-        "wbuf": "1.7.2"
-      }
-    },
-    "html-encoding-sniffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-      "requires": {
-        "whatwg-encoding": "1.0.3"
-      }
-    },
-    "html-entities": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
-      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
-    },
-    "http-deceiver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
-    },
-    "http-errors": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-      "requires": {
-        "depd": "1.1.1",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
-        },
-        "setprototypeof": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
-        }
-      }
-    },
-    "http-parser-js": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz",
-      "integrity": "sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE="
-    },
-    "http-proxy": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
-      "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
-      "requires": {
-        "eventemitter3": "1.2.0",
-        "requires-port": "1.0.0"
-      }
-    },
-    "http-proxy-middleware": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
-      "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
-      "requires": {
-        "http-proxy": "1.16.2",
-        "is-glob": "3.1.0",
-        "lodash": "4.17.4",
-        "micromatch": "2.3.11"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-        },
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "requires": {
-            "is-extglob": "2.1.1"
-          }
-        }
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
-      }
-    },
-    "hullabaloo-config-manager": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.1.1.tgz",
-      "integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
-      "requires": {
-        "dot-prop": "4.2.0",
-        "es6-error": "4.1.1",
-        "graceful-fs": "4.1.11",
-        "indent-string": "3.2.0",
-        "json5": "0.5.1",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.clonedeepwith": "4.5.0",
-        "lodash.isequal": "4.5.0",
-        "lodash.merge": "4.6.0",
-        "md5-hex": "2.0.0",
-        "package-hash": "2.0.0",
-        "pkg-dir": "2.0.0",
-        "resolve-from": "3.0.0",
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-    },
-    "iferr": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
-    },
-    "ignore": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
-    },
-    "ignore-by-default": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk="
-    },
-    "import-lazy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
-    },
-    "import-local": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
-      "integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
-      "requires": {
-        "pkg-dir": "2.0.0",
-        "resolve-cwd": "2.0.0"
-      }
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-    },
-    "indent-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-    },
-    "internal-ip": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
-      "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
-      "requires": {
-        "meow": "3.7.0"
-      }
-    },
-    "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
-    },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-    },
-    "ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-    },
-    "ipaddr.js": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
-      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
-    },
-    "irregular-plurals": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
-      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
-    },
-    "is-accessor-descriptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-      "requires": {
-        "kind-of": "6.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-        }
-      }
-    },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-    },
-    "is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "requires": {
-        "binary-extensions": "1.11.0"
-      }
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "requires": {
-        "builtin-modules": "1.1.1"
-      }
-    },
-    "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
-    },
-    "is-ci": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
-      "requires": {
-        "ci-info": "1.1.2"
-      }
-    },
-    "is-data-descriptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-      "requires": {
-        "kind-of": "6.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-        }
-      }
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
-    },
-    "is-descriptor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-      "requires": {
-        "is-accessor-descriptor": "1.0.0",
-        "is-data-descriptor": "1.0.0",
-        "kind-of": "6.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-        }
-      }
-    },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "requires": {
-        "is-primitive": "2.0.0"
-      }
-    },
-    "is-error": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz",
-      "integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw="
-    },
-    "is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
-    },
-    "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
-    },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-    },
-    "is-generator-fn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-      "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
-    },
-    "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
-    },
-    "is-installed-globally": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-      "requires": {
-        "global-dirs": "0.1.1",
-        "is-path-inside": "1.0.1"
-      }
-    },
-    "is-npm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
-    },
-    "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "requires": {
-        "kind-of": "3.2.2"
-      }
-    },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-    },
-    "is-observable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-      "requires": {
-        "symbol-observable": "1.1.0"
-      }
-    },
-    "is-odd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
-      "integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
-      "requires": {
-        "is-number": "3.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        }
-      }
-    },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "requires": {
-        "is-path-inside": "1.0.1"
-      }
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "requires": {
-        "path-is-inside": "1.0.2"
-      }
-    },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
-    },
-    "is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "requires": {
-        "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        }
-      }
-    },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
-    },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "requires": {
-        "has": "1.0.1"
-      }
-    },
-    "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "is-url": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
-      "integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY="
-    },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-    },
-    "is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "requires": {
-        "isarray": "1.0.0"
-      }
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
-      }
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "js-string-escape": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
-    },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-    },
-    "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-      "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
-      }
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
-    },
-    "jsdom": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.5.1.tgz",
-      "integrity": "sha512-89ztIZ03aYK9f1uUrLXLsZndRge/JnZjzjpaN+lrse3coqz+8PR/dX4WLHpbF5fIKTXhDjFODOJw2328lPJ90g==",
-      "requires": {
-        "abab": "1.0.4",
-        "acorn": "5.3.0",
-        "acorn-globals": "4.1.0",
-        "array-equal": "1.0.0",
-        "browser-process-hrtime": "0.1.2",
-        "content-type-parser": "1.0.2",
-        "cssom": "0.3.2",
-        "cssstyle": "0.2.37",
-        "domexception": "1.0.0",
-        "escodegen": "1.9.0",
-        "html-encoding-sniffer": "1.0.2",
-        "left-pad": "1.2.0",
-        "nwmatcher": "1.4.3",
-        "parse5": "3.0.3",
-        "pn": "1.1.0",
-        "request": "2.83.0",
-        "request-promise-native": "1.0.5",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.3",
-        "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.3",
-        "whatwg-url": "6.4.0",
-        "xml-name-validator": "2.0.1"
-      }
-    },
-    "jsdom-global": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
-      "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk="
-    },
-    "jsesc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-    },
-    "json-parse-better-errors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
-    },
-    "json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
-    "killable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz",
-      "integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms="
-    },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "1.1.6"
-      }
-    },
-    "last-line-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/last-line-stream/-/last-line-stream-1.0.0.tgz",
-      "integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
-      "requires": {
-        "through2": "2.0.3"
-      }
-    },
-    "latest-version": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-      "requires": {
-        "package-json": "4.0.1"
-      }
-    },
-    "lazy-cache": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-      "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-      "requires": {
-        "set-getter": "0.1.0"
-      }
-    },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "1.0.0"
-      }
-    },
-    "left-pad": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
-      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
-    },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
-      }
-    },
-    "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
-      }
-    },
-    "loader-utils": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-      "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-      "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1",
-        "object-assign": "4.1.1"
-      }
-    },
-    "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
-      }
-    },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-    },
-    "lodash-es": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
-    "lodash.clonedeepwith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
-      "integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ="
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-    },
-    "lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
-    },
-    "lodash.flattendeep": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-    },
-    "lodash.merge": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
-    },
-    "lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
-    },
-    "loglevel": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
-      "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
-    },
-    "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "requires": {
-        "js-tokens": "3.0.2"
-      }
-    },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
-      }
-    },
-    "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
-    },
-    "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
-    },
-    "make-dir": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
-      "requires": {
-        "pify": "3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
-      }
-    },
-    "map-cache": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
-    },
-    "map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
-    },
-    "map-visit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-      "requires": {
-        "object-visit": "1.0.1"
-      }
-    },
-    "matcher": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.0.0.tgz",
-      "integrity": "sha1-qvDEgW62m5IJRnQXViXzRmsOPhk=",
-      "requires": {
-        "escape-string-regexp": "1.0.5"
-      }
-    },
-    "md5-hex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
-      "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
-      "requires": {
-        "md5-o-matic": "0.1.1"
-      }
-    },
-    "md5-o-matic": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-      "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
-    },
-    "media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-    },
-    "memory-fs": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-      "requires": {
-        "errno": "0.1.6",
-        "readable-stream": "2.3.3"
-      }
-    },
-    "meow": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        }
-      }
-    },
-    "merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-    },
-    "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-    },
-    "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
-      }
-    },
-    "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-    },
-    "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
-    },
-    "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-      "requires": {
-        "mime-db": "1.30.0"
-      }
-    },
-    "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
-    },
-    "minimalistic-assert": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "requires": {
-        "brace-expansion": "1.1.8"
-      }
-    },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-    },
-    "mississippi": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
-      "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
-      "requires": {
-        "concat-stream": "1.6.0",
-        "duplexify": "3.5.3",
-        "end-of-stream": "1.4.1",
-        "flush-write-stream": "1.0.2",
-        "from2": "2.3.0",
-        "parallel-transform": "1.1.0",
-        "pump": "1.0.3",
-        "pumpify": "1.3.6",
-        "stream-each": "1.2.2",
-        "through2": "2.0.3"
-      }
-    },
-    "mixin-deep": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.0.tgz",
-      "integrity": "sha512-dgaCvoh6i1nosAUBKb0l0pfJ78K8+S9fluyIR2YvAeUD/QuMahnFnF3xYty5eYXMjhGSsB0DsW6A0uAZyetoAg==",
-      "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
-      },
-      "dependencies": {
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "requires": {
-            "is-plain-object": "2.0.4"
-          }
-        }
-      }
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "requires": {
-        "minimist": "0.0.8"
-      }
-    },
-    "move-concurrently": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
-      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-      "requires": {
-        "aproba": "1.2.0",
-        "copy-concurrently": "1.0.5",
-        "fs-write-stream-atomic": "1.0.10",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
-      }
-    },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "multicast-dns": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.1.tgz",
-      "integrity": "sha512-uV3/ckdsffHx9IrGQrx613mturMdMqQ06WTq+C09NsStJ9iNG6RcUWgPKs1Rfjy+idZT6tfQoXEusGNnEZhT3w==",
-      "requires": {
-        "dns-packet": "1.3.1",
-        "thunky": "0.1.0"
-      }
-    },
-    "multicast-dns-service-types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
-      "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
-    },
-    "multimatch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-      "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
-      }
-    },
-    "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-      "optional": true
-    },
-    "nanomatch": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.7.tgz",
-      "integrity": "sha512-/5ldsnyurvEw7wNpxLFgjVvBLMta43niEYOy0CJ4ntcYSbx6bugRUTQeFb4BR/WanEL1o3aQgHuVLHQaB6tOqg==",
-      "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "is-odd": "1.0.0",
-        "kind-of": "5.1.0",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.0",
-        "snapdragon": "0.8.1",
-        "to-regex": "3.0.1"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
-    },
-    "negotiator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
-    },
-    "node-forge": {
-      "version": "0.6.33",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.33.tgz",
-      "integrity": "sha1-RjgRh59XPUUVWtap9D3ClujoXrw="
-    },
-    "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
-      }
-    },
-    "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "requires": {
-        "remove-trailing-separator": "1.1.0"
-      }
-    },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "requires": {
-        "path-key": "2.0.1"
-      }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-    },
-    "nwmatcher": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw=="
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "object-copy": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-      "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-            }
-          }
-        }
-      }
-    },
-    "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
-    },
-    "object-visit": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-      "requires": {
-        "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        }
-      }
-    },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
-      }
-    },
-    "object.pick": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-      "requires": {
-        "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        }
-      }
-    },
-    "observable-to-promise": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-0.5.0.tgz",
-      "integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
-      "requires": {
-        "is-observable": "0.2.0",
-        "symbol-observable": "1.1.0"
-      },
-      "dependencies": {
-        "is-observable": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
-          "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
-          "requires": {
-            "symbol-observable": "0.2.4"
-          },
-          "dependencies": {
-            "symbol-observable": {
-              "version": "0.2.4",
-              "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
-              "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A="
-            }
-          }
-        }
-      }
-    },
-    "obuf": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
-      "integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4="
-    },
-    "on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "requires": {
-        "ee-first": "1.1.1"
-      }
-    },
-    "on-headers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1.0.2"
-      }
-    },
-    "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "requires": {
-        "mimic-fn": "1.1.0"
-      }
-    },
-    "opn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
-      "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
-      "requires": {
-        "is-wsl": "1.1.0"
-      }
-    },
-    "option-chain": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/option-chain/-/option-chain-1.0.0.tgz",
-      "integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI="
-    },
-    "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
-      }
-    },
-    "original": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
-      "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
-      "requires": {
-        "url-parse": "1.0.5"
-      },
-      "dependencies": {
-        "url-parse": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
-          "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
-          "requires": {
-            "querystringify": "0.0.4",
-            "requires-port": "1.0.0"
-          }
-        }
-      }
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "requires": {
-        "lcid": "1.0.0"
-      }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-    },
-    "p-limit": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-      "requires": {
-        "p-try": "1.0.0"
-      }
-    },
-    "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "requires": {
-        "p-limit": "1.2.0"
-      }
-    },
-    "p-map": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
-    },
-    "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-    },
-    "package-hash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
-      "integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "lodash.flattendeep": "4.4.0",
-        "md5-hex": "2.0.0",
-        "release-zalgo": "1.0.0"
-      }
-    },
-    "package-json": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-      "requires": {
-        "got": "6.7.1",
-        "registry-auth-token": "3.3.1",
-        "registry-url": "3.1.0",
-        "semver": "5.4.1"
-      }
-    },
-    "parallel-transform": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
-      "requires": {
-        "cyclist": "0.2.2",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
-      }
-    },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
-      }
-    },
-    "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "requires": {
-        "error-ex": "1.3.1"
-      }
-    },
-    "parse-ms": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0="
-    },
-    "parse5": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-      "requires": {
-        "@types/node": "9.3.0"
-      }
-    },
-    "parseurl": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
-    },
-    "pascalcase": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
-    },
-    "path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
-    },
-    "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-    },
-    "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
-    },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-    },
-    "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
-    },
-    "path-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-      "requires": {
-        "pify": "2.3.0"
-      }
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
-    "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-    },
-    "pinkie": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-      "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q="
-    },
-    "pinkie-promise": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-      "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
-      "requires": {
-        "pinkie": "1.0.0"
-      }
-    },
-    "pkg-conf": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
-      "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
-      "requires": {
-        "find-up": "2.1.0",
-        "load-json-file": "4.0.0"
-      },
-      "dependencies": {
-        "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.1"
-          }
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
-      }
-    },
-    "pkg-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-      "requires": {
-        "find-up": "2.1.0"
-      }
-    },
-    "plur": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
-      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
-      "requires": {
-        "irregular-plurals": "1.4.0"
-      }
-    },
-    "pn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
-    },
-    "portfinder": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
-      "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
-      "requires": {
-        "async": "1.5.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "posix-character-classes": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
-    },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-    },
-    "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-    },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-    },
-    "pretty-ms": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
-      "integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
-      "requires": {
-        "parse-ms": "1.0.1",
-        "plur": "2.1.2"
-      }
-    },
-    "private": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
-    },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-    },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "2.0.6"
-      }
-    },
-    "promise-inflight": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
-    },
-    "prop-types": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
-    },
-    "proxy-addr": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
-      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
-      "requires": {
-        "forwarded": "0.1.2",
-        "ipaddr.js": "1.5.2"
-      }
-    },
-    "prr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
-    "pump": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-      "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
-      }
-    },
-    "pumpify": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.6.tgz",
-      "integrity": "sha512-BurGAcvezsINL5US9T9wGHHcLNrG6MCp//ECtxron3vcR+Rfx5Anqq7HbZXNJvFQli8FGVsWCAvywEJFV5Hx/Q==",
-      "requires": {
-        "duplexify": "3.5.3",
-        "inherits": "2.0.3",
-        "pump": "2.0.0"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.0.tgz",
-          "integrity": "sha512-6MYypjOvtiXhBSTOD0Zs5eNjCGfnqi5mPsCsW+dgKTxrZzQMZQNpBo3XRkLx7id753f3EeyHLBqzqqUymIolgw==",
-          "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
-          }
-        }
-      }
-    },
-    "punycode": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
-    },
-    "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-    },
-    "querystringify": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
-      "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw="
-    },
-    "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-      "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        }
-      }
-    },
-    "range-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
-    },
-    "raw-body": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-      "requires": {
-        "bytes": "3.0.0",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
-        "unpipe": "1.0.0"
-      }
-    },
-    "rc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.3.tgz",
-      "integrity": "sha1-UVdakA+N1oOBxxC0cSwhVMPiA1s=",
-      "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
-      }
-    },
-    "react": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
-      "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
-      }
-    },
-    "react-dom": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
-      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
-      }
-    },
-    "react-redux": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz",
-      "integrity": "sha512-8taaaGu+J7PMJQDJrk/xiWEYQmdo3mkXw6wPr3K3LxvXis3Fymiq7c13S+Tpls/AyNUAsoONkU81AP0RA6y6Vw==",
-      "requires": {
-        "hoist-non-react-statics": "2.3.1",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
-        "loose-envify": "1.3.1",
-        "prop-types": "15.6.0"
-      }
-    },
-    "read-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-      "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-      "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
-      }
-    },
-    "readdirp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
-      }
-    },
-    "redent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
-      },
-      "dependencies": {
-        "indent-string": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-          "requires": {
-            "repeating": "2.0.1"
-          }
-        }
-      }
-    },
-    "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
-      "requires": {
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
-        "loose-envify": "1.3.1",
-        "symbol-observable": "1.1.0"
-      }
-    },
-    "regenerate": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
-    },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-    },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "requires": {
-        "is-equal-shallow": "0.1.3"
-      }
-    },
-    "regex-not": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
-      "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
-      "requires": {
-        "extend-shallow": "2.0.1"
-      }
-    },
-    "regexpu-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      }
-    },
-    "registry-auth-token": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
-      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
-      "requires": {
-        "rc": "1.2.3",
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "registry-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "requires": {
-        "rc": "1.2.3"
-      }
-    },
-    "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
-    },
-    "regjsparser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "requires": {
-        "jsesc": "0.5.0"
-      }
-    },
-    "release-zalgo": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
-      "requires": {
-        "es6-error": "4.1.1"
-      }
-    },
-    "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
-    },
-    "repeat-element": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-    },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "requires": {
-        "is-finite": "1.0.2"
-      }
-    },
-    "request": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-      "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
-      }
-    },
-    "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-      "requires": {
-        "lodash": "4.17.4"
-      }
-    },
-    "request-promise-native": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
-      "requires": {
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.3"
-      }
-    },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-    },
-    "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-    },
-    "require-precompiled": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
-      "integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo="
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
-    },
-    "resolve-cwd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-      "requires": {
-        "resolve-from": "3.0.0"
-      }
-    },
-    "resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
-    },
-    "resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-    },
-    "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
-      }
-    },
-    "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "requires": {
-        "glob": "7.1.2"
-      }
-    },
-    "run-queue": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
-      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
-      "requires": {
-        "aproba": "1.2.0"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
-    "select-hose": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
-    },
-    "selfsigned": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.1.tgz",
-      "integrity": "sha1-v4y3uDJWxFUeMTR8YxF3jbme7FI=",
-      "requires": {
-        "node-forge": "0.6.33"
-      }
-    },
-    "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-    },
-    "semver-diff": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "requires": {
-        "semver": "5.4.1"
-      }
-    },
-    "send": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
-      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
-      "requires": {
-        "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "1.6.2",
-        "mime": "1.4.1",
-        "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "mime": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
-        }
-      }
-    },
-    "serialize-javascript": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
-      "integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU="
-    },
-    "serve-index": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
-      "requires": {
-        "accepts": "1.3.4",
-        "batch": "0.6.1",
-        "debug": "2.6.9",
-        "escape-html": "1.0.3",
-        "http-errors": "1.6.2",
-        "mime-types": "2.1.17",
-        "parseurl": "1.3.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "serve-static": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
-      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
-      "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
-        "send": "0.16.1"
-      }
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-    },
-    "set-getter": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
-      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
-      "requires": {
-        "to-object-path": "0.3.0"
-      }
-    },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
-    },
-    "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-      "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
-      }
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-    },
-    "setprototypeof": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "requires": {
-        "shebang-regex": "1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-    },
-    "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-    },
-    "slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
-    },
-    "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0"
-      }
-    },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
-    },
-    "snapdragon": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
-      "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
-      "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.1",
-        "use": "2.0.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
-    },
-    "snapdragon-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-      "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
-      },
-      "dependencies": {
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        }
-      }
-    },
-    "snapdragon-util": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-      "requires": {
-        "kind-of": "3.2.2"
-      }
-    },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
-    "sockjs": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
-      "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
-      "requires": {
-        "faye-websocket": "0.10.0",
-        "uuid": "3.1.0"
-      }
-    },
-    "sockjs-client": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
-      "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
-      "requires": {
-        "debug": "2.6.9",
-        "eventsource": "0.1.6",
-        "faye-websocket": "0.11.1",
-        "inherits": "2.0.3",
-        "json3": "3.3.2",
-        "url-parse": "1.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "faye-websocket": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
-          "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
-          "requires": {
-            "websocket-driver": "0.7.0"
-          }
-        }
-      }
-    },
-    "sort-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-      "requires": {
-        "is-plain-obj": "1.1.0"
-      }
-    },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-    },
-    "source-map-loader": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.3.tgz",
-      "integrity": "sha512-MYbFX9DYxmTQFfy2v8FC1XZwpwHKYxg3SK8Wb7VPBKuhDjz8gi9re2819MsG4p49HDyiOSUKlmZ+nQBArW5CGw==",
-      "requires": {
-        "async": "2.6.0",
-        "loader-utils": "0.2.17",
-        "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
-    },
-    "source-map-resolve": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
-      "requires": {
-        "atob": "2.0.3",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
-      }
-    },
-    "source-map-support": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
-      "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
-      "requires": {
-        "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
-    },
-    "source-map-url": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
-    },
-    "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "requires": {
-        "spdx-license-ids": "1.2.2"
-      }
-    },
-    "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
-    },
-    "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
-    },
-    "spdy": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
-      "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
-      "requires": {
-        "debug": "2.6.9",
-        "handle-thing": "1.2.5",
-        "http-deceiver": "1.2.7",
-        "safe-buffer": "5.1.1",
-        "select-hose": "2.0.0",
-        "spdy-transport": "2.0.20"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "spdy-transport": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
-      "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
-      "requires": {
-        "debug": "2.6.9",
-        "detect-node": "2.0.3",
-        "hpack.js": "2.1.6",
-        "obuf": "1.1.1",
-        "readable-stream": "2.3.3",
-        "safe-buffer": "5.1.1",
-        "wbuf": "1.7.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "split-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-      "requires": {
-        "extend-shallow": "3.0.2"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
-          }
-        },
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "requires": {
-            "is-plain-object": "2.0.4"
-          }
-        }
-      }
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "ssri": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz",
-      "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "stack-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-      "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
-    },
-    "static-extend": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-      "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
-    },
-    "statuses": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
-    },
-    "stream-each": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
-      "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
-      "requires": {
-        "end-of-stream": "1.4.1",
-        "stream-shift": "1.0.0"
-      }
-    },
-    "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
-    },
-    "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-    },
-    "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "requires": {
-        "ansi-regex": "3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        }
-      }
-    },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-    },
-    "strip-bom-buf": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
-      "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
-      "requires": {
-        "is-utf8": "0.2.1"
-      }
-    },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-    },
-    "strip-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "requires": {
-        "get-stdin": "4.0.1"
-      }
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-    },
-    "supports-color": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-      "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
-      "requires": {
-        "has-flag": "2.0.0"
-      }
-    },
-    "symbol-observable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
-      "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw=="
-    },
-    "symbol-tree": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
-    },
-    "tapable": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
-      "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
-    },
-    "term-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "requires": {
-        "execa": "0.7.0"
-      }
-    },
-    "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
-    },
-    "through2": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-      "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
-      }
-    },
-    "thunky": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
-      "integrity": "sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4="
-    },
-    "time-require": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/time-require/-/time-require-0.1.2.tgz",
-      "integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
-      "requires": {
-        "chalk": "0.4.0",
-        "date-time": "0.1.1",
-        "pretty-ms": "0.2.2",
-        "text-table": "0.2.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
-          }
-        },
-        "date-time": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
-          "integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc="
-        },
-        "parse-ms": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
-          "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4="
-        },
-        "pretty-ms": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
-          "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
-          "requires": {
-            "parse-ms": "0.1.2"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
-        }
-      }
-    },
-    "time-stamp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
-      "integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c="
-    },
-    "time-zone": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
-      "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0="
-    },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-    },
-    "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
-    },
-    "to-object-path": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-      "requires": {
-        "kind-of": "3.2.2"
-      }
-    },
-    "to-regex": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz",
-      "integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
-      "requires": {
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "regex-not": "1.0.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
-    },
-    "to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-      "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        }
-      }
-    },
-    "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-      "requires": {
-        "punycode": "1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        }
-      }
-    },
-    "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "requires": {
-        "punycode": "2.1.0"
-      }
-    },
-    "trim-newlines": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
-    },
-    "trim-off-newlines": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
-    },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
-    },
-    "ts-loader": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-3.2.0.tgz",
-      "integrity": "sha512-4g8BF3gKWBHeM1jAFmMPHofuJlwTUU4iHJ0i3mwXRHwy74RU6VBOgl9kDVMGpapvGcMlVqV5G6v9XmV66Qqd7w==",
-      "requires": {
-        "chalk": "2.3.0",
-        "enhanced-resolve": "3.4.1",
-        "loader-utils": "1.1.0",
-        "semver": "5.4.1"
-      },
-      "dependencies": {
-        "loader-utils": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1"
-          }
-        }
-      }
-    },
-    "tslint-loader": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/tslint-loader/-/tslint-loader-3.5.3.tgz",
-      "integrity": "sha1-ND90Ei2U81a2iUV9P1n2SmmrYG8=",
-      "requires": {
-        "loader-utils": "1.1.0",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1",
-        "rimraf": "2.6.2",
-        "semver": "5.4.1"
-      },
-      "dependencies": {
-        "loader-utils": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1"
-          }
-        }
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
-    },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "requires": {
-        "prelude-ls": "1.1.2"
-      }
-    },
-    "type-is": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "requires": {
-        "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
-      }
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "ua-parser-js": {
-      "version": "0.7.17",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
-    },
-    "uid2": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
-    },
-    "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-      "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
-      },
-      "dependencies": {
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
-          }
-        }
-      }
-    },
-    "unique-filename": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
-      "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
-      "requires": {
-        "unique-slug": "2.0.0"
-      }
-    },
-    "unique-slug": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
-      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-      "requires": {
-        "imurmurhash": "0.1.4"
-      }
-    },
-    "unique-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "requires": {
-        "crypto-random-string": "1.0.0"
-      }
-    },
-    "unique-temp-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
-      "integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
-      "requires": {
-        "mkdirp": "0.5.1",
-        "os-tmpdir": "1.0.2",
-        "uid2": "0.0.3"
-      }
-    },
-    "unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-    },
-    "unset-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-      "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
-      },
-      "dependencies": {
-        "has-value": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-          "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "requires": {
-                "isarray": "1.0.0"
-              }
-            }
-          }
-        },
-        "has-values": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        }
-      }
-    },
-    "unzip-response": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
-    },
-    "update-notifier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
-      "requires": {
-        "boxen": "1.3.0",
-        "chalk": "2.3.0",
-        "configstore": "3.1.1",
-        "import-lazy": "2.1.0",
-        "is-installed-globally": "0.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "3.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "3.0.0"
-      }
-    },
-    "urix": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
-    },
-    "url-parse": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
-      "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
-      "requires": {
-        "querystringify": "1.0.0",
-        "requires-port": "1.0.0"
-      },
-      "dependencies": {
-        "querystringify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
-          "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
-        }
-      }
-    },
-    "url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "requires": {
-        "prepend-http": "1.0.4"
-      }
-    },
-    "use": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
-      "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
-      "requires": {
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-    },
-    "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
-      }
-    },
-    "vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      }
-    },
-    "wbuf": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
-      "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
-      "requires": {
-        "minimalistic-assert": "1.0.0"
-      }
-    },
-    "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-    },
-    "webpack-dev-middleware": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
-      "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
-      "requires": {
-        "memory-fs": "0.4.1",
-        "mime": "1.6.0",
-        "path-is-absolute": "1.0.1",
-        "range-parser": "1.2.0",
-        "time-stamp": "2.0.0"
-      }
-    },
-    "webpack-dev-server": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.10.1.tgz",
-      "integrity": "sha512-R9iZOrbIIsP2mw2j172HVjf479Zb9kcG0chjzHRrE/4M333NZ+3jOWRWJMGEQXwJzUtRNvVKzX2o27qM59TIhQ==",
-      "requires": {
-        "ansi-html": "0.0.7",
-        "array-includes": "3.0.3",
-        "bonjour": "3.5.0",
-        "chokidar": "2.0.0",
-        "compression": "1.7.1",
-        "connect-history-api-fallback": "1.5.0",
-        "debug": "3.1.0",
-        "del": "3.0.0",
-        "express": "4.16.2",
-        "html-entities": "1.2.1",
-        "http-proxy-middleware": "0.17.4",
-        "import-local": "1.0.0",
-        "internal-ip": "1.2.0",
-        "ip": "1.1.5",
-        "killable": "1.0.0",
-        "loglevel": "1.6.1",
-        "opn": "5.1.0",
-        "portfinder": "1.0.13",
-        "selfsigned": "1.10.1",
-        "serve-index": "1.9.1",
-        "sockjs": "0.3.19",
-        "sockjs-client": "1.1.4",
-        "spdy": "3.4.7",
-        "strip-ansi": "4.0.0",
-        "supports-color": "5.1.0",
-        "webpack-dev-middleware": "1.12.2",
-        "yargs": "6.6.0"
-      },
-      "dependencies": {
-        "anymatch": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-          "requires": {
-            "micromatch": "3.1.5",
-            "normalize-path": "2.1.1"
-          }
-        },
-        "arr-diff": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-        },
-        "braces": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.0.tgz",
-          "integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
-          "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.1",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.1"
-          }
-        },
-        "chokidar": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.0.tgz",
-          "integrity": "sha512-OgXCNv2U6TnG04D3tth0gsvdbV4zdbxFG3sYUqcoQMoEFVd1j1pZR6TZ8iknC45o9IJ6PeQI/J6wT/+cHcniAw==",
-          "requires": {
-            "anymatch": "2.0.0",
-            "async-each": "1.0.1",
-            "braces": "2.3.0",
-            "fsevents": "1.1.3",
-            "glob-parent": "3.1.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "4.0.0",
-            "normalize-path": "2.1.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.1.0"
-          }
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-          "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "requires": {
-                "is-descriptor": "0.1.6"
-              }
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.3.tgz",
-          "integrity": "sha512-AyptZexgu7qppEPq59DtN/XJGZDrLcVxSHai+4hdgMMS9EpF4GBvygcWWApno8lL9qSjVpYt7Raao28qzJX1ww==",
-          "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
-          }
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-              "requires": {
-                "is-extglob": "2.1.1"
-              }
-            }
-          }
-        },
-        "import-local": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-          "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
-          "requires": {
-            "pkg-dir": "2.0.0",
-            "resolve-cwd": "2.0.0"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-            }
-          }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-        },
-        "is-glob": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-          "requires": {
-            "is-extglob": "2.1.1"
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-        },
-        "micromatch": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.5.tgz",
-          "integrity": "sha512-ykttrLPQrz1PUJcXjwsTUjGoPJ64StIGNE2lGVD1c9CuguJ+L7/navsE8IcDNndOoCMvYV0qc/exfVbMHkUhvA==",
-          "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.0",
-            "define-property": "1.0.0",
-            "extend-shallow": "2.0.1",
-            "extglob": "2.0.3",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.7",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.1"
-          }
-        }
-      }
-    },
-    "websocket-driver": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
-      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
-      "requires": {
-        "http-parser-js": "0.4.9",
-        "websocket-extensions": "0.1.3"
-      }
-    },
-    "websocket-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
-    },
-    "well-known-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-1.0.0.tgz",
-      "integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg="
-    },
-    "whatwg-encoding": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-      "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
-      "requires": {
-        "iconv-lite": "0.4.19"
-      }
-    },
-    "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
-    },
-    "whatwg-url": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
-      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
-      "requires": {
-        "lodash.sortby": "4.7.0",
-        "tr46": "1.0.1",
-        "webidl-conversions": "4.0.2"
-      }
-    },
-    "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "requires": {
-        "isexe": "2.0.0"
-      }
-    },
-    "which-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-    },
-    "widest-line": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
-      "requires": {
-        "string-width": "2.1.1"
-      }
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-    },
-    "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "write-file-atomic": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
-      }
-    },
-    "write-json-file": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
-      "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
-      "requires": {
-        "detect-indent": "5.0.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
-        "pify": "3.0.0",
-        "sort-keys": "2.0.0",
-        "write-file-atomic": "2.3.0"
-      },
-      "dependencies": {
-        "detect-indent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
-      }
-    },
-    "write-pkg": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.1.0.tgz",
-      "integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
-      "requires": {
-        "sort-keys": "2.0.0",
-        "write-json-file": "2.3.0"
-      }
-    },
-    "xdg-basedir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
-    },
-    "xml-name-validator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-    },
-    "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
-    "yargs": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-      "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-      "requires": {
-        "camelcase": "3.0.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "4.2.1"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-      "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-      "requires": {
-        "camelcase": "3.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-        }
-      }
-    }
-  }
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"@ava/babel-plugin-throws-helper": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-2.0.0.tgz",
+			"integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw="
+		},
+		"@ava/babel-preset-stage-4": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-1.1.0.tgz",
+			"integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
+			"requires": {
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-async-to-generator": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "6.24.1",
+				"package-hash": "1.2.0"
+			},
+			"dependencies": {
+				"md5-hex": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+					"requires": {
+						"md5-o-matic": "0.1.1"
+					}
+				},
+				"package-hash": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-1.2.0.tgz",
+					"integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
+					"requires": {
+						"md5-hex": "1.3.0"
+					}
+				}
+			}
+		},
+		"@ava/babel-preset-transform-test-files": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-3.0.0.tgz",
+			"integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
+			"requires": {
+				"@ava/babel-plugin-throws-helper": "2.0.0",
+				"babel-plugin-espower": "2.4.0"
+			}
+		},
+		"@ava/write-file-atomic": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@ava/write-file-atomic/-/write-file-atomic-2.2.0.tgz",
+			"integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"slide": "1.1.6"
+			}
+		},
+		"@concordance/react": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz",
+			"integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
+			"requires": {
+				"arrify": "1.0.1"
+			}
+		},
+		"abab": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+		},
+		"accepts": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+			"requires": {
+				"mime-types": "2.1.18",
+				"negotiator": "0.6.1"
+			}
+		},
+		"acorn": {
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
+		},
+		"acorn-globals": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+			"requires": {
+				"acorn": "5.5.3"
+			}
+		},
+		"ajv": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"requires": {
+				"co": "4.6.0",
+				"fast-deep-equal": "1.1.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
+			}
+		},
+		"ansi-align": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+			"requires": {
+				"string-width": "2.1.1"
+			}
+		},
+		"ansi-escapes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+		},
+		"ansi-html": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "1.9.1"
+			}
+		},
+		"anymatch": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"requires": {
+				"micromatch": "2.3.11",
+				"normalize-path": "2.1.1"
+			}
+		},
+		"aproba": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"requires": {
+				"sprintf-js": "1.0.3"
+			}
+		},
+		"arr-diff": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"requires": {
+				"arr-flatten": "1.1.0"
+			}
+		},
+		"arr-exclude": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/arr-exclude/-/arr-exclude-1.0.0.tgz",
+			"integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE="
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+		},
+		"array-differ": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+		},
+		"array-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+		},
+		"array-find-index": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+		},
+		"array-flatten": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
+			"integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
+		},
+		"array-includes": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+			"requires": {
+				"define-properties": "1.1.2",
+				"es-abstract": "1.10.0"
+			}
+		},
+		"array-union": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"requires": {
+				"array-uniq": "1.0.3"
+			}
+		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+		},
+		"array-unique": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+		},
+		"async": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"async-each": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"atob": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
+			"integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10="
+		},
+		"auto-bind": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-1.2.0.tgz",
+			"integrity": "sha512-Zw7pZp7tztvKnWWtoII4AmqH5a2PV3ZN5F0BPRTGcc1kpRm4b6QXQnPU7Znbl6BfPfqOVOV29g4JeMqZQaqqOA=="
+		},
+		"ava": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-0.24.0.tgz",
+			"integrity": "sha512-o/ykNzsWB5qgh1cR9jzVw0E1y4E219aXl9njNFGSamSCsD7VhPd3aoZabNZuG1PSVMZmQ8RuwKnTuz/loNhKnw==",
+			"requires": {
+				"@ava/babel-preset-stage-4": "1.1.0",
+				"@ava/babel-preset-transform-test-files": "3.0.0",
+				"@ava/write-file-atomic": "2.2.0",
+				"@concordance/react": "1.0.0",
+				"ansi-escapes": "3.0.0",
+				"ansi-styles": "3.2.1",
+				"arr-flatten": "1.1.0",
+				"array-union": "1.0.2",
+				"array-uniq": "1.0.3",
+				"arrify": "1.0.1",
+				"auto-bind": "1.2.0",
+				"ava-init": "0.2.1",
+				"babel-core": "6.26.0",
+				"babel-generator": "6.26.1",
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"bluebird": "3.5.1",
+				"caching-transform": "1.0.1",
+				"chalk": "2.3.2",
+				"chokidar": "1.7.0",
+				"clean-stack": "1.3.0",
+				"clean-yaml-object": "0.1.0",
+				"cli-cursor": "2.1.0",
+				"cli-spinners": "1.1.0",
+				"cli-truncate": "1.1.0",
+				"co-with-promise": "4.6.0",
+				"code-excerpt": "2.1.1",
+				"common-path-prefix": "1.0.0",
+				"concordance": "3.0.0",
+				"convert-source-map": "1.5.1",
+				"core-assert": "0.2.1",
+				"currently-unhandled": "0.4.1",
+				"debug": "3.1.0",
+				"dot-prop": "4.2.0",
+				"empower-core": "0.6.2",
+				"equal-length": "1.0.1",
+				"figures": "2.0.0",
+				"find-cache-dir": "1.0.0",
+				"fn-name": "2.0.1",
+				"get-port": "3.2.0",
+				"globby": "6.1.0",
+				"has-flag": "2.0.0",
+				"hullabaloo-config-manager": "1.1.1",
+				"ignore-by-default": "1.0.1",
+				"import-local": "0.1.1",
+				"indent-string": "3.2.0",
+				"is-ci": "1.1.0",
+				"is-generator-fn": "1.0.0",
+				"is-obj": "1.0.1",
+				"is-observable": "1.1.0",
+				"is-promise": "2.1.0",
+				"js-yaml": "3.11.0",
+				"last-line-stream": "1.0.0",
+				"lodash.clonedeepwith": "4.5.0",
+				"lodash.debounce": "4.0.8",
+				"lodash.difference": "4.5.0",
+				"lodash.flatten": "4.4.0",
+				"loud-rejection": "1.6.0",
+				"make-dir": "1.2.0",
+				"matcher": "1.1.0",
+				"md5-hex": "2.0.0",
+				"meow": "3.7.0",
+				"ms": "2.1.1",
+				"multimatch": "2.1.0",
+				"observable-to-promise": "0.5.0",
+				"option-chain": "1.0.0",
+				"package-hash": "2.0.0",
+				"pkg-conf": "2.1.0",
+				"plur": "2.1.2",
+				"pretty-ms": "3.1.0",
+				"require-precompiled": "0.1.0",
+				"resolve-cwd": "2.0.0",
+				"safe-buffer": "5.1.1",
+				"semver": "5.5.0",
+				"slash": "1.0.0",
+				"source-map-support": "0.5.3",
+				"stack-utils": "1.0.1",
+				"strip-ansi": "4.0.0",
+				"strip-bom-buf": "1.0.0",
+				"supports-color": "5.3.0",
+				"time-require": "0.1.2",
+				"trim-off-newlines": "1.0.1",
+				"unique-temp-dir": "1.0.0",
+				"update-notifier": "2.3.0"
+			}
+		},
+		"ava-init": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/ava-init/-/ava-init-0.2.1.tgz",
+			"integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
+			"requires": {
+				"arr-exclude": "1.0.0",
+				"execa": "0.7.0",
+				"has-yarn": "1.0.0",
+				"read-pkg-up": "2.0.0",
+				"write-pkg": "3.1.0"
+			}
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+		},
+		"aws4": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"requires": {
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
+			}
+		},
+		"babel-core": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.1",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"convert-source-map": "1.5.1",
+				"debug": "2.6.9",
+				"json5": "0.5.1",
+				"lodash": "4.17.5",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.8",
+				"slash": "1.0.0",
+				"source-map": "0.5.7"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"babel-generator": {
+			"version": "6.26.1",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"requires": {
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.5",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+				}
+			}
+		},
+		"babel-helper-builder-binary-assignment-operator-visitor": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"requires": {
+				"babel-helper-explode-assignable-expression": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-call-delegate": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"requires": {
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-explode-assignable-expression": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-function-name": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"requires": {
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-get-function-arity": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-hoist-variables": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-regex": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.5"
+			}
+		},
+		"babel-helper-remap-async-to-generator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helpers": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
+			}
+		},
+		"babel-messages": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-check-es2015-constants": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-espower": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-2.4.0.tgz",
+			"integrity": "sha512-/+SRpy7pKgTI28oEHfn1wkuM5QFAdRq8WNsOOih1dVrdV6A/WbNbRZyl0eX5eyDgtb0lOE27PeDFuCX2j8OxVg==",
+			"requires": {
+				"babel-generator": "6.26.1",
+				"babylon": "6.18.0",
+				"call-matcher": "1.0.1",
+				"core-js": "2.5.3",
+				"espower-location-detector": "1.0.0",
+				"espurify": "1.7.0",
+				"estraverse": "4.2.0"
+			}
+		},
+		"babel-plugin-syntax-async-functions": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+		},
+		"babel-plugin-syntax-exponentiation-operator": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+		},
+		"babel-plugin-syntax-object-rest-spread": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+		},
+		"babel-plugin-syntax-trailing-function-commas": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+		},
+		"babel-plugin-transform-async-to-generator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"requires": {
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-functions": "6.13.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-destructuring": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-function-name": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-modules-commonjs": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+			"requires": {
+				"babel-plugin-transform-strict-mode": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-parameters": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"requires": {
+				"babel-helper-call-delegate": "6.24.1",
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-spread": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-sticky-regex": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"requires": {
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-unicode-regex": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"requires": {
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"regexpu-core": "2.0.0"
+			}
+		},
+		"babel-plugin-transform-exponentiation-operator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"requires": {
+				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-strict-mode": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-register": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"requires": {
+				"babel-core": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.3",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.5",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.18"
+			},
+			"dependencies": {
+				"source-map-support": {
+					"version": "0.4.18",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+					"requires": {
+						"source-map": "0.5.7"
+					}
+				}
+			}
+		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"requires": {
+				"core-js": "2.5.3",
+				"regenerator-runtime": "0.11.1"
+			}
+		},
+		"babel-template": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.5"
+			}
+		},
+		"babel-traverse": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.9",
+				"globals": "9.18.0",
+				"invariant": "2.2.3",
+				"lodash": "4.17.5"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.5",
+				"to-fast-properties": "1.0.3"
+			}
+		},
+		"babylon": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"requires": {
+				"cache-base": "1.0.1",
+				"class-utils": "0.3.6",
+				"component-emitter": "1.2.1",
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"mixin-deep": "1.3.1",
+				"pascalcase": "0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"batch": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"optional": true,
+			"requires": {
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"big.js": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+		},
+		"binary-extensions": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+		},
+		"bluebird": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+		},
+		"body-parser": {
+			"version": "1.18.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+			"requires": {
+				"bytes": "3.0.0",
+				"content-type": "1.0.4",
+				"debug": "2.6.9",
+				"depd": "1.1.2",
+				"http-errors": "1.6.2",
+				"iconv-lite": "0.4.19",
+				"on-finished": "2.3.0",
+				"qs": "6.5.1",
+				"raw-body": "2.3.2",
+				"type-is": "1.6.16"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"bonjour": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+			"integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+			"requires": {
+				"array-flatten": "2.1.1",
+				"deep-equal": "1.0.1",
+				"dns-equal": "1.0.0",
+				"dns-txt": "2.0.2",
+				"multicast-dns": "6.2.3",
+				"multicast-dns-service-types": "1.1.0"
+			}
+		},
+		"boom": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+			"requires": {
+				"hoek": "4.2.1"
+			}
+		},
+		"boxen": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+			"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+			"requires": {
+				"ansi-align": "2.0.0",
+				"camelcase": "4.1.0",
+				"chalk": "2.3.2",
+				"cli-boxes": "1.0.0",
+				"string-width": "2.1.1",
+				"term-size": "1.2.0",
+				"widest-line": "2.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				}
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"requires": {
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
+			}
+		},
+		"browser-process-hrtime": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
+		},
+		"buf-compare": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
+			"integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o="
+		},
+		"buffer-indexof": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+			"integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+		},
+		"bytes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+		},
+		"cacache": {
+			"version": "10.0.4",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+			"requires": {
+				"bluebird": "3.5.1",
+				"chownr": "1.0.1",
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"lru-cache": "4.1.1",
+				"mississippi": "2.0.0",
+				"mkdirp": "0.5.1",
+				"move-concurrently": "1.0.1",
+				"promise-inflight": "1.0.1",
+				"rimraf": "2.6.2",
+				"ssri": "5.2.4",
+				"unique-filename": "1.1.0",
+				"y18n": "4.0.0"
+			}
+		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"requires": {
+				"collection-visit": "1.0.0",
+				"component-emitter": "1.2.1",
+				"get-value": "2.0.6",
+				"has-value": "1.0.0",
+				"isobject": "3.0.1",
+				"set-value": "2.0.0",
+				"to-object-path": "0.3.0",
+				"union-value": "1.0.0",
+				"unset-value": "1.0.0"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"caching-transform": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+			"integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+			"requires": {
+				"md5-hex": "1.3.0",
+				"mkdirp": "0.5.1",
+				"write-file-atomic": "1.3.4"
+			},
+			"dependencies": {
+				"md5-hex": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+					"requires": {
+						"md5-o-matic": "0.1.1"
+					}
+				},
+				"write-file-atomic": {
+					"version": "1.3.4",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
+					}
+				}
+			}
+		},
+		"call-matcher": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.0.1.tgz",
+			"integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
+			"requires": {
+				"core-js": "2.5.3",
+				"deep-equal": "1.0.1",
+				"espurify": "1.7.0",
+				"estraverse": "4.2.0"
+			}
+		},
+		"call-signature": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
+			"integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY="
+		},
+		"camelcase": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+		},
+		"camelcase-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+			"requires": {
+				"camelcase": "2.1.1",
+				"map-obj": "1.0.1"
+			}
+		},
+		"capture-stack-trace": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+		},
+		"chalk": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+			"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+			"requires": {
+				"ansi-styles": "3.2.1",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "5.3.0"
+			}
+		},
+		"chokidar": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"requires": {
+				"anymatch": "1.3.2",
+				"async-each": "1.0.1",
+				"fsevents": "1.1.3",
+				"glob-parent": "2.0.0",
+				"inherits": "2.0.3",
+				"is-binary-path": "1.0.1",
+				"is-glob": "2.0.1",
+				"path-is-absolute": "1.0.1",
+				"readdirp": "2.1.0"
+			}
+		},
+		"chownr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+		},
+		"ci-info": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+			"integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA=="
+		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"requires": {
+				"arr-union": "3.1.0",
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"static-extend": "0.1.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				}
+			}
+		},
+		"clean-stack": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
+			"integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
+		},
+		"clean-yaml-object": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
+			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g="
+		},
+		"cli-boxes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+		},
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"requires": {
+				"restore-cursor": "2.0.0"
+			}
+		},
+		"cli-spinners": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
+			"integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY="
+		},
+		"cli-truncate": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
+			"integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
+			"requires": {
+				"slice-ansi": "1.0.0",
+				"string-width": "2.1.1"
+			}
+		},
+		"cliui": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+			"requires": {
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1",
+				"wrap-ansi": "2.1.0"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				}
+			}
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+		},
+		"co-with-promise": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co-with-promise/-/co-with-promise-4.6.0.tgz",
+			"integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
+			"requires": {
+				"pinkie-promise": "1.0.0"
+			}
+		},
+		"code-excerpt": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.1.tgz",
+			"integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
+			"requires": {
+				"convert-to-spaces": "1.0.2"
+			}
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"requires": {
+				"map-visit": "1.0.0",
+				"object-visit": "1.0.1"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"combined-stream": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"requires": {
+				"delayed-stream": "1.0.0"
+			}
+		},
+		"common-path-prefix": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
+			"integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA="
+		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+		},
+		"compressible": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
+			"integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
+			"requires": {
+				"mime-db": "1.33.0"
+			}
+		},
+		"compression": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+			"integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
+			"requires": {
+				"accepts": "1.3.5",
+				"bytes": "3.0.0",
+				"compressible": "2.0.13",
+				"debug": "2.6.9",
+				"on-headers": "1.0.1",
+				"safe-buffer": "5.1.1",
+				"vary": "1.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"concat-stream": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
+			"integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5",
+				"typedarray": "0.0.6"
+			}
+		},
+		"concordance": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/concordance/-/concordance-3.0.0.tgz",
+			"integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
+			"requires": {
+				"date-time": "2.1.0",
+				"esutils": "2.0.2",
+				"fast-diff": "1.1.2",
+				"function-name-support": "0.2.0",
+				"js-string-escape": "1.0.1",
+				"lodash.clonedeep": "4.5.0",
+				"lodash.flattendeep": "4.4.0",
+				"lodash.merge": "4.6.1",
+				"md5-hex": "2.0.0",
+				"semver": "5.5.0",
+				"well-known-symbols": "1.0.0"
+			}
+		},
+		"configstore": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
+			"integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+			"requires": {
+				"dot-prop": "4.2.0",
+				"graceful-fs": "4.1.11",
+				"make-dir": "1.2.0",
+				"unique-string": "1.0.0",
+				"write-file-atomic": "2.3.0",
+				"xdg-basedir": "3.0.0"
+			}
+		},
+		"connect-history-api-fallback": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
+			"integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
+		},
+		"content-disposition": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+		},
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+		},
+		"content-type-parser": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
+		},
+		"convert-source-map": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+		},
+		"convert-to-spaces": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
+			"integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU="
+		},
+		"cookie": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+		},
+		"cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+		},
+		"copy-concurrently": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+			"requires": {
+				"aproba": "1.2.0",
+				"fs-write-stream-atomic": "1.0.10",
+				"iferr": "0.1.5",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"run-queue": "1.0.3"
+			}
+		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+		},
+		"copy-webpack-plugin": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.5.0.tgz",
+			"integrity": "sha512-ROQ85fWKuhJfUkBTdHvfV+Zv6Ltm3G/vPVFdLPFwzWzd9RUY1yLw3rt6FmKK2PaeNQCNvmwgFhuarkjuV4PVDQ==",
+			"requires": {
+				"cacache": "10.0.4",
+				"find-cache-dir": "1.0.0",
+				"globby": "7.1.1",
+				"is-glob": "4.0.0",
+				"loader-utils": "1.1.0",
+				"minimatch": "3.0.4",
+				"p-limit": "1.2.0",
+				"serialize-javascript": "1.4.0"
+			},
+			"dependencies": {
+				"globby": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+					"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+					"requires": {
+						"array-union": "1.0.2",
+						"dir-glob": "2.0.0",
+						"glob": "7.1.2",
+						"ignore": "3.3.7",
+						"pify": "3.0.0",
+						"slash": "1.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+				},
+				"is-glob": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"requires": {
+						"is-extglob": "2.1.1"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"core-assert": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
+			"integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
+			"requires": {
+				"buf-compare": "1.0.1",
+				"is-error": "2.2.1"
+			}
+		},
+		"core-js": {
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"create-error-class": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+			"requires": {
+				"capture-stack-trace": "1.0.0"
+			}
+		},
+		"cross-spawn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"requires": {
+				"lru-cache": "4.1.1",
+				"shebang-command": "1.2.0",
+				"which": "1.3.0"
+			}
+		},
+		"cryptiles": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+			"requires": {
+				"boom": "5.2.0"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+					"requires": {
+						"hoek": "4.2.1"
+					}
+				}
+			}
+		},
+		"crypto-random-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+		},
+		"cssom": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+		},
+		"cssstyle": {
+			"version": "0.2.37",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"requires": {
+				"cssom": "0.3.2"
+			}
+		},
+		"currently-unhandled": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+			"requires": {
+				"array-find-index": "1.0.2"
+			}
+		},
+		"cyclist": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			}
+		},
+		"date-time": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
+			"integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
+			"requires": {
+				"time-zone": "1.0.0"
+			}
+		},
+		"debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"requires": {
+				"ms": "2.0.0"
+			},
+			"dependencies": {
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+		},
+		"deep-equal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+		},
+		"deep-extend": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+		},
+		"define-properties": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"requires": {
+				"foreach": "2.0.5",
+				"object-keys": "1.0.11"
+			}
+		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"requires": {
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"del": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+			"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+			"requires": {
+				"globby": "6.1.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.0",
+				"p-map": "1.2.0",
+				"pify": "3.0.0",
+				"rimraf": "2.6.2"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
+		"depd": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+		},
+		"destroy": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+		},
+		"detect-indent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"requires": {
+				"repeating": "2.0.1"
+			}
+		},
+		"detect-node": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
+			"integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
+		},
+		"dir-glob": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+			"requires": {
+				"arrify": "1.0.1",
+				"path-type": "3.0.0"
+			},
+			"dependencies": {
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"requires": {
+						"pify": "3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"dns-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+			"integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
+		},
+		"dns-packet": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
+			"integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+			"requires": {
+				"ip": "1.1.5",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"dns-txt": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+			"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+			"requires": {
+				"buffer-indexof": "1.1.1"
+			}
+		},
+		"document-register-element": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.7.2.tgz",
+			"integrity": "sha512-E+y3qJgckbXK/Ev+jPIF+ussxJRaFRIxYCAkxeYcTdccuQoPw5emVWXkox6JnMejFryjlCs/sw2cokMO2lHxjQ==",
+			"requires": {
+				"lightercollective": "0.0.0"
+			}
+		},
+		"domexception": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"requires": {
+				"webidl-conversions": "4.0.2"
+			}
+		},
+		"dot-prop": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+			"requires": {
+				"is-obj": "1.0.1"
+			}
+		},
+		"duplexer3": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+		},
+		"duplexify": {
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
+			"integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5",
+				"stream-shift": "1.0.0"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"optional": true,
+			"requires": {
+				"jsbn": "0.1.1"
+			}
+		},
+		"ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+		},
+		"emojis-list": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+		},
+		"empower-core": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
+			"integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
+			"requires": {
+				"call-signature": "0.0.2",
+				"core-js": "2.5.3"
+			}
+		},
+		"encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"requires": {
+				"once": "1.4.0"
+			}
+		},
+		"enhanced-resolve": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"memory-fs": "0.4.1",
+				"object-assign": "4.1.1",
+				"tapable": "0.2.8"
+			}
+		},
+		"equal-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/equal-length/-/equal-length-1.0.1.tgz",
+			"integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w="
+		},
+		"errno": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+			"requires": {
+				"prr": "1.0.1"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"requires": {
+				"is-arrayish": "0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+			"integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+			"requires": {
+				"es-to-primitive": "1.1.1",
+				"function-bind": "1.1.1",
+				"has": "1.0.1",
+				"is-callable": "1.1.3",
+				"is-regex": "1.0.4"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"requires": {
+				"is-callable": "1.1.3",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.1"
+			}
+		},
+		"es6-error": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+		},
+		"escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"escodegen": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+			"requires": {
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"optional": true
+				}
+			}
+		},
+		"espower-location-detector": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
+			"integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
+			"requires": {
+				"is-url": "1.2.2",
+				"path-is-absolute": "1.0.1",
+				"source-map": "0.5.7",
+				"xtend": "4.0.1"
+			}
+		},
+		"esprima": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+		},
+		"espurify": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
+			"integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
+			"requires": {
+				"core-js": "2.5.3"
+			}
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
+		"etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+		},
+		"eventemitter3": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+			"integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+		},
+		"eventsource": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+			"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+			"requires": {
+				"original": "1.0.0"
+			}
+		},
+		"execa": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"requires": {
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
+			}
+		},
+		"expand-brackets": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"requires": {
+				"is-posix-bracket": "0.1.1"
+			}
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"requires": {
+				"fill-range": "2.2.3"
+			}
+		},
+		"express": {
+			"version": "4.16.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+			"integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+			"requires": {
+				"accepts": "1.3.5",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.18.2",
+				"content-disposition": "0.5.2",
+				"content-type": "1.0.4",
+				"cookie": "0.3.1",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "1.1.2",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
+				"finalhandler": "1.1.0",
+				"fresh": "0.5.2",
+				"merge-descriptors": "1.0.1",
+				"methods": "1.1.2",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "2.0.3",
+				"qs": "6.5.1",
+				"range-parser": "1.2.0",
+				"safe-buffer": "5.1.1",
+				"send": "0.16.1",
+				"serve-static": "1.13.1",
+				"setprototypeof": "1.1.0",
+				"statuses": "1.3.1",
+				"type-is": "1.6.16",
+				"utils-merge": "1.0.1",
+				"vary": "1.1.2"
+			},
+			"dependencies": {
+				"array-flatten": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"requires": {
+				"assign-symbols": "1.0.0",
+				"is-extendable": "1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "2.0.4"
+					}
+				}
+			}
+		},
+		"extglob": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"requires": {
+				"is-extglob": "1.0.0"
+			}
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"fast-deep-equal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+		},
+		"fast-diff": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+			"integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+		},
+		"faye-websocket": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+			"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+			"requires": {
+				"websocket-driver": "0.7.0"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.16",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"requires": {
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.17"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				}
+			}
+		},
+		"figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"requires": {
+				"escape-string-regexp": "1.0.5"
+			}
+		},
+		"filename-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+		},
+		"fill-range": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"requires": {
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "1.1.7",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"finalhandler": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+			"integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+			"requires": {
+				"debug": "2.6.9",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"statuses": "1.3.1",
+				"unpipe": "1.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"find-cache-dir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+			"requires": {
+				"commondir": "1.0.1",
+				"make-dir": "1.2.0",
+				"pkg-dir": "2.0.0"
+			}
+		},
+		"find-up": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"requires": {
+				"locate-path": "2.0.0"
+			}
+		},
+		"flush-write-stream": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+			"integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
+			}
+		},
+		"fn-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
+			"integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc="
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"requires": {
+				"for-in": "1.0.2"
+			}
+		},
+		"foreach": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+		},
+		"form-data": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"requires": {
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.6",
+				"mime-types": "2.1.18"
+			}
+		},
+		"forwarded": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"requires": {
+				"map-cache": "0.2.2"
+			}
+		},
+		"fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+		},
+		"from2": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
+			}
+		},
+		"fs-write-stream-atomic": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"iferr": "0.1.5",
+				"imurmurhash": "0.1.4",
+				"readable-stream": "2.3.5"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"fsevents": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"optional": true,
+			"requires": {
+				"nan": "2.9.2",
+				"node-pre-gyp": "0.6.39"
+			},
+			"dependencies": {
+				"abbrev": {
+					"version": "1.1.0",
+					"bundled": true,
+					"optional": true
+				},
+				"ajv": {
+					"version": "4.11.8",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"aproba": {
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"delegates": "1.0.0",
+						"readable-stream": "2.2.9"
+					}
+				},
+				"asn1": {
+					"version": "0.2.3",
+					"bundled": true,
+					"optional": true
+				},
+				"assert-plus": {
+					"version": "0.2.0",
+					"bundled": true,
+					"optional": true
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"bundled": true,
+					"optional": true
+				},
+				"aws-sign2": {
+					"version": "0.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"aws4": {
+					"version": "1.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"balanced-match": {
+					"version": "0.4.2",
+					"bundled": true
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"tweetnacl": "0.14.5"
+					}
+				},
+				"block-stream": {
+					"version": "0.0.9",
+					"bundled": true,
+					"requires": {
+						"inherits": "2.0.3"
+					}
+				},
+				"boom": {
+					"version": "2.10.1",
+					"bundled": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.7",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "0.4.2",
+						"concat-map": "0.0.1"
+					}
+				},
+				"buffer-shims": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"bundled": true,
+					"optional": true
+				},
+				"co": {
+					"version": "4.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"combined-stream": {
+					"version": "1.0.5",
+					"bundled": true,
+					"requires": {
+						"delayed-stream": "1.0.0"
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"cryptiles": {
+					"version": "2.0.5",
+					"bundled": true,
+					"requires": {
+						"boom": "2.10.1"
+					}
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.8",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"deep-extend": {
+					"version": "0.4.2",
+					"bundled": true,
+					"optional": true
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"ecc-jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"extend": {
+					"version": "3.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"extsprintf": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"bundled": true,
+					"optional": true
+				},
+				"form-data": {
+					"version": "2.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.15"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"fstream": {
+					"version": "1.0.11",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"inherits": "2.0.3",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.1"
+					}
+				},
+				"fstream-ignore": {
+					"version": "1.0.5",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"fstream": "1.0.11",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4"
+					}
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"aproba": "1.1.1",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
+					}
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true
+				},
+				"har-schema": {
+					"version": "1.0.5",
+					"bundled": true,
+					"optional": true
+				},
+				"har-validator": {
+					"version": "4.2.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ajv": "4.11.8",
+						"har-schema": "1.0.5"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"hawk": {
+					"version": "3.1.3",
+					"bundled": true,
+					"requires": {
+						"boom": "2.10.1",
+						"cryptiles": "2.0.5",
+						"hoek": "2.16.3",
+						"sntp": "1.0.9"
+					}
+				},
+				"hoek": {
+					"version": "2.16.3",
+					"bundled": true
+				},
+				"http-signature": {
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "0.2.0",
+						"jsprim": "1.4.0",
+						"sshpk": "1.13.0"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"ini": {
+					"version": "1.3.4",
+					"bundled": true,
+					"optional": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"bundled": true,
+					"optional": true
+				},
+				"jodid25519": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"bundled": true,
+					"optional": true
+				},
+				"json-stable-stringify": {
+					"version": "1.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsonify": "0.0.0"
+					}
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"jsonify": {
+					"version": "0.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"jsprim": {
+					"version": "1.4.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.0.2",
+						"json-schema": "0.2.3",
+						"verror": "1.3.6"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"mime-db": {
+					"version": "1.27.0",
+					"bundled": true
+				},
+				"mime-types": {
+					"version": "2.1.15",
+					"bundled": true,
+					"requires": {
+						"mime-db": "1.27.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"node-pre-gyp": {
+					"version": "0.6.39",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"detect-libc": "1.0.2",
+						"hawk": "3.1.3",
+						"mkdirp": "0.5.1",
+						"nopt": "4.0.1",
+						"npmlog": "4.1.0",
+						"rc": "1.2.1",
+						"request": "2.81.0",
+						"rimraf": "2.6.1",
+						"semver": "5.3.0",
+						"tar": "2.2.1",
+						"tar-pack": "3.4.0"
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"abbrev": "1.1.0",
+						"osenv": "0.1.4"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"oauth-sign": {
+					"version": "0.8.2",
+					"bundled": true,
+					"optional": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"osenv": {
+					"version": "0.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"performance-now": {
+					"version": "0.2.0",
+					"bundled": true,
+					"optional": true
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"bundled": true
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"bundled": true,
+					"optional": true
+				},
+				"qs": {
+					"version": "6.4.0",
+					"bundled": true,
+					"optional": true
+				},
+				"rc": {
+					"version": "1.2.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"deep-extend": "0.4.2",
+						"ini": "1.3.4",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.2.9",
+					"bundled": true,
+					"requires": {
+						"buffer-shims": "1.0.0",
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "1.0.1",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"request": {
+					"version": "2.81.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "4.2.1",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.15",
+						"oauth-sign": "0.8.2",
+						"performance-now": "0.2.0",
+						"qs": "6.4.0",
+						"safe-buffer": "5.0.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.2",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.1",
+					"bundled": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.0.1",
+					"bundled": true
+				},
+				"semver": {
+					"version": "5.3.0",
+					"bundled": true,
+					"optional": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"sntp": {
+					"version": "1.0.9",
+					"bundled": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"sshpk": {
+					"version": "1.13.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"asn1": "0.2.3",
+						"assert-plus": "1.0.0",
+						"bcrypt-pbkdf": "1.0.1",
+						"dashdash": "1.14.1",
+						"ecc-jsbn": "0.1.1",
+						"getpass": "0.1.7",
+						"jodid25519": "1.0.2",
+						"jsbn": "0.1.1",
+						"tweetnacl": "0.14.5"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"stringstream": {
+					"version": "0.0.5",
+					"bundled": true,
+					"optional": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"tar": {
+					"version": "2.2.1",
+					"bundled": true,
+					"requires": {
+						"block-stream": "0.0.9",
+						"fstream": "1.0.11",
+						"inherits": "2.0.3"
+					}
+				},
+				"tar-pack": {
+					"version": "3.4.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"debug": "2.6.8",
+						"fstream": "1.0.11",
+						"fstream-ignore": "1.0.5",
+						"once": "1.4.0",
+						"readable-stream": "2.2.9",
+						"rimraf": "2.6.1",
+						"tar": "2.2.1",
+						"uid-number": "0.0.6"
+					}
+				},
+				"tough-cookie": {
+					"version": "2.3.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"punycode": "1.4.1"
+					}
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"bundled": true,
+					"optional": true
+				},
+				"uid-number": {
+					"version": "0.0.6",
+					"bundled": true,
+					"optional": true
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"uuid": {
+					"version": "3.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"verror": {
+					"version": "1.3.6",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"extsprintf": "1.0.2"
+					}
+				},
+				"wide-align": {
+					"version": "1.1.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"string-width": "1.0.2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				}
+			}
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		},
+		"function-name-support": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/function-name-support/-/function-name-support-0.2.0.tgz",
+			"integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE="
+		},
+		"get-caller-file": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+		},
+		"get-port": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
+		},
+		"get-stdin": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+		},
+		"get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			}
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"requires": {
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
+			}
+		},
+		"glob-base": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"requires": {
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
+			}
+		},
+		"glob-parent": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"requires": {
+				"is-glob": "2.0.1"
+			}
+		},
+		"global-dirs": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+			"requires": {
+				"ini": "1.3.5"
+			}
+		},
+		"globals": {
+			"version": "9.18.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+		},
+		"globby": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+			"requires": {
+				"array-union": "1.0.2",
+				"glob": "7.1.2",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
+			},
+			"dependencies": {
+				"pinkie": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+					"requires": {
+						"pinkie": "2.0.4"
+					}
+				}
+			}
+		},
+		"got": {
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+			"requires": {
+				"create-error-class": "3.0.2",
+				"duplexer3": "0.1.4",
+				"get-stream": "3.0.0",
+				"is-redirect": "1.0.0",
+				"is-retry-allowed": "1.1.0",
+				"is-stream": "1.1.0",
+				"lowercase-keys": "1.0.0",
+				"safe-buffer": "5.1.1",
+				"timed-out": "4.0.1",
+				"unzip-response": "2.0.1",
+				"url-parse-lax": "1.0.0"
+			}
+		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+		},
+		"handle-thing": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+		},
+		"har-validator": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"requires": {
+				"ajv": "5.5.2",
+				"har-schema": "2.0.0"
+			}
+		},
+		"has": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"requires": {
+				"function-bind": "1.1.1"
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"has-color": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+		},
+		"has-flag": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+		},
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"requires": {
+				"get-value": "2.0.6",
+				"has-values": "1.0.0",
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
+		"has-yarn": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
+			"integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac="
+		},
+		"hawk": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+			"requires": {
+				"boom": "4.3.1",
+				"cryptiles": "3.1.2",
+				"hoek": "4.2.1",
+				"sntp": "2.1.0"
+			}
+		},
+		"hoek": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+		},
+		"hoist-non-react-statics": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
+			"integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
+		},
+		"home-or-tmp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"requires": {
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
+			}
+		},
+		"hosted-git-info": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+		},
+		"hpack.js": {
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+			"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+			"requires": {
+				"inherits": "2.0.3",
+				"obuf": "1.1.1",
+				"readable-stream": "2.3.5",
+				"wbuf": "1.7.2"
+			}
+		},
+		"html-encoding-sniffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"requires": {
+				"whatwg-encoding": "1.0.3"
+			}
+		},
+		"html-entities": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+		},
+		"http-deceiver": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+			"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
+		},
+		"http-errors": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+			"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+			"requires": {
+				"depd": "1.1.1",
+				"inherits": "2.0.3",
+				"setprototypeof": "1.0.3",
+				"statuses": "1.3.1"
+			},
+			"dependencies": {
+				"depd": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+				},
+				"setprototypeof": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+				}
+			}
+		},
+		"http-parser-js": {
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.11.tgz",
+			"integrity": "sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA=="
+		},
+		"http-proxy": {
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+			"integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
+			"requires": {
+				"eventemitter3": "1.2.0",
+				"requires-port": "1.0.0"
+			}
+		},
+		"http-proxy-middleware": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+			"integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+			"requires": {
+				"http-proxy": "1.16.2",
+				"is-glob": "3.1.0",
+				"lodash": "4.17.5",
+				"micromatch": "2.3.11"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+				},
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"requires": {
+						"is-extglob": "2.1.1"
+					}
+				}
+			}
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.13.1"
+			}
+		},
+		"hullabaloo-config-manager": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.1.1.tgz",
+			"integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
+			"requires": {
+				"dot-prop": "4.2.0",
+				"es6-error": "4.1.1",
+				"graceful-fs": "4.1.11",
+				"indent-string": "3.2.0",
+				"json5": "0.5.1",
+				"lodash.clonedeep": "4.5.0",
+				"lodash.clonedeepwith": "4.5.0",
+				"lodash.isequal": "4.5.0",
+				"lodash.merge": "4.6.1",
+				"md5-hex": "2.0.0",
+				"package-hash": "2.0.0",
+				"pkg-dir": "2.0.0",
+				"resolve-from": "3.0.0",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+		},
+		"iferr": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+		},
+		"ignore": {
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+		},
+		"ignore-by-default": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk="
+		},
+		"import-lazy": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+		},
+		"import-local": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
+			"integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
+			"requires": {
+				"pkg-dir": "2.0.0",
+				"resolve-cwd": "2.0.0"
+			}
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+		},
+		"indent-string": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+		},
+		"internal-ip": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
+			"integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
+			"requires": {
+				"meow": "3.7.0"
+			}
+		},
+		"invariant": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
+			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+			"requires": {
+				"loose-envify": "1.3.1"
+			}
+		},
+		"invert-kv": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+		},
+		"ip": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+		},
+		"ipaddr.js": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+			"integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
+		},
+		"irregular-plurals": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+			"integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
+		},
+		"is-accessor-descriptor": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+			"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+			"requires": {
+				"kind-of": "6.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+		},
+		"is-binary-path": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"requires": {
+				"binary-extensions": "1.11.0"
+			}
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+		},
+		"is-builtin-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"requires": {
+				"builtin-modules": "1.1.1"
+			}
+		},
+		"is-callable": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+		},
+		"is-ci": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+			"requires": {
+				"ci-info": "1.1.2"
+			}
+		},
+		"is-data-descriptor": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+			"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+			"requires": {
+				"kind-of": "6.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+		},
+		"is-descriptor": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+			"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+			"requires": {
+				"is-accessor-descriptor": "1.0.0",
+				"is-data-descriptor": "1.0.0",
+				"kind-of": "6.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
+		"is-dotfile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+		},
+		"is-equal-shallow": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"requires": {
+				"is-primitive": "2.0.0"
+			}
+		},
+		"is-error": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz",
+			"integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw="
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+		},
+		"is-extglob": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+		},
+		"is-finite": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"requires": {
+				"number-is-nan": "1.0.1"
+			}
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+		},
+		"is-generator-fn": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
+		},
+		"is-glob": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"requires": {
+				"is-extglob": "1.0.0"
+			}
+		},
+		"is-installed-globally": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+			"requires": {
+				"global-dirs": "0.1.1",
+				"is-path-inside": "1.0.1"
+			}
+		},
+		"is-npm": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+		},
+		"is-number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+		},
+		"is-observable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+			"requires": {
+				"symbol-observable": "1.2.0"
+			}
+		},
+		"is-odd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+			"requires": {
+				"is-number": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+				}
+			}
+		},
+		"is-path-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+		},
+		"is-path-in-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"requires": {
+				"is-path-inside": "1.0.1"
+			}
+		},
+		"is-path-inside": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"requires": {
+				"path-is-inside": "1.0.2"
+			}
+		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"requires": {
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"is-posix-bracket": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+		},
+		"is-primitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+		},
+		"is-redirect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"requires": {
+				"has": "1.0.1"
+			}
+		},
+		"is-retry-allowed": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-symbol": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"is-url": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
+			"integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY="
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+		},
+		"is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"requires": {
+				"isarray": "1.0.0"
+			}
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.3"
+			}
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"js-string-escape": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"js-yaml": {
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+			"requires": {
+				"argparse": "1.0.10",
+				"esprima": "4.0.0"
+			}
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"optional": true
+		},
+		"jsdom": {
+			"version": "11.6.2",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
+			"integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
+			"requires": {
+				"abab": "1.0.4",
+				"acorn": "5.5.3",
+				"acorn-globals": "4.1.0",
+				"array-equal": "1.0.0",
+				"browser-process-hrtime": "0.1.2",
+				"content-type-parser": "1.0.2",
+				"cssom": "0.3.2",
+				"cssstyle": "0.2.37",
+				"domexception": "1.0.1",
+				"escodegen": "1.9.1",
+				"html-encoding-sniffer": "1.0.2",
+				"left-pad": "1.2.0",
+				"nwmatcher": "1.4.3",
+				"parse5": "4.0.0",
+				"pn": "1.1.0",
+				"request": "2.83.0",
+				"request-promise-native": "1.0.5",
+				"sax": "1.2.4",
+				"symbol-tree": "3.2.2",
+				"tough-cookie": "2.3.4",
+				"w3c-hr-time": "1.0.1",
+				"webidl-conversions": "4.0.2",
+				"whatwg-encoding": "1.0.3",
+				"whatwg-url": "6.4.0",
+				"ws": "4.1.0",
+				"xml-name-validator": "3.0.0"
+			}
+		},
+		"jsdom-global": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
+			"integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk="
+		},
+		"jsesc": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+			"integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
+		"json3": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+		},
+		"json5": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			}
+		},
+		"killable": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz",
+			"integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms="
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"requires": {
+				"is-buffer": "1.1.6"
+			}
+		},
+		"last-line-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/last-line-stream/-/last-line-stream-1.0.0.tgz",
+			"integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
+			"requires": {
+				"through2": "2.0.3"
+			}
+		},
+		"latest-version": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+			"requires": {
+				"package-json": "4.0.1"
+			}
+		},
+		"lazy-cache": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+			"integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+			"requires": {
+				"set-getter": "0.1.0"
+			}
+		},
+		"lcid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"requires": {
+				"invert-kv": "1.0.0"
+			}
+		},
+		"left-pad": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
+			"integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"requires": {
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
+			}
+		},
+		"lightercollective": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/lightercollective/-/lightercollective-0.0.0.tgz",
+			"integrity": "sha512-4SdGgHgQjlqhk90QxAYsltGEI6HHt30xy9fOIPKi+c3vcGRcpPDtzm6+kxr1N9ixkrx/ngMhTCe/VpBc/HmNBQ=="
+		},
+		"load-json-file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"strip-bom": "3.0.0"
+			}
+		},
+		"loader-utils": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+			"requires": {
+				"big.js": "3.2.0",
+				"emojis-list": "2.1.0",
+				"json5": "0.5.1"
+			}
+		},
+		"locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"requires": {
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+		},
+		"lodash-es": {
+			"version": "4.17.7",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.7.tgz",
+			"integrity": "sha512-jzqTi3vk4J5Dxq43cNjB0ekfCjPLHixoY2Sc0WHTo+0r928taLqe/VCt02vY5uQBvg0rdXgL3xWkK4X0MCmZcw=="
+		},
+		"lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+		},
+		"lodash.clonedeepwith": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
+			"integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ="
+		},
+		"lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+		},
+		"lodash.difference": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+		},
+		"lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+		},
+		"lodash.flattendeep": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+		},
+		"lodash.merge": {
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+		},
+		"loglevel": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
+			"integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"requires": {
+				"js-tokens": "3.0.2"
+			}
+		},
+		"loud-rejection": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+			"requires": {
+				"currently-unhandled": "0.4.1",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"lowercase-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+			"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+		},
+		"lru-cache": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"requires": {
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
+			}
+		},
+		"make-dir": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
+			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+			"requires": {
+				"pify": "3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+		},
+		"map-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"requires": {
+				"object-visit": "1.0.1"
+			}
+		},
+		"matcher": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.0.tgz",
+			"integrity": "sha512-aZGv6JBTHqfqAd09jmAlbKnAICTfIvb5Z8gXVxPB5WZtFfHMaAMdACL7tQflD2V+6/8KNcY8s6DYtWLgpJP5lA==",
+			"requires": {
+				"escape-string-regexp": "1.0.5"
+			}
+		},
+		"md5-hex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
+			"integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
+			"requires": {
+				"md5-o-matic": "0.1.1"
+			}
+		},
+		"md5-o-matic": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
+		},
+		"media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+		},
+		"memory-fs": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+			"requires": {
+				"errno": "0.1.7",
+				"readable-stream": "2.3.5"
+			}
+		},
+		"meow": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+			"requires": {
+				"camelcase-keys": "2.1.0",
+				"decamelize": "1.2.0",
+				"loud-rejection": "1.6.0",
+				"map-obj": "1.0.1",
+				"minimist": "1.2.0",
+				"normalize-package-data": "2.4.0",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"redent": "1.0.0",
+				"trim-newlines": "1.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+					"requires": {
+						"pinkie": "2.0.4"
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"requires": {
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"requires": {
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				}
+			}
+		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+		},
+		"methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+		},
+		"micromatch": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"requires": {
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.4"
+			}
+		},
+		"mime": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+		},
+		"mime-db": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+		},
+		"mime-types": {
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+			"requires": {
+				"mime-db": "1.33.0"
+			}
+		},
+		"mimic-fn": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+		},
+		"minimalistic-assert": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+			"integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "1.1.11"
+			}
+		},
+		"minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"mississippi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+			"requires": {
+				"concat-stream": "1.6.1",
+				"duplexify": "3.5.4",
+				"end-of-stream": "1.4.1",
+				"flush-write-stream": "1.0.2",
+				"from2": "2.3.0",
+				"parallel-transform": "1.1.0",
+				"pump": "2.0.1",
+				"pumpify": "1.4.0",
+				"stream-each": "1.2.2",
+				"through2": "2.0.3"
+			}
+		},
+		"mixin-deep": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"requires": {
+				"for-in": "1.0.2",
+				"is-extendable": "1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "2.0.4"
+					}
+				}
+			}
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"requires": {
+				"minimist": "0.0.8"
+			}
+		},
+		"move-concurrently": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+			"requires": {
+				"aproba": "1.2.0",
+				"copy-concurrently": "1.0.5",
+				"fs-write-stream-atomic": "1.0.10",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"run-queue": "1.0.3"
+			}
+		},
+		"ms": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+		},
+		"multicast-dns": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
+			"integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+			"requires": {
+				"dns-packet": "1.3.1",
+				"thunky": "1.0.2"
+			}
+		},
+		"multicast-dns-service-types": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+		},
+		"multimatch": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+			"requires": {
+				"array-differ": "1.0.0",
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"minimatch": "3.0.4"
+			}
+		},
+		"nan": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+			"integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+			"optional": true
+		},
+		"nanomatch": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+			"requires": {
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"fragment-cache": "0.2.1",
+				"is-odd": "2.0.0",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.1",
+				"to-regex": "3.0.2"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
+		"negotiator": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
+			}
+		},
+		"node-forge": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
+			"integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA="
+		},
+		"normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"requires": {
+				"hosted-git-info": "2.6.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.5.0",
+				"validate-npm-package-license": "3.0.3"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"requires": {
+				"remove-trailing-separator": "1.1.0"
+			}
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"requires": {
+				"path-key": "2.0.1"
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+		},
+		"nwmatcher": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
+			"integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw=="
+		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"requires": {
+				"copy-descriptor": "0.1.1",
+				"define-property": "0.2.5",
+				"kind-of": "3.2.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				}
+			}
+		},
+		"object-keys": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"requires": {
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"object.omit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"requires": {
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"requires": {
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"observable-to-promise": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-0.5.0.tgz",
+			"integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
+			"requires": {
+				"is-observable": "0.2.0",
+				"symbol-observable": "1.2.0"
+			},
+			"dependencies": {
+				"is-observable": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+					"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+					"requires": {
+						"symbol-observable": "0.2.4"
+					},
+					"dependencies": {
+						"symbol-observable": {
+							"version": "0.2.4",
+							"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+							"integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A="
+						}
+					}
+				}
+			}
+		},
+		"obuf": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
+			"integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4="
+		},
+		"on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"requires": {
+				"ee-first": "1.1.1"
+			}
+		},
+		"on-headers": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1.0.2"
+			}
+		},
+		"onetime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"requires": {
+				"mimic-fn": "1.2.0"
+			}
+		},
+		"opn": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/opn/-/opn-5.2.0.tgz",
+			"integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
+			"requires": {
+				"is-wsl": "1.1.0"
+			}
+		},
+		"option-chain": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/option-chain/-/option-chain-1.0.0.tgz",
+			"integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI="
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"requires": {
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
+			}
+		},
+		"original": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
+			"integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
+			"requires": {
+				"url-parse": "1.0.5"
+			},
+			"dependencies": {
+				"url-parse": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
+					"integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
+					"requires": {
+						"querystringify": "0.0.4",
+						"requires-port": "1.0.0"
+					}
+				}
+			}
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+		},
+		"os-locale": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"requires": {
+				"lcid": "1.0.0"
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+		},
+		"p-limit": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+			"requires": {
+				"p-try": "1.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"requires": {
+				"p-limit": "1.2.0"
+			}
+		},
+		"p-map": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
+		},
+		"p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+		},
+		"package-hash": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
+			"integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"lodash.flattendeep": "4.4.0",
+				"md5-hex": "2.0.0",
+				"release-zalgo": "1.0.0"
+			}
+		},
+		"package-json": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+			"requires": {
+				"got": "6.7.1",
+				"registry-auth-token": "3.3.2",
+				"registry-url": "3.1.0",
+				"semver": "5.5.0"
+			}
+		},
+		"parallel-transform": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+			"requires": {
+				"cyclist": "0.2.2",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
+			}
+		},
+		"parse-glob": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"requires": {
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
+			}
+		},
+		"parse-json": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"requires": {
+				"error-ex": "1.3.1"
+			}
+		},
+		"parse-ms": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
+			"integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0="
+		},
+		"parse5": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+		},
+		"parseurl": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+		},
+		"path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+		},
+		"path-to-regexp": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+		},
+		"path-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"requires": {
+				"pify": "2.3.0"
+			}
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+		},
+		"pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+		},
+		"pinkie": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+			"integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q="
+		},
+		"pinkie-promise": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+			"integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+			"requires": {
+				"pinkie": "1.0.0"
+			}
+		},
+		"pkg-conf": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+			"integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+			"requires": {
+				"find-up": "2.1.0",
+				"load-json-file": "4.0.0"
+			},
+			"dependencies": {
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "4.0.0",
+						"pify": "3.0.0",
+						"strip-bom": "3.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"requires": {
+						"error-ex": "1.3.1",
+						"json-parse-better-errors": "1.0.1"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"pkg-dir": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"requires": {
+				"find-up": "2.1.0"
+			}
+		},
+		"plur": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+			"integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+			"requires": {
+				"irregular-plurals": "1.4.0"
+			}
+		},
+		"pn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+		},
+		"portfinder": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
+			"integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+			"requires": {
+				"async": "1.5.2",
+				"debug": "2.6.9",
+				"mkdirp": "0.5.1"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+		},
+		"prepend-http": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+		},
+		"preserve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+		},
+		"pretty-ms": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
+			"integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
+			"requires": {
+				"parse-ms": "1.0.1",
+				"plur": "2.1.2"
+			}
+		},
+		"private": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+		},
+		"process-nextick-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "2.0.6"
+			}
+		},
+		"promise-inflight": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+		},
+		"prop-types": {
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			}
+		},
+		"proxy-addr": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+			"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+			"requires": {
+				"forwarded": "0.1.2",
+				"ipaddr.js": "1.6.0"
+			}
+		},
+		"prr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		},
+		"pump": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"once": "1.4.0"
+			}
+		},
+		"pumpify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
+			"integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+			"requires": {
+				"duplexify": "3.5.4",
+				"inherits": "2.0.3",
+				"pump": "2.0.1"
+			}
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+		},
+		"qs": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+		},
+		"querystringify": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+			"integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw="
+		},
+		"randomatic": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
+		"range-parser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+		},
+		"raw-body": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+			"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+			"requires": {
+				"bytes": "3.0.0",
+				"http-errors": "1.6.2",
+				"iconv-lite": "0.4.19",
+				"unpipe": "1.0.0"
+			}
+		},
+		"rc": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
+			"integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
+			"requires": {
+				"deep-extend": "0.4.2",
+				"ini": "1.3.5",
+				"minimist": "1.2.0",
+				"strip-json-comments": "2.0.1"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"react": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
+			"integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
+			}
+		},
+		"react-dom": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
+			"integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
+			}
+		},
+		"react-redux": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+			"integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+			"requires": {
+				"hoist-non-react-statics": "2.5.0",
+				"invariant": "2.2.3",
+				"lodash": "4.17.5",
+				"lodash-es": "4.17.7",
+				"loose-envify": "1.3.1",
+				"prop-types": "15.6.1"
+			}
+		},
+		"read-pkg": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"requires": {
+				"load-json-file": "2.0.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "2.0.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"requires": {
+				"find-up": "2.1.0",
+				"read-pkg": "2.0.0"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+			"requires": {
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.0",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.0.3",
+				"util-deprecate": "1.0.2"
+			}
+		},
+		"readdirp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"minimatch": "3.0.4",
+				"readable-stream": "2.3.5",
+				"set-immediate-shim": "1.0.1"
+			}
+		},
+		"redent": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+			"requires": {
+				"indent-string": "2.1.0",
+				"strip-indent": "1.0.1"
+			},
+			"dependencies": {
+				"indent-string": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+					"requires": {
+						"repeating": "2.0.1"
+					}
+				}
+			}
+		},
+		"redux": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"requires": {
+				"lodash": "4.17.5",
+				"lodash-es": "4.17.7",
+				"loose-envify": "1.3.1",
+				"symbol-observable": "1.2.0"
+			}
+		},
+		"regenerate": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+		},
+		"regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+		},
+		"regex-cache": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"requires": {
+				"is-equal-shallow": "0.1.3"
+			}
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"requires": {
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
+			}
+		},
+		"regexpu-core": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"requires": {
+				"regenerate": "1.3.3",
+				"regjsgen": "0.2.0",
+				"regjsparser": "0.1.5"
+			}
+		},
+		"registry-auth-token": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+			"requires": {
+				"rc": "1.2.5",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"registry-url": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+			"requires": {
+				"rc": "1.2.5"
+			}
+		},
+		"regjsgen": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+		},
+		"regjsparser": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"requires": {
+				"jsesc": "0.5.0"
+			}
+		},
+		"release-zalgo": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+			"integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+			"requires": {
+				"es6-error": "4.1.1"
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+		},
+		"repeat-element": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+		},
+		"repeating": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"requires": {
+				"is-finite": "1.0.2"
+			}
+		},
+		"request": {
+			"version": "2.83.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+			"requires": {
+				"aws-sign2": "0.7.0",
+				"aws4": "1.6.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.6",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.2",
+				"har-validator": "5.0.3",
+				"hawk": "6.0.2",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.18",
+				"oauth-sign": "0.8.2",
+				"performance-now": "2.1.0",
+				"qs": "6.5.1",
+				"safe-buffer": "5.1.1",
+				"stringstream": "0.0.5",
+				"tough-cookie": "2.3.4",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.2.1"
+			}
+		},
+		"request-promise-core": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"requires": {
+				"request-promise-core": "1.1.1",
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.3.4"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+		},
+		"require-main-filename": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+		},
+		"require-precompiled": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
+			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo="
+		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+		},
+		"resolve-cwd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"requires": {
+				"resolve-from": "3.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"requires": {
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+		},
+		"rimraf": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"requires": {
+				"glob": "7.1.2"
+			}
+		},
+		"run-queue": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+			"requires": {
+				"aproba": "1.2.0"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"requires": {
+				"ret": "0.1.15"
+			}
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
+		"select-hose": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
+		},
+		"selfsigned": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.2.tgz",
+			"integrity": "sha1-tESVgNmZKbZbEKSDiTAaZZIIh1g=",
+			"requires": {
+				"node-forge": "0.7.1"
+			}
+		},
+		"semver": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+		},
+		"semver-diff": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+			"requires": {
+				"semver": "5.5.0"
+			}
+		},
+		"send": {
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+			"integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+			"requires": {
+				"debug": "2.6.9",
+				"depd": "1.1.2",
+				"destroy": "1.0.4",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "1.6.2",
+				"mime": "1.4.1",
+				"ms": "2.0.0",
+				"on-finished": "2.3.0",
+				"range-parser": "1.2.0",
+				"statuses": "1.3.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"serialize-javascript": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
+			"integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU="
+		},
+		"serve-index": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+			"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+			"requires": {
+				"accepts": "1.3.5",
+				"batch": "0.6.1",
+				"debug": "2.6.9",
+				"escape-html": "1.0.3",
+				"http-errors": "1.6.2",
+				"mime-types": "2.1.18",
+				"parseurl": "1.3.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"serve-static": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+			"integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+			"requires": {
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"parseurl": "1.3.2",
+				"send": "0.16.1"
+			}
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+		},
+		"set-getter": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+			"integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+			"requires": {
+				"to-object-path": "0.3.0"
+			}
+		},
+		"set-immediate-shim": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+		},
+		"set-value": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"requires": {
+				"extend-shallow": "2.0.1",
+				"is-extendable": "0.1.1",
+				"is-plain-object": "2.0.4",
+				"split-string": "3.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				}
+			}
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+		},
+		"setprototypeof": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"requires": {
+				"shebang-regex": "1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
+		"slash": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+		},
+		"slice-ansi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0"
+			}
+		},
+		"slide": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+		},
+		"snapdragon": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
+			"integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
+			"requires": {
+				"base": "0.11.2",
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"map-cache": "0.2.2",
+				"source-map": "0.5.7",
+				"source-map-resolve": "0.5.1",
+				"use": "2.0.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"requires": {
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"snapdragon-util": "3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "1.0.2"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"sntp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+			"requires": {
+				"hoek": "4.2.1"
+			}
+		},
+		"sockjs": {
+			"version": "0.3.19",
+			"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
+			"integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
+			"requires": {
+				"faye-websocket": "0.10.0",
+				"uuid": "3.2.1"
+			}
+		},
+		"sockjs-client": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+			"integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+			"requires": {
+				"debug": "2.6.9",
+				"eventsource": "0.1.6",
+				"faye-websocket": "0.11.1",
+				"inherits": "2.0.3",
+				"json3": "3.3.2",
+				"url-parse": "1.2.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"faye-websocket": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+					"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+					"requires": {
+						"websocket-driver": "0.7.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"sort-keys": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+			"requires": {
+				"is-plain-obj": "1.1.0"
+			}
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"source-map-loader": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.3.tgz",
+			"integrity": "sha512-MYbFX9DYxmTQFfy2v8FC1XZwpwHKYxg3SK8Wb7VPBKuhDjz8gi9re2819MsG4p49HDyiOSUKlmZ+nQBArW5CGw==",
+			"requires": {
+				"async": "2.6.0",
+				"loader-utils": "0.2.17",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"loader-utils": {
+					"version": "0.2.17",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+					"requires": {
+						"big.js": "3.2.0",
+						"emojis-list": "2.1.0",
+						"json5": "0.5.1",
+						"object-assign": "4.1.1"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"source-map-resolve": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+			"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+			"requires": {
+				"atob": "2.0.3",
+				"decode-uri-component": "0.2.0",
+				"resolve-url": "0.2.1",
+				"source-map-url": "0.4.0",
+				"urix": "0.1.0"
+			}
+		},
+		"source-map-support": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
+			"integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
+			"requires": {
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+		},
+		"spdx-correct": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+			"requires": {
+				"spdx-expression-parse": "3.0.0",
+				"spdx-license-ids": "3.0.0"
+			}
+		},
+		"spdx-exceptions": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"requires": {
+				"spdx-exceptions": "2.1.0",
+				"spdx-license-ids": "3.0.0"
+			}
+		},
+		"spdx-license-ids": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+		},
+		"spdy": {
+			"version": "3.4.7",
+			"resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
+			"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+			"requires": {
+				"debug": "2.6.9",
+				"handle-thing": "1.2.5",
+				"http-deceiver": "1.2.7",
+				"safe-buffer": "5.1.1",
+				"select-hose": "2.0.0",
+				"spdy-transport": "2.0.20"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"spdy-transport": {
+			"version": "2.0.20",
+			"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
+			"integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
+			"requires": {
+				"debug": "2.6.9",
+				"detect-node": "2.0.3",
+				"hpack.js": "2.1.6",
+				"obuf": "1.1.1",
+				"readable-stream": "2.3.5",
+				"safe-buffer": "5.1.1",
+				"wbuf": "1.7.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"requires": {
+				"extend-shallow": "3.0.2"
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"sshpk": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"requires": {
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"ssri": {
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.2.4.tgz",
+			"integrity": "sha512-UnEAgMZa15973iH7cUi0AHjJn1ACDIkaMyZILoqwN6yzt+4P81I8tBc5Hl+qwi5auMplZtPQsHrPBR5vJLcQtQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"stack-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
+		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"requires": {
+				"define-property": "0.2.5",
+				"object-copy": "0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				}
+			}
+		},
+		"statuses": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+			"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+		},
+		"stream-each": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+			"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"stream-shift": "1.0.0"
+			}
+		},
+		"stream-shift": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
+			}
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"stringstream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+		},
+		"strip-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"requires": {
+				"ansi-regex": "3.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				}
+			}
+		},
+		"strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+		},
+		"strip-bom-buf": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
+			"integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+			"requires": {
+				"is-utf8": "0.2.1"
+			}
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+		},
+		"strip-indent": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+			"requires": {
+				"get-stdin": "4.0.1"
+			}
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+		},
+		"supports-color": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+			"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+			"requires": {
+				"has-flag": "3.0.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				}
+			}
+		},
+		"symbol-observable": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+		},
+		"symbol-tree": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+		},
+		"tapable": {
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
+			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
+		},
+		"term-size": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+			"requires": {
+				"execa": "0.7.0"
+			}
+		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+		},
+		"through2": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+			"requires": {
+				"readable-stream": "2.3.5",
+				"xtend": "4.0.1"
+			}
+		},
+		"thunky": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz",
+			"integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E="
+		},
+		"time-require": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/time-require/-/time-require-0.1.2.tgz",
+			"integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
+			"requires": {
+				"chalk": "0.4.0",
+				"date-time": "0.1.1",
+				"pretty-ms": "0.2.2",
+				"text-table": "0.2.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
+				},
+				"chalk": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+					"requires": {
+						"ansi-styles": "1.0.0",
+						"has-color": "0.1.7",
+						"strip-ansi": "0.1.1"
+					}
+				},
+				"date-time": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
+					"integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc="
+				},
+				"parse-ms": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
+					"integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4="
+				},
+				"pretty-ms": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
+					"integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
+					"requires": {
+						"parse-ms": "0.1.2"
+					}
+				},
+				"strip-ansi": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
+				}
+			}
+		},
+		"time-stamp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
+			"integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c="
+		},
+		"time-zone": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
+			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0="
+		},
+		"timed-out": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+		},
+		"to-fast-properties": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"requires": {
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"requires": {
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				}
+			}
+		},
+		"tough-cookie": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+			"requires": {
+				"punycode": "1.4.1"
+			}
+		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"requires": {
+				"punycode": "2.1.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+				}
+			}
+		},
+		"trim-newlines": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+		},
+		"trim-off-newlines": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+		},
+		"ts-loader": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-3.5.0.tgz",
+			"integrity": "sha512-JTia3kObhTk36wPFgy0RnkZReiusYx7Le9IhcUWRrCTcFcr6Dy1zGsFd3x8DG4gevlbN65knI8W50FfoykXcng==",
+			"requires": {
+				"chalk": "2.3.2",
+				"enhanced-resolve": "3.4.1",
+				"loader-utils": "1.1.0",
+				"micromatch": "3.1.9",
+				"semver": "5.5.0"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"braces": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
+					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+					"requires": {
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"kind-of": "6.0.2",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.1",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.1",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.1",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"micromatch": {
+					"version": "3.1.9",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
+					"integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
+					"requires": {
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.1",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.1",
+						"to-regex": "3.0.2"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"tslint-loader": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/tslint-loader/-/tslint-loader-3.6.0.tgz",
+			"integrity": "sha512-Me9Qf/87BOfCY8uJJw+J7VMF4U8WiMXKLhKKKugMydF0xMhMOt9wo2mjYTNhwbF9H7SHh8PAIwRG8roisTNekQ==",
+			"requires": {
+				"loader-utils": "1.1.0",
+				"mkdirp": "0.5.1",
+				"object-assign": "4.1.1",
+				"rimraf": "2.6.2",
+				"semver": "5.5.0"
+			}
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"optional": true
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"requires": {
+				"prelude-ls": "1.1.2"
+			}
+		},
+		"type-is": {
+			"version": "1.6.16",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+			"requires": {
+				"media-typer": "0.3.0",
+				"mime-types": "2.1.18"
+			}
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+		},
+		"ua-parser-js": {
+			"version": "0.7.17",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+		},
+		"uid2": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
+		},
+		"union-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"requires": {
+				"arr-union": "3.1.0",
+				"get-value": "2.0.6",
+				"is-extendable": "0.1.1",
+				"set-value": "0.4.3"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "0.1.1"
+					}
+				},
+				"set-value": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"to-object-path": "0.3.0"
+					}
+				}
+			}
+		},
+		"unique-filename": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+			"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+			"requires": {
+				"unique-slug": "2.0.0"
+			}
+		},
+		"unique-slug": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+			"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+			"requires": {
+				"imurmurhash": "0.1.4"
+			}
+		},
+		"unique-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+			"requires": {
+				"crypto-random-string": "1.0.0"
+			}
+		},
+		"unique-temp-dir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
+			"integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
+			"requires": {
+				"mkdirp": "0.5.1",
+				"os-tmpdir": "1.0.2",
+				"uid2": "0.0.3"
+			}
+		},
+		"unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+		},
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"requires": {
+				"has-value": "0.3.1",
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"requires": {
+						"get-value": "2.0.6",
+						"has-values": "0.1.4",
+						"isobject": "2.1.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"unzip-response": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+		},
+		"upath": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
+			"integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw=="
+		},
+		"update-notifier": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
+			"integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+			"requires": {
+				"boxen": "1.3.0",
+				"chalk": "2.3.2",
+				"configstore": "3.1.1",
+				"import-lazy": "2.1.0",
+				"is-installed-globally": "0.1.0",
+				"is-npm": "1.0.0",
+				"latest-version": "3.1.0",
+				"semver-diff": "2.1.0",
+				"xdg-basedir": "3.0.0"
+			}
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+		},
+		"url-parse": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
+			"integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
+			"requires": {
+				"querystringify": "1.0.0",
+				"requires-port": "1.0.0"
+			},
+			"dependencies": {
+				"querystringify": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+					"integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
+				}
+			}
+		},
+		"url-parse-lax": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+			"requires": {
+				"prepend-http": "1.0.4"
+			}
+		},
+		"use": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
+			"integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
+			"requires": {
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"lazy-cache": "2.0.2"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "0.1.6"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				}
+			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+		},
+		"uuid": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+			"requires": {
+				"spdx-correct": "3.0.0",
+				"spdx-expression-parse": "3.0.0"
+			}
+		},
+		"vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "1.3.0"
+			}
+		},
+		"w3c-hr-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"requires": {
+				"browser-process-hrtime": "0.1.2"
+			}
+		},
+		"wbuf": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
+			"integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
+			"requires": {
+				"minimalistic-assert": "1.0.0"
+			}
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+		},
+		"webpack-dev-middleware": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
+			"integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
+			"requires": {
+				"memory-fs": "0.4.1",
+				"mime": "1.6.0",
+				"path-is-absolute": "1.0.1",
+				"range-parser": "1.2.0",
+				"time-stamp": "2.0.0"
+			},
+			"dependencies": {
+				"mime": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+				}
+			}
+		},
+		"webpack-dev-server": {
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz",
+			"integrity": "sha512-zrPoX97bx47vZiAXfDrkw8pe9QjJ+lunQl3dypojyWwWr1M5I2h0VSrMPfTjopHQPRNn+NqfjcMmhoLcUJe2gA==",
+			"requires": {
+				"ansi-html": "0.0.7",
+				"array-includes": "3.0.3",
+				"bonjour": "3.5.0",
+				"chokidar": "2.0.2",
+				"compression": "1.7.2",
+				"connect-history-api-fallback": "1.5.0",
+				"debug": "3.1.0",
+				"del": "3.0.0",
+				"express": "4.16.2",
+				"html-entities": "1.2.1",
+				"http-proxy-middleware": "0.17.4",
+				"import-local": "1.0.0",
+				"internal-ip": "1.2.0",
+				"ip": "1.1.5",
+				"killable": "1.0.0",
+				"loglevel": "1.6.1",
+				"opn": "5.2.0",
+				"portfinder": "1.0.13",
+				"selfsigned": "1.10.2",
+				"serve-index": "1.9.1",
+				"sockjs": "0.3.19",
+				"sockjs-client": "1.1.4",
+				"spdy": "3.4.7",
+				"strip-ansi": "3.0.1",
+				"supports-color": "5.3.0",
+				"webpack-dev-middleware": "1.12.2",
+				"yargs": "6.6.0"
+			},
+			"dependencies": {
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"requires": {
+						"micromatch": "3.1.9",
+						"normalize-path": "2.1.1"
+					}
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"braces": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
+					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+					"requires": {
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"kind-of": "6.0.2",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.1",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"chokidar": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.2.tgz",
+					"integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
+					"requires": {
+						"anymatch": "2.0.0",
+						"async-each": "1.0.1",
+						"braces": "2.3.1",
+						"fsevents": "1.1.3",
+						"glob-parent": "3.1.0",
+						"inherits": "2.0.3",
+						"is-binary-path": "1.0.1",
+						"is-glob": "4.0.0",
+						"normalize-path": "2.1.1",
+						"path-is-absolute": "1.0.1",
+						"readdirp": "2.1.0",
+						"upath": "1.0.4"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.1",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.1",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"glob-parent": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+					"requires": {
+						"is-glob": "3.1.0",
+						"path-dirname": "1.0.2"
+					},
+					"dependencies": {
+						"is-glob": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+							"requires": {
+								"is-extglob": "2.1.1"
+							}
+						}
+					}
+				},
+				"import-local": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+					"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+					"requires": {
+						"pkg-dir": "2.0.0",
+						"resolve-cwd": "2.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+				},
+				"is-glob": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"requires": {
+						"is-extglob": "2.1.1"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"micromatch": {
+					"version": "3.1.9",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
+					"integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
+					"requires": {
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.1",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.1",
+						"to-regex": "3.0.2"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				}
+			}
+		},
+		"websocket-driver": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+			"integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+			"requires": {
+				"http-parser-js": "0.4.11",
+				"websocket-extensions": "0.1.3"
+			}
+		},
+		"websocket-extensions": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
+		},
+		"well-known-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-1.0.0.tgz",
+			"integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg="
+		},
+		"whatwg-encoding": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"whatwg-fetch": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+		},
+		"whatwg-url": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+			"integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+			"requires": {
+				"lodash.sortby": "4.7.0",
+				"tr46": "1.0.1",
+				"webidl-conversions": "4.0.2"
+			}
+		},
+		"which": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"requires": {
+				"isexe": "2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+		},
+		"widest-line": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+			"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+			"requires": {
+				"string-width": "2.1.1"
+			}
+		},
+		"wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"requires": {
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"write-file-atomic": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"write-json-file": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
+			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
+			"requires": {
+				"detect-indent": "5.0.0",
+				"graceful-fs": "4.1.11",
+				"make-dir": "1.2.0",
+				"pify": "3.0.0",
+				"sort-keys": "2.0.0",
+				"write-file-atomic": "2.3.0"
+			},
+			"dependencies": {
+				"detect-indent": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"write-pkg": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.1.0.tgz",
+			"integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
+			"requires": {
+				"sort-keys": "2.0.0",
+				"write-json-file": "2.3.0"
+			}
+		},
+		"ws": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+			"requires": {
+				"async-limiter": "1.0.0",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"xdg-basedir": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+		},
+		"xml-name-validator": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"y18n": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+		},
+		"yargs": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+			"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+			"requires": {
+				"camelcase": "3.0.0",
+				"cliui": "3.2.0",
+				"decamelize": "1.2.0",
+				"get-caller-file": "1.0.2",
+				"os-locale": "1.4.0",
+				"read-pkg-up": "1.0.1",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "1.0.2",
+				"which-module": "1.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "4.2.1"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+				},
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+					"requires": {
+						"pinkie": "2.0.4"
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"requires": {
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"requires": {
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+				}
+			}
+		},
+		"yargs-parser": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+			"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+			"requires": {
+				"camelcase": "3.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+				}
+			}
+		}
+	}
 }

--- a/packages/webcomponent/package-lock.json
+++ b/packages/webcomponent/package-lock.json
@@ -2,15 +2,10 @@
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
-		"@types/node": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.3.0.tgz",
-			"integrity": "sha512-wNBfvNjzsJl4tswIZKXCFQY0lss9nKUyJnG6T94X/eqjRgI2jHZ4evdjhQYBSan/vGtF6XVXPApOmNH2rf0KKw=="
-		},
 		"@webcomponents/webcomponentsjs": {
-			"version": "1.0.22",
-			"resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.0.22.tgz",
-			"integrity": "sha512-VREMJxIe5ydR6LdMpg27ojyfL635jH03680na5X2LNLY2UF1GOzNrNOAVaEf2mr+SDUpc9Rey+gt+qCvtbCGhQ=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.1.0.tgz",
+			"integrity": "sha512-7toNyVlrl7vJnY3PU0eXIK1KWq8phfnEe1IwOdCMxkIl/BfUkUB2aaVs45R0LSx1qxHRnkqj0vlGtskUvKkNkA=="
 		},
 		"abab": {
 			"version": "1.0.4",
@@ -18,22 +13,33 @@
 			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
 		},
 		"acorn": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-			"integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
 		},
 		"acorn-globals": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
 			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
 			"requires": {
-				"acorn": "5.3.0"
+				"acorn": "5.5.3"
+			}
+		},
+		"ajv": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"requires": {
+				"co": "4.6.0",
+				"fast-deep-equal": "1.1.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
 			}
 		},
 		"argparse": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
 				"sprintf-js": "1.0.3"
 			}
@@ -57,6 +63,11 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -87,7 +98,7 @@
 			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
 			"requires": {
-				"hoek": "4.2.0"
+				"hoek": "4.2.1"
 			}
 		},
 		"browser-process-hrtime": {
@@ -106,17 +117,17 @@
 			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
 		},
 		"combined-stream": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"requires": {
 				"delayed-stream": "1.0.0"
 			}
 		},
 		"commander": {
-			"version": "2.13.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-			"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
+			"integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg=="
 		},
 		"component-emitter": {
 			"version": "1.2.1",
@@ -156,7 +167,7 @@
 					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
 					"requires": {
-						"hoek": "4.2.0"
+						"hoek": "4.2.1"
 					}
 				}
 			}
@@ -201,14 +212,20 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
 		"document-register-element": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.7.0.tgz",
-			"integrity": "sha512-qAoWcNm1zW3LVO0KSblYISM0oLQzlNtns2gd1O/YS3QvFYFidG6lF73fC98fIbfPQkws698L0/URrtmN8+ADbQ=="
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.7.2.tgz",
+			"integrity": "sha512-E+y3qJgckbXK/Ev+jPIF+ussxJRaFRIxYCAkxeYcTdccuQoPw5emVWXkox6JnMejFryjlCs/sw2cokMO2lHxjQ==",
+			"requires": {
+				"lightercollective": "0.0.0"
+			}
 		},
 		"domexception": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.0.tgz",
-			"integrity": "sha512-WpwuBlZ2lQRFa4H/4w49deb9rJLot9KmqrKKjMc9qBl7CID+DdC2swoa34ccRl+anL2B6bLp6TjFdIdnzekMBQ=="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"requires": {
+				"webidl-conversions": "4.0.2"
+			}
 		},
 		"ecc-jsbn": {
 			"version": "0.1.1",
@@ -233,15 +250,15 @@
 			"integrity": "sha1-m/tzY/7//4emzbbNk+QF7DxLbyY="
 		},
 		"escodegen": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-			"integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
 			"requires": {
 				"esprima": "3.1.3",
 				"estraverse": "4.2.0",
 				"esutils": "2.0.2",
 				"optionator": "0.8.2",
-				"source-map": "0.5.7"
+				"source-map": "0.6.1"
 			}
 		},
 		"esprima": {
@@ -270,9 +287,9 @@
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
@@ -304,19 +321,19 @@
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-			"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
 				"asynckit": "0.4.0",
-				"combined-stream": "1.0.5",
-				"mime-types": "2.1.17"
+				"combined-stream": "1.0.6",
+				"mime-types": "2.1.18"
 			}
 		},
 		"formidable": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
-			"integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.0.tgz",
+			"integrity": "sha512-hr9aT30rAi7kf8Q2aaTpSP7xGMhlJ+MdrUDVZs3rxbD3L/K46A86s2VY7qC2D2kGYGBtiT/3j6wTx1eeUq5xAQ=="
 		},
 		"getpass": {
 			"version": "0.1.7",
@@ -331,7 +348,7 @@
 			"resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
 			"integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
 			"requires": {
-				"lodash": "4.17.4"
+				"lodash": "4.17.5"
 			}
 		},
 		"har-schema": {
@@ -346,19 +363,6 @@
 			"requires": {
 				"ajv": "5.5.2",
 				"har-schema": "2.0.0"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "5.5.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-					"requires": {
-						"co": "4.6.0",
-						"fast-deep-equal": "1.0.0",
-						"fast-json-stable-stringify": "2.0.0",
-						"json-schema-traverse": "0.3.1"
-					}
-				}
 			}
 		},
 		"hawk": {
@@ -368,19 +372,19 @@
 			"requires": {
 				"boom": "4.3.1",
 				"cryptiles": "3.1.2",
-				"hoek": "4.2.0",
+				"hoek": "4.2.1",
 				"sntp": "2.1.0"
 			}
 		},
 		"hoek": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-			"integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
 		},
 		"hoist-non-react-statics": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
-			"integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
+			"integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
 		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
@@ -411,9 +415,9 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"invariant": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
+			"integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
 			"requires": {
 				"loose-envify": "1.3.1"
 			}
@@ -453,11 +457,11 @@
 			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
 		"js-yaml": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
 			"requires": {
-				"argparse": "1.0.9",
+				"argparse": "1.0.10",
 				"esprima": "4.0.0"
 			},
 			"dependencies": {
@@ -475,34 +479,36 @@
 			"optional": true
 		},
 		"jsdom": {
-			"version": "11.5.1",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.5.1.tgz",
-			"integrity": "sha512-89ztIZ03aYK9f1uUrLXLsZndRge/JnZjzjpaN+lrse3coqz+8PR/dX4WLHpbF5fIKTXhDjFODOJw2328lPJ90g==",
+			"version": "11.6.2",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
+			"integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
 			"requires": {
 				"abab": "1.0.4",
-				"acorn": "5.3.0",
+				"acorn": "5.5.3",
 				"acorn-globals": "4.1.0",
 				"array-equal": "1.0.0",
 				"browser-process-hrtime": "0.1.2",
 				"content-type-parser": "1.0.2",
 				"cssom": "0.3.2",
 				"cssstyle": "0.2.37",
-				"domexception": "1.0.0",
-				"escodegen": "1.9.0",
+				"domexception": "1.0.1",
+				"escodegen": "1.9.1",
 				"html-encoding-sniffer": "1.0.2",
 				"left-pad": "1.2.0",
 				"nwmatcher": "1.4.3",
-				"parse5": "3.0.3",
+				"parse5": "4.0.0",
 				"pn": "1.1.0",
 				"request": "2.83.0",
 				"request-promise-native": "1.0.5",
 				"sax": "1.2.4",
 				"symbol-tree": "3.2.2",
-				"tough-cookie": "2.3.3",
+				"tough-cookie": "2.3.4",
+				"w3c-hr-time": "1.0.1",
 				"webidl-conversions": "4.0.2",
 				"whatwg-encoding": "1.0.3",
 				"whatwg-url": "6.4.0",
-				"xml-name-validator": "2.0.1"
+				"ws": "4.1.0",
+				"xml-name-validator": "3.0.0"
 			}
 		},
 		"jsdom-global": {
@@ -515,9 +521,9 @@
 			"resolved": "https://registry.npmjs.org/json-refs/-/json-refs-2.1.7.tgz",
 			"integrity": "sha1-uesB/in16j6Sh48VrqEK04taz4k=",
 			"requires": {
-				"commander": "2.13.0",
+				"commander": "2.15.0",
 				"graphlib": "2.1.5",
-				"js-yaml": "3.10.0",
+				"js-yaml": "3.11.0",
 				"native-promise-only": "0.8.1",
 				"path-loader": "1.0.4",
 				"slash": "1.0.0",
@@ -564,15 +570,20 @@
 				"type-check": "0.3.2"
 			}
 		},
+		"lightercollective": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/lightercollective/-/lightercollective-0.0.0.tgz",
+			"integrity": "sha512-4SdGgHgQjlqhk90QxAYsltGEI6HHt30xy9fOIPKi+c3vcGRcpPDtzm6+kxr1N9ixkrx/ngMhTCe/VpBc/HmNBQ=="
+		},
 		"lodash": {
-			"version": "4.17.4",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
 		},
 		"lodash-es": {
-			"version": "4.17.4",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-			"integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+			"version": "4.17.7",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.7.tgz",
+			"integrity": "sha512-jzqTi3vk4J5Dxq43cNjB0ekfCjPLHixoY2Sc0WHTo+0r928taLqe/VCt02vY5uQBvg0rdXgL3xWkK4X0MCmZcw=="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
@@ -598,16 +609,16 @@
 			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
 		},
 		"mime-db": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-			"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
 		},
 		"mime-types": {
-			"version": "2.1.17",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"requires": {
-				"mime-db": "1.30.0"
+				"mime-db": "1.33.0"
 			}
 		},
 		"ms": {
@@ -658,12 +669,9 @@
 			}
 		},
 		"parse5": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-			"requires": {
-				"@types/node": "9.3.0"
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
 		},
 		"path-loader": {
 			"version": "1.0.4",
@@ -690,9 +698,9 @@
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
 		"process-nextick-args": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"promise": {
 			"version": "7.3.1",
@@ -703,9 +711,9 @@
 			}
 		},
 		"prop-types": {
-			"version": "15.6.0",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-			"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 			"requires": {
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
@@ -730,7 +738,7 @@
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
 				"object-assign": "4.1.1",
-				"prop-types": "15.6.0"
+				"prop-types": "15.6.1"
 			}
 		},
 		"react-dom": {
@@ -741,31 +749,31 @@
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
 				"object-assign": "4.1.1",
-				"prop-types": "15.6.0"
+				"prop-types": "15.6.1"
 			}
 		},
 		"react-redux": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz",
-			"integrity": "sha512-8taaaGu+J7PMJQDJrk/xiWEYQmdo3mkXw6wPr3K3LxvXis3Fymiq7c13S+Tpls/AyNUAsoONkU81AP0RA6y6Vw==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+			"integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
 			"requires": {
-				"hoist-non-react-statics": "2.3.1",
-				"invariant": "2.2.2",
-				"lodash": "4.17.4",
-				"lodash-es": "4.17.4",
+				"hoist-non-react-statics": "2.5.0",
+				"invariant": "2.2.3",
+				"lodash": "4.17.5",
+				"lodash-es": "4.17.7",
 				"loose-envify": "1.3.1",
-				"prop-types": "15.6.0"
+				"prop-types": "15.6.1"
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
 				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
+				"process-nextick-args": "2.0.0",
 				"safe-buffer": "5.1.1",
 				"string_decoder": "1.0.3",
 				"util-deprecate": "1.0.2"
@@ -776,10 +784,10 @@
 			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
 			"requires": {
-				"lodash": "4.17.4",
-				"lodash-es": "4.17.4",
+				"lodash": "4.17.5",
+				"lodash-es": "4.17.7",
 				"loose-envify": "1.3.1",
-				"symbol-observable": "1.1.0"
+				"symbol-observable": "1.2.0"
 			}
 		},
 		"request": {
@@ -790,23 +798,23 @@
 				"aws-sign2": "0.7.0",
 				"aws4": "1.6.0",
 				"caseless": "0.12.0",
-				"combined-stream": "1.0.5",
+				"combined-stream": "1.0.6",
 				"extend": "3.0.1",
 				"forever-agent": "0.6.1",
-				"form-data": "2.3.1",
+				"form-data": "2.3.2",
 				"har-validator": "5.0.3",
 				"hawk": "6.0.2",
 				"http-signature": "1.2.0",
 				"is-typedarray": "1.0.0",
 				"isstream": "0.1.2",
 				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.17",
+				"mime-types": "2.1.18",
 				"oauth-sign": "0.8.2",
 				"performance-now": "2.1.0",
 				"qs": "6.5.1",
 				"safe-buffer": "5.1.1",
 				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.3",
+				"tough-cookie": "2.3.4",
 				"tunnel-agent": "0.6.0",
 				"uuid": "3.2.1"
 			}
@@ -816,7 +824,7 @@
 			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
 			"requires": {
-				"lodash": "4.17.4"
+				"lodash": "4.17.5"
 			}
 		},
 		"request-promise-native": {
@@ -826,7 +834,7 @@
 			"requires": {
 				"request-promise-core": "1.1.1",
 				"stealthy-require": "1.1.1",
-				"tough-cookie": "2.3.3"
+				"tough-cookie": "2.3.4"
 			}
 		},
 		"safe-buffer": {
@@ -854,13 +862,13 @@
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
 			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
 			"requires": {
-				"hoek": "4.2.0"
+				"hoek": "4.2.1"
 			}
 		},
 		"source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"optional": true
 		},
 		"sprintf-js": {
@@ -910,18 +918,18 @@
 				"cookiejar": "2.1.1",
 				"debug": "3.1.0",
 				"extend": "3.0.1",
-				"form-data": "2.3.1",
-				"formidable": "1.1.1",
+				"form-data": "2.3.2",
+				"formidable": "1.2.0",
 				"methods": "1.1.2",
 				"mime": "1.6.0",
 				"qs": "6.5.1",
-				"readable-stream": "2.3.3"
+				"readable-stream": "2.3.5"
 			}
 		},
 		"symbol-observable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
-			"integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
 		},
 		"symbol-tree": {
 			"version": "3.2.2",
@@ -929,9 +937,9 @@
 			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
 		},
 		"tough-cookie": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 			"requires": {
 				"punycode": "1.4.1"
 			}
@@ -1013,6 +1021,14 @@
 				"extsprintf": "1.3.0"
 			}
 		},
+		"w3c-hr-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"requires": {
+				"browser-process-hrtime": "0.1.2"
+			}
+		},
 		"webidl-conversions": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -1046,10 +1062,19 @@
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
 			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
 		},
+		"ws": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+			"requires": {
+				"async-limiter": "1.0.0",
+				"safe-buffer": "5.1.1"
+			}
+		},
 		"xml-name-validator": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-			"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
 		}
 	}
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,5 +11,6 @@
     "jsx": "react",
     "noUnusedParameters": true,
     "noUnusedLocals": true
-  }
+  },
+  "types": ["jest"]
 }


### PR DESCRIPTION
This was initially motivated because of popper.js, which throws exception about Range being missing. Popper is used by the material tooltips.