### PR TITLE
[Editor] Improve label mapping capabilities

### DIFF
--- a/packages/editor/src/helpers/util.ts
+++ b/packages/editor/src/helpers/util.ts
@@ -10,6 +10,13 @@ import {
 } from '@jsonforms/core';
 import { editorReducer } from '../reducers/index';
 
+export interface LabelDefinition {
+  /** A constant label value displayed for every object for which this label definition applies. */
+  constant?: string;
+  /** The property name that is used to get a variable part of an object's label. */
+  property?: string;
+}
+
 /**
  * Resolves the given local data path against the root data.
  *

--- a/packages/editor/src/ide.ts
+++ b/packages/editor/src/ide.ts
@@ -8,7 +8,7 @@ import {
   configureExportButton,
   configureUploadButton,
   createExportDataDialog
-} from '../src/toolbar';
+} from './toolbar';
 import { SchemaServiceImpl } from './services/schema.service.impl';
 import { EditorContext } from './editor-context';
 import '@jsonforms/webcomponent';


### PR DESCRIPTION
The values of a label mapping can now be either specified as a string or as an object.
In case of a string the behavior does not change. This guarantees old label mappings to behave as always.
The object allows to specify two properties:
`constant`: A constant value that is always displayed
`property`: A property whose content is displayed
If both are specified, the constant value is displayed followed by a space and the property value.

Additionally fixed an import to be resolvable when the editor package is consumed in other packages.