### PR TITLE
separate examples for numbers and texts

### DIFF
--- a/packages/core/src/testers/index.ts
+++ b/packages/core/src/testers/index.ts
@@ -297,9 +297,9 @@ export const isArrayObjectControl = and(
 );
 
 /**
- * Tests whether a given UI schema is of type Control and
- * whether the schema defines a numerical range.
- * Furthermore it checks that the Control has the option 'slider' set to 'true'.
+ * Tests whether a given UI schema is of type Control, if the schema
+ * is of type number or integer and
+ * whether the schema defines a numerical range with a default value.
  * @type {Tester}
  */
 export const isRangeControl = and(

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -14,6 +14,8 @@ import * as layout from './layout';
 import * as person from './person';
 import * as rule from './rule';
 import * as resolve from './resolve';
+import * as text from './text';
+import * as numbers from './numbers';
 import Rating from './Rating';
 import { RatingControl, ratingControlTester } from './RatingControl';
 
@@ -36,5 +38,7 @@ export {
   resolve,
   Rating,
   RatingControl,
-  ratingControlTester
+  ratingControlTester,
+  text,
+  numbers
 };

--- a/packages/examples/src/numbers.ts
+++ b/packages/examples/src/numbers.ts
@@ -1,0 +1,43 @@
+import { registerExamples } from './register';
+
+export const schema = {
+  type: 'object',
+  properties: {
+    price: {
+      type: 'number',
+      maximum: 300,
+      minimum: 1,
+      default: 50
+    }
+  },
+};
+
+export const uischema = {
+  type: 'VerticalLayout',
+  elements: [
+    {
+      type: 'HorizontalLayout',
+      elements: [
+        {
+          type: 'Control',
+          scope: '#/properties/price',
+          label: {
+            text: 'Price'
+          }
+        },
+      ]
+    },
+  ]
+};
+
+export const data = {};
+
+registerExamples([
+  {
+    name: 'numbers',
+    label: 'Numbers',
+    data,
+    schema,
+    uiSchema: uischema,
+  }
+]);

--- a/packages/examples/src/text.ts
+++ b/packages/examples/src/text.ts
@@ -1,0 +1,72 @@
+import { registerExamples } from './register';
+
+export const schema = {
+  type: 'object',
+  properties: {
+    postalCode: {
+      type: 'string',
+    },
+    postalCodeWithoutTrim: {
+      type: 'string',
+      maxLength: 8
+    },
+    postalCodeWithoutRestrict: {
+      type: 'string',
+      maxLength: 8
+    }
+  }
+};
+
+export const uischema = {
+  type: 'VerticalLayout',
+  elements: [
+    {
+      type: 'HorizontalLayout',
+      elements: [
+        {
+          type: 'Control',
+          scope: '#/properties/postalCode',
+          label: 'ZIP Code',
+          options: {
+            trim: true,
+            restrict: true
+          }
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/postalCodeWithoutTrim',
+          label: 'ZIP Code',
+          options: {
+            trim: false,
+            restrict: true
+          }
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/postalCodeWithoutRestrict',
+          label: 'ZIP Code',
+          options: {
+            trim: true,
+            restrict: false
+          }
+        }
+      ]
+    },
+  ]
+};
+
+export const data = {
+  postalCode: '12345678',
+  postalCodeWithoutTrim: '12345678',
+  postalCodeWithoutRestrict: '123456789',
+};
+
+registerExamples([
+  {
+    name: 'text',
+    label: 'Text',
+    data,
+    schema,
+    uiSchema: uischema,
+  }
+]);

--- a/packages/material/src/fields/MaterialTextField.tsx
+++ b/packages/material/src/fields/MaterialTextField.tsx
@@ -18,13 +18,19 @@ export const MaterialTextField = (props: FieldProps) => {
   const { data, className, id, enabled, uischema, schema, isValid, path, handleChange } = props;
   const controlElement = uischema as ControlElement;
   const maxLength = resolveSchema(schema, controlElement.scope).maxLength;
-  let config;
+  let config = {};
   if (uischema.options && uischema.options.restrict) {
-    config = {'maxLength': maxLength};
-  } else {
-    config = {};
+    config = {
+      maxLength: maxLength
+    };
   }
   const trim = uischema.options && uischema.options.trim;
+  if (trim) {
+    config = {
+      ...config,
+      size: maxLength
+    };
+  }
   const onChange = ev => handleChange(path, ev.target.value);
 
   return (


### PR DESCRIPTION
Added new example files to separate examples for numbers and texts.

Fix #865 