### PR TITLE
Add support for primitive types to array renderers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,17 +2,92 @@
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
+		"@angular-redux/store": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@angular-redux/store/-/store-7.1.1.tgz",
+			"integrity": "sha512-Uhj+wzByvQ04j6hh75xYdUMfi/sA71OLcxMl0U8uhfEGsM13GaLmf1cheDfaAMNv04KKNqj72Gdb1j+Ov2S2Nw=="
+		},
+		"@angular/animations": {
+			"version": "5.2.10",
+			"resolved": "https://registry.npmjs.org/@angular/animations/-/animations-5.2.10.tgz",
+			"integrity": "sha512-QNYXqnti8BeFriNaZ/juLnO6l0MVlVNUmLycC9ma+pdTiEJl8rtgZ0WXxgOCjScyKpInkWn2J+m9FI/78SYFpw==",
+			"requires": {
+				"tslib": "1.9.0"
+			}
+		},
+		"@angular/cdk": {
+			"version": "5.2.5",
+			"resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-5.2.5.tgz",
+			"integrity": "sha512-GN8m1d+VcCE9+Bgwv06Y8YJKyZ0i9ZIq2ZPBcJYt+KVgnVVRg4JkyUNxud07LNsvzOX22DquHqmIZiC4hAG7Ag==",
+			"requires": {
+				"tslib": "1.9.0"
+			}
+		},
+		"@angular/common": {
+			"version": "5.2.10",
+			"resolved": "https://registry.npmjs.org/@angular/common/-/common-5.2.10.tgz",
+			"integrity": "sha512-4zgI/Q6bo/KCvrDPf8gc2IpTJ3PFKgd9RF4jZuh1uc+uEYTAj396tDF8o412AJ/iwtYOHWUx+YgzAvT8dHXZ5Q==",
+			"requires": {
+				"tslib": "1.9.0"
+			}
+		},
+		"@angular/compiler": {
+			"version": "5.2.10",
+			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-5.2.10.tgz",
+			"integrity": "sha512-FI9ip+aWGpKQB+VfNbFQ+wyh0K4Th8Q/MrHxW6CN4BYVAfFtfORRohvyyYk0sRxuQO8JFN3W/FFfdXjuL+cZKw==",
+			"requires": {
+				"tslib": "1.9.0"
+			}
+		},
+		"@angular/core": {
+			"version": "5.2.10",
+			"resolved": "https://registry.npmjs.org/@angular/core/-/core-5.2.10.tgz",
+			"integrity": "sha512-glDuTtHTcAVhfU3NVewxz/W+Iweq5IaeW2tnMa+RKLopYk9fRs8eR5iTixTGvegwKR770vfXg/gR7P6Ii5cYGQ==",
+			"requires": {
+				"tslib": "1.9.0"
+			}
+		},
+		"@angular/forms": {
+			"version": "5.2.10",
+			"resolved": "https://registry.npmjs.org/@angular/forms/-/forms-5.2.10.tgz",
+			"integrity": "sha512-XQR4cd1Eey9aDT3CxQ6pbBWSBEg1408ZV/EUblKgMgt4k8PfDiuLSbF+MI/TOYAg3UkcVAxN1no4hWtkou8Rpw==",
+			"requires": {
+				"tslib": "1.9.0"
+			}
+		},
+		"@angular/material": {
+			"version": "5.2.5",
+			"resolved": "https://registry.npmjs.org/@angular/material/-/material-5.2.5.tgz",
+			"integrity": "sha512-IltfBeTJWnmZehOQNQ7KoFs7MGWuZTe0g21hIitGkusVNt1cIoTD24xKH5jwztjH19c04IgiwonpurMKM6pBCQ==",
+			"requires": {
+				"tslib": "1.9.0"
+			}
+		},
+		"@angular/platform-browser": {
+			"version": "5.2.10",
+			"resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-5.2.10.tgz",
+			"integrity": "sha512-oF1A0BS1wpTlxfv6YytkFCkztvvtVllnh5IUnoyV+siVT3qogKat9ZmzCmcDJ5SvIDYkY+rXBhumyFzBZ5ufFg==",
+			"requires": {
+				"tslib": "1.9.0"
+			}
+		},
+		"@angular/platform-browser-dynamic": {
+			"version": "5.2.10",
+			"resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.2.10.tgz",
+			"integrity": "sha512-TquhIkyR6uXfmzk6RiEl5+8Kk653Wqe4F+pKn5gFi+Z6cDm4nkDlT9kgT3e6c08JHw9fGGAvNmsalq7oS+PnNg==",
+			"requires": {
+				"tslib": "1.9.0"
+			}
+		},
 		"@ava/babel-plugin-throws-helper": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-2.0.0.tgz",
-			"integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw=",
-			"dev": true
+			"integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw="
 		},
 		"@ava/babel-preset-stage-4": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-1.1.0.tgz",
 			"integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "6.22.0",
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -32,7 +107,6 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
 					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-					"dev": true,
 					"requires": {
 						"md5-o-matic": "0.1.1"
 					}
@@ -41,7 +115,6 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-1.2.0.tgz",
 					"integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
-					"dev": true,
 					"requires": {
 						"md5-hex": "1.3.0"
 					}
@@ -52,7 +125,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-3.0.0.tgz",
 			"integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
-			"dev": true,
 			"requires": {
 				"@ava/babel-plugin-throws-helper": "2.0.0",
 				"babel-plugin-espower": "2.4.0"
@@ -62,95 +134,117 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@ava/write-file-atomic/-/write-file-atomic-2.2.0.tgz",
 			"integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"imurmurhash": "0.1.4",
 				"slide": "1.1.6"
 			}
 		},
+		"@babel/code-frame": {
+			"version": "7.0.0-beta.46",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz",
+			"integrity": "sha512-7BKRkmYaPZm3Yff5HGZJKCz7RqZ5jUjknsXT6Gz5YKG23J3uq9hAj0epncCB0rlqmnZ8Q+UUpQB2tCR5mT37vw==",
+			"requires": {
+				"@babel/highlight": "7.0.0-beta.46"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0-beta.46",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.46.tgz",
+			"integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
+			"requires": {
+				"chalk": "2.3.2",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			}
+		},
 		"@concordance/react": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz",
 			"integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
-			"dev": true,
 			"requires": {
 				"arrify": "1.0.1"
+			}
+		},
+		"@material-ui/icons": {
+			"version": "1.0.0-beta.43",
+			"resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-1.0.0-beta.43.tgz",
+			"integrity": "sha512-t6Fhq7t6LuZsFH1TtbjcVJiqmdc/vgk1X9pdannBHuWN9tuIaPBkEBhb/YRRn6VpNJIww92uIuyw0xHyaKcsHg==",
+			"requires": {
+				"recompose": "0.26.0"
 			}
 		},
 		"@types/events": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
-			"integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
-			"dev": true
+			"integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
 		},
 		"@types/fs-extra": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.0.tgz",
 			"integrity": "sha512-qtxDULQKUenuaDLW003CgC+0T0eiAfH3BrH+vSt87GLzbz5EZ6Ox6mv9rMttvhDOatbb9nYh0E1m7ydoYwUrAg==",
-			"dev": true,
 			"requires": {
-				"@types/node": "9.6.0"
+				"@types/node": "8.10.13"
 			}
 		},
 		"@types/glob": {
 			"version": "5.0.35",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
 			"integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
-			"dev": true,
 			"requires": {
 				"@types/events": "1.2.0",
 				"@types/minimatch": "3.0.3",
-				"@types/node": "9.6.0"
+				"@types/node": "8.10.13"
 			}
 		},
 		"@types/handlebars": {
 			"version": "4.0.36",
 			"resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.36.tgz",
-			"integrity": "sha512-LjNiTX7TY7wtuC6y3QwC93hKMuqYhgV9A1uXBKNvZtVC8ZvyWAjZkJ5BvT0K7RKqORRYRLMrqCxpw5RgS+MdrQ==",
-			"dev": true
+			"integrity": "sha512-LjNiTX7TY7wtuC6y3QwC93hKMuqYhgV9A1uXBKNvZtVC8ZvyWAjZkJ5BvT0K7RKqORRYRLMrqCxpw5RgS+MdrQ=="
 		},
 		"@types/highlight.js": {
 			"version": "9.12.2",
 			"resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.2.tgz",
-			"integrity": "sha512-y5x0XD/WXDaGSyiTaTcKS4FurULJtSiYbGTeQd0m2LYZGBcZZ/7fM6t5H/DzeUF+kv8y6UfmF6yJABQsHcp9VQ==",
-			"dev": true
+			"integrity": "sha512-y5x0XD/WXDaGSyiTaTcKS4FurULJtSiYbGTeQd0m2LYZGBcZZ/7fM6t5H/DzeUF+kv8y6UfmF6yJABQsHcp9VQ=="
 		},
 		"@types/jest": {
 			"version": "22.2.2",
 			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.2.2.tgz",
-			"integrity": "sha512-Dt7aifQmvMPTLVimzvfQ99qUn4zeSDCQarFNV4otfDLYu0RFdSRBnqSLgksoAnsRL88xJ/UBKbd66iP2XIab0w==",
-			"dev": true
+			"integrity": "sha512-Dt7aifQmvMPTLVimzvfQ99qUn4zeSDCQarFNV4otfDLYu0RFdSRBnqSLgksoAnsRL88xJ/UBKbd66iP2XIab0w=="
+		},
+		"@types/jss": {
+			"version": "9.5.2",
+			"resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.5.2.tgz",
+			"integrity": "sha512-EX87yNYcisXO5BU9tT7stB7OGuDJyV3JwtMwhfUprrmHwYKWh9a3vchAy6DYzUSbmTA7bD46h8qata5jP1V7Zw==",
+			"requires": {
+				"csstype": "2.4.1",
+				"indefinite-observable": "1.0.1"
+			}
 		},
 		"@types/lodash": {
 			"version": "4.14.108",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.108.tgz",
-			"integrity": "sha512-WD2vUOKfBBVHxWUV9iMR9RMfpuf8HquxWeAq2yqGVL7Nc4JW2+sQama0pREMqzNI3Tutj0PyxYUJwuoxxvX+xA==",
-			"dev": true
+			"integrity": "sha512-WD2vUOKfBBVHxWUV9iMR9RMfpuf8HquxWeAq2yqGVL7Nc4JW2+sQama0pREMqzNI3Tutj0PyxYUJwuoxxvX+xA=="
 		},
 		"@types/marked": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.3.0.tgz",
-			"integrity": "sha512-CSf9YWJdX1DkTNu9zcNtdCcn6hkRtB5ILjbhRId4ZOQqx30fXmdecuaXhugQL6eyrhuXtaHJ7PHI+Vm7k9ZJjg==",
-			"dev": true
+			"integrity": "sha512-CSf9YWJdX1DkTNu9zcNtdCcn6hkRtB5ILjbhRId4ZOQqx30fXmdecuaXhugQL6eyrhuXtaHJ7PHI+Vm7k9ZJjg=="
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-			"dev": true
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
 		},
 		"@types/node": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.0.tgz",
-			"integrity": "sha512-h3YZbOq2+ZoDFI1z8Zx0Ck/xRWkOESVaLdgLdd/c25mMQ1Y2CAkILu9ny5A15S5f32gGcQdaUIZ2jzYr8D7IFg==",
-			"dev": true
+			"version": "8.10.13",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.13.tgz",
+			"integrity": "sha512-AorNXRHoPVxIUIVmr6uJXRnvlPOSNKAJF5jZ1JOj1/IxYMocZzvQooNeLU02Db6kpy1IVIySTOvuIxmUF1HrOg=="
 		},
 		"@types/react": {
 			"version": "16.3.12",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.12.tgz",
 			"integrity": "sha512-FfBhLC3QeXXEtjoGGLixS7cB305vzBOM1dZKtbUuXeTfjY0quzRRMxpqylC4QyUaLqdhNLdER0ZdHUGAVlGSCA==",
-			"dev": true,
 			"requires": {
 				"csstype": "2.4.1"
 			}
@@ -159,7 +253,14 @@
 			"version": "2.0.36",
 			"resolved": "https://registry.npmjs.org/@types/react-dnd/-/react-dnd-2.0.36.tgz",
 			"integrity": "sha512-jA95HjQxuHNSnr0PstVBjRwVcFJZoinxbtsS4bpi5nwAL5GUOtjrLrq1bDi4WNYxW+77KHvqSAZ2EgA2q9evdA==",
-			"dev": true,
+			"requires": {
+				"@types/react": "16.3.12"
+			}
+		},
+		"@types/react-transition-group": {
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.0.9.tgz",
+			"integrity": "sha512-Id2MtQcmOgLymqqLqg1VjzNpN7O5vGoF47h3s7jxhzqWdMCtk2GwxFUqcKbGrRmHzzQGyRatfG8yahonIys74Q==",
 			"requires": {
 				"@types/react": "16.3.12"
 			}
@@ -168,33 +269,48 @@
 			"version": "0.7.7",
 			"resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.7.7.tgz",
 			"integrity": "sha512-37gn9J75TVAhhmzBqoX0vzQodsjzri1SxElMX+Wk092IobNZSGW/8X4ygLOQOrKjCQr5nxGN9Ik0UA3fSdL1Pw==",
-			"dev": true,
 			"requires": {
 				"@types/glob": "5.0.35",
-				"@types/node": "9.6.0"
+				"@types/node": "8.10.13"
 			}
+		},
+		"@webcomponents/webcomponentsjs": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.2.0.tgz",
+			"integrity": "sha512-P9JWydfpBR+CK12UwtBaoD/lYF3PR9XBArAWk5J9nfPaJwA3OUox4StZmyFSVDLsvpFq5HsEtxU/OdHAlAWPnw=="
 		},
 		"JSONStream": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
 			"integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-			"dev": true,
 			"requires": {
 				"jsonparse": "1.3.1",
 				"through": "2.3.8"
 			}
 		},
+		"abab": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+		},
+		"accepts": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+			"requires": {
+				"mime-types": "2.1.18",
+				"negotiator": "0.6.1"
+			}
+		},
 		"acorn": {
 			"version": "5.5.3",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
-			"dev": true
+			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
 		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
 			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
-			"dev": true,
 			"requires": {
 				"acorn": "4.0.13"
 			},
@@ -202,28 +318,41 @@
 				"acorn": {
 					"version": "4.0.13",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-					"dev": true
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
 				}
+			}
+		},
+		"acorn-globals": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+			"requires": {
+				"acorn": "5.5.3"
 			}
 		},
 		"add-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
-			"dev": true
+			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo="
+		},
+		"ajv": {
+			"version": "4.11.8",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+			"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+			"requires": {
+				"co": "4.6.0",
+				"json-stable-stringify": "1.0.1"
+			}
 		},
 		"ajv-keywords": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
-			"integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
-			"dev": true
+			"integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74="
 		},
 		"align-text": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2",
 				"longest": "1.0.1",
@@ -233,14 +362,12 @@
 		"amdefine": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-			"dev": true
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
 		},
 		"ansi-align": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
 			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-			"dev": true,
 			"requires": {
 				"string-width": "2.1.1"
 			}
@@ -248,20 +375,22 @@
 		"ansi-escapes": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-			"dev": true
+			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+		},
+		"ansi-html": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"dev": true
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"requires": {
 				"color-convert": "1.9.1"
 			}
@@ -270,23 +399,28 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-			"dev": true,
 			"requires": {
 				"micromatch": "2.3.11",
 				"normalize-path": "2.1.1"
 			}
 		},
+		"append-transform": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+			"requires": {
+				"default-require-extensions": "1.0.0"
+			}
+		},
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-			"dev": true
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 		},
 		"are-we-there-yet": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
 			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-			"dev": true,
 			"requires": {
 				"delegates": "1.0.0",
 				"readable-stream": "2.3.5"
@@ -296,7 +430,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
 			"requires": {
 				"sprintf-js": "1.0.3"
 			}
@@ -305,7 +438,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-			"dev": true,
 			"requires": {
 				"arr-flatten": "1.1.0"
 			}
@@ -313,44 +445,71 @@
 		"arr-exclude": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/arr-exclude/-/arr-exclude-1.0.0.tgz",
-			"integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE=",
-			"dev": true
+			"integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE="
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-			"dev": true
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
 		},
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-			"dev": true
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
 		},
 		"array-differ": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-			"dev": true
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+		},
+		"array-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+		},
+		"array-filter": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
 		},
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-			"dev": true
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+		},
+		"array-flatten": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
+			"integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
 		},
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
-			"dev": true
+			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
+		},
+		"array-includes": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+			"requires": {
+				"define-properties": "1.1.2",
+				"es-abstract": "1.11.0"
+			}
+		},
+		"array-map": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+		},
+		"array-reduce": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
 		},
 		"array-union": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-			"dev": true,
 			"requires": {
 				"array-uniq": "1.0.3"
 			}
@@ -358,32 +517,32 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-			"dev": true
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
 		},
 		"array-unique": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-			"dev": true
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-			"dev": true
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-			"dev": true
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"asn1.js": {
 			"version": "4.10.1",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
 			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-			"dev": true,
 			"requires": {
 				"bn.js": "4.11.8",
 				"inherits": "2.0.3",
@@ -394,7 +553,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
 			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-			"dev": true,
 			"requires": {
 				"util": "0.10.3"
 			}
@@ -402,50 +560,52 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-			"dev": true
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+		},
+		"astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
 		},
 		"async": {
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-			"dev": true
+			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 		},
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-			"dev": true
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-			"dev": true
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"atob": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
-			"integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
-			"dev": true
+			"integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10="
 		},
 		"auto-bind": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-1.2.0.tgz",
-			"integrity": "sha512-Zw7pZp7tztvKnWWtoII4AmqH5a2PV3ZN5F0BPRTGcc1kpRm4b6QXQnPU7Znbl6BfPfqOVOV29g4JeMqZQaqqOA==",
-			"dev": true
+			"integrity": "sha512-Zw7pZp7tztvKnWWtoII4AmqH5a2PV3ZN5F0BPRTGcc1kpRm4b6QXQnPU7Znbl6BfPfqOVOV29g4JeMqZQaqqOA=="
 		},
 		"ava": {
 			"version": "0.24.0",
 			"resolved": "https://registry.npmjs.org/ava/-/ava-0.24.0.tgz",
 			"integrity": "sha512-o/ykNzsWB5qgh1cR9jzVw0E1y4E219aXl9njNFGSamSCsD7VhPd3aoZabNZuG1PSVMZmQ8RuwKnTuz/loNhKnw==",
-			"dev": true,
 			"requires": {
 				"@ava/babel-preset-stage-4": "1.1.0",
 				"@ava/babel-preset-transform-test-files": "3.0.0",
@@ -536,7 +696,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/ava-init/-/ava-init-0.2.1.tgz",
 			"integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
-			"dev": true,
 			"requires": {
 				"arr-exclude": "1.0.0",
 				"execa": "0.7.0",
@@ -545,23 +704,301 @@
 				"write-pkg": "3.1.0"
 			}
 		},
+		"awesome-typescript-loader": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-3.5.0.tgz",
+			"integrity": "sha512-qzgm9SEvodVkSi9QY7Me1/rujg+YBNMjayNSAyzNghwTEez++gXoPCwMvpbHRG7wrOkDCiF6dquvv9ESmUBAuw==",
+			"requires": {
+				"chalk": "2.3.2",
+				"enhanced-resolve": "3.3.0",
+				"loader-utils": "1.1.0",
+				"lodash": "4.17.4",
+				"micromatch": "3.1.10",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.5.4"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"requires": {
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"enhanced-resolve": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.3.0.tgz",
+					"integrity": "sha512-2qbxE7ek3YxPJ1ML6V+satHkzHpJQKWkRHmRx6mfAoW59yP8YH8BFplbegSP+u2hBd6B6KCOpvJQ3dZAP+hkpg==",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"memory-fs": "0.4.1",
+						"object-assign": "4.1.1",
+						"tapable": "0.2.8"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"extend-shallow": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+					"requires": {
+						"assign-symbols": "1.0.0",
+						"is-extendable": "1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+							"requires": {
+								"is-plain-object": "2.0.4"
+							}
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"requires": {
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"dev": true
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-			"dev": true
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"esutils": "2.0.2",
@@ -571,14 +1008,12 @@
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "2.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -591,7 +1026,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -599,8 +1033,7 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -608,7 +1041,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
 			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"babel-generator": "6.26.1",
@@ -635,7 +1067,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -643,8 +1074,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -652,7 +1082,6 @@
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-			"dev": true,
 			"requires": {
 				"babel-messages": "6.23.0",
 				"babel-runtime": "6.26.0",
@@ -667,8 +1096,7 @@
 				"jsesc": {
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-					"dev": true
+					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
 				}
 			}
 		},
@@ -676,7 +1104,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -687,7 +1114,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -699,7 +1125,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-traverse": "6.26.0",
@@ -710,7 +1135,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -723,7 +1147,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -733,7 +1156,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
@@ -743,7 +1165,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0",
@@ -754,7 +1175,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -767,17 +1187,24 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-template": "6.26.0"
+			}
+		},
+		"babel-jest": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.3.tgz",
+			"integrity": "sha512-BgSjmtl3mW3i+VeVHEr9d2zFSAT66G++pJcHQiUjd00pkW+voYXFctIm/indcqOWWXw5a1nUpR1XWszD9fJ1qg==",
+			"requires": {
+				"babel-plugin-istanbul": "4.1.6",
+				"babel-preset-jest": "22.4.3"
 			}
 		},
 		"babel-loader": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz",
 			"integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
-			"dev": true,
 			"requires": {
 				"find-cache-dir": "1.0.0",
 				"loader-utils": "1.1.0",
@@ -788,7 +1215,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -797,7 +1223,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -806,7 +1231,6 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-2.4.0.tgz",
 			"integrity": "sha512-/+SRpy7pKgTI28oEHfn1wkuM5QFAdRq8WNsOOih1dVrdV6A/WbNbRZyl0eX5eyDgtb0lOE27PeDFuCX2j8OxVg==",
-			"dev": true,
 			"requires": {
 				"babel-generator": "6.26.1",
 				"babylon": "6.18.0",
@@ -817,35 +1241,46 @@
 				"estraverse": "4.2.0"
 			}
 		},
+		"babel-plugin-istanbul": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
+			"requires": {
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"find-up": "2.1.0",
+				"istanbul-lib-instrument": "1.10.1",
+				"test-exclude": "4.2.1"
+			}
+		},
+		"babel-plugin-jest-hoist": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz",
+			"integrity": "sha512-zhvv4f6OTWy2bYevcJftwGCWXMFe7pqoz41IhMi4xna7xNsX5NygdagsrE0y6kkfuXq8UalwvPwKTyAxME2E/g=="
+		},
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-			"dev": true
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-			"dev": true
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-			"dev": true
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-			"dev": true
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
 		},
 		"babel-plugin-transform-async-to-generator": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-functions": "6.13.0",
@@ -856,7 +1291,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -865,7 +1299,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -876,7 +1309,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
 			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "6.24.1",
 				"babel-runtime": "6.26.0",
@@ -888,7 +1320,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "6.24.1",
 				"babel-helper-get-function-arity": "6.24.1",
@@ -902,7 +1333,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0"
 			}
@@ -911,7 +1341,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -922,7 +1351,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -933,7 +1361,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -944,17 +1371,24 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-types": "6.26.0"
+			}
+		},
+		"babel-preset-jest": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz",
+			"integrity": "sha512-a+M3LTEXTq3gxv0uBN9Qm6ahUl7a8pj923nFbCUdqFUSsf3YrX8Uc+C3MEwji5Af3LiQjSC7w4ooYewlz8HRTA==",
+			"requires": {
+				"babel-plugin-jest-hoist": "22.4.3",
+				"babel-plugin-syntax-object-rest-spread": "6.13.0"
 			}
 		},
 		"babel-register": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-			"dev": true,
 			"requires": {
 				"babel-core": "6.26.0",
 				"babel-runtime": "6.26.0",
@@ -969,7 +1403,6 @@
 					"version": "0.4.18",
 					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-					"dev": true,
 					"requires": {
 						"source-map": "0.5.7"
 					}
@@ -980,7 +1413,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"dev": true,
 			"requires": {
 				"core-js": "2.5.3",
 				"regenerator-runtime": "0.11.1"
@@ -990,7 +1422,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"babel-traverse": "6.26.0",
@@ -1003,7 +1434,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"babel-messages": "6.23.0",
@@ -1020,7 +1450,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -1028,8 +1457,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -1037,7 +1465,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"esutils": "2.0.2",
@@ -1048,20 +1475,17 @@
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-			"dev": true
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-			"dev": true,
 			"requires": {
 				"cache-base": "1.0.1",
 				"class-utils": "0.3.6",
@@ -1076,7 +1500,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "1.0.2"
 					}
@@ -1084,22 +1507,24 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
 		"base64-js": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
-			"integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
-			"dev": true
+			"integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w=="
+		},
+		"batch": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"tweetnacl": "0.14.5"
@@ -1108,32 +1533,72 @@
 		"big.js": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-			"dev": true
+			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
 		},
 		"binary-extensions": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
-			"dev": true
+			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
 		},
 		"bluebird": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-			"dev": true
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
 		},
 		"bn.js": {
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-			"dev": true
+			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+		},
+		"body-parser": {
+			"version": "1.18.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+			"requires": {
+				"bytes": "3.0.0",
+				"content-type": "1.0.4",
+				"debug": "2.6.9",
+				"depd": "1.1.2",
+				"http-errors": "1.6.3",
+				"iconv-lite": "0.4.19",
+				"on-finished": "2.3.0",
+				"qs": "6.5.1",
+				"raw-body": "2.3.2",
+				"type-is": "1.6.16"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"bonjour": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+			"integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+			"requires": {
+				"array-flatten": "2.1.1",
+				"deep-equal": "1.0.1",
+				"dns-equal": "1.0.0",
+				"dns-txt": "2.0.2",
+				"multicast-dns": "6.2.3",
+				"multicast-dns-service-types": "1.1.0"
+			}
 		},
 		"boom": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-			"dev": true,
 			"requires": {
 				"hoek": "4.2.1"
 			}
@@ -1142,7 +1607,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
 			"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-			"dev": true,
 			"requires": {
 				"ansi-align": "2.0.0",
 				"camelcase": "4.1.0",
@@ -1156,8 +1620,7 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				}
 			}
 		},
@@ -1165,7 +1628,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
@@ -1175,24 +1637,46 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-			"dev": true,
 			"requires": {
 				"expand-range": "1.8.2",
 				"preserve": "0.2.0",
 				"repeat-element": "1.1.2"
 			}
 		},
+		"brcast": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
+			"integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg=="
+		},
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-			"dev": true
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+		},
+		"browser-process-hrtime": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
+		},
+		"browser-resolve": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+			"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+			"requires": {
+				"resolve": "1.1.7"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+				}
+			}
 		},
 		"browserify-aes": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
 			"integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
-			"dev": true,
 			"requires": {
 				"buffer-xor": "1.0.3",
 				"cipher-base": "1.0.4",
@@ -1206,7 +1690,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
 			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
-			"dev": true,
 			"requires": {
 				"browserify-aes": "1.1.1",
 				"browserify-des": "1.0.0",
@@ -1217,7 +1700,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
 			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
-			"dev": true,
 			"requires": {
 				"cipher-base": "1.0.4",
 				"des.js": "1.0.0",
@@ -1228,7 +1710,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-			"dev": true,
 			"requires": {
 				"bn.js": "4.11.8",
 				"randombytes": "2.0.6"
@@ -1238,7 +1719,6 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-			"dev": true,
 			"requires": {
 				"bn.js": "4.11.8",
 				"browserify-rsa": "4.0.1",
@@ -1253,22 +1733,27 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
 			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-			"dev": true,
 			"requires": {
 				"pako": "1.0.6"
+			}
+		},
+		"bser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"requires": {
+				"node-int64": "0.4.0"
 			}
 		},
 		"buf-compare": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
-			"integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=",
-			"dev": true
+			"integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o="
 		},
 		"buffer": {
 			"version": "4.9.1",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-			"dev": true,
 			"requires": {
 				"base64-js": "1.2.3",
 				"ieee754": "1.1.11",
@@ -1278,38 +1763,69 @@
 		"buffer-from": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-			"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
-			"dev": true
+			"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+		},
+		"buffer-indexof": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+			"integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
 		},
 		"buffer-xor": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-			"dev": true
+			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-			"dev": true
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
 		},
 		"builtin-status-codes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
-			"dev": true
+			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
 		},
 		"byline": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
-			"dev": true
+			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
+		},
+		"bytes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+		},
+		"cacache": {
+			"version": "10.0.4",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+			"requires": {
+				"bluebird": "3.5.1",
+				"chownr": "1.0.1",
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"lru-cache": "4.1.2",
+				"mississippi": "2.0.0",
+				"mkdirp": "0.5.1",
+				"move-concurrently": "1.0.1",
+				"promise-inflight": "1.0.1",
+				"rimraf": "2.6.2",
+				"ssri": "5.3.0",
+				"unique-filename": "1.1.0",
+				"y18n": "4.0.0"
+			},
+			"dependencies": {
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+				}
+			}
 		},
 		"cache-base": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-			"dev": true,
 			"requires": {
 				"collection-visit": "1.0.0",
 				"component-emitter": "1.2.1",
@@ -1325,8 +1841,7 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -1334,7 +1849,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
 			"integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
-			"dev": true,
 			"requires": {
 				"md5-hex": "1.3.0",
 				"mkdirp": "0.5.1",
@@ -1345,7 +1859,6 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
 					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-					"dev": true,
 					"requires": {
 						"md5-o-matic": "0.1.1"
 					}
@@ -1354,7 +1867,6 @@
 					"version": "1.3.4",
 					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
 					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"imurmurhash": "0.1.4",
@@ -1367,7 +1879,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.0.1.tgz",
 			"integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
-			"dev": true,
 			"requires": {
 				"core-js": "2.5.3",
 				"deep-equal": "1.0.1",
@@ -1378,42 +1889,49 @@
 		"call-signature": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
-			"integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
-			"dev": true
+			"integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY="
+		},
+		"callsites": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
 		},
 		"camelcase": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-			"dev": true
+			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
 		},
 		"camelcase-keys": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-			"dev": true,
 			"requires": {
 				"camelcase": "2.1.1",
 				"map-obj": "1.0.1"
 			}
 		},
+		"capture-exit": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
+			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+			"requires": {
+				"rsvp": "3.6.2"
+			}
+		},
 		"capture-stack-trace": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-			"dev": true
+			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"dev": true
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"center-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-			"dev": true,
 			"requires": {
 				"align-text": "0.1.4",
 				"lazy-cache": "1.0.4"
@@ -1423,24 +1941,26 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 			"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "3.2.1",
 				"escape-string-regexp": "1.0.5",
 				"supports-color": "5.3.0"
 			}
 		},
+		"change-emitter": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+			"integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
+		},
 		"chardet": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-			"dev": true
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
 		},
 		"chokidar": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-			"dev": true,
 			"requires": {
 				"anymatch": "1.3.2",
 				"async-each": "1.0.1",
@@ -1453,17 +1973,20 @@
 				"readdirp": "2.1.0"
 			}
 		},
+		"chownr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+		},
 		"ci-info": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-			"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
-			"dev": true
+			"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg=="
 		},
 		"cipher-base": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"safe-buffer": "5.1.1"
@@ -1473,7 +1996,6 @@
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-			"dev": true,
 			"requires": {
 				"arr-union": "3.1.0",
 				"define-property": "0.2.5",
@@ -1485,7 +2007,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "0.1.6"
 					}
@@ -1494,7 +2015,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -1503,7 +2023,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -1514,7 +2033,6 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -1523,7 +2041,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -1534,7 +2051,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "0.1.6",
 						"is-data-descriptor": "0.1.4",
@@ -1544,40 +2060,39 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				},
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"dev": true
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
+		},
+		"classnames": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+			"integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
 		},
 		"clean-stack": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
-			"integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE=",
-			"dev": true
+			"integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
 		},
 		"clean-yaml-object": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
-			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
-			"dev": true
+			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g="
 		},
 		"cli-boxes": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-			"dev": true
+			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
 		},
 		"cli-cursor": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-			"dev": true,
 			"requires": {
 				"restore-cursor": "2.0.0"
 			}
@@ -1585,14 +2100,12 @@
 		"cli-spinners": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
-			"integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
-			"dev": true
+			"integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY="
 		},
 		"cli-truncate": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
 			"integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
-			"dev": true,
 			"requires": {
 				"slice-ansi": "1.0.0",
 				"string-width": "2.1.1"
@@ -1601,14 +2114,12 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-			"dev": true
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
 		},
 		"cliui": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
 			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-			"dev": true,
 			"requires": {
 				"center-align": "0.1.3",
 				"right-align": "0.1.3",
@@ -1618,34 +2129,29 @@
 				"wordwrap": {
 					"version": "0.0.2",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-					"dev": true
+					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
 				}
 			}
 		},
 		"clone": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-			"dev": true
+			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
 		},
 		"clone-buffer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-			"dev": true
+			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
 		},
 		"clone-stats": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-			"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-			"dev": true
+			"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
 		},
 		"cloneable-readable": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
 			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
-			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"process-nextick-args": "2.0.0",
@@ -1656,7 +2162,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
 			"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"mkdirp": "0.5.1"
@@ -1665,14 +2170,12 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-			"dev": true
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
 		},
 		"co-with-promise": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co-with-promise/-/co-with-promise-4.6.0.tgz",
 			"integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
-			"dev": true,
 			"requires": {
 				"pinkie-promise": "1.0.0"
 			}
@@ -1681,7 +2184,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.1.tgz",
 			"integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
-			"dev": true,
 			"requires": {
 				"convert-to-spaces": "1.0.2"
 			}
@@ -1689,14 +2191,12 @@
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"collection-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-			"dev": true,
 			"requires": {
 				"map-visit": "1.0.0",
 				"object-visit": "1.0.1"
@@ -1706,7 +2206,6 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -1714,14 +2213,12 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"columnify": {
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
 			"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
-			"dev": true,
 			"requires": {
 				"strip-ansi": "3.0.1",
 				"wcwidth": "1.0.1"
@@ -1731,7 +2228,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -1742,7 +2238,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-			"dev": true,
 			"requires": {
 				"delayed-stream": "1.0.0"
 			}
@@ -1750,32 +2245,27 @@
 		"command-join": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz",
-			"integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8=",
-			"dev": true
+			"integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8="
 		},
 		"commander": {
 			"version": "2.15.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-			"dev": true
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
 		},
 		"common-path-prefix": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
-			"integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA=",
-			"dev": true
+			"integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA="
 		},
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-			"dev": true
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
 		},
 		"compare-func": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
 			"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
-			"dev": true,
 			"requires": {
 				"array-ify": "1.0.0",
 				"dot-prop": "3.0.0"
@@ -1785,30 +2275,68 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
 					"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-					"dev": true,
 					"requires": {
 						"is-obj": "1.0.1"
 					}
 				}
 			}
 		},
+		"compare-versions": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.1.0.tgz",
+			"integrity": "sha512-4hAxDSBypT/yp2ySFD346So6Ragw5xmBn/e/agIGl3bZr6DLUqnoRZPusxKrXdYRZpgexO9daejmIenlq/wrIQ=="
+		},
 		"component-emitter": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-			"dev": true
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+		},
+		"compressible": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
+			"integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
+			"requires": {
+				"mime-db": "1.33.0"
+			}
+		},
+		"compression": {
+			"version": "1.7.2",
+			"resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+			"integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
+			"requires": {
+				"accepts": "1.3.5",
+				"bytes": "3.0.0",
+				"compressible": "2.0.13",
+				"debug": "2.6.9",
+				"on-headers": "1.0.1",
+				"safe-buffer": "5.1.1",
+				"vary": "1.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-			"dev": true,
 			"requires": {
 				"buffer-from": "1.0.0",
 				"inherits": "2.0.3",
@@ -1820,7 +2348,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/concordance/-/concordance-3.0.0.tgz",
 			"integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
-			"dev": true,
 			"requires": {
 				"date-time": "2.1.0",
 				"esutils": "2.0.2",
@@ -1839,7 +2366,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
 			"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
-			"dev": true,
 			"requires": {
 				"dot-prop": "4.2.0",
 				"graceful-fs": "4.1.11",
@@ -1849,11 +2375,15 @@
 				"xdg-basedir": "3.0.0"
 			}
 		},
+		"connect-history-api-fallback": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
+			"integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
+		},
 		"console-browserify": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-			"dev": true,
 			"requires": {
 				"date-now": "0.1.4"
 			}
@@ -1861,20 +2391,27 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-			"dev": true
+			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+		},
+		"content-disposition": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+		},
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
 		},
 		"conventional-changelog": {
 			"version": "1.1.19",
 			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.19.tgz",
 			"integrity": "sha512-QlZpBVekLp5U8FWR8CAu0co5CM80ImhhR+nkRkEvp/cJpeiDSct410Pxz/Xec5F4ii+2tfUVChFa94qFjmLf5A==",
-			"dev": true,
 			"requires": {
 				"conventional-changelog-angular": "1.6.6",
 				"conventional-changelog-atom": "0.2.5",
@@ -1893,7 +2430,6 @@
 			"version": "1.6.6",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
 			"integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
-			"dev": true,
 			"requires": {
 				"compare-func": "1.3.2",
 				"q": "1.5.1"
@@ -1903,7 +2439,6 @@
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.5.tgz",
 			"integrity": "sha512-JNkzZ/T9B7BeY5ec5gxKJY/ZArZF668J+jOtT44l06zkRLEHTBBWYMWB9BW2YBquZjUiJdlsYIK2VKZRpHGMcg==",
-			"dev": true,
 			"requires": {
 				"q": "1.5.1"
 			}
@@ -1912,7 +2447,6 @@
 			"version": "1.3.17",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.17.tgz",
 			"integrity": "sha512-zXGWyxB4MmEbsTjr5PGP9cxOB9wsLskGMa/2+VyMmDrR5c6DJaoRrg/UH6tRaESK3vbIh0yHnKcA+4jDEfmhNw==",
-			"dev": true,
 			"requires": {
 				"add-stream": "1.0.0",
 				"conventional-changelog": "1.1.19",
@@ -2039,7 +2573,6 @@
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.5.tgz",
 			"integrity": "sha512-TRcKG8wNSEOCQf7giKRTcmXH9lPyrLbYT4jMQxh2LtZ/6WUgS/ocyHk+60Pei5x5woxX+KABx2CTorr08eV2Xg==",
-			"dev": true,
 			"requires": {
 				"q": "1.5.1"
 			}
@@ -2048,7 +2581,6 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.6.tgz",
 			"integrity": "sha512-md2KnSj/6UTBHdD/bisCyWOEEX+2pxGDWquGsK9AGUlAdV+PUJEPbK5taEMhpb0fx0o2YiXxS6h92BIBd8HX6w==",
-			"dev": true,
 			"requires": {
 				"conventional-changelog-writer": "3.0.5",
 				"conventional-commits-parser": "2.1.6",
@@ -2150,7 +2682,6 @@
 			"version": "0.3.7",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.7.tgz",
 			"integrity": "sha512-wu0Q6CO/9wll9cedpnWhQqe3z+eJz92hOZxdXyDiu7n0Sp9NC42Nvh/wCNwwWW7/FaPsVXGzbxpYylpebSC1+Q==",
-			"dev": true,
 			"requires": {
 				"q": "1.5.1"
 			}
@@ -2159,7 +2690,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.6.tgz",
 			"integrity": "sha512-+ZOmJez6R3z9DH/OBd6nd4l+saJzyi27i/gqwglW+ibC8XJe+B0lt56MFB1Su8EmjZyX4iDXf/QRUoXT1jzGyQ==",
-			"dev": true,
 			"requires": {
 				"q": "1.5.1"
 			}
@@ -2168,7 +2698,6 @@
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.5.tgz",
 			"integrity": "sha512-1H0+evGa2CLUe0VPpiynI3jSP2uMSuvT/iGKzsd5R7iko85Lkwh91Mx9VVgH8scU6RKweEpy2Wn8HN+/0wM6Lg==",
-			"dev": true,
 			"requires": {
 				"q": "1.5.1"
 			}
@@ -2177,7 +2706,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
 			"integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
-			"dev": true,
 			"requires": {
 				"q": "1.5.1"
 			}
@@ -2186,7 +2714,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
 			"integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
-			"dev": true,
 			"requires": {
 				"q": "1.5.1"
 			}
@@ -2195,7 +2722,6 @@
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.5.tgz",
 			"integrity": "sha512-K1dOn53tMah5ggkR95/V+1foi0cxALl4AWIks6RR0jLE0vOktn9utDgCQD7HcRbQ4i2U2odhYbPTbIFRJs1fIA==",
-			"dev": true,
 			"requires": {
 				"compare-func": "1.3.2",
 				"q": "1.5.1"
@@ -2204,14 +2730,12 @@
 		"conventional-changelog-preset-loader": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.7.tgz",
-			"integrity": "sha512-Lx188u/dEFrwcZ+CWYm/3BXM9HEMUV0hxxVX9VMZ12wsXXZokYnJe5RJC6ZcLvElsjCKehtmT+gGio5QdvCOTg==",
-			"dev": true
+			"integrity": "sha512-Lx188u/dEFrwcZ+CWYm/3BXM9HEMUV0hxxVX9VMZ12wsXXZokYnJe5RJC6ZcLvElsjCKehtmT+gGio5QdvCOTg=="
 		},
 		"conventional-changelog-writer": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.5.tgz",
 			"integrity": "sha512-4nVvhRvvtdbBSfoeK+1QIbjqjx4Y+VddF4NRcsJgInDnA/TuVel0SXLCtTOeRH1DueFctiuILfVqdammBxmWEQ==",
-			"dev": true,
 			"requires": {
 				"compare-func": "1.3.2",
 				"conventional-commits-filter": "1.1.6",
@@ -2343,7 +2867,6 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
 			"integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
-			"dev": true,
 			"requires": {
 				"is-subset": "0.1.1",
 				"modify-values": "1.0.1"
@@ -2353,7 +2876,6 @@
 			"version": "2.1.6",
 			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.6.tgz",
 			"integrity": "sha512-3Z77cAKSvEG3D5BSm3IFkOTP2qz8TZX8e8OPU7BGP2ruP7zPs7laHSqiZ7eYup835FKP4yyj+DHjmcvmOyp/0w==",
-			"dev": true,
 			"requires": {
 				"JSONStream": "1.3.2",
 				"is-text-path": "1.0.1",
@@ -2482,7 +3004,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.2.1.tgz",
 			"integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
-			"dev": true,
 			"requires": {
 				"concat-stream": "1.6.2",
 				"conventional-commits-filter": "1.1.6",
@@ -2496,26 +3017,98 @@
 		"convert-source-map": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-			"dev": true
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
 		},
 		"convert-to-spaces": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
-			"integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU=",
-			"dev": true
+			"integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU="
+		},
+		"cookie": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+		},
+		"cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+		},
+		"cookiejar": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
+			"integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
+		},
+		"copy-concurrently": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+			"requires": {
+				"aproba": "1.2.0",
+				"fs-write-stream-atomic": "1.0.10",
+				"iferr": "0.1.5",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"run-queue": "1.0.3"
+			}
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-			"dev": true
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+		},
+		"copy-webpack-plugin": {
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.5.1.tgz",
+			"integrity": "sha512-OlTo6DYg0XfTKOF8eLf79wcHm4Ut10xU2cRBRPMW/NA5F9VMjZGTfRHWDIYC3s+1kObGYrBLshXWU1K0hILkNQ==",
+			"requires": {
+				"cacache": "10.0.4",
+				"find-cache-dir": "1.0.0",
+				"globby": "7.1.1",
+				"is-glob": "4.0.0",
+				"loader-utils": "1.1.0",
+				"minimatch": "3.0.4",
+				"p-limit": "1.2.0",
+				"serialize-javascript": "1.5.0"
+			},
+			"dependencies": {
+				"globby": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+					"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+					"requires": {
+						"array-union": "1.0.2",
+						"dir-glob": "2.0.0",
+						"glob": "7.1.2",
+						"ignore": "3.3.8",
+						"pify": "3.0.0",
+						"slash": "1.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+				},
+				"is-glob": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"requires": {
+						"is-extglob": "2.1.1"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
 		},
 		"core-assert": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
 			"integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
-			"dev": true,
 			"requires": {
 				"buf-compare": "1.0.1",
 				"is-error": "2.2.1"
@@ -2524,20 +3117,17 @@
 		"core-js": {
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-			"dev": true
+			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"coveralls": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz",
 			"integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
-			"dev": true,
 			"requires": {
 				"js-yaml": "3.11.0",
 				"lcov-parse": "0.0.10",
@@ -2549,16 +3139,32 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
+			}
+		},
+		"cpx": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/cpx/-/cpx-1.5.0.tgz",
+			"integrity": "sha1-GFvgGFEdhycN7czCkxceN2VauI8=",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"chokidar": "1.7.0",
+				"duplexer": "0.1.1",
+				"glob": "7.1.2",
+				"glob2base": "0.0.12",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"resolve": "1.6.0",
+				"safe-buffer": "5.1.1",
+				"shell-quote": "1.6.1",
+				"subarg": "1.0.0"
 			}
 		},
 		"create-ecdh": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
 			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
-			"dev": true,
 			"requires": {
 				"bn.js": "4.11.8",
 				"elliptic": "6.4.0"
@@ -2568,7 +3174,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
 			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-			"dev": true,
 			"requires": {
 				"capture-stack-trace": "1.0.0"
 			}
@@ -2577,7 +3182,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
 			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
-			"dev": true,
 			"requires": {
 				"cipher-base": "1.0.4",
 				"inherits": "2.0.3",
@@ -2589,7 +3193,6 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
 			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
-			"dev": true,
 			"requires": {
 				"cipher-base": "1.0.4",
 				"create-hash": "1.1.3",
@@ -2603,7 +3206,6 @@
 			"version": "5.1.4",
 			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.4.tgz",
 			"integrity": "sha512-Mx8mw6JWhfpYoEk7PGvHxJMLQwQHORAs8+2bX+C1lGQ4h3GkDb1zbzC2Nw85YH9ZQMlO0BHZxMacgrfPmMFxbg==",
-			"dev": true,
 			"requires": {
 				"cross-spawn": "5.1.0",
 				"is-windows": "1.0.2"
@@ -2613,7 +3215,6 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-			"dev": true,
 			"requires": {
 				"lru-cache": "4.1.2",
 				"shebang-command": "1.2.0",
@@ -2624,7 +3225,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
 			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-			"dev": true,
 			"requires": {
 				"boom": "5.2.0"
 			},
@@ -2633,7 +3233,6 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-					"dev": true,
 					"requires": {
 						"hoek": "4.2.1"
 					}
@@ -2644,7 +3243,6 @@
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
 			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
-			"dev": true,
 			"requires": {
 				"browserify-cipher": "1.0.0",
 				"browserify-sign": "4.0.4",
@@ -2662,29 +3260,51 @@
 		"crypto-random-string": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-			"dev": true
+			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+		},
+		"css-vendor": {
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-0.3.8.tgz",
+			"integrity": "sha1-ZCHP0wNM5mT+dnOXL9ARn8KJQfo=",
+			"requires": {
+				"is-in-browser": "1.1.3"
+			}
+		},
+		"cssom": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+		},
+		"cssstyle": {
+			"version": "0.2.37",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"requires": {
+				"cssom": "0.3.2"
+			}
 		},
 		"csstype": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.4.1.tgz",
-			"integrity": "sha512-JuXYT9dt8xtpc4mwHSOYnZtQS3TmYVhmZDyXbppTid29krM8Eyn5CmsZjIDTSvzunvutYOBwQmnziR5vgFkJGw==",
-			"dev": true
+			"integrity": "sha512-JuXYT9dt8xtpc4mwHSOYnZtQS3TmYVhmZDyXbppTid29krM8Eyn5CmsZjIDTSvzunvutYOBwQmnziR5vgFkJGw=="
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-			"dev": true,
 			"requires": {
 				"array-find-index": "1.0.2"
 			}
+		},
+		"cyclist": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
 		},
 		"d": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-			"dev": true,
 			"requires": {
 				"es5-ext": "0.10.41"
 			}
@@ -2693,7 +3313,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
 			"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -2702,22 +3321,29 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0"
+			}
+		},
+		"data-urls": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
+			"integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+			"requires": {
+				"abab": "1.0.4",
+				"whatwg-mimetype": "2.1.0",
+				"whatwg-url": "6.4.1"
 			}
 		},
 		"date-now": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
-			"dev": true
+			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
 		},
 		"date-time": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
 			"integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
-			"dev": true,
 			"requires": {
 				"time-zone": "1.0.0"
 			}
@@ -2725,14 +3351,12 @@
 		"dateformat": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-			"dev": true
+			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
 		},
 		"debug": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			},
@@ -2740,22 +3364,19 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"decamelize-keys": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
-			"dev": true,
 			"requires": {
 				"decamelize": "1.2.0",
 				"map-obj": "1.0.1"
@@ -2764,32 +3385,55 @@
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-			"dev": true
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
 		},
 		"dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
-			"dev": true
+			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
 		},
 		"deep-equal": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-			"dev": true
+			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
 		},
 		"deep-extend": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-			"dev": true
+			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+		},
+		"deepmerge": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.1.0.tgz",
+			"integrity": "sha512-Q89Z26KAfA3lpPGhbF6XMfYAm3jIV3avViy6KOJ2JLzFbeWHOvPQUu5aSJIWXap3gDZC2y1eF5HXEPI2wGqgvw=="
+		},
+		"default-require-extensions": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+			"requires": {
+				"strip-bom": "2.0.0"
+			},
+			"dependencies": {
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				}
+			}
 		},
 		"defaults": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-			"dev": true,
 			"requires": {
 				"clone": "1.0.4"
 			},
@@ -2797,16 +3441,23 @@
 				"clone": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-					"dev": true
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
 				}
+			}
+		},
+		"define-properties": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"requires": {
+				"foreach": "2.0.5",
+				"object-keys": "1.0.11"
 			}
 		},
 		"define-property": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-			"dev": true,
 			"requires": {
 				"is-descriptor": "1.0.2",
 				"isobject": "3.0.1"
@@ -2815,70 +3466,189 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				}
+			}
+		},
+		"del": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+			"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+			"requires": {
+				"globby": "6.1.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.1",
+				"p-map": "1.2.0",
+				"pify": "3.0.0",
+				"rimraf": "2.6.2"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+		},
+		"depd": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
 		},
 		"des.js": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"minimalistic-assert": "1.0.0"
 			}
 		},
+		"destroy": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+		},
 		"detect-indent": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-			"dev": true,
 			"requires": {
 				"repeating": "2.0.1"
 			}
 		},
+		"detect-newline": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+		},
+		"detect-node": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
+			"integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
+		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-			"dev": true
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
 		"diffie-hellman": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
 			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
-			"dev": true,
 			"requires": {
 				"bn.js": "4.11.8",
 				"miller-rabin": "4.0.1",
 				"randombytes": "2.0.6"
 			}
 		},
+		"dir-glob": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+			"requires": {
+				"arrify": "1.0.1",
+				"path-type": "3.0.0"
+			},
+			"dependencies": {
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"requires": {
+						"pify": "3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"disposables": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/disposables/-/disposables-1.0.2.tgz",
+			"integrity": "sha1-NsamdEdfVaLWkTVnpgFETkh7S24="
+		},
+		"dnd-core": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-2.6.0.tgz",
+			"integrity": "sha1-ErrWbVh0LG5ffPKUP7aFlED4CcQ=",
+			"requires": {
+				"asap": "2.0.6",
+				"invariant": "2.2.4",
+				"lodash": "4.17.4",
+				"redux": "3.7.2"
+			}
+		},
+		"dns-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+			"integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
+		},
+		"dns-packet": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
+			"integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+			"requires": {
+				"ip": "1.1.5",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"dns-txt": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+			"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+			"requires": {
+				"buffer-indexof": "1.1.1"
+			}
+		},
+		"document-register-element": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.8.1.tgz",
+			"integrity": "sha512-WqUnZzRZByeur0YsQBDHG9mYWJR83Un4LeSRhZNfXZ0hlqDwP6WuxPK+a/tLIX/r5BCp+UAv/b0Z73KkCsdPjQ==",
+			"requires": {
+				"lightercollective": "0.0.0"
+			}
+		},
+		"dom-helpers": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
+			"integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
+		},
+		"dom-walk": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+		},
 		"domain-browser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-			"dev": true
+			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
+		},
+		"domexception": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"requires": {
+				"webidl-conversions": "4.0.2"
+			}
 		},
 		"dot-prop": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
 			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-			"dev": true,
 			"requires": {
 				"is-obj": "1.0.1"
 			}
@@ -2886,20 +3656,17 @@
 		"duplexer": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-			"dev": true
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
 		},
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-			"dev": true
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
 		},
 		"duplexify": {
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
 			"integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "1.4.1",
 				"inherits": "2.0.3",
@@ -2911,17 +3678,20 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"jsbn": "0.1.1"
 			}
 		},
+		"ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+		},
 		"elliptic": {
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
 			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
-			"dev": true,
 			"requires": {
 				"bn.js": "4.11.8",
 				"brorand": "1.1.0",
@@ -2935,24 +3705,34 @@
 		"emojis-list": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-			"dev": true
+			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
 		},
 		"empower-core": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
 			"integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
-			"dev": true,
 			"requires": {
 				"call-signature": "0.0.2",
 				"core-js": "2.5.3"
+			}
+		},
+		"encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "0.4.19"
 			}
 		},
 		"end-of-stream": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-			"dev": true,
 			"requires": {
 				"once": "1.4.0"
 			}
@@ -2961,7 +3741,6 @@
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
 			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"memory-fs": "0.4.1",
@@ -2972,14 +3751,12 @@
 		"equal-length": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/equal-length/-/equal-length-1.0.1.tgz",
-			"integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w=",
-			"dev": true
+			"integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w="
 		},
 		"errno": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-			"dev": true,
 			"requires": {
 				"prr": "1.0.1"
 			}
@@ -2988,16 +3765,36 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-			"dev": true,
 			"requires": {
 				"is-arrayish": "0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+			"integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
+			"requires": {
+				"es-to-primitive": "1.1.1",
+				"function-bind": "1.1.1",
+				"has": "1.0.1",
+				"is-callable": "1.1.3",
+				"is-regex": "1.0.4"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"requires": {
+				"is-callable": "1.1.3",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.1"
 			}
 		},
 		"es5-ext": {
 			"version": "0.10.41",
 			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.41.tgz",
 			"integrity": "sha512-MYK02wXfwTMie5TEJWPolgOsXEmz7wKCQaGzgmRjZOoV6VLG8I5dSv2bn6AOClXhK64gnSQTQ9W9MKvx87J4gw==",
-			"dev": true,
 			"requires": {
 				"es6-iterator": "2.0.3",
 				"es6-symbol": "3.1.1",
@@ -3007,14 +3804,12 @@
 		"es6-error": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-			"dev": true
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
 		},
 		"es6-iterator": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
 			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.41",
@@ -3025,7 +3820,6 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
 			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.41",
@@ -3039,7 +3833,6 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
 			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.41",
@@ -3048,11 +3841,15 @@
 				"event-emitter": "0.3.5"
 			}
 		},
+		"es6-shim": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.3.tgz",
+			"integrity": "sha1-m/tzY/7//4emzbbNk+QF7DxLbyY="
+		},
 		"es6-symbol": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
 			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.41"
@@ -3062,7 +3859,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
 			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.41",
@@ -3070,17 +3866,45 @@
 				"es6-symbol": "3.1.1"
 			}
 		},
+		"escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"escodegen": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+			"requires": {
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"optional": true
+				}
+			}
 		},
 		"escope": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
 			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-			"dev": true,
 			"requires": {
 				"es6-map": "0.1.5",
 				"es6-weak-map": "2.0.2",
@@ -3092,7 +3916,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
 			"integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
-			"dev": true,
 			"requires": {
 				"is-url": "1.2.4",
 				"path-is-absolute": "1.0.1",
@@ -3103,14 +3926,12 @@
 		"esprima": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-			"dev": true
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
 		},
 		"espurify": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
 			"integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
-			"dev": true,
 			"requires": {
 				"core-js": "2.5.3"
 			}
@@ -3119,7 +3940,6 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0"
 			}
@@ -3127,46 +3947,66 @@
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-			"dev": true
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-			"dev": true
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
+		"etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
 		},
 		"event-emitter": {
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
 			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.41"
 			}
 		},
+		"eventemitter3": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+			"integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+		},
 		"events": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-			"dev": true
+			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+		},
+		"eventsource": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+			"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+			"requires": {
+				"original": "1.0.0"
+			}
 		},
 		"evp_bytestokey": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-			"dev": true,
 			"requires": {
 				"md5.js": "1.3.4",
 				"safe-buffer": "5.1.1"
+			}
+		},
+		"exec-sh": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+			"requires": {
+				"merge": "1.2.0"
 			}
 		},
 		"execa": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-			"dev": true,
 			"requires": {
 				"cross-spawn": "5.1.0",
 				"get-stream": "3.0.0",
@@ -3177,11 +4017,15 @@
 				"strip-eof": "1.0.0"
 			}
 		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+		},
 		"expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-			"dev": true,
 			"requires": {
 				"is-posix-bracket": "0.1.1"
 			}
@@ -3190,22 +4034,89 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"dev": true,
 			"requires": {
 				"fill-range": "2.2.3"
+			}
+		},
+		"expect": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
+			"integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
+			"requires": {
+				"ansi-styles": "3.2.1",
+				"jest-diff": "22.4.3",
+				"jest-get-type": "22.4.3",
+				"jest-matcher-utils": "22.4.3",
+				"jest-message-util": "22.4.3",
+				"jest-regex-util": "22.4.3"
+			}
+		},
+		"express": {
+			"version": "4.16.3",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+			"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+			"requires": {
+				"accepts": "1.3.5",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.18.2",
+				"content-disposition": "0.5.2",
+				"content-type": "1.0.4",
+				"cookie": "0.3.1",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "1.1.2",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
+				"finalhandler": "1.1.1",
+				"fresh": "0.5.2",
+				"merge-descriptors": "1.0.1",
+				"methods": "1.1.2",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "2.0.3",
+				"qs": "6.5.1",
+				"range-parser": "1.2.0",
+				"safe-buffer": "5.1.1",
+				"send": "0.16.2",
+				"serve-static": "1.13.2",
+				"setprototypeof": "1.1.0",
+				"statuses": "1.4.0",
+				"type-is": "1.6.16",
+				"utils-merge": "1.0.1",
+				"vary": "1.1.2"
+			},
+			"dependencies": {
+				"array-flatten": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"extend": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-			"dev": true
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
 		},
 		"extend-shallow": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-			"dev": true,
 			"requires": {
 				"is-extendable": "0.1.1"
 			}
@@ -3214,7 +4125,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
 			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
-			"dev": true,
 			"requires": {
 				"chardet": "0.4.2",
 				"iconv-lite": "0.4.19",
@@ -3225,7 +4135,6 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -3233,32 +4142,69 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-			"dev": true
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
 		},
 		"fast-diff": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-			"integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
-			"dev": true
+			"integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-			"dev": true
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+		},
+		"faye-websocket": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+			"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+			"requires": {
+				"websocket-driver": "0.7.0"
+			}
+		},
+		"fb-watchman": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"requires": {
+				"bser": "2.0.0"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.16",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"requires": {
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.18"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				}
+			}
 		},
 		"figures": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-			"dev": true,
 			"requires": {
 				"escape-string-regexp": "1.0.5"
 			}
@@ -3266,14 +4212,21 @@
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-			"dev": true
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+		},
+		"fileset": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+			"requires": {
+				"glob": "7.1.2",
+				"minimatch": "3.0.4"
+			}
 		},
 		"fill-range": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-			"dev": true,
 			"requires": {
 				"is-number": "2.1.0",
 				"isobject": "2.1.0",
@@ -3282,22 +4235,54 @@
 				"repeat-string": "1.6.1"
 			}
 		},
+		"finalhandler": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+			"requires": {
+				"debug": "2.6.9",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"statuses": "1.4.0",
+				"unpipe": "1.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
 		"find-cache-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-			"dev": true,
 			"requires": {
 				"commondir": "1.0.1",
 				"make-dir": "1.2.0",
 				"pkg-dir": "2.0.0"
 			}
 		},
+		"find-index": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+			"integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ="
+		},
 		"find-up": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-			"dev": true,
 			"requires": {
 				"locate-path": "2.0.0"
 			}
@@ -3305,78 +4290,125 @@
 		"first-chunk-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-			"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-			"dev": true
+			"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
+		},
+		"flush-write-stream": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
+			}
 		},
 		"fn-name": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-			"integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
-			"dev": true
+			"integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc="
+		},
+		"follow-redirects": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+			"integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+			"requires": {
+				"debug": "3.1.0"
+			}
 		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-			"dev": true
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true,
 			"requires": {
 				"for-in": "1.0.2"
 			}
 		},
+		"foreach": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-			"dev": true,
 			"requires": {
 				"asynckit": "0.4.0",
 				"combined-stream": "1.0.6",
 				"mime-types": "2.1.18"
 			}
 		},
+		"formidable": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+			"integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+		},
+		"forwarded": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-			"dev": true,
 			"requires": {
 				"map-cache": "0.2.2"
+			}
+		},
+		"fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+		},
+		"from2": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
 			}
 		},
 		"fs-extra": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
 			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"jsonfile": "4.0.0",
 				"universalify": "0.1.1"
 			}
 		},
+		"fs-write-stream-atomic": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"iferr": "0.1.5",
+				"imurmurhash": "0.1.4",
+				"readable-stream": "2.3.5"
+			}
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
 			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "2.10.0",
@@ -4276,17 +5308,20 @@
 				}
 			}
 		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		},
 		"function-name-support": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/function-name-support/-/function-name-support-0.2.0.tgz",
-			"integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE=",
-			"dev": true
+			"integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE="
 		},
 		"gauge": {
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"dev": true,
 			"requires": {
 				"aproba": "1.2.0",
 				"console-control-strings": "1.1.0",
@@ -4302,7 +5337,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -4311,7 +5345,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -4322,7 +5355,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -4332,14 +5364,12 @@
 		"get-caller-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-			"dev": true
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
 		},
 		"get-pkg-repo": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
 			"integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
-			"dev": true,
 			"requires": {
 				"hosted-git-info": "2.6.0",
 				"meow": "3.7.0",
@@ -4351,32 +5381,27 @@
 		"get-port": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
-			"dev": true
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
 		},
 		"get-stdin": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-			"dev": true
+			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
 		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-			"dev": true
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-			"dev": true
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0"
 			}
@@ -4385,7 +5410,6 @@
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.5.tgz",
 			"integrity": "sha512-r6NFrgh9oGzHwMA0go6sEa8jgR+N2/74HPXIXR59asiJzxPXpmk3aM5SMH2bLGsmTPwJtysgbf8EE/LwWHqGgg==",
-			"dev": true,
 			"requires": {
 				"dargs": "4.1.0",
 				"lodash.template": "4.4.0",
@@ -4512,7 +5536,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
 			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
-			"dev": true,
 			"requires": {
 				"gitconfiglocal": "1.0.0",
 				"pify": "2.3.0"
@@ -4522,7 +5545,6 @@
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.5.tgz",
 			"integrity": "sha512-+uttbaoLSIvxdJWQKmRcs/G3uHitbypvpM41rz1C48Eeq7AI47Mzh+hQ5xX2mY1Kehpv5WGe4yXg1LbSw29d2A==",
-			"dev": true,
 			"requires": {
 				"meow": "4.0.0",
 				"semver": "5.5.0"
@@ -4646,7 +5668,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
 			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
-			"dev": true,
 			"requires": {
 				"ini": "1.3.5"
 			}
@@ -4655,7 +5676,6 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
@@ -4669,7 +5689,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true,
 			"requires": {
 				"glob-parent": "2.0.0",
 				"is-glob": "2.0.1"
@@ -4679,7 +5698,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"dev": true,
 			"requires": {
 				"is-glob": "2.0.1"
 			}
@@ -4688,7 +5706,6 @@
 			"version": "5.3.5",
 			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
 			"integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
-			"dev": true,
 			"requires": {
 				"extend": "3.0.1",
 				"glob": "5.0.15",
@@ -4704,7 +5721,6 @@
 					"version": "5.0.15",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"dev": true,
 					"requires": {
 						"inflight": "1.0.6",
 						"inherits": "2.0.3",
@@ -4717,7 +5733,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"dev": true,
 					"requires": {
 						"is-glob": "3.1.0",
 						"path-dirname": "1.0.2"
@@ -4726,14 +5741,12 @@
 				"is-extglob": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 				},
 				"is-glob": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "2.1.1"
 					}
@@ -4741,14 +5754,12 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
 					"requires": {
 						"core-util-is": "1.0.2",
 						"inherits": "2.0.3",
@@ -4759,14 +5770,12 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"through2": {
 					"version": "0.6.5",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
 					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"dev": true,
 					"requires": {
 						"readable-stream": "1.0.34",
 						"xtend": "4.0.1"
@@ -4774,11 +5783,34 @@
 				}
 			}
 		},
+		"glob2base": {
+			"version": "0.0.12",
+			"resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+			"integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
+			"requires": {
+				"find-index": "0.1.1"
+			}
+		},
+		"global": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+			"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+			"requires": {
+				"min-document": "2.19.0",
+				"process": "0.5.2"
+			},
+			"dependencies": {
+				"process": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+					"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+				}
+			}
+		},
 		"global-dirs": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
 			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-			"dev": true,
 			"requires": {
 				"ini": "1.3.5"
 			}
@@ -4786,14 +5818,12 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-			"dev": true
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
 		},
 		"globby": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-			"dev": true,
 			"requires": {
 				"array-union": "1.0.2",
 				"glob": "7.1.2",
@@ -4805,14 +5835,12 @@
 				"pinkie": {
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-					"dev": true
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-					"dev": true,
 					"requires": {
 						"pinkie": "2.0.4"
 					}
@@ -4823,7 +5851,6 @@
 			"version": "6.7.1",
 			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-			"dev": true,
 			"requires": {
 				"create-error-class": "3.0.2",
 				"duplexer3": "0.1.4",
@@ -4841,14 +5868,25 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-			"dev": true
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+		},
+		"graphlib": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
+			"integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
+			"requires": {
+				"lodash": "4.17.4"
+			}
+		},
+		"growly": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
 		},
 		"gulp-sourcemaps": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
 			"integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
-			"dev": true,
 			"requires": {
 				"convert-source-map": "1.5.1",
 				"graceful-fs": "4.1.11",
@@ -4860,26 +5898,22 @@
 				"clone": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-					"dev": true
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
 				},
 				"clone-stats": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-					"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-					"dev": true
+					"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
 				},
 				"replace-ext": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-					"dev": true
+					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "0.2.1"
 					}
@@ -4888,7 +5922,6 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
 					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-					"dev": true,
 					"requires": {
 						"clone": "1.0.4",
 						"clone-stats": "0.0.1",
@@ -4897,11 +5930,15 @@
 				}
 			}
 		},
+		"handle-thing": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
+		},
 		"handlebars": {
 			"version": "4.0.11",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
 			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-			"dev": true,
 			"requires": {
 				"async": "1.5.2",
 				"optimist": "0.6.1",
@@ -4913,7 +5950,6 @@
 					"version": "0.4.4",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"dev": true,
 					"requires": {
 						"amdefine": "1.0.1"
 					}
@@ -4923,14 +5959,12 @@
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"dev": true
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 		},
 		"har-validator": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-			"dev": true,
 			"requires": {
 				"ajv": "5.5.2",
 				"har-schema": "2.0.0"
@@ -4940,7 +5974,6 @@
 					"version": "5.5.2",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-					"dev": true,
 					"requires": {
 						"co": "4.6.0",
 						"fast-deep-equal": "1.1.0",
@@ -4950,11 +5983,18 @@
 				}
 			}
 		},
+		"has": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"requires": {
+				"function-bind": "1.1.1"
+			}
+		},
 		"has-ansi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -4962,26 +6002,22 @@
 		"has-color": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-			"dev": true
+			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
 		},
 		"has-flag": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-			"dev": true
+			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
 		},
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"dev": true
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 		},
 		"has-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-			"dev": true,
 			"requires": {
 				"get-value": "2.0.6",
 				"has-values": "1.0.0",
@@ -4991,8 +6027,7 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -5000,7 +6035,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-			"dev": true,
 			"requires": {
 				"is-number": "3.0.0",
 				"kind-of": "4.0.0"
@@ -5010,7 +6044,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -5019,7 +6052,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -5030,7 +6062,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -5040,14 +6071,12 @@
 		"has-yarn": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
-			"integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
-			"dev": true
+			"integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac="
 		},
 		"hash-base": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
 			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-			"dev": true,
 			"requires": {
 				"inherits": "2.0.3"
 			}
@@ -5056,7 +6085,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
 			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"minimalistic-assert": "1.0.0"
@@ -5066,7 +6094,6 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
 			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-			"dev": true,
 			"requires": {
 				"boom": "4.3.1",
 				"cryptiles": "3.1.2",
@@ -5077,14 +6104,12 @@
 		"highlight.js": {
 			"version": "9.12.0",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
-			"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
-			"dev": true
+			"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-			"dev": true,
 			"requires": {
 				"hash.js": "1.1.3",
 				"minimalistic-assert": "1.0.0",
@@ -5094,14 +6119,17 @@
 		"hoek": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-			"dev": true
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+		},
+		"hoist-non-react-statics": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
+			"integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-			"dev": true,
 			"requires": {
 				"os-homedir": "1.0.2",
 				"os-tmpdir": "1.0.2"
@@ -5110,14 +6138,93 @@
 		"hosted-git-info": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
-			"dev": true
+			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+		},
+		"hpack.js": {
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+			"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+			"requires": {
+				"inherits": "2.0.3",
+				"obuf": "1.1.2",
+				"readable-stream": "2.3.5",
+				"wbuf": "1.7.3"
+			}
+		},
+		"html-encoding-sniffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"requires": {
+				"whatwg-encoding": "1.0.3"
+			}
+		},
+		"html-entities": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+		},
+		"http-deceiver": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+			"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
+		},
+		"http-errors": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+			"requires": {
+				"depd": "1.1.2",
+				"inherits": "2.0.3",
+				"setprototypeof": "1.1.0",
+				"statuses": "1.4.0"
+			}
+		},
+		"http-parser-js": {
+			"version": "0.4.12",
+			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.12.tgz",
+			"integrity": "sha1-uc+/Sizybw/DSxDKFImid3HjR08="
+		},
+		"http-proxy": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+			"integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+			"requires": {
+				"eventemitter3": "3.1.0",
+				"follow-redirects": "1.4.1",
+				"requires-port": "1.0.0"
+			}
+		},
+		"http-proxy-middleware": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+			"integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+			"requires": {
+				"http-proxy": "1.17.0",
+				"is-glob": "3.1.0",
+				"lodash": "4.17.4",
+				"micromatch": "2.3.11"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+				},
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"requires": {
+						"is-extglob": "2.1.1"
+					}
+				}
+			}
 		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"jsprim": "1.4.1",
@@ -5127,14 +6234,12 @@
 		"https-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
-			"dev": true
+			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
 		},
 		"hullabaloo-config-manager": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.1.1.tgz",
 			"integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
-			"dev": true,
 			"requires": {
 				"dot-prop": "4.2.0",
 				"es6-error": "4.1.1",
@@ -5152,35 +6257,45 @@
 				"safe-buffer": "5.1.1"
 			}
 		},
+		"hyphenate-style-name": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
+			"integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
+		},
 		"iconv-lite": {
 			"version": "0.4.19",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-			"dev": true
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
 		},
 		"ieee754": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
-			"integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
-			"dev": true
+			"integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg=="
+		},
+		"iferr": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+		},
+		"ignore": {
+			"version": "3.3.8",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
+			"integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg=="
 		},
 		"ignore-by-default": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
-			"dev": true
+			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk="
 		},
 		"import-lazy": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-			"dev": true
+			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
 		},
 		"import-local": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
 			"integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
-			"dev": true,
 			"requires": {
 				"pkg-dir": "2.0.0",
 				"resolve-cwd": "2.0.0"
@@ -5189,26 +6304,37 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-			"dev": true
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+		},
+		"indefinite-observable": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-1.0.1.tgz",
+			"integrity": "sha1-CZFUI8yNb36xy3iCrRNGM8mm7cM=",
+			"requires": {
+				"symbol-observable": "1.0.4"
+			},
+			"dependencies": {
+				"symbol-observable": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+					"integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
+				}
+			}
 		},
 		"indent-string": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-			"dev": true
+			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
 		},
 		"indexof": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
-			"dev": true
+			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "1.4.0",
 				"wrappy": "1.0.2"
@@ -5217,20 +6343,17 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-			"dev": true
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inquirer": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-			"dev": true,
 			"requires": {
 				"ansi-escapes": "3.1.0",
 				"chalk": "2.3.2",
@@ -5248,17 +6371,23 @@
 				"through": "2.3.8"
 			}
 		},
+		"internal-ip": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
+			"integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
+			"requires": {
+				"meow": "3.7.0"
+			}
+		},
 		"interpret": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
-			"dev": true
+			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
 		},
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "1.3.1"
 			}
@@ -5266,20 +6395,27 @@
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-			"dev": true
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+		},
+		"ip": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+		},
+		"ipaddr.js": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+			"integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
 		},
 		"irregular-plurals": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
-			"integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
-			"dev": true
+			"integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
 		},
 		"is-accessor-descriptor": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 			"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-			"dev": true,
 			"requires": {
 				"kind-of": "6.0.2"
 			},
@@ -5287,22 +6423,19 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-			"dev": true
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-			"dev": true,
 			"requires": {
 				"binary-extensions": "1.11.0"
 			}
@@ -5310,23 +6443,25 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"dev": true,
 			"requires": {
 				"builtin-modules": "1.1.1"
 			}
+		},
+		"is-callable": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
 		},
 		"is-ci": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
 			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
-			"dev": true,
 			"requires": {
 				"ci-info": "1.1.3"
 			}
@@ -5335,7 +6470,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 			"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-			"dev": true,
 			"requires": {
 				"kind-of": "6.0.2"
 			},
@@ -5343,16 +6477,19 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
 		},
 		"is-descriptor": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 			"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-			"dev": true,
 			"requires": {
 				"is-accessor-descriptor": "1.0.0",
 				"is-data-descriptor": "1.0.0",
@@ -5362,22 +6499,19 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"dev": true
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"dev": true,
 			"requires": {
 				"is-primitive": "2.0.0"
 			}
@@ -5385,26 +6519,22 @@
 		"is-error": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz",
-			"integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw=",
-			"dev": true
+			"integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw="
 		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-			"dev": true
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-			"dev": true
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -5412,29 +6542,35 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+		},
+		"is-function": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
 		},
 		"is-generator-fn": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
-			"dev": true
+			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
 		},
 		"is-glob": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
+		},
+		"is-in-browser": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+			"integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
 		},
 		"is-installed-globally": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
 			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-			"dev": true,
 			"requires": {
 				"global-dirs": "0.1.1",
 				"is-path-inside": "1.0.1"
@@ -5443,14 +6579,12 @@
 		"is-npm": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-			"dev": true
+			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
 		},
 		"is-number": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2"
 			}
@@ -5458,14 +6592,12 @@
 		"is-obj": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-			"dev": true
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
 		},
 		"is-observable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
 			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-			"dev": true,
 			"requires": {
 				"symbol-observable": "1.2.0"
 			}
@@ -5474,7 +6606,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
 			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-			"dev": true,
 			"requires": {
 				"is-number": "4.0.0"
 			},
@@ -5482,16 +6613,27 @@
 				"is-number": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-					"dev": true
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
 				}
+			}
+		},
+		"is-path-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+		},
+		"is-path-in-cwd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+			"requires": {
+				"is-path-inside": "1.0.1"
 			}
 		},
 		"is-path-inside": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-			"dev": true,
 			"requires": {
 				"path-is-inside": "1.0.2"
 			}
@@ -5499,14 +6641,12 @@
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-			"dev": true
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"dev": true,
 			"requires": {
 				"isobject": "3.0.1"
 			},
@@ -5514,58 +6654,62 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-			"dev": true
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"dev": true
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
 		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-			"dev": true
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
 		},
 		"is-redirect": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-			"dev": true
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"requires": {
+				"has": "1.0.1"
+			}
 		},
 		"is-retry-allowed": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-			"dev": true
+			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
 		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-subset": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-			"dev": true
+			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
+		},
+		"is-symbol": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
 		},
 		"is-text-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
 			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
-			"dev": true,
 			"requires": {
 				"text-extensions": "1.7.0"
 			}
@@ -5573,77 +6717,602 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
 		"is-url": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-			"dev": true
+			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
 		},
 		"is-utf8": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-			"dev": true
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
 		},
 		"is-valid-glob": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
-			"dev": true
+			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
 		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-			"dev": true
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+		},
+		"is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-			"dev": true,
 			"requires": {
 				"isarray": "1.0.0"
+			}
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.4"
 			}
 		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"istanbul-api": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
+			"integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
+			"requires": {
+				"async": "2.6.0",
+				"compare-versions": "3.1.0",
+				"fileset": "2.0.3",
+				"istanbul-lib-coverage": "1.2.0",
+				"istanbul-lib-hook": "1.2.0",
+				"istanbul-lib-instrument": "1.10.1",
+				"istanbul-lib-report": "1.1.4",
+				"istanbul-lib-source-maps": "1.2.4",
+				"istanbul-reports": "1.3.0",
+				"js-yaml": "3.11.0",
+				"mkdirp": "0.5.1",
+				"once": "1.4.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+					"requires": {
+						"lodash": "4.17.4"
+					}
+				},
+				"istanbul-lib-source-maps": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz",
+					"integrity": "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
+					"requires": {
+						"debug": "3.1.0",
+						"istanbul-lib-coverage": "1.2.0",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.2",
+						"source-map": "0.5.7"
+					}
+				}
+			}
+		},
+		"istanbul-lib-coverage": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
+			"integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A=="
+		},
+		"istanbul-lib-hook": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.0.tgz",
+			"integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
+			"requires": {
+				"append-transform": "0.4.0"
+			}
+		},
+		"istanbul-lib-instrument": {
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
+			"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
+			"requires": {
+				"babel-generator": "6.26.1",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"istanbul-lib-coverage": "1.2.0",
+				"semver": "5.5.0"
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
+			"integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
+			"requires": {
+				"istanbul-lib-coverage": "1.2.0",
+				"mkdirp": "0.5.1",
+				"path-parse": "1.0.5",
+				"supports-color": "3.2.3"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
+			"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+			"requires": {
+				"debug": "3.1.0",
+				"istanbul-lib-coverage": "1.2.0",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"source-map": "0.5.7"
+			}
+		},
+		"istanbul-reports": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
+			"integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
+			"requires": {
+				"handlebars": "4.0.11"
+			}
+		},
+		"jest": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-22.4.3.tgz",
+			"integrity": "sha512-FFCdU/pXOEASfHxFDOWUysI/+FFoqiXJADEIXgDKuZyqSmBD3tZ4BEGH7+M79v7czj7bbkhwtd2LaEDcJiM/GQ==",
+			"requires": {
+				"import-local": "1.0.0",
+				"jest-cli": "22.4.3"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"cliui": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+					"requires": {
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"import-local": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+					"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+					"requires": {
+						"pkg-dir": "2.0.0",
+						"resolve-cwd": "2.0.0"
+					}
+				},
+				"jest-cli": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.3.tgz",
+					"integrity": "sha512-IiHybF0DJNqZPsbjn4Cy4vcqcmImpoFwNFnkehzVw8lTUSl4axZh5DHewu5bdpZF2Y5gUqFKYzH0FH4Qx2k+UA==",
+					"requires": {
+						"ansi-escapes": "3.1.0",
+						"chalk": "2.3.2",
+						"exit": "0.1.2",
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"import-local": "1.0.0",
+						"is-ci": "1.1.0",
+						"istanbul-api": "1.3.1",
+						"istanbul-lib-coverage": "1.2.0",
+						"istanbul-lib-instrument": "1.10.1",
+						"istanbul-lib-source-maps": "1.2.3",
+						"jest-changed-files": "22.4.3",
+						"jest-config": "22.4.3",
+						"jest-environment-jsdom": "22.4.3",
+						"jest-get-type": "22.4.3",
+						"jest-haste-map": "22.4.3",
+						"jest-message-util": "22.4.3",
+						"jest-regex-util": "22.4.3",
+						"jest-resolve-dependencies": "22.4.3",
+						"jest-runner": "22.4.3",
+						"jest-runtime": "22.4.3",
+						"jest-snapshot": "22.4.3",
+						"jest-util": "22.4.3",
+						"jest-validate": "22.4.3",
+						"jest-worker": "22.4.3",
+						"micromatch": "2.3.11",
+						"node-notifier": "5.2.1",
+						"realpath-native": "1.0.0",
+						"rimraf": "2.6.2",
+						"slash": "1.0.0",
+						"string-length": "2.0.0",
+						"strip-ansi": "4.0.0",
+						"which": "1.3.0",
+						"yargs": "10.1.2"
+					}
+				},
+				"yargs": {
+					"version": "10.1.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+					"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+					"requires": {
+						"cliui": "4.1.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "8.1.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+					"requires": {
+						"camelcase": "4.1.0"
+					}
+				}
+			}
+		},
+		"jest-changed-files": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.4.3.tgz",
+			"integrity": "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
+			"requires": {
+				"throat": "4.1.0"
+			}
+		},
+		"jest-config": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.3.tgz",
+			"integrity": "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
+			"requires": {
+				"chalk": "2.3.2",
+				"glob": "7.1.2",
+				"jest-environment-jsdom": "22.4.3",
+				"jest-environment-node": "22.4.3",
+				"jest-get-type": "22.4.3",
+				"jest-jasmine2": "22.4.3",
+				"jest-regex-util": "22.4.3",
+				"jest-resolve": "22.4.3",
+				"jest-util": "22.4.3",
+				"jest-validate": "22.4.3",
+				"pretty-format": "22.4.3"
+			}
+		},
+		"jest-diff": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
+			"integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+			"requires": {
+				"chalk": "2.3.2",
+				"diff": "3.5.0",
+				"jest-get-type": "22.4.3",
+				"pretty-format": "22.4.3"
+			}
+		},
+		"jest-docblock": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
+			"integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
+			"requires": {
+				"detect-newline": "2.1.0"
+			}
+		},
+		"jest-environment-jsdom": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
+			"integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
+			"requires": {
+				"jest-mock": "22.4.3",
+				"jest-util": "22.4.3",
+				"jsdom": "11.10.0"
+			}
+		},
+		"jest-environment-node": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
+			"integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
+			"requires": {
+				"jest-mock": "22.4.3",
+				"jest-util": "22.4.3"
+			}
+		},
+		"jest-get-type": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
+		},
+		"jest-haste-map": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz",
+			"integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
+			"requires": {
+				"fb-watchman": "2.0.0",
+				"graceful-fs": "4.1.11",
+				"jest-docblock": "22.4.3",
+				"jest-serializer": "22.4.3",
+				"jest-worker": "22.4.3",
+				"micromatch": "2.3.11",
+				"sane": "2.5.2"
+			}
+		},
+		"jest-jasmine2": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.3.tgz",
+			"integrity": "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
+			"requires": {
+				"chalk": "2.3.2",
+				"co": "4.6.0",
+				"expect": "22.4.3",
+				"graceful-fs": "4.1.11",
+				"is-generator-fn": "1.0.0",
+				"jest-diff": "22.4.3",
+				"jest-matcher-utils": "22.4.3",
+				"jest-message-util": "22.4.3",
+				"jest-snapshot": "22.4.3",
+				"jest-util": "22.4.3",
+				"source-map-support": "0.5.4"
+			}
+		},
+		"jest-leak-detector": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
+			"integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
+			"requires": {
+				"pretty-format": "22.4.3"
+			}
+		},
+		"jest-matcher-utils": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+			"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+			"requires": {
+				"chalk": "2.3.2",
+				"jest-get-type": "22.4.3",
+				"pretty-format": "22.4.3"
+			}
+		},
+		"jest-message-util": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+			"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.46",
+				"chalk": "2.3.2",
+				"micromatch": "2.3.11",
+				"slash": "1.0.0",
+				"stack-utils": "1.0.1"
+			}
+		},
+		"jest-mock": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
+			"integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q=="
+		},
+		"jest-regex-util": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
+			"integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg=="
+		},
+		"jest-resolve": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
+			"integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
+			"requires": {
+				"browser-resolve": "1.11.2",
+				"chalk": "2.3.2"
+			}
+		},
+		"jest-resolve-dependencies": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
+			"integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
+			"requires": {
+				"jest-regex-util": "22.4.3"
+			}
+		},
+		"jest-runner": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.3.tgz",
+			"integrity": "sha512-U7PLlQPRlWNbvOHWOrrVay9sqhBJmiKeAdKIkvX4n1G2tsvzLlf77nBD28GL1N6tGv4RmuTfI8R8JrkvCa+IBg==",
+			"requires": {
+				"exit": "0.1.2",
+				"jest-config": "22.4.3",
+				"jest-docblock": "22.4.3",
+				"jest-haste-map": "22.4.3",
+				"jest-jasmine2": "22.4.3",
+				"jest-leak-detector": "22.4.3",
+				"jest-message-util": "22.4.3",
+				"jest-runtime": "22.4.3",
+				"jest-util": "22.4.3",
+				"jest-worker": "22.4.3",
+				"throat": "4.1.0"
+			}
+		},
+		"jest-runtime": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.3.tgz",
+			"integrity": "sha512-Eat/esQjevhx9BgJEC8udye+FfoJ2qvxAZfOAWshYGS22HydHn5BgsvPdTtt9cp0fSl5LxYOFA1Pja9Iz2Zt8g==",
+			"requires": {
+				"babel-core": "6.26.0",
+				"babel-jest": "22.4.3",
+				"babel-plugin-istanbul": "4.1.6",
+				"chalk": "2.3.2",
+				"convert-source-map": "1.5.1",
+				"exit": "0.1.2",
+				"graceful-fs": "4.1.11",
+				"jest-config": "22.4.3",
+				"jest-haste-map": "22.4.3",
+				"jest-regex-util": "22.4.3",
+				"jest-resolve": "22.4.3",
+				"jest-util": "22.4.3",
+				"jest-validate": "22.4.3",
+				"json-stable-stringify": "1.0.1",
+				"micromatch": "2.3.11",
+				"realpath-native": "1.0.0",
+				"slash": "1.0.0",
+				"strip-bom": "3.0.0",
+				"write-file-atomic": "2.3.0",
+				"yargs": "10.1.2"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"cliui": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+					"requires": {
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"yargs": {
+					"version": "10.1.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+					"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+					"requires": {
+						"cliui": "4.1.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "8.1.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+					"requires": {
+						"camelcase": "4.1.0"
+					}
+				}
+			}
+		},
+		"jest-serializer": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.3.tgz",
+			"integrity": "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw=="
+		},
+		"jest-snapshot": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
+			"integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
+			"requires": {
+				"chalk": "2.3.2",
+				"jest-diff": "22.4.3",
+				"jest-matcher-utils": "22.4.3",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"pretty-format": "22.4.3"
+			}
+		},
+		"jest-util": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
+			"integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
+			"requires": {
+				"callsites": "2.0.0",
+				"chalk": "2.3.2",
+				"graceful-fs": "4.1.11",
+				"is-ci": "1.1.0",
+				"jest-message-util": "22.4.3",
+				"mkdirp": "0.5.1",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"jest-validate": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.3.tgz",
+			"integrity": "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
+			"requires": {
+				"chalk": "2.3.2",
+				"jest-config": "22.4.3",
+				"jest-get-type": "22.4.3",
+				"leven": "2.1.0",
+				"pretty-format": "22.4.3"
+			}
+		},
+		"jest-worker": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
+			"integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
+			"requires": {
+				"merge-stream": "1.0.1"
+			}
 		},
 		"js-string-escape": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
-			"dev": true
+			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
 		},
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-			"dev": true
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
 		"js-yaml": {
 			"version": "3.11.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
 			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
-			"dev": true,
 			"requires": {
 				"argparse": "1.0.10",
 				"esprima": "4.0.0"
@@ -5653,44 +7322,97 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true,
 			"optional": true
+		},
+		"jsdom": {
+			"version": "11.10.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.10.0.tgz",
+			"integrity": "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
+			"requires": {
+				"abab": "1.0.4",
+				"acorn": "5.5.3",
+				"acorn-globals": "4.1.0",
+				"array-equal": "1.0.0",
+				"cssom": "0.3.2",
+				"cssstyle": "0.2.37",
+				"data-urls": "1.0.0",
+				"domexception": "1.0.1",
+				"escodegen": "1.9.1",
+				"html-encoding-sniffer": "1.0.2",
+				"left-pad": "1.3.0",
+				"nwmatcher": "1.4.4",
+				"parse5": "4.0.0",
+				"pn": "1.1.0",
+				"request": "2.85.0",
+				"request-promise-native": "1.0.5",
+				"sax": "1.2.4",
+				"symbol-tree": "3.2.2",
+				"tough-cookie": "2.3.4",
+				"w3c-hr-time": "1.0.1",
+				"webidl-conversions": "4.0.2",
+				"whatwg-encoding": "1.0.3",
+				"whatwg-mimetype": "2.1.0",
+				"whatwg-url": "6.4.1",
+				"ws": "4.1.0",
+				"xml-name-validator": "3.0.0"
+			}
+		},
+		"jsdom-global": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
+			"integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk="
 		},
 		"jsesc": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-			"dev": true
+			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 		},
 		"json-loader": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-			"integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
-			"dev": true
+			"integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-			"integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
-			"dev": true
+			"integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
+		},
+		"json-refs": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/json-refs/-/json-refs-3.0.4.tgz",
+			"integrity": "sha512-UFnB5j1C7XrUWQIlFGrjerFVuc04TZAyoEavfb0VofdjguWWN97aCtWsv1uX6pXylJiLw+agsyTPCnNjL6W4ag==",
+			"requires": {
+				"commander": "2.11.0",
+				"graphlib": "2.1.5",
+				"js-yaml": "3.11.0",
+				"lodash": "4.17.4",
+				"native-promise-only": "0.8.1",
+				"path-loader": "1.0.4",
+				"slash": "1.0.0",
+				"uri-js": "3.0.2"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+				}
+			}
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"dev": true
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-			"dev": true
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"dev": true,
 			"requires": {
 				"jsonify": "0.0.0"
 			}
@@ -5698,20 +7420,22 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
+		"json3": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
 		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-			"dev": true
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
 		},
 		"jsonfile": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11"
 			}
@@ -5719,20 +7443,17 @@
 		"jsonify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-			"dev": true
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-			"dev": true
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
 		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -5740,11 +7461,115 @@
 				"verror": "1.10.0"
 			}
 		},
+		"jss": {
+			"version": "9.8.1",
+			"resolved": "https://registry.npmjs.org/jss/-/jss-9.8.1.tgz",
+			"integrity": "sha512-a9dXInEPTRmdSmzw3LNhbAwdQVZgCRmFU7dFzrpLTMAcdolHXNamhxQ6J+PNIqUtWa9yRbZIzWX6aUlI55LZ/A==",
+			"requires": {
+				"is-in-browser": "1.1.3",
+				"symbol-observable": "1.2.0",
+				"warning": "3.0.0"
+			}
+		},
+		"jss-camel-case": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jss-camel-case/-/jss-camel-case-6.1.0.tgz",
+			"integrity": "sha512-HPF2Q7wmNW1t79mCqSeU2vdd/vFFGpkazwvfHMOhPlMgXrJDzdj9viA2SaHk9ZbD5pfL63a8ylp4++irYbbzMQ==",
+			"requires": {
+				"hyphenate-style-name": "1.0.2"
+			}
+		},
+		"jss-compose": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/jss-compose/-/jss-compose-5.0.0.tgz",
+			"integrity": "sha512-YofRYuiA0+VbeOw0VjgkyO380sA4+TWDrW52nSluD9n+1FWOlDzNbgpZ/Sb3Y46+DcAbOS21W5jo6SAqUEiuwA==",
+			"requires": {
+				"warning": "3.0.0"
+			}
+		},
+		"jss-default-unit": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
+			"integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg=="
+		},
+		"jss-expand": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/jss-expand/-/jss-expand-5.3.0.tgz",
+			"integrity": "sha512-NiM4TbDVE0ykXSAw6dfFmB1LIqXP/jdd0ZMnlvlGgEMkMt+weJIl8Ynq1DsuBY9WwkNyzWktdqcEW2VN0RAtQg=="
+		},
+		"jss-extend": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/jss-extend/-/jss-extend-6.2.0.tgz",
+			"integrity": "sha512-YszrmcB6o9HOsKPszK7NeDBNNjVyiW864jfoiHoMlgMIg2qlxKw70axZHqgczXHDcoyi/0/ikP1XaHDPRvYtEA==",
+			"requires": {
+				"warning": "3.0.0"
+			}
+		},
+		"jss-global": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
+			"integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q=="
+		},
+		"jss-nested": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/jss-nested/-/jss-nested-6.0.1.tgz",
+			"integrity": "sha512-rn964TralHOZxoyEgeq3hXY8hyuCElnvQoVrQwKHVmu55VRDd6IqExAx9be5HgK0yN/+hQdgAXQl/GUrBbbSTA==",
+			"requires": {
+				"warning": "3.0.0"
+			}
+		},
+		"jss-preset-default": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/jss-preset-default/-/jss-preset-default-4.5.0.tgz",
+			"integrity": "sha512-qZbpRVtHT7hBPpZEBPFfafZKWmq3tA/An5RNqywDsZQGrlinIF/mGD9lmj6jGqu8GrED2SMHZ3pPKLmjCZoiaQ==",
+			"requires": {
+				"jss-camel-case": "6.1.0",
+				"jss-compose": "5.0.0",
+				"jss-default-unit": "8.0.2",
+				"jss-expand": "5.3.0",
+				"jss-extend": "6.2.0",
+				"jss-global": "3.0.0",
+				"jss-nested": "6.0.1",
+				"jss-props-sort": "6.0.0",
+				"jss-template": "1.0.1",
+				"jss-vendor-prefixer": "7.0.0"
+			}
+		},
+		"jss-props-sort": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
+			"integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g=="
+		},
+		"jss-template": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/jss-template/-/jss-template-1.0.1.tgz",
+			"integrity": "sha512-m5BqEWha17fmIVXm1z8xbJhY6GFJxNB9H68GVnCWPyGYfxiAgY9WTQyvDAVj+pYRgrXSOfN5V1T4+SzN1sJTeg==",
+			"requires": {
+				"warning": "3.0.0"
+			}
+		},
+		"jss-vendor-prefixer": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz",
+			"integrity": "sha512-Agd+FKmvsI0HLcYXkvy8GYOw3AAASBUpsmIRvVQheps+JWaN892uFOInTr0DRydwaD91vSSUCU4NssschvF7MA==",
+			"requires": {
+				"css-vendor": "0.3.8"
+			}
+		},
+		"keycode": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
+			"integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
+		},
+		"killable": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz",
+			"integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms="
+		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-			"dev": true,
 			"requires": {
 				"is-buffer": "1.1.6"
 			}
@@ -5753,7 +7578,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/last-line-stream/-/last-line-stream-1.0.0.tgz",
 			"integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
-			"dev": true,
 			"requires": {
 				"through2": "2.0.3"
 			}
@@ -5762,7 +7586,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
 			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-			"dev": true,
 			"requires": {
 				"package-json": "4.0.1"
 			}
@@ -5770,14 +7593,12 @@
 		"lazy-cache": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-			"dev": true
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
 		},
 		"lazystream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
 			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "2.3.5"
 			}
@@ -5786,7 +7607,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-			"dev": true,
 			"requires": {
 				"invert-kv": "1.0.0"
 			}
@@ -5794,25 +7614,27 @@
 		"lcov-parse": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
-			"dev": true
+			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
 		},
 		"lcov-result-merger": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/lcov-result-merger/-/lcov-result-merger-2.0.0.tgz",
 			"integrity": "sha512-CMjYOcPtl0G3SLrPWYDtZ4zyhsy/2heUf6RKwvyDcJRfyUBQbqLhAlS2PBhTKVCxGp7Ri8AYJ5SGNVEtbEo0fA==",
-			"dev": true,
 			"requires": {
 				"through2": "2.0.3",
 				"vinyl": "2.1.0",
 				"vinyl-fs": "2.4.4"
 			}
 		},
+		"left-pad": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+		},
 		"lerna": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/lerna/-/lerna-2.11.0.tgz",
 			"integrity": "sha512-kgM6zwe2P2tR30MYvgiLLW+9buFCm6E7o8HnRlhTgm70WVBvXVhydqv+q/MF2HrVZkCawfVtCfetyQmtd4oHhQ==",
-			"dev": true,
 			"requires": {
 				"async": "1.5.2",
 				"chalk": "2.3.2",
@@ -5859,7 +7681,6 @@
 					"version": "0.8.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
 					"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-					"dev": true,
 					"requires": {
 						"cross-spawn": "5.1.0",
 						"get-stream": "3.0.0",
@@ -5874,7 +7695,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"dev": true,
 					"requires": {
 						"is-glob": "3.1.0",
 						"path-dirname": "1.0.2"
@@ -5883,14 +7703,12 @@
 				"is-extglob": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 				},
 				"is-glob": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "2.1.1"
 					}
@@ -5899,7 +7717,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"parse-json": "4.0.0",
@@ -5911,7 +7728,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "1.3.1",
 						"json-parse-better-errors": "1.0.1"
@@ -5921,7 +7737,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
 					"requires": {
 						"pify": "3.0.0"
 					}
@@ -5929,14 +7744,12 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "4.0.0",
 						"normalize-package-data": "2.4.0",
@@ -5945,11 +7758,29 @@
 				}
 			}
 		},
+		"leven": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"requires": {
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
+			}
+		},
+		"lightercollective": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/lightercollective/-/lightercollective-0.0.0.tgz",
+			"integrity": "sha512-4SdGgHgQjlqhk90QxAYsltGEI6HHt30xy9fOIPKi+c3vcGRcpPDtzm6+kxr1N9ixkrx/ngMhTCe/VpBc/HmNBQ=="
+		},
 		"load-json-file": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"parse-json": "2.2.0",
@@ -5960,14 +7791,12 @@
 		"loader-runner": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
-			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
-			"dev": true
+			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI="
 		},
 		"loader-utils": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-			"dev": true,
 			"requires": {
 				"big.js": "3.2.0",
 				"emojis-list": "2.1.0",
@@ -5978,7 +7807,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-			"dev": true,
 			"requires": {
 				"p-locate": "2.0.0",
 				"path-exists": "3.0.0"
@@ -5987,68 +7815,72 @@
 		"lodash": {
 			"version": "4.17.4",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-			"dev": true
+			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+		},
+		"lodash-es": {
+			"version": "4.17.10",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
+			"integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-			"dev": true
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
 		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-			"dev": true
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
 		},
 		"lodash.clonedeepwith": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
-			"integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ=",
-			"dev": true
+			"integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ="
 		},
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-			"dev": true
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
 		},
 		"lodash.difference": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-			"dev": true
+			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
 		},
 		"lodash.flatten": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-			"dev": true
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
 		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-			"dev": true
+			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
 		},
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-			"dev": true
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
 		},
 		"lodash.merge": {
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
-			"dev": true
+			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
 		},
 		"lodash.template": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
 			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "3.0.0",
 				"lodash.templatesettings": "4.1.0"
@@ -6058,7 +7890,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
 			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "3.0.0"
 			}
@@ -6066,20 +7897,22 @@
 		"log-driver": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
-			"dev": true
+			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
+		},
+		"loglevel": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
+			"integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
 		},
 		"longest": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-			"dev": true
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
 		},
 		"loose-envify": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-			"dev": true,
 			"requires": {
 				"js-tokens": "3.0.2"
 			}
@@ -6088,7 +7921,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-			"dev": true,
 			"requires": {
 				"currently-unhandled": "0.4.1",
 				"signal-exit": "3.0.2"
@@ -6097,14 +7929,12 @@
 		"lowercase-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-			"dev": true
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
 		},
 		"lru-cache": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
 			"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
-			"dev": true,
 			"requires": {
 				"pseudomap": "1.0.2",
 				"yallist": "2.1.2"
@@ -6114,7 +7944,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
 			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
-			"dev": true,
 			"requires": {
 				"pify": "3.0.0"
 			},
@@ -6122,28 +7951,32 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
+			}
+		},
+		"makeerror": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"requires": {
+				"tmpl": "1.0.4"
 			}
 		},
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-			"dev": true
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
 		},
 		"map-obj": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-			"dev": true
+			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
 		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-			"dev": true,
 			"requires": {
 				"object-visit": "1.0.1"
 			}
@@ -6151,23 +7984,65 @@
 		"marked": {
 			"version": "0.3.19",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-			"integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
-			"dev": true
+			"integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
 		},
 		"matcher": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.0.tgz",
 			"integrity": "sha512-aZGv6JBTHqfqAd09jmAlbKnAICTfIvb5Z8gXVxPB5WZtFfHMaAMdACL7tQflD2V+6/8KNcY8s6DYtWLgpJP5lA==",
-			"dev": true,
 			"requires": {
 				"escape-string-regexp": "1.0.5"
+			}
+		},
+		"material-ui": {
+			"version": "1.0.0-beta.45",
+			"resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.45.tgz",
+			"integrity": "sha512-+WWlVYFd/71JoNWiAsLJzLmS8ludPwfNbqE5vYibEuXQGA3TfC+ko4RYvBNkAq7pR/ZvQylRaXqcu5d+H5UIOw==",
+			"requires": {
+				"@types/jss": "9.5.2",
+				"@types/react-transition-group": "2.0.9",
+				"babel-runtime": "6.26.0",
+				"brcast": "3.0.1",
+				"classnames": "2.2.5",
+				"deepmerge": "2.1.0",
+				"dom-helpers": "3.3.1",
+				"hoist-non-react-statics": "2.5.0",
+				"jss": "9.8.1",
+				"jss-camel-case": "6.1.0",
+				"jss-default-unit": "8.0.2",
+				"jss-global": "3.0.0",
+				"jss-nested": "6.0.1",
+				"jss-props-sort": "6.0.0",
+				"jss-vendor-prefixer": "7.0.0",
+				"keycode": "2.2.0",
+				"lodash": "4.17.4",
+				"normalize-scroll-left": "0.1.2",
+				"npm": "6.0.0",
+				"prop-types": "15.6.1",
+				"react-event-listener": "0.5.3",
+				"react-jss": "8.4.0",
+				"react-lifecycles-compat": "3.0.2",
+				"react-popper": "0.10.4",
+				"react-scrollbar-size": "2.1.0",
+				"react-transition-group": "2.3.1",
+				"recompose": "0.26.0",
+				"scroll": "2.0.3",
+				"warning": "3.0.0"
+			}
+		},
+		"material-ui-pickers": {
+			"version": "1.0.0-rc.7",
+			"resolved": "https://registry.npmjs.org/material-ui-pickers/-/material-ui-pickers-1.0.0-rc.7.tgz",
+			"integrity": "sha512-DVEkymZM+yKdE0088Ny1T+Ylr9tlcMHhOdeAMN0afXEq8xHnawxma3TYa304mWMt1dVzBQY5543FVLlo3aXZ+w==",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"react-text-mask": "5.4.1"
 			}
 		},
 		"md5-hex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
 			"integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
-			"dev": true,
 			"requires": {
 				"md5-o-matic": "0.1.1"
 			}
@@ -6175,14 +8050,12 @@
 		"md5-o-matic": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
-			"dev": true
+			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
 		},
 		"md5.js": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
 			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
-			"dev": true,
 			"requires": {
 				"hash-base": "3.0.4",
 				"inherits": "2.0.3"
@@ -6192,7 +8065,6 @@
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
 					"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-					"dev": true,
 					"requires": {
 						"inherits": "2.0.3",
 						"safe-buffer": "5.1.1"
@@ -6200,11 +8072,15 @@
 				}
 			}
 		},
+		"media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+		},
 		"mem": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-			"dev": true,
 			"requires": {
 				"mimic-fn": "1.2.0"
 			}
@@ -6213,7 +8089,6 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-			"dev": true,
 			"requires": {
 				"errno": "0.1.7",
 				"readable-stream": "2.3.5"
@@ -6223,7 +8098,6 @@
 			"version": "3.7.0",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-			"dev": true,
 			"requires": {
 				"camelcase-keys": "2.1.0",
 				"decamelize": "1.2.0",
@@ -6241,7 +8115,6 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
 					"requires": {
 						"path-exists": "2.1.0",
 						"pinkie-promise": "2.0.1"
@@ -6251,7 +8124,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"parse-json": "2.2.0",
@@ -6263,14 +8135,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"path-exists": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
 					"requires": {
 						"pinkie-promise": "2.0.1"
 					}
@@ -6279,7 +8149,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"pify": "2.3.0",
@@ -6289,14 +8158,12 @@
 				"pinkie": {
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-					"dev": true
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-					"dev": true,
 					"requires": {
 						"pinkie": "2.0.4"
 					}
@@ -6305,7 +8172,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "1.1.0",
 						"normalize-package-data": "2.4.0",
@@ -6316,7 +8182,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"dev": true,
 					"requires": {
 						"find-up": "1.1.2",
 						"read-pkg": "1.1.0"
@@ -6326,27 +8191,39 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "0.2.1"
 					}
 				}
 			}
 		},
+		"merge": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+		},
 		"merge-stream": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "2.3.5"
 			}
+		},
+		"methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
 		"micromatch": {
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-			"dev": true,
 			"requires": {
 				"arr-diff": "2.0.0",
 				"array-unique": "0.2.1",
@@ -6367,23 +8244,25 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-			"dev": true,
 			"requires": {
 				"bn.js": "4.11.8",
 				"brorand": "1.1.0"
 			}
 		},
+		"mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+		},
 		"mime-db": {
 			"version": "1.33.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-			"dev": true
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
 		},
 		"mime-types": {
 			"version": "2.1.18",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
 			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-			"dev": true,
 			"requires": {
 				"mime-db": "1.33.0"
 			}
@@ -6391,26 +8270,30 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-			"dev": true
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+		},
+		"min-document": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+			"requires": {
+				"dom-walk": "0.1.1"
+			}
 		},
 		"minimalistic-assert": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-			"integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
-			"dev": true
+			"integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-			"dev": true
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "1.1.11"
 			}
@@ -6418,24 +8301,38 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"minimist-options": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
 			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
-			"dev": true,
 			"requires": {
 				"arrify": "1.0.1",
 				"is-plain-obj": "1.1.0"
+			}
+		},
+		"mississippi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+			"requires": {
+				"concat-stream": "1.6.2",
+				"duplexify": "3.5.4",
+				"end-of-stream": "1.4.1",
+				"flush-write-stream": "1.0.3",
+				"from2": "2.3.0",
+				"parallel-transform": "1.1.0",
+				"pump": "2.0.1",
+				"pumpify": "1.5.0",
+				"stream-each": "1.2.2",
+				"through2": "2.0.3"
 			}
 		},
 		"mixin-deep": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
-			"dev": true,
 			"requires": {
 				"for-in": "1.0.2",
 				"is-extendable": "1.0.1"
@@ -6445,7 +8342,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "2.0.4"
 					}
@@ -6456,7 +8352,6 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -6464,26 +8359,49 @@
 		"modify-values": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
-			"dev": true
+			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw=="
 		},
 		"moment": {
 			"version": "2.21.0",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-			"integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ==",
-			"dev": true
+			"integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
+		},
+		"move-concurrently": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+			"requires": {
+				"aproba": "1.2.0",
+				"copy-concurrently": "1.0.5",
+				"fs-write-stream-atomic": "1.0.10",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"run-queue": "1.0.3"
+			}
 		},
 		"ms": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-			"dev": true
+			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+		},
+		"multicast-dns": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
+			"integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+			"requires": {
+				"dns-packet": "1.3.1",
+				"thunky": "1.0.2"
+			}
+		},
+		"multicast-dns-service-types": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
 		},
 		"multimatch": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-			"dev": true,
 			"requires": {
 				"array-differ": "1.0.0",
 				"array-union": "1.0.2",
@@ -6494,21 +8412,18 @@
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-			"dev": true
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"nan": {
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
 			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-			"dev": true,
 			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.9",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
 			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
-			"dev": true,
 			"requires": {
 				"arr-diff": "4.0.0",
 				"array-unique": "0.3.2",
@@ -6527,20 +8442,17 @@
 				"arr-diff": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 				},
 				"array-unique": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 				},
 				"extend-shallow": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-					"dev": true,
 					"requires": {
 						"assign-symbols": "1.0.0",
 						"is-extendable": "1.0.1"
@@ -6550,7 +8462,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "2.0.4"
 					}
@@ -6558,28 +8469,63 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
+		},
+		"native-promise-only": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+			"integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+		},
+		"ncp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+			"integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
+		},
+		"negotiator": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
 		},
 		"neo-async": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.0.tgz",
-			"integrity": "sha512-nJmSswG4As/MkRq7QZFuH/sf/yuv8ODdMZrY4Bedjp77a5MK4A6s7YbBB64c9u79EBUOfXUXBvArmvzTD0X+6g==",
-			"dev": true
+			"integrity": "sha512-nJmSswG4As/MkRq7QZFuH/sf/yuv8ODdMZrY4Bedjp77a5MK4A6s7YbBB64c9u79EBUOfXUXBvArmvzTD0X+6g=="
 		},
 		"next-tick": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-			"dev": true
+			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
+			}
+		},
+		"node-forge": {
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+			"integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
+		},
+		"node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
 		},
 		"node-libs-browser": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
 			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
-			"dev": true,
 			"requires": {
 				"assert": "1.4.1",
 				"browserify-zlib": "0.2.0",
@@ -6606,11 +8552,21 @@
 				"vm-browserify": "0.0.4"
 			}
 		},
+		"node-notifier": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+			"requires": {
+				"growly": "1.3.0",
+				"semver": "5.5.0",
+				"shellwords": "0.1.1",
+				"which": "1.3.0"
+			}
+		},
 		"normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-			"dev": true,
 			"requires": {
 				"hosted-git-info": "2.6.0",
 				"is-builtin-module": "1.0.0",
@@ -6622,16 +8578,5130 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "1.1.0"
+			}
+		},
+		"normalize-scroll-left": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz",
+			"integrity": "sha512-F9YMRls0zCF6BFIE2YnXDRpHPpfd91nOIaNdDgrx5YMoPLo8Wqj+6jNXHQsYBavJeXP4ww8HCt0xQAKc5qk2Fg=="
+		},
+		"npm": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-6.0.0.tgz",
+			"integrity": "sha512-EtM7gNAgMdQeUh8SW2bsaogywVS37lPhf2GYAf2vxR1pktxxT02CW8BHrx59MSbG3ZrRBbcOhpe03gts+eAbdA==",
+			"requires": {
+				"JSONStream": "1.3.2",
+				"abbrev": "1.1.1",
+				"ansi-regex": "3.0.0",
+				"ansicolors": "0.3.2",
+				"ansistyles": "0.1.3",
+				"aproba": "1.2.0",
+				"archy": "1.0.0",
+				"bin-links": "1.1.2",
+				"bluebird": "3.5.1",
+				"byte-size": "4.0.2",
+				"cacache": "11.0.1",
+				"call-limit": "1.1.0",
+				"chownr": "1.0.1",
+				"cli-columns": "3.1.2",
+				"cli-table2": "0.2.0",
+				"cmd-shim": "2.0.2",
+				"columnify": "1.5.4",
+				"config-chain": "1.1.11",
+				"debuglog": "1.0.1",
+				"detect-indent": "5.0.0",
+				"detect-newline": "2.1.0",
+				"dezalgo": "1.0.3",
+				"editor": "1.0.0",
+				"figgy-pudding": "3.1.0",
+				"find-npm-prefix": "1.0.2",
+				"fs-vacuum": "1.2.10",
+				"fs-write-stream-atomic": "1.0.10",
+				"gentle-fs": "2.0.1",
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"has-unicode": "2.0.1",
+				"hosted-git-info": "2.6.0",
+				"iferr": "1.0.0",
+				"imurmurhash": "0.1.4",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"ini": "1.3.5",
+				"init-package-json": "1.10.3",
+				"is-cidr": "2.0.5",
+				"json-parse-better-errors": "1.0.2",
+				"lazy-property": "1.0.0",
+				"libcipm": "1.6.2",
+				"libnpmhook": "4.0.1",
+				"libnpx": "10.2.0",
+				"lockfile": "1.0.3",
+				"lodash._baseindexof": "3.1.0",
+				"lodash._baseuniq": "4.6.0",
+				"lodash._bindcallback": "3.0.1",
+				"lodash._cacheindexof": "3.0.2",
+				"lodash._createcache": "3.1.2",
+				"lodash._getnative": "3.9.1",
+				"lodash.clonedeep": "4.5.0",
+				"lodash.restparam": "3.6.1",
+				"lodash.union": "4.6.0",
+				"lodash.uniq": "4.5.0",
+				"lodash.without": "4.4.0",
+				"lru-cache": "4.1.2",
+				"meant": "1.0.1",
+				"mississippi": "3.0.0",
+				"mkdirp": "0.5.1",
+				"move-concurrently": "1.0.1",
+				"node-gyp": "3.6.2",
+				"nopt": "4.0.1",
+				"normalize-package-data": "2.4.0",
+				"npm-audit-report": "1.0.5",
+				"npm-cache-filename": "1.0.2",
+				"npm-install-checks": "3.0.0",
+				"npm-lifecycle": "2.0.1",
+				"npm-package-arg": "6.1.0",
+				"npm-packlist": "1.1.10",
+				"npm-pick-manifest": "2.1.0",
+				"npm-profile": "3.0.1",
+				"npm-registry-client": "8.5.1",
+				"npm-registry-fetch": "1.1.0",
+				"npm-user-validate": "1.0.0",
+				"npmlog": "4.1.2",
+				"once": "1.4.0",
+				"opener": "1.4.3",
+				"osenv": "0.1.5",
+				"pacote": "8.1.0",
+				"path-is-inside": "1.0.2",
+				"promise-inflight": "1.0.1",
+				"qrcode-terminal": "0.12.0",
+				"query-string": "6.0.0",
+				"qw": "1.0.1",
+				"read": "1.0.7",
+				"read-cmd-shim": "1.0.1",
+				"read-installed": "4.0.3",
+				"read-package-json": "2.0.13",
+				"read-package-tree": "5.2.1",
+				"readable-stream": "2.3.6",
+				"readdir-scoped-modules": "1.0.2",
+				"request": "2.85.0",
+				"retry": "0.12.0",
+				"rimraf": "2.6.2",
+				"safe-buffer": "5.1.1",
+				"semver": "5.5.0",
+				"sha": "2.0.1",
+				"slide": "1.1.6",
+				"sorted-object": "2.0.1",
+				"sorted-union-stream": "2.1.3",
+				"ssri": "6.0.0",
+				"strip-ansi": "4.0.0",
+				"tar": "4.4.1",
+				"text-table": "0.2.0",
+				"tiny-relative-date": "1.3.0",
+				"uid-number": "0.0.6",
+				"umask": "1.1.0",
+				"unique-filename": "1.1.0",
+				"unpipe": "1.0.0",
+				"update-notifier": "2.4.0",
+				"uuid": "3.2.1",
+				"validate-npm-package-license": "3.0.3",
+				"validate-npm-package-name": "3.0.0",
+				"which": "1.3.0",
+				"worker-farm": "1.6.0",
+				"wrappy": "1.0.2",
+				"write-file-atomic": "2.3.0"
+			},
+			"dependencies": {
+				"JSONStream": {
+					"version": "1.3.2",
+					"bundled": true,
+					"requires": {
+						"jsonparse": "1.3.1",
+						"through": "2.3.8"
+					},
+					"dependencies": {
+						"jsonparse": {
+							"version": "1.3.1",
+							"bundled": true
+						},
+						"through": {
+							"version": "2.3.8",
+							"bundled": true
+						}
+					}
+				},
+				"abbrev": {
+					"version": "1.1.1",
+					"bundled": true
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"ansicolors": {
+					"version": "0.3.2",
+					"bundled": true
+				},
+				"ansistyles": {
+					"version": "0.1.3",
+					"bundled": true
+				},
+				"aproba": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"archy": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"bin-links": {
+					"version": "1.1.2",
+					"bundled": true,
+					"requires": {
+						"bluebird": "3.5.1",
+						"cmd-shim": "2.0.2",
+						"gentle-fs": "2.0.1",
+						"graceful-fs": "4.1.11",
+						"write-file-atomic": "2.3.0"
+					}
+				},
+				"bluebird": {
+					"version": "3.5.1",
+					"bundled": true
+				},
+				"byte-size": {
+					"version": "4.0.2",
+					"bundled": true
+				},
+				"cacache": {
+					"version": "11.0.1",
+					"bundled": true,
+					"requires": {
+						"bluebird": "3.5.1",
+						"chownr": "1.0.1",
+						"figgy-pudding": "3.1.0",
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"lru-cache": "4.1.2",
+						"mississippi": "3.0.0",
+						"mkdirp": "0.5.1",
+						"move-concurrently": "1.0.1",
+						"promise-inflight": "1.0.1",
+						"rimraf": "2.6.2",
+						"ssri": "6.0.0",
+						"unique-filename": "1.1.0",
+						"y18n": "4.0.0"
+					},
+					"dependencies": {
+						"y18n": {
+							"version": "4.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"call-limit": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"chownr": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"cli-columns": {
+					"version": "3.1.2",
+					"bundled": true,
+					"requires": {
+						"string-width": "2.1.1",
+						"strip-ansi": "3.0.1"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "2.1.1",
+							"bundled": true,
+							"requires": {
+								"is-fullwidth-code-point": "2.0.0",
+								"strip-ansi": "4.0.0"
+							},
+							"dependencies": {
+								"is-fullwidth-code-point": {
+									"version": "2.0.0",
+									"bundled": true
+								},
+								"strip-ansi": {
+									"version": "4.0.0",
+									"bundled": true,
+									"requires": {
+										"ansi-regex": "3.0.0"
+									}
+								}
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "2.1.1"
+							},
+							"dependencies": {
+								"ansi-regex": {
+									"version": "2.1.1",
+									"bundled": true
+								}
+							}
+						}
+					}
+				},
+				"cli-table2": {
+					"version": "0.2.0",
+					"bundled": true,
+					"requires": {
+						"colors": "1.1.2",
+						"lodash": "3.10.1",
+						"string-width": "1.0.2"
+					},
+					"dependencies": {
+						"colors": {
+							"version": "1.1.2",
+							"bundled": true,
+							"optional": true
+						},
+						"lodash": {
+							"version": "3.10.1",
+							"bundled": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							},
+							"dependencies": {
+								"code-point-at": {
+									"version": "1.1.0",
+									"bundled": true
+								},
+								"is-fullwidth-code-point": {
+									"version": "1.0.0",
+									"bundled": true,
+									"requires": {
+										"number-is-nan": "1.0.1"
+									},
+									"dependencies": {
+										"number-is-nan": {
+											"version": "1.0.1",
+											"bundled": true
+										}
+									}
+								},
+								"strip-ansi": {
+									"version": "3.0.1",
+									"bundled": true,
+									"requires": {
+										"ansi-regex": "2.1.1"
+									},
+									"dependencies": {
+										"ansi-regex": {
+											"version": "2.1.1",
+											"bundled": true
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"cmd-shim": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"mkdirp": "0.5.1"
+					}
+				},
+				"columnify": {
+					"version": "1.5.4",
+					"bundled": true,
+					"requires": {
+						"strip-ansi": "3.0.1",
+						"wcwidth": "1.0.1"
+					},
+					"dependencies": {
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "2.1.1"
+							},
+							"dependencies": {
+								"ansi-regex": {
+									"version": "2.1.1",
+									"bundled": true
+								}
+							}
+						},
+						"wcwidth": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"defaults": "1.0.3"
+							},
+							"dependencies": {
+								"defaults": {
+									"version": "1.0.3",
+									"bundled": true,
+									"requires": {
+										"clone": "1.0.2"
+									},
+									"dependencies": {
+										"clone": {
+											"version": "1.0.2",
+											"bundled": true
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"config-chain": {
+					"version": "1.1.11",
+					"bundled": true,
+					"requires": {
+						"ini": "1.3.5",
+						"proto-list": "1.2.4"
+					},
+					"dependencies": {
+						"proto-list": {
+							"version": "1.2.4",
+							"bundled": true
+						}
+					}
+				},
+				"debuglog": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"detect-indent": {
+					"version": "5.0.0",
+					"bundled": true
+				},
+				"detect-newline": {
+					"version": "2.1.0",
+					"bundled": true
+				},
+				"dezalgo": {
+					"version": "1.0.3",
+					"bundled": true,
+					"requires": {
+						"asap": "2.0.5",
+						"wrappy": "1.0.2"
+					},
+					"dependencies": {
+						"asap": {
+							"version": "2.0.5",
+							"bundled": true
+						}
+					}
+				},
+				"editor": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"figgy-pudding": {
+					"version": "3.1.0",
+					"bundled": true
+				},
+				"find-npm-prefix": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"fs-vacuum": {
+					"version": "1.2.10",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"path-is-inside": "1.0.2",
+						"rimraf": "2.6.2"
+					}
+				},
+				"fs-write-stream-atomic": {
+					"version": "1.0.10",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"iferr": "0.1.5",
+						"imurmurhash": "0.1.4",
+						"readable-stream": "2.3.6"
+					},
+					"dependencies": {
+						"iferr": {
+							"version": "0.1.5",
+							"bundled": true
+						}
+					}
+				},
+				"gentle-fs": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"aproba": "1.2.0",
+						"fs-vacuum": "1.2.10",
+						"graceful-fs": "4.1.11",
+						"iferr": "0.1.5",
+						"mkdirp": "0.5.1",
+						"path-is-inside": "1.0.2",
+						"read-cmd-shim": "1.0.1",
+						"slide": "1.1.6"
+					},
+					"dependencies": {
+						"iferr": {
+							"version": "0.1.5",
+							"bundled": true
+						}
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					},
+					"dependencies": {
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"requires": {
+								"brace-expansion": "1.1.8"
+							},
+							"dependencies": {
+								"brace-expansion": {
+									"version": "1.1.8",
+									"bundled": true,
+									"requires": {
+										"balanced-match": "1.0.0",
+										"concat-map": "0.0.1"
+									},
+									"dependencies": {
+										"balanced-match": {
+											"version": "1.0.0",
+											"bundled": true
+										},
+										"concat-map": {
+											"version": "0.0.1",
+											"bundled": true
+										}
+									}
+								}
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"hosted-git-info": {
+					"version": "2.6.0",
+					"bundled": true
+				},
+				"iferr": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"bundled": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"ini": {
+					"version": "1.3.5",
+					"bundled": true
+				},
+				"init-package-json": {
+					"version": "1.10.3",
+					"bundled": true,
+					"requires": {
+						"glob": "7.1.2",
+						"npm-package-arg": "6.1.0",
+						"promzard": "0.3.0",
+						"read": "1.0.7",
+						"read-package-json": "2.0.13",
+						"semver": "5.5.0",
+						"validate-npm-package-license": "3.0.3",
+						"validate-npm-package-name": "3.0.0"
+					},
+					"dependencies": {
+						"promzard": {
+							"version": "0.3.0",
+							"bundled": true,
+							"requires": {
+								"read": "1.0.7"
+							}
+						}
+					}
+				},
+				"is-cidr": {
+					"version": "2.0.5",
+					"bundled": true,
+					"requires": {
+						"cidr-regex": "2.0.8"
+					},
+					"dependencies": {
+						"cidr-regex": {
+							"version": "2.0.8",
+							"bundled": true,
+							"requires": {
+								"ip-regex": "2.1.0"
+							},
+							"dependencies": {
+								"ip-regex": {
+									"version": "2.1.0",
+									"bundled": true
+								}
+							}
+						}
+					}
+				},
+				"json-parse-better-errors": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"lazy-property": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"libcipm": {
+					"version": "1.6.2",
+					"bundled": true,
+					"requires": {
+						"bin-links": "1.1.2",
+						"bluebird": "3.5.1",
+						"find-npm-prefix": "1.0.2",
+						"graceful-fs": "4.1.11",
+						"lock-verify": "2.0.1",
+						"npm-lifecycle": "2.0.1",
+						"npm-logical-tree": "1.2.1",
+						"npm-package-arg": "6.1.0",
+						"pacote": "7.6.1",
+						"protoduck": "5.0.0",
+						"read-package-json": "2.0.13",
+						"rimraf": "2.6.2",
+						"worker-farm": "1.6.0"
+					},
+					"dependencies": {
+						"lock-verify": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"npm-package-arg": "5.1.2",
+								"semver": "5.5.0"
+							},
+							"dependencies": {
+								"npm-package-arg": {
+									"version": "5.1.2",
+									"bundled": true,
+									"requires": {
+										"hosted-git-info": "2.6.0",
+										"osenv": "0.1.5",
+										"semver": "5.5.0",
+										"validate-npm-package-name": "3.0.0"
+									}
+								}
+							}
+						},
+						"npm-logical-tree": {
+							"version": "1.2.1",
+							"bundled": true
+						},
+						"pacote": {
+							"version": "7.6.1",
+							"bundled": true,
+							"requires": {
+								"bluebird": "3.5.1",
+								"cacache": "10.0.4",
+								"get-stream": "3.0.0",
+								"glob": "7.1.2",
+								"lru-cache": "4.1.2",
+								"make-fetch-happen": "2.6.0",
+								"minimatch": "3.0.4",
+								"mississippi": "3.0.0",
+								"mkdirp": "0.5.1",
+								"normalize-package-data": "2.4.0",
+								"npm-package-arg": "6.1.0",
+								"npm-packlist": "1.1.10",
+								"npm-pick-manifest": "2.1.0",
+								"osenv": "0.1.5",
+								"promise-inflight": "1.0.1",
+								"promise-retry": "1.1.1",
+								"protoduck": "5.0.0",
+								"rimraf": "2.6.2",
+								"safe-buffer": "5.1.1",
+								"semver": "5.5.0",
+								"ssri": "5.3.0",
+								"tar": "4.4.1",
+								"unique-filename": "1.1.0",
+								"which": "1.3.0"
+							},
+							"dependencies": {
+								"cacache": {
+									"version": "10.0.4",
+									"bundled": true,
+									"requires": {
+										"bluebird": "3.5.1",
+										"chownr": "1.0.1",
+										"glob": "7.1.2",
+										"graceful-fs": "4.1.11",
+										"lru-cache": "4.1.2",
+										"mississippi": "2.0.0",
+										"mkdirp": "0.5.1",
+										"move-concurrently": "1.0.1",
+										"promise-inflight": "1.0.1",
+										"rimraf": "2.6.2",
+										"ssri": "5.3.0",
+										"unique-filename": "1.1.0",
+										"y18n": "4.0.0"
+									},
+									"dependencies": {
+										"mississippi": {
+											"version": "2.0.0",
+											"bundled": true,
+											"requires": {
+												"concat-stream": "1.6.2",
+												"duplexify": "3.5.4",
+												"end-of-stream": "1.4.1",
+												"flush-write-stream": "1.0.3",
+												"from2": "2.3.0",
+												"parallel-transform": "1.1.0",
+												"pump": "2.0.1",
+												"pumpify": "1.4.0",
+												"stream-each": "1.2.2",
+												"through2": "2.0.3"
+											},
+											"dependencies": {
+												"concat-stream": {
+													"version": "1.6.2",
+													"bundled": true,
+													"requires": {
+														"buffer-from": "1.0.0",
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6",
+														"typedarray": "0.0.6"
+													},
+													"dependencies": {
+														"buffer-from": {
+															"version": "1.0.0",
+															"bundled": true
+														},
+														"typedarray": {
+															"version": "0.0.6",
+															"bundled": true
+														}
+													}
+												},
+												"duplexify": {
+													"version": "3.5.4",
+													"bundled": true,
+													"requires": {
+														"end-of-stream": "1.4.1",
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6",
+														"stream-shift": "1.0.0"
+													},
+													"dependencies": {
+														"stream-shift": {
+															"version": "1.0.0",
+															"bundled": true
+														}
+													}
+												},
+												"end-of-stream": {
+													"version": "1.4.1",
+													"bundled": true,
+													"requires": {
+														"once": "1.4.0"
+													}
+												},
+												"flush-write-stream": {
+													"version": "1.0.3",
+													"bundled": true,
+													"requires": {
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6"
+													}
+												},
+												"from2": {
+													"version": "2.3.0",
+													"bundled": true,
+													"requires": {
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6"
+													}
+												},
+												"parallel-transform": {
+													"version": "1.1.0",
+													"bundled": true,
+													"requires": {
+														"cyclist": "0.2.2",
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6"
+													},
+													"dependencies": {
+														"cyclist": {
+															"version": "0.2.2",
+															"bundled": true
+														}
+													}
+												},
+												"pump": {
+													"version": "2.0.1",
+													"bundled": true,
+													"requires": {
+														"end-of-stream": "1.4.1",
+														"once": "1.4.0"
+													}
+												},
+												"pumpify": {
+													"version": "1.4.0",
+													"bundled": true,
+													"requires": {
+														"duplexify": "3.5.4",
+														"inherits": "2.0.3",
+														"pump": "2.0.1"
+													}
+												},
+												"stream-each": {
+													"version": "1.2.2",
+													"bundled": true,
+													"requires": {
+														"end-of-stream": "1.4.1",
+														"stream-shift": "1.0.0"
+													},
+													"dependencies": {
+														"stream-shift": {
+															"version": "1.0.0",
+															"bundled": true
+														}
+													}
+												},
+												"through2": {
+													"version": "2.0.3",
+													"bundled": true,
+													"requires": {
+														"readable-stream": "2.3.6",
+														"xtend": "4.0.1"
+													},
+													"dependencies": {
+														"xtend": {
+															"version": "4.0.1",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"y18n": {
+											"version": "4.0.0",
+											"bundled": true
+										}
+									}
+								},
+								"get-stream": {
+									"version": "3.0.0",
+									"bundled": true
+								},
+								"make-fetch-happen": {
+									"version": "2.6.0",
+									"bundled": true,
+									"requires": {
+										"agentkeepalive": "3.4.1",
+										"cacache": "10.0.4",
+										"http-cache-semantics": "3.8.1",
+										"http-proxy-agent": "2.1.0",
+										"https-proxy-agent": "2.2.1",
+										"lru-cache": "4.1.2",
+										"mississippi": "1.3.1",
+										"node-fetch-npm": "2.0.2",
+										"promise-retry": "1.1.1",
+										"socks-proxy-agent": "3.0.1",
+										"ssri": "5.3.0"
+									},
+									"dependencies": {
+										"agentkeepalive": {
+											"version": "3.4.1",
+											"bundled": true,
+											"requires": {
+												"humanize-ms": "1.2.1"
+											},
+											"dependencies": {
+												"humanize-ms": {
+													"version": "1.2.1",
+													"bundled": true,
+													"requires": {
+														"ms": "2.1.1"
+													},
+													"dependencies": {
+														"ms": {
+															"version": "2.1.1",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"http-cache-semantics": {
+											"version": "3.8.1",
+											"bundled": true
+										},
+										"http-proxy-agent": {
+											"version": "2.1.0",
+											"bundled": true,
+											"requires": {
+												"agent-base": "4.2.0",
+												"debug": "3.1.0"
+											},
+											"dependencies": {
+												"agent-base": {
+													"version": "4.2.0",
+													"bundled": true,
+													"requires": {
+														"es6-promisify": "5.0.0"
+													},
+													"dependencies": {
+														"es6-promisify": {
+															"version": "5.0.0",
+															"bundled": true,
+															"requires": {
+																"es6-promise": "4.2.4"
+															},
+															"dependencies": {
+																"es6-promise": {
+																	"version": "4.2.4",
+																	"bundled": true
+																}
+															}
+														}
+													}
+												},
+												"debug": {
+													"version": "3.1.0",
+													"bundled": true,
+													"requires": {
+														"ms": "2.0.0"
+													},
+													"dependencies": {
+														"ms": {
+															"version": "2.0.0",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"https-proxy-agent": {
+											"version": "2.2.1",
+											"bundled": true,
+											"requires": {
+												"agent-base": "4.2.0",
+												"debug": "3.1.0"
+											},
+											"dependencies": {
+												"agent-base": {
+													"version": "4.2.0",
+													"bundled": true,
+													"requires": {
+														"es6-promisify": "5.0.0"
+													},
+													"dependencies": {
+														"es6-promisify": {
+															"version": "5.0.0",
+															"bundled": true,
+															"requires": {
+																"es6-promise": "4.2.4"
+															},
+															"dependencies": {
+																"es6-promise": {
+																	"version": "4.2.4",
+																	"bundled": true
+																}
+															}
+														}
+													}
+												},
+												"debug": {
+													"version": "3.1.0",
+													"bundled": true,
+													"requires": {
+														"ms": "2.0.0"
+													},
+													"dependencies": {
+														"ms": {
+															"version": "2.0.0",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"mississippi": {
+											"version": "1.3.1",
+											"bundled": true,
+											"requires": {
+												"concat-stream": "1.6.2",
+												"duplexify": "3.5.4",
+												"end-of-stream": "1.4.1",
+												"flush-write-stream": "1.0.3",
+												"from2": "2.3.0",
+												"parallel-transform": "1.1.0",
+												"pump": "1.0.3",
+												"pumpify": "1.4.0",
+												"stream-each": "1.2.2",
+												"through2": "2.0.3"
+											},
+											"dependencies": {
+												"concat-stream": {
+													"version": "1.6.2",
+													"bundled": true,
+													"requires": {
+														"buffer-from": "1.0.0",
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6",
+														"typedarray": "0.0.6"
+													},
+													"dependencies": {
+														"buffer-from": {
+															"version": "1.0.0",
+															"bundled": true
+														},
+														"typedarray": {
+															"version": "0.0.6",
+															"bundled": true
+														}
+													}
+												},
+												"duplexify": {
+													"version": "3.5.4",
+													"bundled": true,
+													"requires": {
+														"end-of-stream": "1.4.1",
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6",
+														"stream-shift": "1.0.0"
+													},
+													"dependencies": {
+														"stream-shift": {
+															"version": "1.0.0",
+															"bundled": true
+														}
+													}
+												},
+												"end-of-stream": {
+													"version": "1.4.1",
+													"bundled": true,
+													"requires": {
+														"once": "1.4.0"
+													}
+												},
+												"flush-write-stream": {
+													"version": "1.0.3",
+													"bundled": true,
+													"requires": {
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6"
+													}
+												},
+												"from2": {
+													"version": "2.3.0",
+													"bundled": true,
+													"requires": {
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6"
+													}
+												},
+												"parallel-transform": {
+													"version": "1.1.0",
+													"bundled": true,
+													"requires": {
+														"cyclist": "0.2.2",
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6"
+													},
+													"dependencies": {
+														"cyclist": {
+															"version": "0.2.2",
+															"bundled": true
+														}
+													}
+												},
+												"pump": {
+													"version": "1.0.3",
+													"bundled": true,
+													"requires": {
+														"end-of-stream": "1.4.1",
+														"once": "1.4.0"
+													}
+												},
+												"pumpify": {
+													"version": "1.4.0",
+													"bundled": true,
+													"requires": {
+														"duplexify": "3.5.4",
+														"inherits": "2.0.3",
+														"pump": "2.0.1"
+													},
+													"dependencies": {
+														"pump": {
+															"version": "2.0.1",
+															"bundled": true,
+															"requires": {
+																"end-of-stream": "1.4.1",
+																"once": "1.4.0"
+															}
+														}
+													}
+												},
+												"stream-each": {
+													"version": "1.2.2",
+													"bundled": true,
+													"requires": {
+														"end-of-stream": "1.4.1",
+														"stream-shift": "1.0.0"
+													},
+													"dependencies": {
+														"stream-shift": {
+															"version": "1.0.0",
+															"bundled": true
+														}
+													}
+												},
+												"through2": {
+													"version": "2.0.3",
+													"bundled": true,
+													"requires": {
+														"readable-stream": "2.3.6",
+														"xtend": "4.0.1"
+													},
+													"dependencies": {
+														"xtend": {
+															"version": "4.0.1",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"node-fetch-npm": {
+											"version": "2.0.2",
+											"bundled": true,
+											"requires": {
+												"encoding": "0.1.12",
+												"json-parse-better-errors": "1.0.2",
+												"safe-buffer": "5.1.1"
+											},
+											"dependencies": {
+												"encoding": {
+													"version": "0.1.12",
+													"bundled": true,
+													"requires": {
+														"iconv-lite": "0.4.21"
+													},
+													"dependencies": {
+														"iconv-lite": {
+															"version": "0.4.21",
+															"bundled": true,
+															"requires": {
+																"safer-buffer": "2.1.2"
+															},
+															"dependencies": {
+																"safer-buffer": {
+																	"version": "2.1.2",
+																	"bundled": true
+																}
+															}
+														}
+													}
+												}
+											}
+										},
+										"socks-proxy-agent": {
+											"version": "3.0.1",
+											"bundled": true,
+											"requires": {
+												"agent-base": "4.2.0",
+												"socks": "1.1.10"
+											},
+											"dependencies": {
+												"agent-base": {
+													"version": "4.2.0",
+													"bundled": true,
+													"requires": {
+														"es6-promisify": "5.0.0"
+													},
+													"dependencies": {
+														"es6-promisify": {
+															"version": "5.0.0",
+															"bundled": true,
+															"requires": {
+																"es6-promise": "4.2.4"
+															},
+															"dependencies": {
+																"es6-promise": {
+																	"version": "4.2.4",
+																	"bundled": true
+																}
+															}
+														}
+													}
+												},
+												"socks": {
+													"version": "1.1.10",
+													"bundled": true,
+													"requires": {
+														"ip": "1.1.5",
+														"smart-buffer": "1.1.15"
+													},
+													"dependencies": {
+														"ip": {
+															"version": "1.1.5",
+															"bundled": true
+														},
+														"smart-buffer": {
+															"version": "1.1.15",
+															"bundled": true
+														}
+													}
+												}
+											}
+										}
+									}
+								},
+								"minimatch": {
+									"version": "3.0.4",
+									"bundled": true,
+									"requires": {
+										"brace-expansion": "1.1.11"
+									},
+									"dependencies": {
+										"brace-expansion": {
+											"version": "1.1.11",
+											"bundled": true,
+											"requires": {
+												"balanced-match": "1.0.0",
+												"concat-map": "0.0.1"
+											},
+											"dependencies": {
+												"balanced-match": {
+													"version": "1.0.0",
+													"bundled": true
+												},
+												"concat-map": {
+													"version": "0.0.1",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"promise-retry": {
+									"version": "1.1.1",
+									"bundled": true,
+									"requires": {
+										"err-code": "1.1.2",
+										"retry": "0.10.1"
+									},
+									"dependencies": {
+										"err-code": {
+											"version": "1.1.2",
+											"bundled": true
+										},
+										"retry": {
+											"version": "0.10.1",
+											"bundled": true
+										}
+									}
+								},
+								"ssri": {
+									"version": "5.3.0",
+									"bundled": true,
+									"requires": {
+										"safe-buffer": "5.1.1"
+									}
+								}
+							}
+						},
+						"protoduck": {
+							"version": "5.0.0",
+							"bundled": true,
+							"requires": {
+								"genfun": "4.0.1"
+							},
+							"dependencies": {
+								"genfun": {
+									"version": "4.0.1",
+									"bundled": true
+								}
+							}
+						}
+					}
+				},
+				"libnpmhook": {
+					"version": "4.0.1",
+					"bundled": true,
+					"requires": {
+						"figgy-pudding": "3.1.0",
+						"npm-registry-fetch": "3.1.1"
+					},
+					"dependencies": {
+						"npm-registry-fetch": {
+							"version": "3.1.1",
+							"bundled": true,
+							"requires": {
+								"bluebird": "3.5.1",
+								"figgy-pudding": "3.1.0",
+								"lru-cache": "4.1.2",
+								"make-fetch-happen": "4.0.1",
+								"npm-package-arg": "6.1.0"
+							},
+							"dependencies": {
+								"make-fetch-happen": {
+									"version": "4.0.1",
+									"bundled": true,
+									"requires": {
+										"agentkeepalive": "3.4.1",
+										"cacache": "11.0.1",
+										"http-cache-semantics": "3.8.1",
+										"http-proxy-agent": "2.1.0",
+										"https-proxy-agent": "2.2.1",
+										"lru-cache": "4.1.2",
+										"mississippi": "3.0.0",
+										"node-fetch-npm": "2.0.2",
+										"promise-retry": "1.1.1",
+										"socks-proxy-agent": "4.0.0",
+										"ssri": "6.0.0"
+									},
+									"dependencies": {
+										"agentkeepalive": {
+											"version": "3.4.1",
+											"bundled": true,
+											"requires": {
+												"humanize-ms": "1.2.1"
+											},
+											"dependencies": {
+												"humanize-ms": {
+													"version": "1.2.1",
+													"bundled": true,
+													"requires": {
+														"ms": "2.1.1"
+													},
+													"dependencies": {
+														"ms": {
+															"version": "2.1.1",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"http-cache-semantics": {
+											"version": "3.8.1",
+											"bundled": true
+										},
+										"http-proxy-agent": {
+											"version": "2.1.0",
+											"bundled": true,
+											"requires": {
+												"agent-base": "4.2.0",
+												"debug": "3.1.0"
+											},
+											"dependencies": {
+												"agent-base": {
+													"version": "4.2.0",
+													"bundled": true,
+													"requires": {
+														"es6-promisify": "5.0.0"
+													},
+													"dependencies": {
+														"es6-promisify": {
+															"version": "5.0.0",
+															"bundled": true,
+															"requires": {
+																"es6-promise": "4.2.4"
+															},
+															"dependencies": {
+																"es6-promise": {
+																	"version": "4.2.4",
+																	"bundled": true
+																}
+															}
+														}
+													}
+												},
+												"debug": {
+													"version": "3.1.0",
+													"bundled": true,
+													"requires": {
+														"ms": "2.0.0"
+													},
+													"dependencies": {
+														"ms": {
+															"version": "2.0.0",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"https-proxy-agent": {
+											"version": "2.2.1",
+											"bundled": true,
+											"requires": {
+												"agent-base": "4.2.0",
+												"debug": "3.1.0"
+											},
+											"dependencies": {
+												"agent-base": {
+													"version": "4.2.0",
+													"bundled": true,
+													"requires": {
+														"es6-promisify": "5.0.0"
+													},
+													"dependencies": {
+														"es6-promisify": {
+															"version": "5.0.0",
+															"bundled": true,
+															"requires": {
+																"es6-promise": "4.2.4"
+															},
+															"dependencies": {
+																"es6-promise": {
+																	"version": "4.2.4",
+																	"bundled": true
+																}
+															}
+														}
+													}
+												},
+												"debug": {
+													"version": "3.1.0",
+													"bundled": true,
+													"requires": {
+														"ms": "2.0.0"
+													},
+													"dependencies": {
+														"ms": {
+															"version": "2.0.0",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"node-fetch-npm": {
+											"version": "2.0.2",
+											"bundled": true,
+											"requires": {
+												"encoding": "0.1.12",
+												"json-parse-better-errors": "1.0.2",
+												"safe-buffer": "5.1.1"
+											},
+											"dependencies": {
+												"encoding": {
+													"version": "0.1.12",
+													"bundled": true,
+													"requires": {
+														"iconv-lite": "0.4.21"
+													},
+													"dependencies": {
+														"iconv-lite": {
+															"version": "0.4.21",
+															"bundled": true,
+															"requires": {
+																"safer-buffer": "2.1.2"
+															},
+															"dependencies": {
+																"safer-buffer": {
+																	"version": "2.1.2",
+																	"bundled": true
+																}
+															}
+														}
+													}
+												}
+											}
+										},
+										"promise-retry": {
+											"version": "1.1.1",
+											"bundled": true,
+											"requires": {
+												"err-code": "1.1.2",
+												"retry": "0.10.1"
+											},
+											"dependencies": {
+												"err-code": {
+													"version": "1.1.2",
+													"bundled": true
+												},
+												"retry": {
+													"version": "0.10.1",
+													"bundled": true
+												}
+											}
+										},
+										"socks-proxy-agent": {
+											"version": "4.0.0",
+											"bundled": true,
+											"requires": {
+												"agent-base": "4.1.2",
+												"socks": "2.1.6"
+											},
+											"dependencies": {
+												"agent-base": {
+													"version": "4.1.2",
+													"bundled": true,
+													"requires": {
+														"es6-promisify": "5.0.0"
+													},
+													"dependencies": {
+														"es6-promisify": {
+															"version": "5.0.0",
+															"bundled": true,
+															"requires": {
+																"es6-promise": "4.2.4"
+															},
+															"dependencies": {
+																"es6-promise": {
+																	"version": "4.2.4",
+																	"bundled": true
+																}
+															}
+														}
+													}
+												},
+												"socks": {
+													"version": "2.1.6",
+													"bundled": true,
+													"requires": {
+														"ip": "1.1.5",
+														"smart-buffer": "4.0.1"
+													},
+													"dependencies": {
+														"ip": {
+															"version": "1.1.5",
+															"bundled": true
+														},
+														"smart-buffer": {
+															"version": "4.0.1",
+															"bundled": true
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"libnpx": {
+					"version": "10.2.0",
+					"bundled": true,
+					"requires": {
+						"dotenv": "5.0.1",
+						"npm-package-arg": "6.1.0",
+						"rimraf": "2.6.2",
+						"safe-buffer": "5.1.1",
+						"update-notifier": "2.4.0",
+						"which": "1.3.0",
+						"y18n": "4.0.0",
+						"yargs": "11.0.0"
+					},
+					"dependencies": {
+						"dotenv": {
+							"version": "5.0.1",
+							"bundled": true
+						},
+						"y18n": {
+							"version": "4.0.0",
+							"bundled": true
+						},
+						"yargs": {
+							"version": "11.0.0",
+							"bundled": true,
+							"requires": {
+								"cliui": "4.0.0",
+								"decamelize": "1.2.0",
+								"find-up": "2.1.0",
+								"get-caller-file": "1.0.2",
+								"os-locale": "2.1.0",
+								"require-directory": "2.1.1",
+								"require-main-filename": "1.0.1",
+								"set-blocking": "2.0.0",
+								"string-width": "2.1.1",
+								"which-module": "2.0.0",
+								"y18n": "3.2.1",
+								"yargs-parser": "9.0.2"
+							},
+							"dependencies": {
+								"cliui": {
+									"version": "4.0.0",
+									"bundled": true,
+									"requires": {
+										"string-width": "2.1.1",
+										"strip-ansi": "4.0.0",
+										"wrap-ansi": "2.1.0"
+									},
+									"dependencies": {
+										"wrap-ansi": {
+											"version": "2.1.0",
+											"bundled": true,
+											"requires": {
+												"string-width": "1.0.2",
+												"strip-ansi": "3.0.1"
+											},
+											"dependencies": {
+												"string-width": {
+													"version": "1.0.2",
+													"bundled": true,
+													"requires": {
+														"code-point-at": "1.1.0",
+														"is-fullwidth-code-point": "1.0.0",
+														"strip-ansi": "3.0.1"
+													},
+													"dependencies": {
+														"code-point-at": {
+															"version": "1.1.0",
+															"bundled": true
+														},
+														"is-fullwidth-code-point": {
+															"version": "1.0.0",
+															"bundled": true,
+															"requires": {
+																"number-is-nan": "1.0.1"
+															},
+															"dependencies": {
+																"number-is-nan": {
+																	"version": "1.0.1",
+																	"bundled": true
+																}
+															}
+														}
+													}
+												},
+												"strip-ansi": {
+													"version": "3.0.1",
+													"bundled": true,
+													"requires": {
+														"ansi-regex": "2.1.1"
+													},
+													"dependencies": {
+														"ansi-regex": {
+															"version": "2.1.1",
+															"bundled": true
+														}
+													}
+												}
+											}
+										}
+									}
+								},
+								"decamelize": {
+									"version": "1.2.0",
+									"bundled": true
+								},
+								"find-up": {
+									"version": "2.1.0",
+									"bundled": true,
+									"requires": {
+										"locate-path": "2.0.0"
+									},
+									"dependencies": {
+										"locate-path": {
+											"version": "2.0.0",
+											"bundled": true,
+											"requires": {
+												"p-locate": "2.0.0",
+												"path-exists": "3.0.0"
+											},
+											"dependencies": {
+												"p-locate": {
+													"version": "2.0.0",
+													"bundled": true,
+													"requires": {
+														"p-limit": "1.2.0"
+													},
+													"dependencies": {
+														"p-limit": {
+															"version": "1.2.0",
+															"bundled": true,
+															"requires": {
+																"p-try": "1.0.0"
+															},
+															"dependencies": {
+																"p-try": {
+																	"version": "1.0.0",
+																	"bundled": true
+																}
+															}
+														}
+													}
+												},
+												"path-exists": {
+													"version": "3.0.0",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"get-caller-file": {
+									"version": "1.0.2",
+									"bundled": true
+								},
+								"os-locale": {
+									"version": "2.1.0",
+									"bundled": true,
+									"requires": {
+										"execa": "0.7.0",
+										"lcid": "1.0.0",
+										"mem": "1.1.0"
+									},
+									"dependencies": {
+										"execa": {
+											"version": "0.7.0",
+											"bundled": true,
+											"requires": {
+												"cross-spawn": "5.1.0",
+												"get-stream": "3.0.0",
+												"is-stream": "1.1.0",
+												"npm-run-path": "2.0.2",
+												"p-finally": "1.0.0",
+												"signal-exit": "3.0.2",
+												"strip-eof": "1.0.0"
+											},
+											"dependencies": {
+												"cross-spawn": {
+													"version": "5.1.0",
+													"bundled": true,
+													"requires": {
+														"lru-cache": "4.1.2",
+														"shebang-command": "1.2.0",
+														"which": "1.3.0"
+													},
+													"dependencies": {
+														"shebang-command": {
+															"version": "1.2.0",
+															"bundled": true,
+															"requires": {
+																"shebang-regex": "1.0.0"
+															},
+															"dependencies": {
+																"shebang-regex": {
+																	"version": "1.0.0",
+																	"bundled": true
+																}
+															}
+														}
+													}
+												},
+												"get-stream": {
+													"version": "3.0.0",
+													"bundled": true
+												},
+												"is-stream": {
+													"version": "1.1.0",
+													"bundled": true
+												},
+												"npm-run-path": {
+													"version": "2.0.2",
+													"bundled": true,
+													"requires": {
+														"path-key": "2.0.1"
+													},
+													"dependencies": {
+														"path-key": {
+															"version": "2.0.1",
+															"bundled": true
+														}
+													}
+												},
+												"p-finally": {
+													"version": "1.0.0",
+													"bundled": true
+												},
+												"signal-exit": {
+													"version": "3.0.2",
+													"bundled": true
+												},
+												"strip-eof": {
+													"version": "1.0.0",
+													"bundled": true
+												}
+											}
+										},
+										"lcid": {
+											"version": "1.0.0",
+											"bundled": true,
+											"requires": {
+												"invert-kv": "1.0.0"
+											},
+											"dependencies": {
+												"invert-kv": {
+													"version": "1.0.0",
+													"bundled": true
+												}
+											}
+										},
+										"mem": {
+											"version": "1.1.0",
+											"bundled": true,
+											"requires": {
+												"mimic-fn": "1.2.0"
+											},
+											"dependencies": {
+												"mimic-fn": {
+													"version": "1.2.0",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"require-directory": {
+									"version": "2.1.1",
+									"bundled": true
+								},
+								"require-main-filename": {
+									"version": "1.0.1",
+									"bundled": true
+								},
+								"set-blocking": {
+									"version": "2.0.0",
+									"bundled": true
+								},
+								"string-width": {
+									"version": "2.1.1",
+									"bundled": true,
+									"requires": {
+										"is-fullwidth-code-point": "2.0.0",
+										"strip-ansi": "4.0.0"
+									},
+									"dependencies": {
+										"is-fullwidth-code-point": {
+											"version": "2.0.0",
+											"bundled": true
+										}
+									}
+								},
+								"which-module": {
+									"version": "2.0.0",
+									"bundled": true
+								},
+								"y18n": {
+									"version": "3.2.1",
+									"bundled": true
+								},
+								"yargs-parser": {
+									"version": "9.0.2",
+									"bundled": true,
+									"requires": {
+										"camelcase": "4.1.0"
+									},
+									"dependencies": {
+										"camelcase": {
+											"version": "4.1.0",
+											"bundled": true
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"lockfile": {
+					"version": "1.0.3",
+					"bundled": true
+				},
+				"lodash._baseindexof": {
+					"version": "3.1.0",
+					"bundled": true
+				},
+				"lodash._baseuniq": {
+					"version": "4.6.0",
+					"bundled": true,
+					"requires": {
+						"lodash._createset": "4.0.3",
+						"lodash._root": "3.0.1"
+					},
+					"dependencies": {
+						"lodash._createset": {
+							"version": "4.0.3",
+							"bundled": true
+						},
+						"lodash._root": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"lodash._bindcallback": {
+					"version": "3.0.1",
+					"bundled": true
+				},
+				"lodash._cacheindexof": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"lodash._createcache": {
+					"version": "3.1.2",
+					"bundled": true,
+					"requires": {
+						"lodash._getnative": "3.9.1"
+					}
+				},
+				"lodash._getnative": {
+					"version": "3.9.1",
+					"bundled": true
+				},
+				"lodash.clonedeep": {
+					"version": "4.5.0",
+					"bundled": true
+				},
+				"lodash.restparam": {
+					"version": "3.6.1",
+					"bundled": true
+				},
+				"lodash.union": {
+					"version": "4.6.0",
+					"bundled": true
+				},
+				"lodash.uniq": {
+					"version": "4.5.0",
+					"bundled": true
+				},
+				"lodash.without": {
+					"version": "4.4.0",
+					"bundled": true
+				},
+				"lru-cache": {
+					"version": "4.1.2",
+					"bundled": true,
+					"requires": {
+						"pseudomap": "1.0.2",
+						"yallist": "2.1.2"
+					},
+					"dependencies": {
+						"pseudomap": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"yallist": {
+							"version": "2.1.2",
+							"bundled": true
+						}
+					}
+				},
+				"meant": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"mississippi": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"concat-stream": "1.6.1",
+						"duplexify": "3.5.4",
+						"end-of-stream": "1.4.1",
+						"flush-write-stream": "1.0.2",
+						"from2": "2.3.0",
+						"parallel-transform": "1.1.0",
+						"pump": "3.0.0",
+						"pumpify": "1.4.0",
+						"stream-each": "1.2.2",
+						"through2": "2.0.3"
+					},
+					"dependencies": {
+						"concat-stream": {
+							"version": "1.6.1",
+							"bundled": true,
+							"requires": {
+								"inherits": "2.0.3",
+								"readable-stream": "2.3.6",
+								"typedarray": "0.0.6"
+							},
+							"dependencies": {
+								"typedarray": {
+									"version": "0.0.6",
+									"bundled": true
+								}
+							}
+						},
+						"duplexify": {
+							"version": "3.5.4",
+							"bundled": true,
+							"requires": {
+								"end-of-stream": "1.4.1",
+								"inherits": "2.0.3",
+								"readable-stream": "2.3.6",
+								"stream-shift": "1.0.0"
+							},
+							"dependencies": {
+								"stream-shift": {
+									"version": "1.0.0",
+									"bundled": true
+								}
+							}
+						},
+						"end-of-stream": {
+							"version": "1.4.1",
+							"bundled": true,
+							"requires": {
+								"once": "1.4.0"
+							}
+						},
+						"flush-write-stream": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"inherits": "2.0.3",
+								"readable-stream": "2.3.6"
+							}
+						},
+						"from2": {
+							"version": "2.3.0",
+							"bundled": true,
+							"requires": {
+								"inherits": "2.0.3",
+								"readable-stream": "2.3.6"
+							}
+						},
+						"parallel-transform": {
+							"version": "1.1.0",
+							"bundled": true,
+							"requires": {
+								"cyclist": "0.2.2",
+								"inherits": "2.0.3",
+								"readable-stream": "2.3.6"
+							},
+							"dependencies": {
+								"cyclist": {
+									"version": "0.2.2",
+									"bundled": true
+								}
+							}
+						},
+						"pump": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"end-of-stream": "1.4.1",
+								"once": "1.4.0"
+							}
+						},
+						"pumpify": {
+							"version": "1.4.0",
+							"bundled": true,
+							"requires": {
+								"duplexify": "3.5.4",
+								"inherits": "2.0.3",
+								"pump": "2.0.1"
+							},
+							"dependencies": {
+								"pump": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"end-of-stream": "1.4.1",
+										"once": "1.4.0"
+									}
+								}
+							}
+						},
+						"stream-each": {
+							"version": "1.2.2",
+							"bundled": true,
+							"requires": {
+								"end-of-stream": "1.4.1",
+								"stream-shift": "1.0.0"
+							},
+							"dependencies": {
+								"stream-shift": {
+									"version": "1.0.0",
+									"bundled": true
+								}
+							}
+						},
+						"through2": {
+							"version": "2.0.3",
+							"bundled": true,
+							"requires": {
+								"readable-stream": "2.3.6",
+								"xtend": "4.0.1"
+							},
+							"dependencies": {
+								"xtend": {
+									"version": "4.0.1",
+									"bundled": true
+								}
+							}
+						}
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true
+						}
+					}
+				},
+				"move-concurrently": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"aproba": "1.2.0",
+						"copy-concurrently": "1.0.5",
+						"fs-write-stream-atomic": "1.0.10",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.2",
+						"run-queue": "1.0.3"
+					},
+					"dependencies": {
+						"copy-concurrently": {
+							"version": "1.0.5",
+							"bundled": true,
+							"requires": {
+								"aproba": "1.2.0",
+								"fs-write-stream-atomic": "1.0.10",
+								"iferr": "0.1.5",
+								"mkdirp": "0.5.1",
+								"rimraf": "2.6.2",
+								"run-queue": "1.0.3"
+							},
+							"dependencies": {
+								"iferr": {
+									"version": "0.1.5",
+									"bundled": true
+								}
+							}
+						},
+						"run-queue": {
+							"version": "1.0.3",
+							"bundled": true,
+							"requires": {
+								"aproba": "1.2.0"
+							}
+						}
+					}
+				},
+				"node-gyp": {
+					"version": "3.6.2",
+					"bundled": true,
+					"requires": {
+						"fstream": "1.0.11",
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"minimatch": "3.0.4",
+						"mkdirp": "0.5.1",
+						"nopt": "3.0.6",
+						"npmlog": "4.1.2",
+						"osenv": "0.1.5",
+						"request": "2.85.0",
+						"rimraf": "2.6.2",
+						"semver": "5.3.0",
+						"tar": "2.2.1",
+						"which": "1.3.0"
+					},
+					"dependencies": {
+						"fstream": {
+							"version": "1.0.11",
+							"bundled": true,
+							"requires": {
+								"graceful-fs": "4.1.11",
+								"inherits": "2.0.3",
+								"mkdirp": "0.5.1",
+								"rimraf": "2.6.2"
+							}
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"requires": {
+								"brace-expansion": "1.1.11"
+							},
+							"dependencies": {
+								"brace-expansion": {
+									"version": "1.1.11",
+									"bundled": true,
+									"requires": {
+										"balanced-match": "1.0.0",
+										"concat-map": "0.0.1"
+									},
+									"dependencies": {
+										"balanced-match": {
+											"version": "1.0.0",
+											"bundled": true
+										},
+										"concat-map": {
+											"version": "0.0.1",
+											"bundled": true
+										}
+									}
+								}
+							}
+						},
+						"nopt": {
+							"version": "3.0.6",
+							"bundled": true,
+							"requires": {
+								"abbrev": "1.1.1"
+							}
+						},
+						"semver": {
+							"version": "5.3.0",
+							"bundled": true
+						},
+						"tar": {
+							"version": "2.2.1",
+							"bundled": true,
+							"requires": {
+								"block-stream": "0.0.9",
+								"fstream": "1.0.11",
+								"inherits": "2.0.3"
+							},
+							"dependencies": {
+								"block-stream": {
+									"version": "0.0.9",
+									"bundled": true,
+									"requires": {
+										"inherits": "2.0.3"
+									}
+								}
+							}
+						}
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"bundled": true,
+					"requires": {
+						"abbrev": "1.1.1",
+						"osenv": "0.1.5"
+					}
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"bundled": true,
+					"requires": {
+						"hosted-git-info": "2.6.0",
+						"is-builtin-module": "1.0.0",
+						"semver": "5.5.0",
+						"validate-npm-package-license": "3.0.3"
+					},
+					"dependencies": {
+						"is-builtin-module": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"builtin-modules": "1.1.1"
+							},
+							"dependencies": {
+								"builtin-modules": {
+									"version": "1.1.1",
+									"bundled": true
+								}
+							}
+						}
+					}
+				},
+				"npm-audit-report": {
+					"version": "1.0.5",
+					"bundled": true,
+					"requires": {
+						"ansicolors": "0.3.2",
+						"ansistyles": "0.1.3",
+						"cli-table2": "0.2.0"
+					}
+				},
+				"npm-cache-filename": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"npm-install-checks": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"semver": "5.5.0"
+					}
+				},
+				"npm-lifecycle": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"byline": "5.0.0",
+						"graceful-fs": "4.1.11",
+						"node-gyp": "3.6.2",
+						"resolve-from": "4.0.0",
+						"slide": "1.1.6",
+						"uid-number": "0.0.6",
+						"umask": "1.1.0",
+						"which": "1.3.0"
+					},
+					"dependencies": {
+						"byline": {
+							"version": "5.0.0",
+							"bundled": true
+						},
+						"resolve-from": {
+							"version": "4.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"npm-package-arg": {
+					"version": "6.1.0",
+					"bundled": true,
+					"requires": {
+						"hosted-git-info": "2.6.0",
+						"osenv": "0.1.5",
+						"semver": "5.5.0",
+						"validate-npm-package-name": "3.0.0"
+					}
+				},
+				"npm-packlist": {
+					"version": "1.1.10",
+					"bundled": true,
+					"requires": {
+						"ignore-walk": "3.0.1",
+						"npm-bundled": "1.0.3"
+					},
+					"dependencies": {
+						"ignore-walk": {
+							"version": "3.0.1",
+							"bundled": true,
+							"requires": {
+								"minimatch": "3.0.4"
+							},
+							"dependencies": {
+								"minimatch": {
+									"version": "3.0.4",
+									"bundled": true,
+									"requires": {
+										"brace-expansion": "1.1.8"
+									},
+									"dependencies": {
+										"brace-expansion": {
+											"version": "1.1.8",
+											"bundled": true,
+											"requires": {
+												"balanced-match": "1.0.0",
+												"concat-map": "0.0.1"
+											},
+											"dependencies": {
+												"balanced-match": {
+													"version": "1.0.0",
+													"bundled": true
+												},
+												"concat-map": {
+													"version": "0.0.1",
+													"bundled": true
+												}
+											}
+										}
+									}
+								}
+							}
+						},
+						"npm-bundled": {
+							"version": "1.0.3",
+							"bundled": true
+						}
+					}
+				},
+				"npm-pick-manifest": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"npm-package-arg": "6.1.0",
+						"semver": "5.5.0"
+					}
+				},
+				"npm-profile": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"aproba": "1.2.0",
+						"make-fetch-happen": "2.6.0"
+					},
+					"dependencies": {
+						"make-fetch-happen": {
+							"version": "2.6.0",
+							"bundled": true,
+							"requires": {
+								"agentkeepalive": "3.3.0",
+								"cacache": "10.0.4",
+								"http-cache-semantics": "3.8.1",
+								"http-proxy-agent": "2.0.0",
+								"https-proxy-agent": "2.1.1",
+								"lru-cache": "4.1.2",
+								"mississippi": "1.3.1",
+								"node-fetch-npm": "2.0.2",
+								"promise-retry": "1.1.1",
+								"socks-proxy-agent": "3.0.1",
+								"ssri": "5.3.0"
+							},
+							"dependencies": {
+								"agentkeepalive": {
+									"version": "3.3.0",
+									"bundled": true,
+									"requires": {
+										"humanize-ms": "1.2.1"
+									},
+									"dependencies": {
+										"humanize-ms": {
+											"version": "1.2.1",
+											"bundled": true,
+											"requires": {
+												"ms": "2.1.1"
+											},
+											"dependencies": {
+												"ms": {
+													"version": "2.1.1",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"cacache": {
+									"version": "10.0.4",
+									"bundled": true,
+									"requires": {
+										"bluebird": "3.5.1",
+										"chownr": "1.0.1",
+										"glob": "7.1.2",
+										"graceful-fs": "4.1.11",
+										"lru-cache": "4.1.2",
+										"mississippi": "2.0.0",
+										"mkdirp": "0.5.1",
+										"move-concurrently": "1.0.1",
+										"promise-inflight": "1.0.1",
+										"rimraf": "2.6.2",
+										"ssri": "5.3.0",
+										"unique-filename": "1.1.0",
+										"y18n": "4.0.0"
+									},
+									"dependencies": {
+										"mississippi": {
+											"version": "2.0.0",
+											"bundled": true,
+											"requires": {
+												"concat-stream": "1.6.2",
+												"duplexify": "3.5.4",
+												"end-of-stream": "1.4.1",
+												"flush-write-stream": "1.0.3",
+												"from2": "2.3.0",
+												"parallel-transform": "1.1.0",
+												"pump": "2.0.1",
+												"pumpify": "1.4.0",
+												"stream-each": "1.2.2",
+												"through2": "2.0.3"
+											},
+											"dependencies": {
+												"concat-stream": {
+													"version": "1.6.2",
+													"bundled": true,
+													"requires": {
+														"buffer-from": "1.0.0",
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6",
+														"typedarray": "0.0.6"
+													},
+													"dependencies": {
+														"buffer-from": {
+															"version": "1.0.0",
+															"bundled": true
+														},
+														"typedarray": {
+															"version": "0.0.6",
+															"bundled": true
+														}
+													}
+												},
+												"duplexify": {
+													"version": "3.5.4",
+													"bundled": true,
+													"requires": {
+														"end-of-stream": "1.4.1",
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6",
+														"stream-shift": "1.0.0"
+													},
+													"dependencies": {
+														"stream-shift": {
+															"version": "1.0.0",
+															"bundled": true
+														}
+													}
+												},
+												"end-of-stream": {
+													"version": "1.4.1",
+													"bundled": true,
+													"requires": {
+														"once": "1.4.0"
+													}
+												},
+												"flush-write-stream": {
+													"version": "1.0.3",
+													"bundled": true,
+													"requires": {
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6"
+													}
+												},
+												"from2": {
+													"version": "2.3.0",
+													"bundled": true,
+													"requires": {
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6"
+													}
+												},
+												"parallel-transform": {
+													"version": "1.1.0",
+													"bundled": true,
+													"requires": {
+														"cyclist": "0.2.2",
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6"
+													},
+													"dependencies": {
+														"cyclist": {
+															"version": "0.2.2",
+															"bundled": true
+														}
+													}
+												},
+												"pump": {
+													"version": "2.0.1",
+													"bundled": true,
+													"requires": {
+														"end-of-stream": "1.4.1",
+														"once": "1.4.0"
+													}
+												},
+												"pumpify": {
+													"version": "1.4.0",
+													"bundled": true,
+													"requires": {
+														"duplexify": "3.5.4",
+														"inherits": "2.0.3",
+														"pump": "2.0.1"
+													}
+												},
+												"stream-each": {
+													"version": "1.2.2",
+													"bundled": true,
+													"requires": {
+														"end-of-stream": "1.4.1",
+														"stream-shift": "1.0.0"
+													},
+													"dependencies": {
+														"stream-shift": {
+															"version": "1.0.0",
+															"bundled": true
+														}
+													}
+												},
+												"through2": {
+													"version": "2.0.3",
+													"bundled": true,
+													"requires": {
+														"readable-stream": "2.3.6",
+														"xtend": "4.0.1"
+													},
+													"dependencies": {
+														"xtend": {
+															"version": "4.0.1",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"y18n": {
+											"version": "4.0.0",
+											"bundled": true
+										}
+									}
+								},
+								"http-cache-semantics": {
+									"version": "3.8.1",
+									"bundled": true
+								},
+								"http-proxy-agent": {
+									"version": "2.0.0",
+									"bundled": true,
+									"requires": {
+										"agent-base": "4.2.0",
+										"debug": "2.6.9"
+									},
+									"dependencies": {
+										"agent-base": {
+											"version": "4.2.0",
+											"bundled": true,
+											"requires": {
+												"es6-promisify": "5.0.0"
+											},
+											"dependencies": {
+												"es6-promisify": {
+													"version": "5.0.0",
+													"bundled": true,
+													"requires": {
+														"es6-promise": "4.2.4"
+													},
+													"dependencies": {
+														"es6-promise": {
+															"version": "4.2.4",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"debug": {
+											"version": "2.6.9",
+											"bundled": true,
+											"requires": {
+												"ms": "2.0.0"
+											},
+											"dependencies": {
+												"ms": {
+													"version": "2.0.0",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"https-proxy-agent": {
+									"version": "2.1.1",
+									"bundled": true,
+									"requires": {
+										"agent-base": "4.2.0",
+										"debug": "3.1.0"
+									},
+									"dependencies": {
+										"agent-base": {
+											"version": "4.2.0",
+											"bundled": true,
+											"requires": {
+												"es6-promisify": "5.0.0"
+											},
+											"dependencies": {
+												"es6-promisify": {
+													"version": "5.0.0",
+													"bundled": true,
+													"requires": {
+														"es6-promise": "4.2.4"
+													},
+													"dependencies": {
+														"es6-promise": {
+															"version": "4.2.4",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"debug": {
+											"version": "3.1.0",
+											"bundled": true,
+											"requires": {
+												"ms": "2.0.0"
+											},
+											"dependencies": {
+												"ms": {
+													"version": "2.0.0",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"mississippi": {
+									"version": "1.3.1",
+									"bundled": true,
+									"requires": {
+										"concat-stream": "1.6.0",
+										"duplexify": "3.5.3",
+										"end-of-stream": "1.4.1",
+										"flush-write-stream": "1.0.2",
+										"from2": "2.3.0",
+										"parallel-transform": "1.1.0",
+										"pump": "1.0.3",
+										"pumpify": "1.4.0",
+										"stream-each": "1.2.2",
+										"through2": "2.0.3"
+									},
+									"dependencies": {
+										"concat-stream": {
+											"version": "1.6.0",
+											"bundled": true,
+											"requires": {
+												"inherits": "2.0.3",
+												"readable-stream": "2.3.6",
+												"typedarray": "0.0.6"
+											},
+											"dependencies": {
+												"typedarray": {
+													"version": "0.0.6",
+													"bundled": true
+												}
+											}
+										},
+										"duplexify": {
+											"version": "3.5.3",
+											"bundled": true,
+											"requires": {
+												"end-of-stream": "1.4.1",
+												"inherits": "2.0.3",
+												"readable-stream": "2.3.6",
+												"stream-shift": "1.0.0"
+											},
+											"dependencies": {
+												"stream-shift": {
+													"version": "1.0.0",
+													"bundled": true
+												}
+											}
+										},
+										"end-of-stream": {
+											"version": "1.4.1",
+											"bundled": true,
+											"requires": {
+												"once": "1.4.0"
+											}
+										},
+										"flush-write-stream": {
+											"version": "1.0.2",
+											"bundled": true,
+											"requires": {
+												"inherits": "2.0.3",
+												"readable-stream": "2.3.6"
+											}
+										},
+										"from2": {
+											"version": "2.3.0",
+											"bundled": true,
+											"requires": {
+												"inherits": "2.0.3",
+												"readable-stream": "2.3.6"
+											}
+										},
+										"parallel-transform": {
+											"version": "1.1.0",
+											"bundled": true,
+											"requires": {
+												"cyclist": "0.2.2",
+												"inherits": "2.0.3",
+												"readable-stream": "2.3.6"
+											},
+											"dependencies": {
+												"cyclist": {
+													"version": "0.2.2",
+													"bundled": true
+												}
+											}
+										},
+										"pump": {
+											"version": "1.0.3",
+											"bundled": true,
+											"requires": {
+												"end-of-stream": "1.4.1",
+												"once": "1.4.0"
+											}
+										},
+										"pumpify": {
+											"version": "1.4.0",
+											"bundled": true,
+											"requires": {
+												"duplexify": "3.5.3",
+												"inherits": "2.0.3",
+												"pump": "2.0.1"
+											},
+											"dependencies": {
+												"pump": {
+													"version": "2.0.1",
+													"bundled": true,
+													"requires": {
+														"end-of-stream": "1.4.1",
+														"once": "1.4.0"
+													}
+												}
+											}
+										},
+										"stream-each": {
+											"version": "1.2.2",
+											"bundled": true,
+											"requires": {
+												"end-of-stream": "1.4.1",
+												"stream-shift": "1.0.0"
+											},
+											"dependencies": {
+												"stream-shift": {
+													"version": "1.0.0",
+													"bundled": true
+												}
+											}
+										},
+										"through2": {
+											"version": "2.0.3",
+											"bundled": true,
+											"requires": {
+												"readable-stream": "2.3.6",
+												"xtend": "4.0.1"
+											},
+											"dependencies": {
+												"xtend": {
+													"version": "4.0.1",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"node-fetch-npm": {
+									"version": "2.0.2",
+									"bundled": true,
+									"requires": {
+										"encoding": "0.1.12",
+										"json-parse-better-errors": "1.0.1",
+										"safe-buffer": "5.1.1"
+									},
+									"dependencies": {
+										"encoding": {
+											"version": "0.1.12",
+											"bundled": true,
+											"requires": {
+												"iconv-lite": "0.4.19"
+											},
+											"dependencies": {
+												"iconv-lite": {
+													"version": "0.4.19",
+													"bundled": true
+												}
+											}
+										},
+										"json-parse-better-errors": {
+											"version": "1.0.1",
+											"bundled": true
+										}
+									}
+								},
+								"promise-retry": {
+									"version": "1.1.1",
+									"bundled": true,
+									"requires": {
+										"err-code": "1.1.2",
+										"retry": "0.10.1"
+									},
+									"dependencies": {
+										"err-code": {
+											"version": "1.1.2",
+											"bundled": true
+										},
+										"retry": {
+											"version": "0.10.1",
+											"bundled": true
+										}
+									}
+								},
+								"socks-proxy-agent": {
+									"version": "3.0.1",
+									"bundled": true,
+									"requires": {
+										"agent-base": "4.2.0",
+										"socks": "1.1.10"
+									},
+									"dependencies": {
+										"agent-base": {
+											"version": "4.2.0",
+											"bundled": true,
+											"requires": {
+												"es6-promisify": "5.0.0"
+											},
+											"dependencies": {
+												"es6-promisify": {
+													"version": "5.0.0",
+													"bundled": true,
+													"requires": {
+														"es6-promise": "4.2.4"
+													},
+													"dependencies": {
+														"es6-promise": {
+															"version": "4.2.4",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"socks": {
+											"version": "1.1.10",
+											"bundled": true,
+											"requires": {
+												"ip": "1.1.5",
+												"smart-buffer": "1.1.15"
+											},
+											"dependencies": {
+												"ip": {
+													"version": "1.1.5",
+													"bundled": true
+												},
+												"smart-buffer": {
+													"version": "1.1.15",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"ssri": {
+									"version": "5.3.0",
+									"bundled": true,
+									"requires": {
+										"safe-buffer": "5.1.1"
+									}
+								}
+							}
+						}
+					}
+				},
+				"npm-registry-client": {
+					"version": "8.5.1",
+					"bundled": true,
+					"requires": {
+						"concat-stream": "1.6.1",
+						"graceful-fs": "4.1.11",
+						"normalize-package-data": "2.4.0",
+						"npm-package-arg": "6.1.0",
+						"npmlog": "4.1.2",
+						"once": "1.4.0",
+						"request": "2.85.0",
+						"retry": "0.10.1",
+						"safe-buffer": "5.1.1",
+						"semver": "5.5.0",
+						"slide": "1.1.6",
+						"ssri": "5.3.0"
+					},
+					"dependencies": {
+						"concat-stream": {
+							"version": "1.6.1",
+							"bundled": true,
+							"requires": {
+								"inherits": "2.0.3",
+								"readable-stream": "2.3.6",
+								"typedarray": "0.0.6"
+							},
+							"dependencies": {
+								"typedarray": {
+									"version": "0.0.6",
+									"bundled": true
+								}
+							}
+						},
+						"retry": {
+							"version": "0.10.1",
+							"bundled": true
+						},
+						"ssri": {
+							"version": "5.3.0",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "5.1.1"
+							}
+						}
+					}
+				},
+				"npm-registry-fetch": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"bluebird": "3.5.1",
+						"figgy-pudding": "2.0.1",
+						"lru-cache": "4.1.2",
+						"make-fetch-happen": "3.0.0",
+						"npm-package-arg": "6.1.0",
+						"safe-buffer": "5.1.1"
+					},
+					"dependencies": {
+						"figgy-pudding": {
+							"version": "2.0.1",
+							"bundled": true
+						},
+						"make-fetch-happen": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"agentkeepalive": "3.4.1",
+								"cacache": "10.0.4",
+								"http-cache-semantics": "3.8.1",
+								"http-proxy-agent": "2.1.0",
+								"https-proxy-agent": "2.2.1",
+								"lru-cache": "4.1.2",
+								"mississippi": "3.0.0",
+								"node-fetch-npm": "2.0.2",
+								"promise-retry": "1.1.1",
+								"socks-proxy-agent": "3.0.1",
+								"ssri": "5.3.0"
+							},
+							"dependencies": {
+								"agentkeepalive": {
+									"version": "3.4.1",
+									"bundled": true,
+									"requires": {
+										"humanize-ms": "1.2.1"
+									},
+									"dependencies": {
+										"humanize-ms": {
+											"version": "1.2.1",
+											"bundled": true,
+											"requires": {
+												"ms": "2.1.1"
+											},
+											"dependencies": {
+												"ms": {
+													"version": "2.1.1",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"cacache": {
+									"version": "10.0.4",
+									"bundled": true,
+									"requires": {
+										"bluebird": "3.5.1",
+										"chownr": "1.0.1",
+										"glob": "7.1.2",
+										"graceful-fs": "4.1.11",
+										"lru-cache": "4.1.2",
+										"mississippi": "2.0.0",
+										"mkdirp": "0.5.1",
+										"move-concurrently": "1.0.1",
+										"promise-inflight": "1.0.1",
+										"rimraf": "2.6.2",
+										"ssri": "5.3.0",
+										"unique-filename": "1.1.0",
+										"y18n": "4.0.0"
+									},
+									"dependencies": {
+										"mississippi": {
+											"version": "2.0.0",
+											"bundled": true,
+											"requires": {
+												"concat-stream": "1.6.2",
+												"duplexify": "3.5.4",
+												"end-of-stream": "1.4.1",
+												"flush-write-stream": "1.0.3",
+												"from2": "2.3.0",
+												"parallel-transform": "1.1.0",
+												"pump": "2.0.1",
+												"pumpify": "1.4.0",
+												"stream-each": "1.2.2",
+												"through2": "2.0.3"
+											},
+											"dependencies": {
+												"concat-stream": {
+													"version": "1.6.2",
+													"bundled": true,
+													"requires": {
+														"buffer-from": "1.0.0",
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6",
+														"typedarray": "0.0.6"
+													},
+													"dependencies": {
+														"buffer-from": {
+															"version": "1.0.0",
+															"bundled": true
+														},
+														"typedarray": {
+															"version": "0.0.6",
+															"bundled": true
+														}
+													}
+												},
+												"duplexify": {
+													"version": "3.5.4",
+													"bundled": true,
+													"requires": {
+														"end-of-stream": "1.4.1",
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6",
+														"stream-shift": "1.0.0"
+													},
+													"dependencies": {
+														"stream-shift": {
+															"version": "1.0.0",
+															"bundled": true
+														}
+													}
+												},
+												"end-of-stream": {
+													"version": "1.4.1",
+													"bundled": true,
+													"requires": {
+														"once": "1.4.0"
+													}
+												},
+												"flush-write-stream": {
+													"version": "1.0.3",
+													"bundled": true,
+													"requires": {
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6"
+													}
+												},
+												"from2": {
+													"version": "2.3.0",
+													"bundled": true,
+													"requires": {
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6"
+													}
+												},
+												"parallel-transform": {
+													"version": "1.1.0",
+													"bundled": true,
+													"requires": {
+														"cyclist": "0.2.2",
+														"inherits": "2.0.3",
+														"readable-stream": "2.3.6"
+													},
+													"dependencies": {
+														"cyclist": {
+															"version": "0.2.2",
+															"bundled": true
+														}
+													}
+												},
+												"pump": {
+													"version": "2.0.1",
+													"bundled": true,
+													"requires": {
+														"end-of-stream": "1.4.1",
+														"once": "1.4.0"
+													}
+												},
+												"pumpify": {
+													"version": "1.4.0",
+													"bundled": true,
+													"requires": {
+														"duplexify": "3.5.4",
+														"inherits": "2.0.3",
+														"pump": "2.0.1"
+													}
+												},
+												"stream-each": {
+													"version": "1.2.2",
+													"bundled": true,
+													"requires": {
+														"end-of-stream": "1.4.1",
+														"stream-shift": "1.0.0"
+													},
+													"dependencies": {
+														"stream-shift": {
+															"version": "1.0.0",
+															"bundled": true
+														}
+													}
+												},
+												"through2": {
+													"version": "2.0.3",
+													"bundled": true,
+													"requires": {
+														"readable-stream": "2.3.6",
+														"xtend": "4.0.1"
+													},
+													"dependencies": {
+														"xtend": {
+															"version": "4.0.1",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"y18n": {
+											"version": "4.0.0",
+											"bundled": true
+										}
+									}
+								},
+								"http-cache-semantics": {
+									"version": "3.8.1",
+									"bundled": true
+								},
+								"http-proxy-agent": {
+									"version": "2.1.0",
+									"bundled": true,
+									"requires": {
+										"agent-base": "4.2.0",
+										"debug": "3.1.0"
+									},
+									"dependencies": {
+										"agent-base": {
+											"version": "4.2.0",
+											"bundled": true,
+											"requires": {
+												"es6-promisify": "5.0.0"
+											},
+											"dependencies": {
+												"es6-promisify": {
+													"version": "5.0.0",
+													"bundled": true,
+													"requires": {
+														"es6-promise": "4.2.4"
+													},
+													"dependencies": {
+														"es6-promise": {
+															"version": "4.2.4",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"debug": {
+											"version": "3.1.0",
+											"bundled": true,
+											"requires": {
+												"ms": "2.0.0"
+											},
+											"dependencies": {
+												"ms": {
+													"version": "2.0.0",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"https-proxy-agent": {
+									"version": "2.2.1",
+									"bundled": true,
+									"requires": {
+										"agent-base": "4.2.0",
+										"debug": "3.1.0"
+									},
+									"dependencies": {
+										"agent-base": {
+											"version": "4.2.0",
+											"bundled": true,
+											"requires": {
+												"es6-promisify": "5.0.0"
+											},
+											"dependencies": {
+												"es6-promisify": {
+													"version": "5.0.0",
+													"bundled": true,
+													"requires": {
+														"es6-promise": "4.2.4"
+													},
+													"dependencies": {
+														"es6-promise": {
+															"version": "4.2.4",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"debug": {
+											"version": "3.1.0",
+											"bundled": true,
+											"requires": {
+												"ms": "2.0.0"
+											},
+											"dependencies": {
+												"ms": {
+													"version": "2.0.0",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"node-fetch-npm": {
+									"version": "2.0.2",
+									"bundled": true,
+									"requires": {
+										"encoding": "0.1.12",
+										"json-parse-better-errors": "1.0.2",
+										"safe-buffer": "5.1.1"
+									},
+									"dependencies": {
+										"encoding": {
+											"version": "0.1.12",
+											"bundled": true,
+											"requires": {
+												"iconv-lite": "0.4.21"
+											},
+											"dependencies": {
+												"iconv-lite": {
+													"version": "0.4.21",
+													"bundled": true,
+													"requires": {
+														"safer-buffer": "2.1.2"
+													},
+													"dependencies": {
+														"safer-buffer": {
+															"version": "2.1.2",
+															"bundled": true
+														}
+													}
+												}
+											}
+										}
+									}
+								},
+								"promise-retry": {
+									"version": "1.1.1",
+									"bundled": true,
+									"requires": {
+										"err-code": "1.1.2",
+										"retry": "0.10.1"
+									},
+									"dependencies": {
+										"err-code": {
+											"version": "1.1.2",
+											"bundled": true
+										},
+										"retry": {
+											"version": "0.10.1",
+											"bundled": true
+										}
+									}
+								},
+								"socks-proxy-agent": {
+									"version": "3.0.1",
+									"bundled": true,
+									"requires": {
+										"agent-base": "4.2.0",
+										"socks": "1.1.10"
+									},
+									"dependencies": {
+										"agent-base": {
+											"version": "4.2.0",
+											"bundled": true,
+											"requires": {
+												"es6-promisify": "5.0.0"
+											},
+											"dependencies": {
+												"es6-promisify": {
+													"version": "5.0.0",
+													"bundled": true,
+													"requires": {
+														"es6-promise": "4.2.4"
+													},
+													"dependencies": {
+														"es6-promise": {
+															"version": "4.2.4",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"socks": {
+											"version": "1.1.10",
+											"bundled": true,
+											"requires": {
+												"ip": "1.1.5",
+												"smart-buffer": "1.1.15"
+											},
+											"dependencies": {
+												"ip": {
+													"version": "1.1.5",
+													"bundled": true
+												},
+												"smart-buffer": {
+													"version": "1.1.15",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"ssri": {
+									"version": "5.3.0",
+									"bundled": true,
+									"requires": {
+										"safe-buffer": "5.1.1"
+									}
+								}
+							}
+						}
+					}
+				},
+				"npm-user-validate": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"npmlog": {
+					"version": "4.1.2",
+					"bundled": true,
+					"requires": {
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
+					},
+					"dependencies": {
+						"are-we-there-yet": {
+							"version": "1.1.4",
+							"bundled": true,
+							"requires": {
+								"delegates": "1.0.0",
+								"readable-stream": "2.3.6"
+							},
+							"dependencies": {
+								"delegates": {
+									"version": "1.0.0",
+									"bundled": true
+								}
+							}
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"requires": {
+								"aproba": "1.2.0",
+								"console-control-strings": "1.1.0",
+								"has-unicode": "2.0.1",
+								"object-assign": "4.1.1",
+								"signal-exit": "3.0.2",
+								"string-width": "1.0.2",
+								"strip-ansi": "3.0.1",
+								"wide-align": "1.1.2"
+							},
+							"dependencies": {
+								"object-assign": {
+									"version": "4.1.1",
+									"bundled": true
+								},
+								"signal-exit": {
+									"version": "3.0.2",
+									"bundled": true
+								},
+								"string-width": {
+									"version": "1.0.2",
+									"bundled": true,
+									"requires": {
+										"code-point-at": "1.1.0",
+										"is-fullwidth-code-point": "1.0.0",
+										"strip-ansi": "3.0.1"
+									},
+									"dependencies": {
+										"code-point-at": {
+											"version": "1.1.0",
+											"bundled": true
+										},
+										"is-fullwidth-code-point": {
+											"version": "1.0.0",
+											"bundled": true,
+											"requires": {
+												"number-is-nan": "1.0.1"
+											},
+											"dependencies": {
+												"number-is-nan": {
+													"version": "1.0.1",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"strip-ansi": {
+									"version": "3.0.1",
+									"bundled": true,
+									"requires": {
+										"ansi-regex": "2.1.1"
+									},
+									"dependencies": {
+										"ansi-regex": {
+											"version": "2.1.1",
+											"bundled": true
+										}
+									}
+								},
+								"wide-align": {
+									"version": "1.1.2",
+									"bundled": true,
+									"requires": {
+										"string-width": "1.0.2"
+									}
+								}
+							}
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"opener": {
+					"version": "1.4.3",
+					"bundled": true
+				},
+				"osenv": {
+					"version": "0.1.5",
+					"bundled": true,
+					"requires": {
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
+					},
+					"dependencies": {
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"pacote": {
+					"version": "8.1.0",
+					"bundled": true,
+					"requires": {
+						"bluebird": "3.5.1",
+						"cacache": "11.0.1",
+						"get-stream": "3.0.0",
+						"glob": "7.1.2",
+						"lru-cache": "4.1.2",
+						"make-fetch-happen": "4.0.1",
+						"minimatch": "3.0.4",
+						"mississippi": "3.0.0",
+						"mkdirp": "0.5.1",
+						"normalize-package-data": "2.4.0",
+						"npm-package-arg": "6.1.0",
+						"npm-packlist": "1.1.10",
+						"npm-pick-manifest": "2.1.0",
+						"osenv": "0.1.5",
+						"promise-inflight": "1.0.1",
+						"promise-retry": "1.1.1",
+						"protoduck": "5.0.0",
+						"rimraf": "2.6.2",
+						"safe-buffer": "5.1.1",
+						"semver": "5.5.0",
+						"ssri": "6.0.0",
+						"tar": "4.4.1",
+						"unique-filename": "1.1.0",
+						"which": "1.3.0"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "3.0.0",
+							"bundled": true
+						},
+						"make-fetch-happen": {
+							"version": "4.0.1",
+							"bundled": true,
+							"requires": {
+								"agentkeepalive": "3.4.1",
+								"cacache": "11.0.1",
+								"http-cache-semantics": "3.8.1",
+								"http-proxy-agent": "2.1.0",
+								"https-proxy-agent": "2.2.1",
+								"lru-cache": "4.1.2",
+								"mississippi": "3.0.0",
+								"node-fetch-npm": "2.0.2",
+								"promise-retry": "1.1.1",
+								"socks-proxy-agent": "4.0.1",
+								"ssri": "6.0.0"
+							},
+							"dependencies": {
+								"agentkeepalive": {
+									"version": "3.4.1",
+									"bundled": true,
+									"requires": {
+										"humanize-ms": "1.2.1"
+									},
+									"dependencies": {
+										"humanize-ms": {
+											"version": "1.2.1",
+											"bundled": true,
+											"requires": {
+												"ms": "2.1.1"
+											},
+											"dependencies": {
+												"ms": {
+													"version": "2.1.1",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"http-cache-semantics": {
+									"version": "3.8.1",
+									"bundled": true
+								},
+								"http-proxy-agent": {
+									"version": "2.1.0",
+									"bundled": true,
+									"requires": {
+										"agent-base": "4.2.0",
+										"debug": "3.1.0"
+									},
+									"dependencies": {
+										"agent-base": {
+											"version": "4.2.0",
+											"bundled": true,
+											"requires": {
+												"es6-promisify": "5.0.0"
+											},
+											"dependencies": {
+												"es6-promisify": {
+													"version": "5.0.0",
+													"bundled": true,
+													"requires": {
+														"es6-promise": "4.2.4"
+													},
+													"dependencies": {
+														"es6-promise": {
+															"version": "4.2.4",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"debug": {
+											"version": "3.1.0",
+											"bundled": true,
+											"requires": {
+												"ms": "2.0.0"
+											},
+											"dependencies": {
+												"ms": {
+													"version": "2.0.0",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"https-proxy-agent": {
+									"version": "2.2.1",
+									"bundled": true,
+									"requires": {
+										"agent-base": "4.2.0",
+										"debug": "3.1.0"
+									},
+									"dependencies": {
+										"agent-base": {
+											"version": "4.2.0",
+											"bundled": true,
+											"requires": {
+												"es6-promisify": "5.0.0"
+											},
+											"dependencies": {
+												"es6-promisify": {
+													"version": "5.0.0",
+													"bundled": true,
+													"requires": {
+														"es6-promise": "4.2.4"
+													},
+													"dependencies": {
+														"es6-promise": {
+															"version": "4.2.4",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"debug": {
+											"version": "3.1.0",
+											"bundled": true,
+											"requires": {
+												"ms": "2.0.0"
+											},
+											"dependencies": {
+												"ms": {
+													"version": "2.0.0",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"node-fetch-npm": {
+									"version": "2.0.2",
+									"bundled": true,
+									"requires": {
+										"encoding": "0.1.12",
+										"json-parse-better-errors": "1.0.2",
+										"safe-buffer": "5.1.1"
+									},
+									"dependencies": {
+										"encoding": {
+											"version": "0.1.12",
+											"bundled": true,
+											"requires": {
+												"iconv-lite": "0.4.21"
+											},
+											"dependencies": {
+												"iconv-lite": {
+													"version": "0.4.21",
+													"bundled": true,
+													"requires": {
+														"safer-buffer": "2.1.2"
+													},
+													"dependencies": {
+														"safer-buffer": {
+															"version": "2.1.2",
+															"bundled": true
+														}
+													}
+												}
+											}
+										}
+									}
+								},
+								"socks-proxy-agent": {
+									"version": "4.0.1",
+									"bundled": true,
+									"requires": {
+										"agent-base": "4.2.0",
+										"socks": "2.2.0"
+									},
+									"dependencies": {
+										"agent-base": {
+											"version": "4.2.0",
+											"bundled": true,
+											"requires": {
+												"es6-promisify": "5.0.0"
+											},
+											"dependencies": {
+												"es6-promisify": {
+													"version": "5.0.0",
+													"bundled": true,
+													"requires": {
+														"es6-promise": "4.2.4"
+													},
+													"dependencies": {
+														"es6-promise": {
+															"version": "4.2.4",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"socks": {
+											"version": "2.2.0",
+											"bundled": true,
+											"requires": {
+												"ip": "1.1.5",
+												"smart-buffer": "4.0.1"
+											},
+											"dependencies": {
+												"ip": {
+													"version": "1.1.5",
+													"bundled": true
+												},
+												"smart-buffer": {
+													"version": "4.0.1",
+													"bundled": true
+												}
+											}
+										}
+									}
+								}
+							}
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"requires": {
+								"brace-expansion": "1.1.11"
+							},
+							"dependencies": {
+								"brace-expansion": {
+									"version": "1.1.11",
+									"bundled": true,
+									"requires": {
+										"balanced-match": "1.0.0",
+										"concat-map": "0.0.1"
+									},
+									"dependencies": {
+										"balanced-match": {
+											"version": "1.0.0",
+											"bundled": true
+										},
+										"concat-map": {
+											"version": "0.0.1",
+											"bundled": true
+										}
+									}
+								}
+							}
+						},
+						"promise-retry": {
+							"version": "1.1.1",
+							"bundled": true,
+							"requires": {
+								"err-code": "1.1.2",
+								"retry": "0.10.1"
+							},
+							"dependencies": {
+								"err-code": {
+									"version": "1.1.2",
+									"bundled": true
+								},
+								"retry": {
+									"version": "0.10.1",
+									"bundled": true
+								}
+							}
+						},
+						"protoduck": {
+							"version": "5.0.0",
+							"bundled": true,
+							"requires": {
+								"genfun": "4.0.1"
+							},
+							"dependencies": {
+								"genfun": {
+									"version": "4.0.1",
+									"bundled": true
+								}
+							}
+						}
+					}
+				},
+				"path-is-inside": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"promise-inflight": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"qrcode-terminal": {
+					"version": "0.12.0",
+					"bundled": true
+				},
+				"query-string": {
+					"version": "6.0.0",
+					"bundled": true,
+					"requires": {
+						"decode-uri-component": "0.2.0",
+						"strict-uri-encode": "2.0.0"
+					},
+					"dependencies": {
+						"decode-uri-component": {
+							"version": "0.2.0",
+							"bundled": true
+						},
+						"strict-uri-encode": {
+							"version": "2.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"qw": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"read": {
+					"version": "1.0.7",
+					"bundled": true,
+					"requires": {
+						"mute-stream": "0.0.7"
+					},
+					"dependencies": {
+						"mute-stream": {
+							"version": "0.0.7",
+							"bundled": true
+						}
+					}
+				},
+				"read-cmd-shim": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11"
+					}
+				},
+				"read-installed": {
+					"version": "4.0.3",
+					"bundled": true,
+					"requires": {
+						"debuglog": "1.0.1",
+						"graceful-fs": "4.1.11",
+						"read-package-json": "2.0.13",
+						"readdir-scoped-modules": "1.0.2",
+						"semver": "5.5.0",
+						"slide": "1.1.6",
+						"util-extend": "1.0.3"
+					},
+					"dependencies": {
+						"util-extend": {
+							"version": "1.0.3",
+							"bundled": true
+						}
+					}
+				},
+				"read-package-json": {
+					"version": "2.0.13",
+					"bundled": true,
+					"requires": {
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"json-parse-better-errors": "1.0.1",
+						"normalize-package-data": "2.4.0",
+						"slash": "1.0.0"
+					},
+					"dependencies": {
+						"json-parse-better-errors": {
+							"version": "1.0.1",
+							"bundled": true
+						},
+						"slash": {
+							"version": "1.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"read-package-tree": {
+					"version": "5.2.1",
+					"bundled": true,
+					"requires": {
+						"debuglog": "1.0.1",
+						"dezalgo": "1.0.3",
+						"once": "1.4.0",
+						"read-package-json": "2.0.13",
+						"readdir-scoped-modules": "1.0.2"
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"bundled": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
+					},
+					"dependencies": {
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.0",
+							"bundled": true
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "5.1.1"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"readdir-scoped-modules": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"debuglog": "1.0.1",
+						"dezalgo": "1.0.3",
+						"graceful-fs": "4.1.11",
+						"once": "1.4.0"
+					}
+				},
+				"request": {
+					"version": "2.85.0",
+					"bundled": true,
+					"requires": {
+						"aws-sign2": "0.7.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.6",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.3.2",
+						"har-validator": "5.0.3",
+						"hawk": "6.0.2",
+						"http-signature": "1.2.0",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.18",
+						"oauth-sign": "0.8.2",
+						"performance-now": "2.1.0",
+						"qs": "6.5.1",
+						"safe-buffer": "5.1.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.4",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.2.1"
+					},
+					"dependencies": {
+						"aws-sign2": {
+							"version": "0.7.0",
+							"bundled": true
+						},
+						"aws4": {
+							"version": "1.6.0",
+							"bundled": true
+						},
+						"caseless": {
+							"version": "0.12.0",
+							"bundled": true
+						},
+						"combined-stream": {
+							"version": "1.0.6",
+							"bundled": true,
+							"requires": {
+								"delayed-stream": "1.0.0"
+							},
+							"dependencies": {
+								"delayed-stream": {
+									"version": "1.0.0",
+									"bundled": true
+								}
+							}
+						},
+						"extend": {
+							"version": "3.0.1",
+							"bundled": true
+						},
+						"forever-agent": {
+							"version": "0.6.1",
+							"bundled": true
+						},
+						"form-data": {
+							"version": "2.3.2",
+							"bundled": true,
+							"requires": {
+								"asynckit": "0.4.0",
+								"combined-stream": "1.0.6",
+								"mime-types": "2.1.18"
+							},
+							"dependencies": {
+								"asynckit": {
+									"version": "0.4.0",
+									"bundled": true
+								}
+							}
+						},
+						"har-validator": {
+							"version": "5.0.3",
+							"bundled": true,
+							"requires": {
+								"ajv": "5.5.2",
+								"har-schema": "2.0.0"
+							},
+							"dependencies": {
+								"ajv": {
+									"version": "5.5.2",
+									"bundled": true,
+									"requires": {
+										"co": "4.6.0",
+										"fast-deep-equal": "1.1.0",
+										"fast-json-stable-stringify": "2.0.0",
+										"json-schema-traverse": "0.3.1"
+									},
+									"dependencies": {
+										"co": {
+											"version": "4.6.0",
+											"bundled": true
+										},
+										"fast-deep-equal": {
+											"version": "1.1.0",
+											"bundled": true
+										},
+										"fast-json-stable-stringify": {
+											"version": "2.0.0",
+											"bundled": true
+										},
+										"json-schema-traverse": {
+											"version": "0.3.1",
+											"bundled": true
+										}
+									}
+								},
+								"har-schema": {
+									"version": "2.0.0",
+									"bundled": true
+								}
+							}
+						},
+						"hawk": {
+							"version": "6.0.2",
+							"bundled": true,
+							"requires": {
+								"boom": "4.3.1",
+								"cryptiles": "3.1.2",
+								"hoek": "4.2.1",
+								"sntp": "2.1.0"
+							},
+							"dependencies": {
+								"boom": {
+									"version": "4.3.1",
+									"bundled": true,
+									"requires": {
+										"hoek": "4.2.1"
+									}
+								},
+								"cryptiles": {
+									"version": "3.1.2",
+									"bundled": true,
+									"requires": {
+										"boom": "5.2.0"
+									},
+									"dependencies": {
+										"boom": {
+											"version": "5.2.0",
+											"bundled": true,
+											"requires": {
+												"hoek": "4.2.1"
+											}
+										}
+									}
+								},
+								"hoek": {
+									"version": "4.2.1",
+									"bundled": true
+								},
+								"sntp": {
+									"version": "2.1.0",
+									"bundled": true,
+									"requires": {
+										"hoek": "4.2.1"
+									}
+								}
+							}
+						},
+						"http-signature": {
+							"version": "1.2.0",
+							"bundled": true,
+							"requires": {
+								"assert-plus": "1.0.0",
+								"jsprim": "1.4.1",
+								"sshpk": "1.14.1"
+							},
+							"dependencies": {
+								"assert-plus": {
+									"version": "1.0.0",
+									"bundled": true
+								},
+								"jsprim": {
+									"version": "1.4.1",
+									"bundled": true,
+									"requires": {
+										"assert-plus": "1.0.0",
+										"extsprintf": "1.3.0",
+										"json-schema": "0.2.3",
+										"verror": "1.10.0"
+									},
+									"dependencies": {
+										"extsprintf": {
+											"version": "1.3.0",
+											"bundled": true
+										},
+										"json-schema": {
+											"version": "0.2.3",
+											"bundled": true
+										},
+										"verror": {
+											"version": "1.10.0",
+											"bundled": true,
+											"requires": {
+												"assert-plus": "1.0.0",
+												"core-util-is": "1.0.2",
+												"extsprintf": "1.3.0"
+											},
+											"dependencies": {
+												"core-util-is": {
+													"version": "1.0.2",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"sshpk": {
+									"version": "1.14.1",
+									"bundled": true,
+									"requires": {
+										"asn1": "0.2.3",
+										"assert-plus": "1.0.0",
+										"bcrypt-pbkdf": "1.0.1",
+										"dashdash": "1.14.1",
+										"ecc-jsbn": "0.1.1",
+										"getpass": "0.1.7",
+										"jsbn": "0.1.1",
+										"tweetnacl": "0.14.5"
+									},
+									"dependencies": {
+										"asn1": {
+											"version": "0.2.3",
+											"bundled": true
+										},
+										"bcrypt-pbkdf": {
+											"version": "1.0.1",
+											"bundled": true,
+											"optional": true,
+											"requires": {
+												"tweetnacl": "0.14.5"
+											}
+										},
+										"dashdash": {
+											"version": "1.14.1",
+											"bundled": true,
+											"requires": {
+												"assert-plus": "1.0.0"
+											}
+										},
+										"ecc-jsbn": {
+											"version": "0.1.1",
+											"bundled": true,
+											"optional": true,
+											"requires": {
+												"jsbn": "0.1.1"
+											}
+										},
+										"getpass": {
+											"version": "0.1.7",
+											"bundled": true,
+											"requires": {
+												"assert-plus": "1.0.0"
+											}
+										},
+										"jsbn": {
+											"version": "0.1.1",
+											"bundled": true,
+											"optional": true
+										},
+										"tweetnacl": {
+											"version": "0.14.5",
+											"bundled": true,
+											"optional": true
+										}
+									}
+								}
+							}
+						},
+						"is-typedarray": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"isstream": {
+							"version": "0.1.2",
+							"bundled": true
+						},
+						"json-stringify-safe": {
+							"version": "5.0.1",
+							"bundled": true
+						},
+						"mime-types": {
+							"version": "2.1.18",
+							"bundled": true,
+							"requires": {
+								"mime-db": "1.33.0"
+							},
+							"dependencies": {
+								"mime-db": {
+									"version": "1.33.0",
+									"bundled": true
+								}
+							}
+						},
+						"oauth-sign": {
+							"version": "0.8.2",
+							"bundled": true
+						},
+						"performance-now": {
+							"version": "2.1.0",
+							"bundled": true
+						},
+						"qs": {
+							"version": "6.5.1",
+							"bundled": true
+						},
+						"stringstream": {
+							"version": "0.0.5",
+							"bundled": true
+						},
+						"tough-cookie": {
+							"version": "2.3.4",
+							"bundled": true,
+							"requires": {
+								"punycode": "1.4.1"
+							},
+							"dependencies": {
+								"punycode": {
+									"version": "1.4.1",
+									"bundled": true
+								}
+							}
+						},
+						"tunnel-agent": {
+							"version": "0.6.0",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "5.1.1"
+							}
+						}
+					}
+				},
+				"retry": {
+					"version": "0.12.0",
+					"bundled": true
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"bundled": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.1",
+					"bundled": true
+				},
+				"semver": {
+					"version": "5.5.0",
+					"bundled": true
+				},
+				"sha": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"readable-stream": "2.3.6"
+					}
+				},
+				"slide": {
+					"version": "1.1.6",
+					"bundled": true
+				},
+				"sorted-object": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"sorted-union-stream": {
+					"version": "2.1.3",
+					"bundled": true,
+					"requires": {
+						"from2": "1.3.0",
+						"stream-iterate": "1.2.0"
+					},
+					"dependencies": {
+						"from2": {
+							"version": "1.3.0",
+							"bundled": true,
+							"requires": {
+								"inherits": "2.0.3",
+								"readable-stream": "1.1.14"
+							},
+							"dependencies": {
+								"readable-stream": {
+									"version": "1.1.14",
+									"bundled": true,
+									"requires": {
+										"core-util-is": "1.0.2",
+										"inherits": "2.0.3",
+										"isarray": "0.0.1",
+										"string_decoder": "0.10.31"
+									},
+									"dependencies": {
+										"core-util-is": {
+											"version": "1.0.2",
+											"bundled": true
+										},
+										"isarray": {
+											"version": "0.0.1",
+											"bundled": true
+										},
+										"string_decoder": {
+											"version": "0.10.31",
+											"bundled": true
+										}
+									}
+								}
+							}
+						},
+						"stream-iterate": {
+							"version": "1.2.0",
+							"bundled": true,
+							"requires": {
+								"readable-stream": "2.3.6",
+								"stream-shift": "1.0.0"
+							},
+							"dependencies": {
+								"stream-shift": {
+									"version": "1.0.0",
+									"bundled": true
+								}
+							}
+						}
+					}
+				},
+				"ssri": {
+					"version": "6.0.0",
+					"bundled": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "3.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"tar": {
+					"version": "4.4.1",
+					"bundled": true,
+					"requires": {
+						"chownr": "1.0.1",
+						"fs-minipass": "1.2.5",
+						"minipass": "2.2.4",
+						"minizlib": "1.1.0",
+						"mkdirp": "0.5.1",
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
+					},
+					"dependencies": {
+						"fs-minipass": {
+							"version": "1.2.5",
+							"bundled": true,
+							"requires": {
+								"minipass": "2.2.4"
+							}
+						},
+						"minipass": {
+							"version": "2.2.4",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "5.1.1",
+								"yallist": "3.0.2"
+							}
+						},
+						"minizlib": {
+							"version": "1.1.0",
+							"bundled": true,
+							"requires": {
+								"minipass": "2.2.4"
+							}
+						},
+						"yallist": {
+							"version": "3.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"text-table": {
+					"version": "0.2.0",
+					"bundled": true
+				},
+				"tiny-relative-date": {
+					"version": "1.3.0",
+					"bundled": true
+				},
+				"uid-number": {
+					"version": "0.0.6",
+					"bundled": true
+				},
+				"umask": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"unique-filename": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"unique-slug": "2.0.0"
+					},
+					"dependencies": {
+						"unique-slug": {
+							"version": "2.0.0",
+							"bundled": true,
+							"requires": {
+								"imurmurhash": "0.1.4"
+							}
+						}
+					}
+				},
+				"unpipe": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"update-notifier": {
+					"version": "2.4.0",
+					"bundled": true,
+					"requires": {
+						"boxen": "1.3.0",
+						"chalk": "2.3.2",
+						"configstore": "3.1.2",
+						"import-lazy": "2.1.0",
+						"is-ci": "1.1.0",
+						"is-installed-globally": "0.1.0",
+						"is-npm": "1.0.0",
+						"latest-version": "3.1.0",
+						"semver-diff": "2.1.0",
+						"xdg-basedir": "3.0.0"
+					},
+					"dependencies": {
+						"boxen": {
+							"version": "1.3.0",
+							"bundled": true,
+							"requires": {
+								"ansi-align": "2.0.0",
+								"camelcase": "4.1.0",
+								"chalk": "2.3.2",
+								"cli-boxes": "1.0.0",
+								"string-width": "2.1.1",
+								"term-size": "1.2.0",
+								"widest-line": "2.0.0"
+							},
+							"dependencies": {
+								"ansi-align": {
+									"version": "2.0.0",
+									"bundled": true,
+									"requires": {
+										"string-width": "2.1.1"
+									}
+								},
+								"camelcase": {
+									"version": "4.1.0",
+									"bundled": true
+								},
+								"cli-boxes": {
+									"version": "1.0.0",
+									"bundled": true
+								},
+								"string-width": {
+									"version": "2.1.1",
+									"bundled": true,
+									"requires": {
+										"is-fullwidth-code-point": "2.0.0",
+										"strip-ansi": "4.0.0"
+									},
+									"dependencies": {
+										"is-fullwidth-code-point": {
+											"version": "2.0.0",
+											"bundled": true
+										}
+									}
+								},
+								"term-size": {
+									"version": "1.2.0",
+									"bundled": true,
+									"requires": {
+										"execa": "0.7.0"
+									},
+									"dependencies": {
+										"execa": {
+											"version": "0.7.0",
+											"bundled": true,
+											"requires": {
+												"cross-spawn": "5.1.0",
+												"get-stream": "3.0.0",
+												"is-stream": "1.1.0",
+												"npm-run-path": "2.0.2",
+												"p-finally": "1.0.0",
+												"signal-exit": "3.0.2",
+												"strip-eof": "1.0.0"
+											},
+											"dependencies": {
+												"cross-spawn": {
+													"version": "5.1.0",
+													"bundled": true,
+													"requires": {
+														"lru-cache": "4.1.2",
+														"shebang-command": "1.2.0",
+														"which": "1.3.0"
+													},
+													"dependencies": {
+														"shebang-command": {
+															"version": "1.2.0",
+															"bundled": true,
+															"requires": {
+																"shebang-regex": "1.0.0"
+															},
+															"dependencies": {
+																"shebang-regex": {
+																	"version": "1.0.0",
+																	"bundled": true
+																}
+															}
+														}
+													}
+												},
+												"get-stream": {
+													"version": "3.0.0",
+													"bundled": true
+												},
+												"is-stream": {
+													"version": "1.1.0",
+													"bundled": true
+												},
+												"npm-run-path": {
+													"version": "2.0.2",
+													"bundled": true,
+													"requires": {
+														"path-key": "2.0.1"
+													},
+													"dependencies": {
+														"path-key": {
+															"version": "2.0.1",
+															"bundled": true
+														}
+													}
+												},
+												"p-finally": {
+													"version": "1.0.0",
+													"bundled": true
+												},
+												"signal-exit": {
+													"version": "3.0.2",
+													"bundled": true
+												},
+												"strip-eof": {
+													"version": "1.0.0",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"widest-line": {
+									"version": "2.0.0",
+									"bundled": true,
+									"requires": {
+										"string-width": "2.1.1"
+									}
+								}
+							}
+						},
+						"chalk": {
+							"version": "2.3.2",
+							"bundled": true,
+							"requires": {
+								"ansi-styles": "3.2.1",
+								"escape-string-regexp": "1.0.5",
+								"supports-color": "5.3.0"
+							},
+							"dependencies": {
+								"ansi-styles": {
+									"version": "3.2.1",
+									"bundled": true,
+									"requires": {
+										"color-convert": "1.9.1"
+									},
+									"dependencies": {
+										"color-convert": {
+											"version": "1.9.1",
+											"bundled": true,
+											"requires": {
+												"color-name": "1.1.3"
+											},
+											"dependencies": {
+												"color-name": {
+													"version": "1.1.3",
+													"bundled": true
+												}
+											}
+										}
+									}
+								},
+								"escape-string-regexp": {
+									"version": "1.0.5",
+									"bundled": true
+								},
+								"supports-color": {
+									"version": "5.3.0",
+									"bundled": true,
+									"requires": {
+										"has-flag": "3.0.0"
+									},
+									"dependencies": {
+										"has-flag": {
+											"version": "3.0.0",
+											"bundled": true
+										}
+									}
+								}
+							}
+						},
+						"configstore": {
+							"version": "3.1.2",
+							"bundled": true,
+							"requires": {
+								"dot-prop": "4.2.0",
+								"graceful-fs": "4.1.11",
+								"make-dir": "1.2.0",
+								"unique-string": "1.0.0",
+								"write-file-atomic": "2.3.0",
+								"xdg-basedir": "3.0.0"
+							},
+							"dependencies": {
+								"dot-prop": {
+									"version": "4.2.0",
+									"bundled": true,
+									"requires": {
+										"is-obj": "1.0.1"
+									},
+									"dependencies": {
+										"is-obj": {
+											"version": "1.0.1",
+											"bundled": true
+										}
+									}
+								},
+								"make-dir": {
+									"version": "1.2.0",
+									"bundled": true,
+									"requires": {
+										"pify": "3.0.0"
+									},
+									"dependencies": {
+										"pify": {
+											"version": "3.0.0",
+											"bundled": true
+										}
+									}
+								},
+								"unique-string": {
+									"version": "1.0.0",
+									"bundled": true,
+									"requires": {
+										"crypto-random-string": "1.0.0"
+									},
+									"dependencies": {
+										"crypto-random-string": {
+											"version": "1.0.0",
+											"bundled": true
+										}
+									}
+								}
+							}
+						},
+						"import-lazy": {
+							"version": "2.1.0",
+							"bundled": true
+						},
+						"is-ci": {
+							"version": "1.1.0",
+							"bundled": true,
+							"requires": {
+								"ci-info": "1.1.3"
+							},
+							"dependencies": {
+								"ci-info": {
+									"version": "1.1.3",
+									"bundled": true
+								}
+							}
+						},
+						"is-installed-globally": {
+							"version": "0.1.0",
+							"bundled": true,
+							"requires": {
+								"global-dirs": "0.1.1",
+								"is-path-inside": "1.0.1"
+							},
+							"dependencies": {
+								"global-dirs": {
+									"version": "0.1.1",
+									"bundled": true,
+									"requires": {
+										"ini": "1.3.5"
+									}
+								},
+								"is-path-inside": {
+									"version": "1.0.1",
+									"bundled": true,
+									"requires": {
+										"path-is-inside": "1.0.2"
+									}
+								}
+							}
+						},
+						"is-npm": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"latest-version": {
+							"version": "3.1.0",
+							"bundled": true,
+							"requires": {
+								"package-json": "4.0.1"
+							},
+							"dependencies": {
+								"package-json": {
+									"version": "4.0.1",
+									"bundled": true,
+									"requires": {
+										"got": "6.7.1",
+										"registry-auth-token": "3.3.2",
+										"registry-url": "3.1.0",
+										"semver": "5.5.0"
+									},
+									"dependencies": {
+										"got": {
+											"version": "6.7.1",
+											"bundled": true,
+											"requires": {
+												"create-error-class": "3.0.2",
+												"duplexer3": "0.1.4",
+												"get-stream": "3.0.0",
+												"is-redirect": "1.0.0",
+												"is-retry-allowed": "1.1.0",
+												"is-stream": "1.1.0",
+												"lowercase-keys": "1.0.1",
+												"safe-buffer": "5.1.1",
+												"timed-out": "4.0.1",
+												"unzip-response": "2.0.1",
+												"url-parse-lax": "1.0.0"
+											},
+											"dependencies": {
+												"create-error-class": {
+													"version": "3.0.2",
+													"bundled": true,
+													"requires": {
+														"capture-stack-trace": "1.0.0"
+													},
+													"dependencies": {
+														"capture-stack-trace": {
+															"version": "1.0.0",
+															"bundled": true
+														}
+													}
+												},
+												"duplexer3": {
+													"version": "0.1.4",
+													"bundled": true
+												},
+												"get-stream": {
+													"version": "3.0.0",
+													"bundled": true
+												},
+												"is-redirect": {
+													"version": "1.0.0",
+													"bundled": true
+												},
+												"is-retry-allowed": {
+													"version": "1.1.0",
+													"bundled": true
+												},
+												"is-stream": {
+													"version": "1.1.0",
+													"bundled": true
+												},
+												"lowercase-keys": {
+													"version": "1.0.1",
+													"bundled": true
+												},
+												"timed-out": {
+													"version": "4.0.1",
+													"bundled": true
+												},
+												"unzip-response": {
+													"version": "2.0.1",
+													"bundled": true
+												},
+												"url-parse-lax": {
+													"version": "1.0.0",
+													"bundled": true,
+													"requires": {
+														"prepend-http": "1.0.4"
+													},
+													"dependencies": {
+														"prepend-http": {
+															"version": "1.0.4",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"registry-auth-token": {
+											"version": "3.3.2",
+											"bundled": true,
+											"requires": {
+												"rc": "1.2.6",
+												"safe-buffer": "5.1.1"
+											},
+											"dependencies": {
+												"rc": {
+													"version": "1.2.6",
+													"bundled": true,
+													"requires": {
+														"deep-extend": "0.4.2",
+														"ini": "1.3.5",
+														"minimist": "1.2.0",
+														"strip-json-comments": "2.0.1"
+													},
+													"dependencies": {
+														"deep-extend": {
+															"version": "0.4.2",
+															"bundled": true
+														},
+														"minimist": {
+															"version": "1.2.0",
+															"bundled": true
+														},
+														"strip-json-comments": {
+															"version": "2.0.1",
+															"bundled": true
+														}
+													}
+												}
+											}
+										},
+										"registry-url": {
+											"version": "3.1.0",
+											"bundled": true,
+											"requires": {
+												"rc": "1.2.6"
+											},
+											"dependencies": {
+												"rc": {
+													"version": "1.2.6",
+													"bundled": true,
+													"requires": {
+														"deep-extend": "0.4.2",
+														"ini": "1.3.5",
+														"minimist": "1.2.0",
+														"strip-json-comments": "2.0.1"
+													},
+													"dependencies": {
+														"deep-extend": {
+															"version": "0.4.2",
+															"bundled": true
+														},
+														"minimist": {
+															"version": "1.2.0",
+															"bundled": true
+														},
+														"strip-json-comments": {
+															"version": "2.0.1",
+															"bundled": true
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						},
+						"semver-diff": {
+							"version": "2.1.0",
+							"bundled": true,
+							"requires": {
+								"semver": "5.5.0"
+							}
+						},
+						"xdg-basedir": {
+							"version": "3.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"uuid": {
+					"version": "3.2.1",
+					"bundled": true
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.3",
+					"bundled": true,
+					"requires": {
+						"spdx-correct": "3.0.0",
+						"spdx-expression-parse": "3.0.0"
+					},
+					"dependencies": {
+						"spdx-correct": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"spdx-expression-parse": "3.0.0",
+								"spdx-license-ids": "3.0.0"
+							},
+							"dependencies": {
+								"spdx-license-ids": {
+									"version": "3.0.0",
+									"bundled": true
+								}
+							}
+						},
+						"spdx-expression-parse": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"spdx-exceptions": "2.1.0",
+								"spdx-license-ids": "3.0.0"
+							},
+							"dependencies": {
+								"spdx-exceptions": {
+									"version": "2.1.0",
+									"bundled": true
+								},
+								"spdx-license-ids": {
+									"version": "3.0.0",
+									"bundled": true
+								}
+							}
+						}
+					}
+				},
+				"validate-npm-package-name": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"builtins": "1.0.3"
+					},
+					"dependencies": {
+						"builtins": {
+							"version": "1.0.3",
+							"bundled": true
+						}
+					}
+				},
+				"which": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"isexe": "2.0.0"
+					},
+					"dependencies": {
+						"isexe": {
+							"version": "2.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"worker-farm": {
+					"version": "1.6.0",
+					"bundled": true,
+					"requires": {
+						"errno": "0.1.7"
+					},
+					"dependencies": {
+						"errno": {
+							"version": "0.1.7",
+							"bundled": true,
+							"requires": {
+								"prr": "1.0.1"
+							},
+							"dependencies": {
+								"prr": {
+									"version": "1.0.1",
+									"bundled": true
+								}
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"write-file-atomic": {
+					"version": "2.3.0",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"signal-exit": "3.0.2"
+					},
+					"dependencies": {
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true
+						}
+					}
+				}
 			}
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"dev": true,
 			"requires": {
 				"path-key": "2.0.1"
 			}
@@ -6640,7 +13710,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"dev": true,
 			"requires": {
 				"are-we-there-yet": "1.1.4",
 				"console-control-strings": "1.1.0",
@@ -6651,14 +13720,17 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+		},
+		"nwmatcher": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+			"integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
 		},
 		"nyc": {
 			"version": "11.6.0",
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.6.0.tgz",
 			"integrity": "sha512-ZaXCh0wmbk2aSBH2B5hZGGvK2s9aM8DIm2rVY+BG3Fx8tUS+bpJSswUVZqOD1YfCmnYRFSqgYJSr7UeeUcW0jg==",
-			"dev": true,
 			"requires": {
 				"archy": "1.0.0",
 				"arrify": "1.0.1",
@@ -6692,7 +13764,6 @@
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2",
 						"longest": "1.0.1",
@@ -6701,79 +13772,65 @@
 				},
 				"amdefine": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"append-transform": {
 					"version": "0.4.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"default-require-extensions": "1.0.0"
 					}
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"arr-diff": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"arr-flatten": "1.1.0"
 					}
 				},
 				"arr-flatten": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"arr-union": {
 					"version": "3.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"array-unique": {
 					"version": "0.2.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"arrify": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"assign-symbols": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"async": {
 					"version": "1.5.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"atob": {
 					"version": "2.0.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"babel-code-frame": {
 					"version": "6.26.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"chalk": "1.1.3",
 						"esutils": "2.0.2",
@@ -6783,7 +13840,6 @@
 				"babel-generator": {
 					"version": "6.26.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"babel-messages": "6.23.0",
 						"babel-runtime": "6.26.0",
@@ -6798,7 +13854,6 @@
 				"babel-messages": {
 					"version": "6.23.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0"
 					}
@@ -6806,7 +13861,6 @@
 				"babel-runtime": {
 					"version": "6.26.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"core-js": "2.5.3",
 						"regenerator-runtime": "0.11.1"
@@ -6815,7 +13869,6 @@
 				"babel-template": {
 					"version": "6.26.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0",
 						"babel-traverse": "6.26.0",
@@ -6827,7 +13880,6 @@
 				"babel-traverse": {
 					"version": "6.26.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"babel-code-frame": "6.26.0",
 						"babel-messages": "6.23.0",
@@ -6843,7 +13895,6 @@
 				"babel-types": {
 					"version": "6.26.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"babel-runtime": "6.26.0",
 						"esutils": "2.0.2",
@@ -6853,18 +13904,15 @@
 				},
 				"babylon": {
 					"version": "6.18.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"base": {
 					"version": "0.11.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"cache-base": "1.0.1",
 						"class-utils": "0.3.6",
@@ -6878,22 +13926,19 @@
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-descriptor": "1.0.2"
 							}
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
@@ -6902,7 +13947,6 @@
 				"braces": {
 					"version": "1.8.5",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"expand-range": "1.8.2",
 						"preserve": "0.2.0",
@@ -6911,13 +13955,11 @@
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"cache-base": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"collection-visit": "1.0.0",
 						"component-emitter": "1.2.1",
@@ -6932,15 +13974,13 @@
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"caching-transform": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"md5-hex": "1.3.0",
 						"mkdirp": "0.5.1",
@@ -6950,13 +13990,11 @@
 				"camelcase": {
 					"version": "1.2.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"center-align": {
 					"version": "0.1.3",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "0.1.4",
@@ -6966,7 +14004,6 @@
 				"chalk": {
 					"version": "1.1.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ansi-styles": "2.2.1",
 						"escape-string-regexp": "1.0.5",
@@ -6978,7 +14015,6 @@
 				"class-utils": {
 					"version": "0.3.6",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"arr-union": "3.1.0",
 						"define-property": "0.2.5",
@@ -6989,7 +14025,6 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-descriptor": "0.1.6"
 							}
@@ -6997,7 +14032,6 @@
 						"is-accessor-descriptor": {
 							"version": "0.1.6",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							},
@@ -7005,7 +14039,6 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-buffer": "1.1.6"
 									}
@@ -7015,7 +14048,6 @@
 						"is-data-descriptor": {
 							"version": "0.1.4",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							},
@@ -7023,7 +14055,6 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-buffer": "1.1.6"
 									}
@@ -7033,7 +14064,6 @@
 						"is-descriptor": {
 							"version": "0.1.6",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "0.1.6",
 								"is-data-descriptor": "0.1.4",
@@ -7042,20 +14072,17 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"kind-of": {
 							"version": "5.1.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"cliui": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"center-align": "0.1.3",
@@ -7066,20 +14093,17 @@
 						"wordwrap": {
 							"version": "0.0.2",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"collection-visit": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"map-visit": "1.0.0",
 						"object-visit": "1.0.1"
@@ -7087,38 +14111,31 @@
 				},
 				"commondir": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"component-emitter": {
 					"version": "1.2.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"convert-source-map": {
 					"version": "1.5.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"copy-descriptor": {
 					"version": "0.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"core-js": {
 					"version": "2.5.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"lru-cache": "4.1.2",
 						"which": "1.3.0"
@@ -7127,30 +14144,25 @@
 				"debug": {
 					"version": "2.6.9",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
 				"debug-log": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"decode-uri-component": {
 					"version": "0.2.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"default-require-extensions": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"strip-bom": "2.0.0"
 					}
@@ -7158,7 +14170,6 @@
 				"define-property": {
 					"version": "2.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-descriptor": "1.0.2",
 						"isobject": "3.0.1"
@@ -7166,15 +14177,13 @@
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"detect-indent": {
 					"version": "4.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"repeating": "2.0.1"
 					}
@@ -7182,25 +14191,21 @@
 				"error-ex": {
 					"version": "1.3.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-arrayish": "0.2.1"
 					}
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"esutils": {
 					"version": "2.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"execa": {
 					"version": "0.7.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"cross-spawn": "5.1.0",
 						"get-stream": "3.0.0",
@@ -7214,7 +14219,6 @@
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"lru-cache": "4.1.2",
 								"shebang-command": "1.2.0",
@@ -7226,7 +14230,6 @@
 				"expand-brackets": {
 					"version": "0.1.5",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-posix-bracket": "0.1.1"
 					}
@@ -7234,7 +14237,6 @@
 				"expand-range": {
 					"version": "1.8.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"fill-range": "2.2.3"
 					}
@@ -7242,7 +14244,6 @@
 				"extend-shallow": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"assign-symbols": "1.0.0",
 						"is-extendable": "1.0.1"
@@ -7251,7 +14252,6 @@
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-plain-object": "2.0.4"
 							}
@@ -7261,20 +14261,17 @@
 				"extglob": {
 					"version": "0.3.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
 				},
 				"filename-regex": {
 					"version": "2.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"fill-range": {
 					"version": "2.2.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-number": "2.1.0",
 						"isobject": "2.1.0",
@@ -7286,7 +14283,6 @@
 				"find-cache-dir": {
 					"version": "0.1.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"commondir": "1.0.1",
 						"mkdirp": "0.5.1",
@@ -7296,20 +14292,17 @@
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"locate-path": "2.0.0"
 					}
 				},
 				"for-in": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"for-own": {
 					"version": "0.1.5",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"for-in": "1.0.2"
 					}
@@ -7317,7 +14310,6 @@
 				"foreground-child": {
 					"version": "1.5.6",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"cross-spawn": "4.0.2",
 						"signal-exit": "3.0.2"
@@ -7326,35 +14318,29 @@
 				"fragment-cache": {
 					"version": "0.2.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"map-cache": "0.2.2"
 					}
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"get-value": {
 					"version": "2.0.6",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -7367,7 +14353,6 @@
 				"glob-base": {
 					"version": "0.3.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"glob-parent": "2.0.0",
 						"is-glob": "2.0.1"
@@ -7376,25 +14361,21 @@
 				"glob-parent": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-glob": "2.0.1"
 					}
 				},
 				"globals": {
 					"version": "9.18.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"handlebars": {
 					"version": "4.0.11",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"async": "1.5.2",
 						"optimist": "0.6.1",
@@ -7405,7 +14386,6 @@
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"amdefine": "1.0.1"
 							}
@@ -7415,20 +14395,17 @@
 				"has-ansi": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"has-value": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"get-value": "2.0.6",
 						"has-values": "1.0.0",
@@ -7437,15 +14414,13 @@
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"has-values": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-number": "3.0.0",
 						"kind-of": "4.0.0"
@@ -7454,7 +14429,6 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							},
@@ -7462,7 +14436,6 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-buffer": "1.1.6"
 									}
@@ -7472,7 +14445,6 @@
 						"kind-of": {
 							"version": "4.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -7481,18 +14453,15 @@
 				},
 				"hosted-git-info": {
 					"version": "2.6.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -7500,51 +14469,43 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"invariant": {
 					"version": "2.2.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"loose-envify": "1.3.1"
 					}
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"kind-of": "6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-buffer": {
 					"version": "1.1.6",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"builtin-modules": "1.1.1"
 					}
@@ -7552,22 +14513,19 @@
 				"is-data-descriptor": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"kind-of": "6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "1.0.0",
 						"is-data-descriptor": "1.0.0",
@@ -7576,51 +14534,43 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"is-dotfile": {
 					"version": "1.0.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-equal-shallow": {
 					"version": "0.1.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-primitive": "2.0.0"
 					}
 				},
 				"is-extendable": {
 					"version": "0.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-extglob": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-finite": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-extglob": "1.0.0"
 					}
@@ -7628,7 +14578,6 @@
 				"is-number": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					}
@@ -7636,85 +14585,71 @@
 				"is-odd": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-number": "4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
 							"version": "4.0.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"is-plain-object": {
 					"version": "2.0.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"isobject": "3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"is-posix-bracket": {
 					"version": "0.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-primitive": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-utf8": {
 					"version": "0.2.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-windows": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"isobject": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"isarray": "1.0.0"
 					}
 				},
 				"istanbul-lib-coverage": {
 					"version": "1.2.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"istanbul-lib-hook": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"append-transform": "0.4.0"
 					}
@@ -7722,7 +14657,6 @@
 				"istanbul-lib-instrument": {
 					"version": "1.10.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"babel-generator": "6.26.1",
 						"babel-template": "6.26.0",
@@ -7736,7 +14670,6 @@
 				"istanbul-lib-report": {
 					"version": "1.1.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"istanbul-lib-coverage": "1.2.0",
 						"mkdirp": "0.5.1",
@@ -7747,7 +14680,6 @@
 						"supports-color": {
 							"version": "3.2.3",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"has-flag": "1.0.0"
 							}
@@ -7757,7 +14689,6 @@
 				"istanbul-lib-source-maps": {
 					"version": "1.2.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"debug": "3.1.0",
 						"istanbul-lib-coverage": "1.2.0",
@@ -7769,7 +14700,6 @@
 						"debug": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"ms": "2.0.0"
 							}
@@ -7779,25 +14709,21 @@
 				"istanbul-reports": {
 					"version": "1.3.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"handlebars": "4.0.11"
 					}
 				},
 				"js-tokens": {
 					"version": "3.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"jsesc": {
 					"version": "1.3.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -7805,13 +14731,11 @@
 				"lazy-cache": {
 					"version": "1.0.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"lcid": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"invert-kv": "1.0.0"
 					}
@@ -7819,7 +14743,6 @@
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"parse-json": "2.2.0",
@@ -7831,7 +14754,6 @@
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"p-locate": "2.0.0",
 						"path-exists": "3.0.0"
@@ -7839,25 +14761,21 @@
 					"dependencies": {
 						"path-exists": {
 							"version": "3.0.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"lodash": {
 					"version": "4.17.5",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"longest": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"loose-envify": {
 					"version": "1.3.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"js-tokens": "3.0.2"
 					}
@@ -7865,7 +14783,6 @@
 				"lru-cache": {
 					"version": "4.1.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"pseudomap": "1.0.2",
 						"yallist": "2.1.2"
@@ -7873,13 +14790,11 @@
 				},
 				"map-cache": {
 					"version": "0.2.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"map-visit": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"object-visit": "1.0.1"
 					}
@@ -7887,20 +14802,17 @@
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"md5-o-matic": "0.1.1"
 					}
 				},
 				"md5-o-matic": {
 					"version": "0.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"mem": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"mimic-fn": "1.2.0"
 					}
@@ -7908,22 +14820,19 @@
 				"merge-source-map": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"source-map": "0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
 							"version": "0.6.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"micromatch": {
 					"version": "2.3.11",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"arr-diff": "2.0.0",
 						"array-unique": "0.2.1",
@@ -7942,26 +14851,22 @@
 				},
 				"mimic-fn": {
 					"version": "1.2.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"mixin-deep": {
 					"version": "1.3.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"for-in": "1.0.2",
 						"is-extendable": "1.0.1"
@@ -7970,7 +14875,6 @@
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-plain-object": "2.0.4"
 							}
@@ -7980,20 +14884,17 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"nanomatch": {
 					"version": "1.2.9",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"arr-diff": "4.0.0",
 						"array-unique": "0.3.2",
@@ -8011,25 +14912,21 @@
 					"dependencies": {
 						"arr-diff": {
 							"version": "4.0.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"array-unique": {
 							"version": "0.3.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"hosted-git-info": "2.6.0",
 						"is-builtin-module": "1.0.0",
@@ -8040,7 +14937,6 @@
 				"normalize-path": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"remove-trailing-separator": "1.1.0"
 					}
@@ -8048,25 +14944,21 @@
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"path-key": "2.0.1"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"object-copy": {
 					"version": "0.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"copy-descriptor": "0.1.1",
 						"define-property": "0.2.5",
@@ -8076,7 +14968,6 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-descriptor": "0.1.6"
 							}
@@ -8084,7 +14975,6 @@
 						"is-accessor-descriptor": {
 							"version": "0.1.6",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							}
@@ -8092,7 +14982,6 @@
 						"is-data-descriptor": {
 							"version": "0.1.4",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							}
@@ -8100,7 +14989,6 @@
 						"is-descriptor": {
 							"version": "0.1.6",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "0.1.6",
 								"is-data-descriptor": "0.1.4",
@@ -8109,8 +14997,7 @@
 							"dependencies": {
 								"kind-of": {
 									"version": "5.1.0",
-									"bundled": true,
-									"dev": true
+									"bundled": true
 								}
 							}
 						}
@@ -8119,22 +15006,19 @@
 				"object-visit": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"isobject": "3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"object.omit": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"for-own": "0.1.5",
 						"is-extendable": "0.1.1"
@@ -8143,22 +15027,19 @@
 				"object.pick": {
 					"version": "1.3.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"isobject": "3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -8166,7 +15047,6 @@
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"minimist": "0.0.8",
 						"wordwrap": "0.0.3"
@@ -8174,13 +15054,11 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"execa": "0.7.0",
 						"lcid": "1.0.0",
@@ -8189,13 +15067,11 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"p-limit": {
 					"version": "1.2.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"p-try": "1.0.0"
 					}
@@ -8203,20 +15079,17 @@
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"p-limit": "1.2.0"
 					}
 				},
 				"p-try": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"parse-glob": {
 					"version": "3.0.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"glob-base": "0.3.0",
 						"is-dotfile": "1.0.3",
@@ -8227,43 +15100,36 @@
 				"parse-json": {
 					"version": "2.2.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"error-ex": "1.3.1"
 					}
 				},
 				"pascalcase": {
 					"version": "0.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"path-exists": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"path-parse": {
 					"version": "1.0.5",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"pify": "2.3.0",
@@ -8272,18 +15138,15 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"pinkie": {
 					"version": "2.0.4",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"pinkie": "2.0.4"
 					}
@@ -8291,7 +15154,6 @@
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"find-up": "1.1.2"
 					},
@@ -8299,7 +15161,6 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"path-exists": "2.1.0",
 								"pinkie-promise": "2.0.1"
@@ -8309,23 +15170,19 @@
 				},
 				"posix-character-classes": {
 					"version": "0.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"preserve": {
 					"version": "0.2.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"randomatic": {
 					"version": "1.1.7",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-number": "3.0.0",
 						"kind-of": "4.0.0"
@@ -8334,7 +15191,6 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							},
@@ -8342,7 +15198,6 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-buffer": "1.1.6"
 									}
@@ -8352,7 +15207,6 @@
 						"kind-of": {
 							"version": "4.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -8362,7 +15216,6 @@
 				"read-pkg": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"load-json-file": "1.1.0",
 						"normalize-package-data": "2.4.0",
@@ -8372,7 +15225,6 @@
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"find-up": "1.1.2",
 						"read-pkg": "1.1.0"
@@ -8381,7 +15233,6 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"path-exists": "2.1.0",
 								"pinkie-promise": "2.0.1"
@@ -8391,13 +15242,11 @@
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"regex-cache": {
 					"version": "0.4.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-equal-shallow": "0.1.3"
 					}
@@ -8405,7 +15254,6 @@
 				"regex-not": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"extend-shallow": "3.0.2",
 						"safe-regex": "1.1.0"
@@ -8413,56 +15261,46 @@
 				},
 				"remove-trailing-separator": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"repeat-element": {
 					"version": "1.1.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"repeat-string": {
 					"version": "1.6.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"repeating": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-finite": "1.0.2"
 					}
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"resolve-from": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"resolve-url": {
 					"version": "0.2.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"ret": {
 					"version": "0.1.15",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"right-align": {
 					"version": "0.1.3",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "0.1.4"
@@ -8471,7 +15309,6 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
 					}
@@ -8479,25 +15316,21 @@
 				"safe-regex": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ret": "0.1.15"
 					}
 				},
 				"semver": {
 					"version": "5.5.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"set-value": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"extend-shallow": "2.0.1",
 						"is-extendable": "0.1.1",
@@ -8508,7 +15341,6 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-extendable": "0.1.1"
 							}
@@ -8518,30 +15350,25 @@
 				"shebang-command": {
 					"version": "1.2.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"shebang-regex": "1.0.0"
 					}
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"snapdragon": {
 					"version": "0.8.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"base": "0.11.2",
 						"debug": "2.6.9",
@@ -8556,7 +15383,6 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-descriptor": "0.1.6"
 							}
@@ -8564,7 +15390,6 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-extendable": "0.1.1"
 							}
@@ -8572,7 +15397,6 @@
 						"is-accessor-descriptor": {
 							"version": "0.1.6",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							},
@@ -8580,7 +15404,6 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-buffer": "1.1.6"
 									}
@@ -8590,7 +15413,6 @@
 						"is-data-descriptor": {
 							"version": "0.1.4",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							},
@@ -8598,7 +15420,6 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-buffer": "1.1.6"
 									}
@@ -8608,7 +15429,6 @@
 						"is-descriptor": {
 							"version": "0.1.6",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "0.1.6",
 								"is-data-descriptor": "0.1.4",
@@ -8617,15 +15437,13 @@
 						},
 						"kind-of": {
 							"version": "5.1.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"snapdragon-node": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"define-property": "1.0.0",
 						"isobject": "3.0.1",
@@ -8635,35 +15453,30 @@
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-descriptor": "1.0.2"
 							}
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"snapdragon-util": {
 					"version": "3.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"source-map-resolve": {
 					"version": "0.5.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"atob": "2.0.3",
 						"decode-uri-component": "0.2.0",
@@ -8674,13 +15487,11 @@
 				},
 				"source-map-url": {
 					"version": "0.4.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"spawn-wrap": {
 					"version": "1.4.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"foreground-child": "1.5.6",
 						"mkdirp": "0.5.1",
@@ -8693,7 +15504,6 @@
 				"spdx-correct": {
 					"version": "3.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"spdx-expression-parse": "3.0.0",
 						"spdx-license-ids": "3.0.0"
@@ -8701,13 +15511,11 @@
 				},
 				"spdx-exceptions": {
 					"version": "2.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"spdx-expression-parse": {
 					"version": "3.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"spdx-exceptions": "2.1.0",
 						"spdx-license-ids": "3.0.0"
@@ -8715,13 +15523,11 @@
 				},
 				"spdx-license-ids": {
 					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"split-string": {
 					"version": "3.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"extend-shallow": "3.0.2"
 					}
@@ -8729,7 +15535,6 @@
 				"static-extend": {
 					"version": "0.1.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"define-property": "0.2.5",
 						"object-copy": "0.1.0"
@@ -8738,7 +15543,6 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-descriptor": "0.1.6"
 							}
@@ -8746,7 +15550,6 @@
 						"is-accessor-descriptor": {
 							"version": "0.1.6",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							},
@@ -8754,7 +15557,6 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-buffer": "1.1.6"
 									}
@@ -8764,7 +15566,6 @@
 						"is-data-descriptor": {
 							"version": "0.1.4",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							},
@@ -8772,7 +15573,6 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-buffer": "1.1.6"
 									}
@@ -8782,7 +15582,6 @@
 						"is-descriptor": {
 							"version": "0.1.6",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "0.1.6",
 								"is-data-descriptor": "0.1.4",
@@ -8791,15 +15590,13 @@
 						},
 						"kind-of": {
 							"version": "5.1.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "2.0.0",
 						"strip-ansi": "4.0.0"
@@ -8807,13 +15604,11 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"ansi-regex": "3.0.0"
 							}
@@ -8823,7 +15618,6 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -8831,25 +15625,21 @@
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-utf8": "0.2.1"
 					}
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"supports-color": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"test-exclude": {
 					"version": "4.2.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"arrify": "1.0.1",
 						"micromatch": "3.1.9",
@@ -8860,18 +15650,15 @@
 					"dependencies": {
 						"arr-diff": {
 							"version": "4.0.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"array-unique": {
 							"version": "0.3.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"braces": {
 							"version": "2.3.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"arr-flatten": "1.1.0",
 								"array-unique": "0.3.2",
@@ -8890,7 +15677,6 @@
 								"define-property": {
 									"version": "1.0.0",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-descriptor": "1.0.2"
 									}
@@ -8898,7 +15684,6 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-extendable": "0.1.1"
 									}
@@ -8908,7 +15693,6 @@
 						"expand-brackets": {
 							"version": "2.1.4",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"debug": "2.6.9",
 								"define-property": "0.2.5",
@@ -8922,7 +15706,6 @@
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-descriptor": "0.1.6"
 									}
@@ -8930,7 +15713,6 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-extendable": "0.1.1"
 									}
@@ -8938,7 +15720,6 @@
 								"is-descriptor": {
 									"version": "0.1.6",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-accessor-descriptor": "0.1.6",
 										"is-data-descriptor": "0.1.4",
@@ -8947,15 +15728,13 @@
 								},
 								"kind-of": {
 									"version": "5.1.0",
-									"bundled": true,
-									"dev": true
+									"bundled": true
 								}
 							}
 						},
 						"extglob": {
 							"version": "2.0.4",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"array-unique": "0.3.2",
 								"define-property": "1.0.0",
@@ -8970,7 +15749,6 @@
 								"define-property": {
 									"version": "1.0.0",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-descriptor": "1.0.2"
 									}
@@ -8978,7 +15756,6 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-extendable": "0.1.1"
 									}
@@ -8988,7 +15765,6 @@
 						"fill-range": {
 							"version": "4.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"extend-shallow": "2.0.1",
 								"is-number": "3.0.0",
@@ -8999,7 +15775,6 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-extendable": "0.1.1"
 									}
@@ -9009,7 +15784,6 @@
 						"is-accessor-descriptor": {
 							"version": "0.1.6",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							},
@@ -9017,7 +15791,6 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-buffer": "1.1.6"
 									}
@@ -9027,7 +15800,6 @@
 						"is-data-descriptor": {
 							"version": "0.1.4",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							},
@@ -9035,7 +15807,6 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-buffer": "1.1.6"
 									}
@@ -9045,7 +15816,6 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							},
@@ -9053,7 +15823,6 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-buffer": "1.1.6"
 									}
@@ -9062,18 +15831,15 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"micromatch": {
 							"version": "3.1.9",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"arr-diff": "4.0.0",
 								"array-unique": "0.3.2",
@@ -9094,13 +15860,11 @@
 				},
 				"to-fast-properties": {
 					"version": "1.0.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"to-object-path": {
 					"version": "0.3.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					}
@@ -9108,7 +15872,6 @@
 				"to-regex": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"define-property": "2.0.2",
 						"extend-shallow": "3.0.2",
@@ -9119,7 +15882,6 @@
 				"to-regex-range": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-number": "3.0.0",
 						"repeat-string": "1.6.1"
@@ -9128,7 +15890,6 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "3.2.2"
 							}
@@ -9137,13 +15898,11 @@
 				},
 				"trim-right": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"uglify-js": {
 					"version": "2.8.29",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"source-map": "0.5.7",
@@ -9154,7 +15913,6 @@
 						"yargs": {
 							"version": "3.10.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"camelcase": "1.2.1",
@@ -9168,13 +15926,11 @@
 				"uglify-to-browserify": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"union-value": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"arr-union": "3.1.0",
 						"get-value": "2.0.6",
@@ -9185,7 +15941,6 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-extendable": "0.1.1"
 							}
@@ -9193,7 +15948,6 @@
 						"set-value": {
 							"version": "0.4.3",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"extend-shallow": "2.0.1",
 								"is-extendable": "0.1.1",
@@ -9206,7 +15960,6 @@
 				"unset-value": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"has-value": "0.3.1",
 						"isobject": "3.0.1"
@@ -9215,7 +15968,6 @@
 						"has-value": {
 							"version": "0.3.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"get-value": "2.0.6",
 								"has-values": "0.1.4",
@@ -9225,7 +15977,6 @@
 								"isobject": {
 									"version": "2.1.0",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"isarray": "1.0.0"
 									}
@@ -9234,40 +15985,34 @@
 						},
 						"has-values": {
 							"version": "0.1.4",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"urix": {
 					"version": "0.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"use": {
 					"version": "3.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"kind-of": "6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"spdx-correct": "3.0.0",
 						"spdx-expression-parse": "3.0.0"
@@ -9276,31 +16021,26 @@
 				"which": {
 					"version": "1.3.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"isexe": "2.0.0"
 					}
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"window-size": {
 					"version": "0.1.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1"
@@ -9309,7 +16049,6 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"number-is-nan": "1.0.1"
 							}
@@ -9317,7 +16056,6 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"code-point-at": "1.1.0",
 								"is-fullwidth-code-point": "1.0.0",
@@ -9328,13 +16066,11 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"write-file-atomic": {
 					"version": "1.3.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"imurmurhash": "0.1.4",
@@ -9343,18 +16079,15 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"yargs": {
 					"version": "11.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"cliui": "4.0.0",
 						"decamelize": "1.2.0",
@@ -9372,18 +16105,15 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"cliui": {
 							"version": "4.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"string-width": "2.1.1",
 								"strip-ansi": "4.0.0",
@@ -9393,7 +16123,6 @@
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"ansi-regex": "3.0.0"
 							}
@@ -9401,7 +16130,6 @@
 						"yargs-parser": {
 							"version": "9.0.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"camelcase": "4.1.0"
 							}
@@ -9411,15 +16139,13 @@
 				"yargs-parser": {
 					"version": "8.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"camelcase": "4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				}
@@ -9428,20 +16154,17 @@
 		"oauth-sign": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-			"dev": true
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
 		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-			"dev": true,
 			"requires": {
 				"copy-descriptor": "0.1.1",
 				"define-property": "0.2.5",
@@ -9452,7 +16175,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "0.1.6"
 					}
@@ -9461,7 +16183,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					}
@@ -9470,7 +16191,6 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					}
@@ -9479,7 +16199,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "0.1.6",
 						"is-data-descriptor": "0.1.4",
@@ -9489,18 +16208,21 @@
 						"kind-of": {
 							"version": "5.1.0",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 						}
 					}
 				}
 			}
 		},
+		"object-keys": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-			"dev": true,
 			"requires": {
 				"isobject": "3.0.1"
 			},
@@ -9508,16 +16230,23 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"requires": {
+				"define-properties": "1.1.2",
+				"es-abstract": "1.11.0"
 			}
 		},
 		"object.omit": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"dev": true,
 			"requires": {
 				"for-own": "0.1.5",
 				"is-extendable": "0.1.1"
@@ -9527,7 +16256,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-			"dev": true,
 			"requires": {
 				"isobject": "3.0.1"
 			},
@@ -9535,8 +16263,7 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -9544,7 +16271,6 @@
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-0.5.0.tgz",
 			"integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
-			"dev": true,
 			"requires": {
 				"is-observable": "0.2.0",
 				"symbol-observable": "1.2.0"
@@ -9554,7 +16280,6 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
 					"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
-					"dev": true,
 					"requires": {
 						"symbol-observable": "0.2.4"
 					},
@@ -9562,18 +16287,34 @@
 						"symbol-observable": {
 							"version": "0.2.4",
 							"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
-							"integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
-							"dev": true
+							"integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A="
 						}
 					}
 				}
 			}
 		},
+		"obuf": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+			"integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
+		},
+		"on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"requires": {
+				"ee-first": "1.1.1"
+			}
+		},
+		"on-headers": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1.0.2"
 			}
@@ -9582,16 +16323,22 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-			"dev": true,
 			"requires": {
 				"mimic-fn": "1.2.0"
+			}
+		},
+		"opn": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+			"integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+			"requires": {
+				"is-wsl": "1.1.0"
 			}
 		},
 		"optimist": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8",
 				"wordwrap": "0.0.3"
@@ -9600,36 +16347,70 @@
 		"option-chain": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/option-chain/-/option-chain-1.0.0.tgz",
-			"integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI=",
-			"dev": true
+			"integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI="
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"requires": {
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+				}
+			}
 		},
 		"ordered-read-streams": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 			"integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
-			"dev": true,
 			"requires": {
 				"is-stream": "1.1.0",
 				"readable-stream": "2.3.5"
 			}
 		},
+		"original": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
+			"integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
+			"requires": {
+				"url-parse": "1.0.5"
+			},
+			"dependencies": {
+				"url-parse": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
+					"integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
+					"requires": {
+						"querystringify": "0.0.4",
+						"requires-port": "1.0.0"
+					}
+				}
+			}
+		},
 		"os-browserify": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
-			"dev": true
+			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
 		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-			"dev": true
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-			"dev": true,
 			"requires": {
 				"execa": "0.7.0",
 				"lcid": "1.0.0",
@@ -9639,20 +16420,17 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-limit": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
 			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-			"dev": true,
 			"requires": {
 				"p-try": "1.0.0"
 			}
@@ -9661,22 +16439,24 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-			"dev": true,
 			"requires": {
 				"p-limit": "1.2.0"
 			}
 		},
+		"p-map": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
+		},
 		"p-try": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-			"dev": true
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 		},
 		"package-hash": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
 			"integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"lodash.flattendeep": "4.4.0",
@@ -9688,7 +16468,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
 			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-			"dev": true,
 			"requires": {
 				"got": "6.7.1",
 				"registry-auth-token": "3.3.2",
@@ -9699,14 +16478,22 @@
 		"pako": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
-			"dev": true
+			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+		},
+		"parallel-transform": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+			"requires": {
+				"cyclist": "0.2.2",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
+			}
 		},
 		"parse-asn1": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
 			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
-			"dev": true,
 			"requires": {
 				"asn1.js": "4.10.1",
 				"browserify-aes": "1.1.1",
@@ -9718,14 +16505,12 @@
 		"parse-github-repo-url": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
-			"dev": true
+			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A="
 		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"dev": true,
 			"requires": {
 				"glob-base": "0.3.0",
 				"is-dotfile": "1.0.3",
@@ -9737,7 +16522,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-			"dev": true,
 			"requires": {
 				"error-ex": "1.3.1"
 			}
@@ -9745,62 +16529,76 @@
 		"parse-ms": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-			"integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
-			"dev": true
+			"integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0="
+		},
+		"parse5": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+		},
+		"parseurl": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
 		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-			"dev": true
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
 		},
 		"path-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
-			"dev": true
+			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
 		},
 		"path-dirname": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-			"dev": true
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
 		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-			"dev": true
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
 		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-			"dev": true
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+		},
+		"path-loader": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/path-loader/-/path-loader-1.0.4.tgz",
+			"integrity": "sha512-k/IPo9OWyofATP5gwIehHHQoFShS37zsSIsejKe6fjI+tqK+FnRpiSg4ZfWUpxb0g2PfCreWPqBD4ayjqjqkdQ==",
+			"requires": {
+				"native-promise-only": "0.8.1",
+				"superagent": "3.8.3"
+			}
 		},
 		"path-parse": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-			"dev": true
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+		},
+		"path-to-regexp": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
 		"path-type": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-			"dev": true,
 			"requires": {
 				"pify": "2.3.0"
 			}
@@ -9809,7 +16607,6 @@
 			"version": "3.0.14",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
 			"integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
-			"dev": true,
 			"requires": {
 				"create-hash": "1.1.3",
 				"create-hmac": "1.1.6",
@@ -9821,26 +16618,22 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-			"dev": true
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 		},
 		"pinkie": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-			"integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
-			"dev": true
+			"integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q="
 		},
 		"pinkie-promise": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
 			"integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
-			"dev": true,
 			"requires": {
 				"pinkie": "1.0.0"
 			}
@@ -9849,7 +16642,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
 			"integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
-			"dev": true,
 			"requires": {
 				"find-up": "2.1.0",
 				"load-json-file": "4.0.0"
@@ -9859,7 +16651,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"parse-json": "4.0.0",
@@ -9871,7 +16662,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "1.3.1",
 						"json-parse-better-errors": "1.0.1"
@@ -9880,8 +16670,7 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
@@ -9889,7 +16678,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-			"dev": true,
 			"requires": {
 				"find-up": "2.1.0"
 			}
@@ -9898,34 +16686,85 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
 			"integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
-			"dev": true,
 			"requires": {
 				"irregular-plurals": "1.4.0"
+			}
+		},
+		"pn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+		},
+		"popper.js": {
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.3.tgz",
+			"integrity": "sha1-FDj5jQRqz3tNeM1QK/QYrGTU8JU="
+		},
+		"portfinder": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
+			"integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+			"requires": {
+				"async": "1.5.2",
+				"debug": "2.6.9",
+				"mkdirp": "0.5.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-			"dev": true
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
 		"prepend-http": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-			"dev": true
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-			"dev": true
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+		},
+		"pretty-format": {
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+			"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+			"requires": {
+				"ansi-regex": "3.0.0",
+				"ansi-styles": "3.2.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				}
+			}
 		},
 		"pretty-ms": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
 			"integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
-			"dev": true,
 			"requires": {
 				"parse-ms": "1.0.1",
 				"plur": "2.1.2"
@@ -9934,44 +16773,69 @@
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-			"dev": true
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
 		},
 		"process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-			"dev": true
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-			"dev": true
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"progress": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
-			"dev": true
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "2.0.6"
+			}
+		},
+		"promise-inflight": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+		},
+		"prop-types": {
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			}
+		},
+		"proxy-addr": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+			"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+			"requires": {
+				"forwarded": "0.1.2",
+				"ipaddr.js": "1.6.0"
+			}
 		},
 		"prr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-			"dev": true
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"public-encrypt": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
 			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
-			"dev": true,
 			"requires": {
 				"bn.js": "4.11.8",
 				"browserify-rsa": "4.0.1",
@@ -9980,47 +16844,85 @@
 				"randombytes": "2.0.6"
 			}
 		},
+		"pump": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"once": "1.4.0"
+			}
+		},
+		"pumpify": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.0.tgz",
+			"integrity": "sha512-UWi0klDoq8xtVzlMRgENV9F7iCTZExaJQSQL187UXsxpk9NnrKGqTqqUNYAKGOzucSOxs2+jUnRNI+rLviPhJg==",
+			"requires": {
+				"duplexify": "3.6.0",
+				"inherits": "2.0.3",
+				"pump": "2.0.1"
+			},
+			"dependencies": {
+				"duplexify": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+					"integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
+					"requires": {
+						"end-of-stream": "1.4.1",
+						"inherits": "2.0.3",
+						"readable-stream": "2.3.5",
+						"stream-shift": "1.0.0"
+					}
+				}
+			}
+		},
 		"punycode": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-			"dev": true
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
 		},
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-			"dev": true
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
 		},
 		"qs": {
 			"version": "6.5.1",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-			"dev": true
+			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
 		},
 		"querystring": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-			"dev": true
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
 		},
 		"querystring-es3": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
-			"dev": true
+			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+		},
+		"querystringify": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+			"integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw="
 		},
 		"quick-lru": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
-			"dev": true
+			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
+		},
+		"rafl": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/rafl/-/rafl-1.2.2.tgz",
+			"integrity": "sha1-/pMPdYIRAg1H44gV9Rlqi+QVB0A=",
+			"requires": {
+				"global": "4.3.2"
+			}
 		},
 		"randomatic": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-			"dev": true,
 			"requires": {
 				"is-number": "3.0.0",
 				"kind-of": "4.0.0"
@@ -10030,7 +16932,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -10039,7 +16940,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -10050,7 +16950,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -10061,7 +16960,6 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
 			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -10070,17 +16968,54 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
 			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-			"dev": true,
 			"requires": {
 				"randombytes": "2.0.6",
 				"safe-buffer": "5.1.1"
+			}
+		},
+		"range-parser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+		},
+		"raw-body": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+			"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+			"requires": {
+				"bytes": "3.0.0",
+				"http-errors": "1.6.2",
+				"iconv-lite": "0.4.19",
+				"unpipe": "1.0.0"
+			},
+			"dependencies": {
+				"depd": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+				},
+				"http-errors": {
+					"version": "1.6.2",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+					"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+					"requires": {
+						"depd": "1.1.1",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.0.3",
+						"statuses": "1.4.0"
+					}
+				},
+				"setprototypeof": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+				}
 			}
 		},
 		"rc": {
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
 			"integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
-			"dev": true,
 			"requires": {
 				"deep-extend": "0.4.2",
 				"ini": "1.3.5",
@@ -10095,11 +17030,139 @@
 				}
 			}
 		},
+		"react": {
+			"version": "16.3.2",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz",
+			"integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
+			}
+		},
+		"react-dnd": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-2.6.0.tgz",
+			"integrity": "sha1-f6JWds+CfViokSk+PBq1naACVFo=",
+			"requires": {
+				"disposables": "1.0.2",
+				"dnd-core": "2.6.0",
+				"hoist-non-react-statics": "2.5.0",
+				"invariant": "2.2.4",
+				"lodash": "4.17.4",
+				"prop-types": "15.6.1"
+			}
+		},
+		"react-dnd-html5-backend": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-2.6.0.tgz",
+			"integrity": "sha1-WQzRzKeEQbsnTt1XH+9MCxbdz44=",
+			"requires": {
+				"lodash": "4.17.4"
+			}
+		},
+		"react-dom": {
+			"version": "16.3.2",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
+			"integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
+			}
+		},
+		"react-event-listener": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.5.3.tgz",
+			"integrity": "sha512-fTGYvhe7eTsqq0m664Km0rxKQcqLIGZWZINmy1LU0fu312tay8Mt3Twq2P5Xj1dfDVvvzT1Ql3/FDkiMPJ1MOg==",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"fbjs": "0.8.16",
+				"prop-types": "15.6.1",
+				"warning": "3.0.0"
+			}
+		},
+		"react-jss": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/react-jss/-/react-jss-8.4.0.tgz",
+			"integrity": "sha512-yIi4udcTIIh5u4KJ47wsL3UZYMuSrp5xR1YBvPeRNshpCdRoJxt5BWmCu1RA3LIa+//dnRsAtAQmMAYeg1W9oQ==",
+			"requires": {
+				"hoist-non-react-statics": "2.5.0",
+				"jss": "9.8.1",
+				"jss-preset-default": "4.5.0",
+				"prop-types": "15.6.1",
+				"theming": "1.3.0"
+			}
+		},
+		"react-lifecycles-compat": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.2.tgz",
+			"integrity": "sha512-pbZOSMVVkvppW7XRn9fcHK5OgEDnYLwMva7P6TgS44/SN9uGGjfh3Z1c8tomO+y4IsHQ6Fsz2EGwmE7sMeNZgQ=="
+		},
+		"react-popper": {
+			"version": "0.10.4",
+			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.10.4.tgz",
+			"integrity": "sha1-rypBXqIike3VBGeNev2opu4ylao=",
+			"requires": {
+				"popper.js": "1.14.3",
+				"prop-types": "15.6.1"
+			}
+		},
+		"react-redux": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+			"integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+			"requires": {
+				"hoist-non-react-statics": "2.5.0",
+				"invariant": "2.2.4",
+				"lodash": "4.17.10",
+				"lodash-es": "4.17.10",
+				"loose-envify": "1.3.1",
+				"prop-types": "15.6.1"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.10",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+				}
+			}
+		},
+		"react-scrollbar-size": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/react-scrollbar-size/-/react-scrollbar-size-2.1.0.tgz",
+			"integrity": "sha512-9dDUJvk7S48r0TRKjlKJ9e/LkLLYgc9LdQR6W21I8ZqtSrEsedPOoMji4nU3DHy7fx2l8YMScJS/N7qiloYzXQ==",
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"prop-types": "15.6.1",
+				"react-event-listener": "0.5.3",
+				"stifle": "1.0.4"
+			}
+		},
+		"react-text-mask": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/react-text-mask/-/react-text-mask-5.4.1.tgz",
+			"integrity": "sha512-mGx1n0x0skktwsKcpgAGnrgExFlXDflbWEHh8PC1UaQP8+EdHkW7JYczTghsBo2rnVwU9/4A9x/2bVt3HY46/w==",
+			"requires": {
+				"prop-types": "15.6.1"
+			}
+		},
+		"react-transition-group": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.3.1.tgz",
+			"integrity": "sha512-hu4/LAOFSKjWt1+1hgnOv3ldxmt6lvZGTWz4KUkFrqzXrNDIVSu6txIcPszw7PNduR8en9YTN55JLRyd/L1ZiQ==",
+			"requires": {
+				"dom-helpers": "3.3.1",
+				"loose-envify": "1.3.1",
+				"prop-types": "15.6.1"
+			}
+		},
 		"read-cmd-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
 			"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11"
 			}
@@ -10108,7 +17171,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-			"dev": true,
 			"requires": {
 				"load-json-file": "2.0.0",
 				"normalize-package-data": "2.4.0",
@@ -10119,7 +17181,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-			"dev": true,
 			"requires": {
 				"find-up": "2.1.0",
 				"read-pkg": "2.0.0"
@@ -10129,7 +17190,6 @@
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
 			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
-			"dev": true,
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
@@ -10144,7 +17204,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"minimatch": "3.0.4",
@@ -10152,20 +17211,37 @@
 				"set-immediate-shim": "1.0.1"
 			}
 		},
+		"realpath-native": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
+			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+			"requires": {
+				"util.promisify": "1.0.0"
+			}
+		},
 		"rechoir": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-			"dev": true,
 			"requires": {
 				"resolve": "1.6.0"
+			}
+		},
+		"recompose": {
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
+			"integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
+			"requires": {
+				"change-emitter": "0.1.6",
+				"fbjs": "0.8.16",
+				"hoist-non-react-statics": "2.5.0",
+				"symbol-observable": "1.2.0"
 			}
 		},
 		"redent": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-			"dev": true,
 			"requires": {
 				"indent-string": "2.1.0",
 				"strip-indent": "1.0.1"
@@ -10175,30 +17251,45 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-					"dev": true,
 					"requires": {
 						"repeating": "2.0.1"
 					}
 				}
 			}
 		},
+		"redux": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+			"requires": {
+				"lodash": "4.17.4",
+				"lodash-es": "4.17.10",
+				"loose-envify": "1.3.1",
+				"symbol-observable": "1.2.0"
+			}
+		},
+		"redux-mock-store": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.4.0.tgz",
+			"integrity": "sha512-y+SGh/SONWwqs4DiyHjd0H6NMgz368wXDiUjSHuOnMEr4dN9PmjV6N3bNvxoILaIQ7zeVKclLyxsCQ2TwGZfEw==",
+			"requires": {
+				"lodash.isplainobject": "4.0.6"
+			}
+		},
 		"regenerate": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
-			"dev": true
+			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
 		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-			"dev": true
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		},
 		"regex-cache": {
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-			"dev": true,
 			"requires": {
 				"is-equal-shallow": "0.1.3"
 			}
@@ -10207,7 +17298,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "3.0.2",
 				"safe-regex": "1.1.0"
@@ -10217,7 +17307,6 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-					"dev": true,
 					"requires": {
 						"assign-symbols": "1.0.0",
 						"is-extendable": "1.0.1"
@@ -10227,7 +17316,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "2.0.4"
 					}
@@ -10238,7 +17326,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-			"dev": true,
 			"requires": {
 				"regenerate": "1.3.3",
 				"regjsgen": "0.2.0",
@@ -10249,7 +17336,6 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
 			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-			"dev": true,
 			"requires": {
 				"rc": "1.2.6",
 				"safe-buffer": "5.1.1"
@@ -10259,7 +17345,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-			"dev": true,
 			"requires": {
 				"rc": "1.2.6"
 			}
@@ -10267,14 +17352,12 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-			"dev": true
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-			"dev": true,
 			"requires": {
 				"jsesc": "0.5.0"
 			}
@@ -10283,7 +17366,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
 			"integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
-			"dev": true,
 			"requires": {
 				"es6-error": "4.1.1"
 			}
@@ -10291,26 +17373,22 @@
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"dev": true
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-			"dev": true
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"dev": true,
 			"requires": {
 				"is-finite": "1.0.2"
 			}
@@ -10318,14 +17396,12 @@
 		"replace-ext": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-			"dev": true
+			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
 		},
 		"request": {
 			"version": "2.85.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
 			"integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
-			"dev": true,
 			"requires": {
 				"aws-sign2": "0.7.0",
 				"aws4": "1.6.0",
@@ -10351,29 +17427,48 @@
 				"uuid": "3.2.1"
 			}
 		},
+		"request-promise-core": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"requires": {
+				"lodash": "4.17.4"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"requires": {
+				"request-promise-core": "1.1.1",
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.3.4"
+			}
+		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-			"dev": true
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"require-precompiled": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
-			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo=",
-			"dev": true
+			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo="
+		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
 		"resolve": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
 			"integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
-			"dev": true,
 			"requires": {
 				"path-parse": "1.0.5"
 			}
@@ -10382,7 +17477,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-			"dev": true,
 			"requires": {
 				"resolve-from": "3.0.0"
 			}
@@ -10390,20 +17484,17 @@
 		"resolve-from": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-			"dev": true
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
 		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-			"dev": true
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
 		},
 		"restore-cursor": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-			"dev": true,
 			"requires": {
 				"onetime": "2.0.1",
 				"signal-exit": "3.0.2"
@@ -10412,14 +17503,12 @@
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-			"dev": true
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
 		"right-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-			"dev": true,
 			"requires": {
 				"align-text": "0.1.4"
 			}
@@ -10428,7 +17517,6 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-			"dev": true,
 			"requires": {
 				"glob": "7.1.2"
 			}
@@ -10437,83 +17525,959 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
 			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
-			"dev": true,
 			"requires": {
 				"hash-base": "2.0.2",
 				"inherits": "2.0.3"
 			}
 		},
+		"rsvp": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+			"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+		},
 		"run-async": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-			"dev": true,
 			"requires": {
 				"is-promise": "2.1.0"
+			}
+		},
+		"run-queue": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+			"requires": {
+				"aproba": "1.2.0"
 			}
 		},
 		"rx-lite": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-			"dev": true
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
 		},
 		"rx-lite-aggregates": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"dev": true,
 			"requires": {
 				"rx-lite": "4.0.8"
+			}
+		},
+		"rxjs": {
+			"version": "5.5.10",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.10.tgz",
+			"integrity": "sha512-SRjimIDUHJkon+2hFo7xnvNC4ZEHGzCRwh9P7nzX3zPkCGFEg/tuElrNR7L/rZMagnK2JeH2jQwPRpmyXyLB6A==",
+			"requires": {
+				"symbol-observable": "1.0.1"
+			},
+			"dependencies": {
+				"symbol-observable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+					"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
+				}
 			}
 		},
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-			"dev": true
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-			"dev": true,
 			"requires": {
 				"ret": "0.1.15"
+			}
+		},
+		"sane": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
+			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
+			"requires": {
+				"anymatch": "2.0.0",
+				"capture-exit": "1.2.0",
+				"exec-sh": "0.2.1",
+				"fb-watchman": "2.0.0",
+				"fsevents": "1.2.3",
+				"micromatch": "3.1.10",
+				"minimist": "1.2.0",
+				"walker": "1.0.7",
+				"watch": "0.18.0"
+			},
+			"dependencies": {
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"requires": {
+						"micromatch": "3.1.10",
+						"normalize-path": "2.1.1"
+					}
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"requires": {
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"extend-shallow": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+					"requires": {
+						"assign-symbols": "1.0.0",
+						"is-extendable": "1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+							"requires": {
+								"is-plain-object": "2.0.4"
+							}
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"fsevents": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
+					"integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
+					"optional": true,
+					"requires": {
+						"nan": "2.10.0",
+						"node-pre-gyp": "0.9.1"
+					},
+					"dependencies": {
+						"abbrev": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true
+						},
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"optional": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.4",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"delegates": "1.0.0",
+								"readable-stream": "2.3.6"
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"requires": {
+								"balanced-match": "1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"chownr": {
+							"version": "1.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"debug": {
+							"version": "2.6.9",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"deep-extend": {
+							"version": "0.4.2",
+							"bundled": true,
+							"optional": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"detect-libc": {
+							"version": "1.0.3",
+							"bundled": true,
+							"optional": true
+						},
+						"fs-minipass": {
+							"version": "1.2.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minipass": "2.2.4"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"aproba": "1.2.0",
+								"console-control-strings": "1.1.0",
+								"has-unicode": "2.0.1",
+								"object-assign": "4.1.1",
+								"signal-exit": "3.0.2",
+								"string-width": "1.0.2",
+								"strip-ansi": "3.0.1",
+								"wide-align": "1.1.2"
+							}
+						},
+						"glob": {
+							"version": "7.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"fs.realpath": "1.0.0",
+								"inflight": "1.0.6",
+								"inherits": "2.0.3",
+								"minimatch": "3.0.4",
+								"once": "1.4.0",
+								"path-is-absolute": "1.0.1"
+							}
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"iconv-lite": {
+							"version": "0.4.21",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safer-buffer": "2.1.2"
+							}
+						},
+						"ignore-walk": {
+							"version": "3.0.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minimatch": "3.0.4"
+							}
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"once": "1.4.0",
+								"wrappy": "1.0.2"
+							}
+						},
+						"inherits": {
+							"version": "2.0.3",
+							"bundled": true
+						},
+						"ini": {
+							"version": "1.3.5",
+							"bundled": true,
+							"optional": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"number-is-nan": "1.0.1"
+							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"requires": {
+								"brace-expansion": "1.1.11"
+							}
+						},
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true
+						},
+						"minipass": {
+							"version": "2.2.4",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "5.1.1",
+								"yallist": "3.0.2"
+							}
+						},
+						"minizlib": {
+							"version": "1.1.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minipass": "2.2.4"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"requires": {
+								"minimist": "0.0.8"
+							}
+						},
+						"ms": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"needle": {
+							"version": "2.2.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"debug": "2.6.9",
+								"iconv-lite": "0.4.21",
+								"sax": "1.2.4"
+							}
+						},
+						"node-pre-gyp": {
+							"version": "0.9.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"detect-libc": "1.0.3",
+								"mkdirp": "0.5.1",
+								"needle": "2.2.0",
+								"nopt": "4.0.1",
+								"npm-packlist": "1.1.10",
+								"npmlog": "4.1.2",
+								"rc": "1.2.6",
+								"rimraf": "2.6.2",
+								"semver": "5.5.0",
+								"tar": "4.4.1"
+							}
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"abbrev": "1.1.1",
+								"osenv": "0.1.5"
+							}
+						},
+						"npm-bundled": {
+							"version": "1.0.3",
+							"bundled": true,
+							"optional": true
+						},
+						"npm-packlist": {
+							"version": "1.1.10",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ignore-walk": "3.0.1",
+								"npm-bundled": "1.0.3"
+							}
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"are-we-there-yet": "1.1.4",
+								"console-control-strings": "1.1.0",
+								"gauge": "2.7.4",
+								"set-blocking": "2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"requires": {
+								"wrappy": "1.0.2"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"osenv": {
+							"version": "0.1.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"os-homedir": "1.0.2",
+								"os-tmpdir": "1.0.2"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"rc": {
+							"version": "1.2.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"deep-extend": "0.4.2",
+								"ini": "1.3.5",
+								"minimist": "1.2.0",
+								"strip-json-comments": "2.0.1"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "1.2.0",
+									"bundled": true,
+									"optional": true
+								}
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"core-util-is": "1.0.2",
+								"inherits": "2.0.3",
+								"isarray": "1.0.0",
+								"process-nextick-args": "2.0.0",
+								"safe-buffer": "5.1.1",
+								"string_decoder": "1.1.1",
+								"util-deprecate": "1.0.2"
+							}
+						},
+						"rimraf": {
+							"version": "2.6.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"glob": "7.1.2"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.1",
+							"bundled": true
+						},
+						"safer-buffer": {
+							"version": "2.1.2",
+							"bundled": true,
+							"optional": true
+						},
+						"sax": {
+							"version": "1.2.4",
+							"bundled": true,
+							"optional": true
+						},
+						"semver": {
+							"version": "5.5.0",
+							"bundled": true,
+							"optional": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "5.1.1"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "2.1.1"
+							}
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"tar": {
+							"version": "4.4.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"chownr": "1.0.1",
+								"fs-minipass": "1.2.5",
+								"minipass": "2.2.4",
+								"minizlib": "1.1.0",
+								"mkdirp": "0.5.1",
+								"safe-buffer": "5.1.1",
+								"yallist": "3.0.2"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"wide-align": {
+							"version": "1.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"string-width": "1.0.2"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"yallist": {
+							"version": "3.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"requires": {
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
+		"scroll": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/scroll/-/scroll-2.0.3.tgz",
+			"integrity": "sha512-3ncZzf8gUW739h3LeS68nSssO60O+GGjT3SxzgofQmT8PIoyHzebql9HHPJopZX8iT6TKOdwaWFMqL6LzUN3DQ==",
+			"requires": {
+				"rafl": "1.2.2"
+			}
+		},
+		"select-hose": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
+		},
+		"selfsigned": {
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.3.tgz",
+			"integrity": "sha512-vmZenZ+8Al3NLHkWnhBQ0x6BkML1eCP2xEi3JE+f3D9wW9fipD9NNJHYtE9XJM4TsPaHGZJIamrSI6MTg1dU2Q==",
+			"requires": {
+				"node-forge": "0.7.5"
 			}
 		},
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-			"dev": true
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
 		},
 		"semver-diff": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
 			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-			"dev": true,
 			"requires": {
 				"semver": "5.5.0"
+			}
+		},
+		"send": {
+			"version": "0.16.2",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+			"requires": {
+				"debug": "2.6.9",
+				"depd": "1.1.2",
+				"destroy": "1.0.4",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "1.6.3",
+				"mime": "1.4.1",
+				"ms": "2.0.0",
+				"on-finished": "2.3.0",
+				"range-parser": "1.2.0",
+				"statuses": "1.4.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"mime": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+					"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"serialize-javascript": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
+			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
+		},
+		"serve-index": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+			"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+			"requires": {
+				"accepts": "1.3.5",
+				"batch": "0.6.1",
+				"debug": "2.6.9",
+				"escape-html": "1.0.3",
+				"http-errors": "1.6.3",
+				"mime-types": "2.1.18",
+				"parseurl": "1.3.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"serve-static": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+			"requires": {
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"parseurl": "1.3.2",
+				"send": "0.16.2"
 			}
 		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-			"dev": true
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
 		"set-value": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "2.0.1",
 				"is-extendable": "0.1.1",
@@ -10524,14 +18488,17 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+		},
+		"setprototypeof": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
 		},
 		"sha.js": {
 			"version": "2.4.11",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"safe-buffer": "5.1.1"
@@ -10541,7 +18508,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"dev": true,
 			"requires": {
 				"shebang-regex": "1.0.0"
 			}
@@ -10549,37 +18515,48 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-			"dev": true
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+		},
+		"shell-quote": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+			"requires": {
+				"array-filter": "0.0.1",
+				"array-map": "0.0.0",
+				"array-reduce": "0.0.0",
+				"jsonify": "0.0.0"
+			}
 		},
 		"shelljs": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
 			"integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
-			"dev": true,
 			"requires": {
 				"glob": "7.1.2",
 				"interpret": "1.1.0",
 				"rechoir": "0.6.2"
 			}
 		},
+		"shellwords": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-			"dev": true
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-			"dev": true
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 		},
 		"slice-ansi": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0"
 			}
@@ -10587,14 +18564,12 @@
 		"slide": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-			"dev": true
+			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
 		},
 		"snapdragon": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-			"dev": true,
 			"requires": {
 				"base": "0.11.2",
 				"debug": "2.6.9",
@@ -10610,7 +18585,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -10619,7 +18593,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "0.1.6"
 					}
@@ -10628,7 +18601,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -10637,7 +18609,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -10648,7 +18619,6 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -10657,7 +18627,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -10668,7 +18637,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "0.1.6",
 						"is-data-descriptor": "0.1.4",
@@ -10678,14 +18646,12 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"dev": true
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				},
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -10693,7 +18659,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-			"dev": true,
 			"requires": {
 				"define-property": "1.0.0",
 				"isobject": "3.0.1",
@@ -10704,7 +18669,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "1.0.2"
 					}
@@ -10712,8 +18676,7 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -10721,7 +18684,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2"
 			}
@@ -10730,16 +18692,59 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
 			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-			"dev": true,
 			"requires": {
 				"hoek": "4.2.1"
+			}
+		},
+		"sockjs": {
+			"version": "0.3.19",
+			"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
+			"integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
+			"requires": {
+				"faye-websocket": "0.10.0",
+				"uuid": "3.2.1"
+			}
+		},
+		"sockjs-client": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+			"integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+			"requires": {
+				"debug": "2.6.9",
+				"eventsource": "0.1.6",
+				"faye-websocket": "0.11.1",
+				"inherits": "2.0.3",
+				"json3": "3.3.2",
+				"url-parse": "1.4.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"faye-websocket": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+					"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+					"requires": {
+						"websocket-driver": "0.7.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
 			}
 		},
 		"sort-keys": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-			"dev": true,
 			"requires": {
 				"is-plain-obj": "1.1.0"
 			}
@@ -10747,20 +18752,17 @@
 		"source-list-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
-			"dev": true
+			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
 		},
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-			"dev": true
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
 		"source-map-loader": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.3.tgz",
 			"integrity": "sha512-MYbFX9DYxmTQFfy2v8FC1XZwpwHKYxg3SK8Wb7VPBKuhDjz8gi9re2819MsG4p49HDyiOSUKlmZ+nQBArW5CGw==",
-			"dev": true,
 			"requires": {
 				"async": "2.6.0",
 				"loader-utils": "0.2.17",
@@ -10771,7 +18773,6 @@
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
 					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-					"dev": true,
 					"requires": {
 						"lodash": "4.17.4"
 					}
@@ -10780,7 +18781,6 @@
 					"version": "0.2.17",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
 					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-					"dev": true,
 					"requires": {
 						"big.js": "3.2.0",
 						"emojis-list": "2.1.0",
@@ -10791,8 +18791,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -10800,7 +18799,6 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
 			"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
-			"dev": true,
 			"requires": {
 				"atob": "2.0.3",
 				"decode-uri-component": "0.2.0",
@@ -10813,7 +18811,6 @@
 			"version": "0.5.4",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
 			"integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
-			"dev": true,
 			"requires": {
 				"source-map": "0.6.1"
 			},
@@ -10828,14 +18825,12 @@
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-			"dev": true
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"spdx-correct": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
 			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
-			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "3.0.0",
 				"spdx-license-ids": "3.0.0"
@@ -10844,14 +18839,12 @@
 		"spdx-exceptions": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
-			"dev": true
+			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-			"dev": true,
 			"requires": {
 				"spdx-exceptions": "2.1.0",
 				"spdx-license-ids": "3.0.0"
@@ -10860,14 +18853,69 @@
 		"spdx-license-ids": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
-			"dev": true
+			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+		},
+		"spdy": {
+			"version": "3.4.7",
+			"resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
+			"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+			"requires": {
+				"debug": "2.6.9",
+				"handle-thing": "1.2.5",
+				"http-deceiver": "1.2.7",
+				"safe-buffer": "5.1.1",
+				"select-hose": "2.0.0",
+				"spdy-transport": "2.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"spdy-transport": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
+			"integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
+			"requires": {
+				"debug": "2.6.9",
+				"detect-node": "2.0.3",
+				"hpack.js": "2.1.6",
+				"obuf": "1.1.2",
+				"readable-stream": "2.3.5",
+				"safe-buffer": "5.1.1",
+				"wbuf": "1.7.3"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
 		},
 		"split": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
 			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
 			"requires": {
 				"through": "2.3.8"
 			}
@@ -10876,7 +18924,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "3.0.2"
 			},
@@ -10885,7 +18932,6 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-					"dev": true,
 					"requires": {
 						"assign-symbols": "1.0.0",
 						"is-extendable": "1.0.1"
@@ -10895,7 +18941,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "2.0.4"
 					}
@@ -10906,7 +18951,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
 			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
-			"dev": true,
 			"requires": {
 				"through2": "2.0.3"
 			}
@@ -10914,14 +18958,12 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
 			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
-			"dev": true,
 			"requires": {
 				"asn1": "0.2.3",
 				"assert-plus": "1.0.0",
@@ -10933,17 +18975,23 @@
 				"tweetnacl": "0.14.5"
 			}
 		},
+		"ssri": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+			"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
 		"stack-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
-			"dev": true
+			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
 		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-			"dev": true,
 			"requires": {
 				"define-property": "0.2.5",
 				"object-copy": "0.1.0"
@@ -10953,7 +19001,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "0.1.6"
 					}
@@ -10962,7 +19009,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -10971,7 +19017,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -10982,7 +19027,6 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -10991,7 +19035,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -11002,7 +19045,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "0.1.6",
 						"is-data-descriptor": "0.1.4",
@@ -11012,26 +19054,47 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"dev": true
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
+		},
+		"statuses": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+		},
+		"stifle": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/stifle/-/stifle-1.0.4.tgz",
+			"integrity": "sha1-izvN9SQZsKnHnjWtrc5QEjwdjpk="
 		},
 		"stream-browserify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
-			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"readable-stream": "2.3.5"
+			}
+		},
+		"stream-each": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+			"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"stream-shift": "1.0.0"
 			}
 		},
 		"stream-http": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
 			"integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
-			"dev": true,
 			"requires": {
 				"builtin-status-codes": "3.0.0",
 				"inherits": "2.0.3",
@@ -11043,14 +19106,21 @@
 		"stream-shift": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-			"dev": true
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+		},
+		"string-length": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+			"requires": {
+				"astral-regex": "1.0.0",
+				"strip-ansi": "4.0.0"
+			}
 		},
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0",
 				"strip-ansi": "4.0.0"
@@ -11060,7 +19130,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -11068,14 +19137,12 @@
 		"stringstream": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-			"dev": true
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
 		},
 		"strip-ansi": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "3.0.0"
 			},
@@ -11083,22 +19150,19 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				}
 			}
 		},
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-			"dev": true
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 		},
 		"strip-bom-buf": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
 			"integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
-			"dev": true,
 			"requires": {
 				"is-utf8": "0.2.1"
 			}
@@ -11107,7 +19171,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 			"integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-			"dev": true,
 			"requires": {
 				"first-chunk-stream": "1.0.0",
 				"strip-bom": "2.0.0"
@@ -11117,7 +19180,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "0.2.1"
 					}
@@ -11127,14 +19189,12 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-			"dev": true
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"strip-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-			"dev": true,
 			"requires": {
 				"get-stdin": "4.0.1"
 			}
@@ -11142,14 +19202,12 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"strong-log-transformer": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz",
 			"integrity": "sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=",
-			"dev": true,
 			"requires": {
 				"byline": "5.0.0",
 				"duplexer": "0.1.1",
@@ -11161,16 +19219,46 @@
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
-					"dev": true
+					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
 				}
+			}
+		},
+		"subarg": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+			"integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+			"requires": {
+				"minimist": "1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"superagent": {
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+			"integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+			"requires": {
+				"component-emitter": "1.2.1",
+				"cookiejar": "2.1.1",
+				"debug": "3.1.0",
+				"extend": "3.0.1",
+				"form-data": "2.3.2",
+				"formidable": "1.2.1",
+				"methods": "1.1.2",
+				"mime": "1.6.0",
+				"qs": "6.5.1",
+				"readable-stream": "2.3.5"
 			}
 		},
 		"supports-color": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 			"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-			"dev": true,
 			"requires": {
 				"has-flag": "3.0.0"
 			},
@@ -11178,34 +19266,34 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				}
 			}
 		},
 		"symbol-observable": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-			"dev": true
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+		},
+		"symbol-tree": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
 		},
 		"tapable": {
 			"version": "0.2.8",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
-			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
-			"dev": true
+			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
 		},
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
-			"dev": true
+			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
 		},
 		"temp-write": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/temp-write/-/temp-write-3.4.0.tgz",
 			"integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"is-stream": "1.1.0",
@@ -11218,8 +19306,7 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
@@ -11227,7 +19314,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
 			"integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "1.0.2",
 				"uuid": "2.0.3"
@@ -11236,8 +19322,7 @@
 				"uuid": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-					"dev": true
+					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
 				}
 			}
 		},
@@ -11245,34 +19330,392 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
 			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-			"dev": true,
 			"requires": {
 				"execa": "0.7.0"
+			}
+		},
+		"test-exclude": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
+			"integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
+			"requires": {
+				"arrify": "1.0.1",
+				"micromatch": "3.1.10",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"require-main-filename": "1.0.1"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"requires": {
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"extend-shallow": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+					"requires": {
+						"assign-symbols": "1.0.0",
+						"is-extendable": "1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+							"requires": {
+								"is-plain-object": "2.0.4"
+							}
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"requires": {
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+					"requires": {
+						"pinkie": "2.0.4"
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"requires": {
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"requires": {
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				}
 			}
 		},
 		"text-extensions": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
-			"integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
-			"dev": true
+			"integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg=="
 		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-			"dev": true
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+		},
+		"theming": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/theming/-/theming-1.3.0.tgz",
+			"integrity": "sha512-ya5Ef7XDGbTPBv5ENTwrwkPUexrlPeiAg/EI9kdlUAZhNlRbCdhMKRgjNX1IcmsmiPcqDQZE6BpSaH+cr31FKw==",
+			"requires": {
+				"brcast": "3.0.1",
+				"is-function": "1.0.1",
+				"is-plain-object": "2.0.4",
+				"prop-types": "15.6.1"
+			}
+		},
+		"throat": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "2.3.5",
 				"xtend": "4.0.1"
@@ -11282,17 +19725,20 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
 			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
-			"dev": true,
 			"requires": {
 				"through2": "2.0.3",
 				"xtend": "4.0.1"
 			}
 		},
+		"thunky": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz",
+			"integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E="
+		},
 		"time-require": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/time-require/-/time-require-0.1.2.tgz",
 			"integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
-			"dev": true,
 			"requires": {
 				"chalk": "0.4.0",
 				"date-time": "0.1.1",
@@ -11303,14 +19749,12 @@
 				"ansi-styles": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-					"dev": true
+					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
 				},
 				"chalk": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "1.0.0",
 						"has-color": "0.1.7",
@@ -11320,20 +19764,17 @@
 				"date-time": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
-					"integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
-					"dev": true
+					"integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc="
 				},
 				"parse-ms": {
 					"version": "0.1.2",
 					"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
-					"integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
-					"dev": true
+					"integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4="
 				},
 				"pretty-ms": {
 					"version": "0.2.2",
 					"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
 					"integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
-					"dev": true,
 					"requires": {
 						"parse-ms": "0.1.2"
 					}
@@ -11341,28 +19782,29 @@
 				"strip-ansi": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-					"dev": true
+					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
 				}
 			}
+		},
+		"time-stamp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
+			"integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c="
 		},
 		"time-zone": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
-			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
-			"dev": true
+			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0="
 		},
 		"timed-out": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-			"dev": true
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 		},
 		"timers-browserify": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
 			"integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
-			"dev": true,
 			"requires": {
 				"setimmediate": "1.0.5"
 			}
@@ -11371,16 +19813,19 @@
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "1.0.2"
 			}
+		},
+		"tmpl": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
 		},
 		"to-absolute-glob": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
 			"integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "2.0.1"
 			}
@@ -11388,20 +19833,17 @@
 		"to-arraybuffer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
-			"dev": true
+			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
 		},
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-			"dev": true
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
 		},
 		"to-object-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2"
 			}
@@ -11410,7 +19852,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-			"dev": true,
 			"requires": {
 				"define-property": "2.0.2",
 				"extend-shallow": "3.0.2",
@@ -11422,7 +19863,6 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-					"dev": true,
 					"requires": {
 						"assign-symbols": "1.0.0",
 						"is-extendable": "1.0.1"
@@ -11432,7 +19872,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "2.0.4"
 					}
@@ -11443,7 +19882,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-			"dev": true,
 			"requires": {
 				"is-number": "3.0.0",
 				"repeat-string": "1.6.1"
@@ -11453,7 +19891,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					}
@@ -11464,34 +19901,170 @@
 			"version": "2.3.4",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
 			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-			"dev": true,
 			"requires": {
 				"punycode": "1.4.1"
+			}
+		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"requires": {
+				"punycode": "2.1.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+				}
 			}
 		},
 		"trim-newlines": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-			"dev": true
+			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
 		},
 		"trim-off-newlines": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
-			"dev": true
+			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-			"dev": true
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+		},
+		"ts-jest": {
+			"version": "22.4.5",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-22.4.5.tgz",
+			"integrity": "sha512-3LkEkPzKutk+klOxtAhvTdYc9ZK7lHugyPg4VNj+l8jg7CCOBgAHqp009MWdT6WllYeSoWHcQaB3aJ6/JbTMJg==",
+			"requires": {
+				"babel-core": "6.26.3",
+				"babel-plugin-istanbul": "4.1.6",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+				"babel-preset-jest": "22.4.3",
+				"cpx": "1.5.0",
+				"fs-extra": "6.0.0",
+				"jest-config": "22.4.3",
+				"lodash": "4.17.10",
+				"pkg-dir": "2.0.0",
+				"yargs": "11.0.0"
+			},
+			"dependencies": {
+				"babel-core": {
+					"version": "6.26.3",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+					"requires": {
+						"babel-code-frame": "6.26.0",
+						"babel-generator": "6.26.1",
+						"babel-helpers": "6.24.1",
+						"babel-messages": "6.23.0",
+						"babel-register": "6.26.0",
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"convert-source-map": "1.5.1",
+						"debug": "2.6.9",
+						"json5": "0.5.1",
+						"lodash": "4.17.10",
+						"minimatch": "3.0.4",
+						"path-is-absolute": "1.0.1",
+						"private": "0.1.8",
+						"slash": "1.0.0",
+						"source-map": "0.5.7"
+					}
+				},
+				"babel-plugin-transform-es2015-modules-commonjs": {
+					"version": "6.26.2",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+					"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+					"requires": {
+						"babel-plugin-transform-strict-mode": "6.24.1",
+						"babel-runtime": "6.26.0",
+						"babel-template": "6.26.0",
+						"babel-types": "6.26.0"
+					}
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"cliui": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+					"requires": {
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"fs-extra": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.0.tgz",
+					"integrity": "sha512-lk2cUCo8QzbiEWEbt7Cw3m27WMiRG321xsssbcIpfMhpRjrlC08WBOVQqj1/nQYYNnPtyIhP1oqLO3QwT2tPCw==",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"jsonfile": "4.0.0",
+						"universalify": "0.1.1"
+					}
+				},
+				"lodash": {
+					"version": "4.17.10",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"yargs": {
+					"version": "11.0.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+					"requires": {
+						"cliui": "4.1.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "9.0.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "9.0.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+					"requires": {
+						"camelcase": "4.1.0"
+					}
+				}
+			}
 		},
 		"ts-loader": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-3.5.0.tgz",
 			"integrity": "sha512-JTia3kObhTk36wPFgy0RnkZReiusYx7Le9IhcUWRrCTcFcr6Dy1zGsFd3x8DG4gevlbN65knI8W50FfoykXcng==",
-			"dev": true,
 			"requires": {
 				"chalk": "2.3.2",
 				"enhanced-resolve": "3.4.1",
@@ -11503,20 +20076,17 @@
 				"arr-diff": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 				},
 				"array-unique": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 				},
 				"braces": {
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
 					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "1.1.0",
 						"array-unique": "0.3.2",
@@ -11536,7 +20106,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "1.0.2"
 							}
@@ -11545,7 +20114,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "0.1.1"
 							}
@@ -11556,7 +20124,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -11565,7 +20132,6 @@
 					"version": "2.1.4",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
 					"requires": {
 						"debug": "2.6.9",
 						"define-property": "0.2.5",
@@ -11580,7 +20146,6 @@
 							"version": "0.2.5",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "0.1.6"
 							}
@@ -11589,7 +20154,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "0.1.1"
 							}
@@ -11598,7 +20162,6 @@
 							"version": "0.1.6",
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "0.1.6",
 								"is-data-descriptor": "0.1.4",
@@ -11608,8 +20171,7 @@
 						"kind-of": {
 							"version": "5.1.0",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 						}
 					}
 				},
@@ -11617,7 +20179,6 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-					"dev": true,
 					"requires": {
 						"assign-symbols": "1.0.0",
 						"is-extendable": "1.0.1"
@@ -11627,7 +20188,6 @@
 							"version": "1.0.1",
 							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-							"dev": true,
 							"requires": {
 								"is-plain-object": "2.0.4"
 							}
@@ -11638,7 +20198,6 @@
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"dev": true,
 					"requires": {
 						"array-unique": "0.3.2",
 						"define-property": "1.0.0",
@@ -11654,7 +20213,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "1.0.2"
 							}
@@ -11663,7 +20221,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "0.1.1"
 							}
@@ -11674,7 +20231,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
 					"requires": {
 						"extend-shallow": "2.0.1",
 						"is-number": "3.0.0",
@@ -11686,7 +20242,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "0.1.1"
 							}
@@ -11697,7 +20252,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -11706,7 +20260,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -11717,7 +20270,6 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -11726,7 +20278,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -11737,7 +20288,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -11746,7 +20296,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -11756,20 +20305,17 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				},
 				"micromatch": {
 					"version": "3.1.10",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
 					"requires": {
 						"arr-diff": "4.0.0",
 						"array-unique": "0.3.2",
@@ -11789,22 +20335,19 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
 		"tslib": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
-			"dev": true
+			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
 		},
 		"tslint": {
 			"version": "5.9.1",
 			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
 			"integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
 				"builtin-modules": "1.1.1",
@@ -11824,7 +20367,6 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/tslint-loader/-/tslint-loader-3.6.0.tgz",
 			"integrity": "sha512-Me9Qf/87BOfCY8uJJw+J7VMF4U8WiMXKLhKKKugMydF0xMhMOt9wo2mjYTNhwbF9H7SHh8PAIwRG8roisTNekQ==",
-			"dev": true,
 			"requires": {
 				"loader-utils": "1.1.0",
 				"mkdirp": "0.5.1",
@@ -11837,7 +20379,6 @@
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/tslint-react/-/tslint-react-3.5.1.tgz",
 			"integrity": "sha512-ndS/iOOGrasATcf5YU3JxoIwPGVykjrKhzmlVsRdT1xzl/RbNg9n627rtAGbCjkQepyiaQYgxWQT5G/qUpQCaA==",
-			"dev": true,
 			"requires": {
 				"tsutils": "2.22.2"
 			}
@@ -11846,7 +20387,6 @@
 			"version": "2.22.2",
 			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.22.2.tgz",
 			"integrity": "sha512-u06FUSulCJ+Y8a2ftuqZN6kIGqdP2yJjUPEngXqmdPND4UQfb04igcotH+dw+IFr417yP6muCLE8/5/Qlfnx0w==",
-			"dev": true,
 			"requires": {
 				"tslib": "1.9.0"
 			}
@@ -11854,14 +20394,12 @@
 		"tty-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
-			"dev": true
+			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -11870,20 +20408,34 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true,
 			"optional": true
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"requires": {
+				"prelude-ls": "1.1.2"
+			}
+		},
+		"type-is": {
+			"version": "1.6.16",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+			"requires": {
+				"media-typer": "0.3.0",
+				"mime-types": "2.1.18"
+			}
 		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-			"dev": true
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
 		"typedoc": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.10.0.tgz",
 			"integrity": "sha512-+lnM/ZAv+JHfeEpGcdoE++1nsHFmfexg64gCUsQEyxzfmGJrJ2gXcaKv0dZVrxckdr9m9S6ty+OAT0Z8NICkLg==",
-			"dev": true,
 			"requires": {
 				"@types/fs-extra": "5.0.0",
 				"@types/handlebars": "4.0.36",
@@ -11907,14 +20459,12 @@
 				"@types/lodash": {
 					"version": "4.14.99",
 					"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.99.tgz",
-					"integrity": "sha512-h9uv6EUxjfDWNmJCNEoulQF/pFS4ua09LgSGjj6GgmIoyJ/MO5JsK8m9y+9CoG+8j2kDWCW+piPdR9fL7QoQYA==",
-					"dev": true
+					"integrity": "sha512-h9uv6EUxjfDWNmJCNEoulQF/pFS4ua09LgSGjj6GgmIoyJ/MO5JsK8m9y+9CoG+8j2kDWCW+piPdR9fL7QoQYA=="
 				},
 				"fs-extra": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
 					"integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"jsonfile": "4.0.0",
@@ -11924,28 +20474,29 @@
 				"typescript": {
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
-					"integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw==",
-					"dev": true
+					"integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw=="
 				}
 			}
 		},
 		"typedoc-default-themes": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
-			"integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
-			"dev": true
+			"integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic="
 		},
 		"typescript": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-			"integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
-			"dev": true
+			"integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
+		},
+		"ua-parser-js": {
+			"version": "0.7.18",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+			"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
 		},
 		"uglify-js": {
 			"version": "2.8.29",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
 			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-			"dev": true,
 			"requires": {
 				"source-map": "0.5.7",
 				"uglify-to-browserify": "1.0.2",
@@ -11955,14 +20506,12 @@
 				"camelcase": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-					"dev": true
+					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
 				},
 				"yargs": {
 					"version": "3.10.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-					"dev": true,
 					"requires": {
 						"camelcase": "1.2.1",
 						"cliui": "2.1.0",
@@ -11976,14 +20525,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
 			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-			"dev": true,
 			"optional": true
 		},
 		"uglifyjs-webpack-plugin": {
 			"version": "0.4.6",
 			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
 			"integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
-			"dev": true,
 			"requires": {
 				"source-map": "0.5.7",
 				"uglify-js": "2.8.29",
@@ -11993,14 +20540,12 @@
 		"uid2": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
-			"dev": true
+			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
 		},
 		"union-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-			"dev": true,
 			"requires": {
 				"arr-union": "3.1.0",
 				"get-value": "2.0.6",
@@ -12012,7 +20557,6 @@
 					"version": "0.4.3",
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"dev": true,
 					"requires": {
 						"extend-shallow": "2.0.1",
 						"is-extendable": "0.1.1",
@@ -12022,11 +20566,26 @@
 				}
 			}
 		},
+		"unique-filename": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+			"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+			"requires": {
+				"unique-slug": "2.0.0"
+			}
+		},
+		"unique-slug": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+			"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+			"requires": {
+				"imurmurhash": "0.1.4"
+			}
+		},
 		"unique-stream": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
 			"integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
-			"dev": true,
 			"requires": {
 				"json-stable-stringify": "1.0.1",
 				"through2-filter": "2.0.0"
@@ -12036,7 +20595,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
 			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-			"dev": true,
 			"requires": {
 				"crypto-random-string": "1.0.0"
 			}
@@ -12045,7 +20603,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
 			"integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
-			"dev": true,
 			"requires": {
 				"mkdirp": "0.5.1",
 				"os-tmpdir": "1.0.2",
@@ -12055,14 +20612,17 @@
 		"universalify": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-			"dev": true
+			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+		},
+		"unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 		},
 		"unset-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-			"dev": true,
 			"requires": {
 				"has-value": "0.3.1",
 				"isobject": "3.0.1"
@@ -12072,7 +20632,6 @@
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-					"dev": true,
 					"requires": {
 						"get-value": "2.0.6",
 						"has-values": "0.1.4",
@@ -12083,7 +20642,6 @@
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-							"dev": true,
 							"requires": {
 								"isarray": "1.0.0"
 							}
@@ -12093,34 +20651,29 @@
 				"has-values": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-					"dev": true
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
 				},
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
 		"unzip-response": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-			"dev": true
+			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
 		},
 		"upath": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
-			"integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw==",
-			"dev": true
+			"integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw=="
 		},
 		"update-notifier": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.4.0.tgz",
 			"integrity": "sha1-+bTHAPv9TsEsgRWHJYd31WPYyGY=",
-			"dev": true,
 			"requires": {
 				"boxen": "1.3.0",
 				"chalk": "2.3.2",
@@ -12138,7 +20691,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
 			"integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
-			"dev": true,
 			"requires": {
 				"punycode": "2.1.0"
 			},
@@ -12146,22 +20698,19 @@
 				"punycode": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
-					"dev": true
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
 				}
 			}
 		},
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-			"dev": true
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
 		},
 		"url": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
 			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-			"dev": true,
 			"requires": {
 				"punycode": "1.3.2",
 				"querystring": "0.2.0"
@@ -12170,8 +20719,23 @@
 				"punycode": {
 					"version": "1.3.2",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-					"dev": true
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+				}
+			}
+		},
+		"url-parse": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
+			"integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
+			"requires": {
+				"querystringify": "2.0.0",
+				"requires-port": "1.0.0"
+			},
+			"dependencies": {
+				"querystringify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+					"integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
 				}
 			}
 		},
@@ -12179,7 +20743,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-			"dev": true,
 			"requires": {
 				"prepend-http": "1.0.4"
 			}
@@ -12188,7 +20751,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
 			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-			"dev": true,
 			"requires": {
 				"kind-of": "6.0.2"
 			},
@@ -12196,8 +20758,7 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -12205,7 +20766,6 @@
 			"version": "0.10.3",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
 			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-			"dev": true,
 			"requires": {
 				"inherits": "2.0.1"
 			},
@@ -12213,44 +20773,57 @@
 				"inherits": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-					"dev": true
+					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
 				}
 			}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"util.promisify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"requires": {
+				"define-properties": "1.1.2",
+				"object.getownpropertydescriptors": "2.0.3"
+			}
+		},
+		"utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-			"dev": true
+			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
 		},
 		"vali-date": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
-			"dev": true
+			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
 			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
-			"dev": true,
 			"requires": {
 				"spdx-correct": "3.0.0",
 				"spdx-expression-parse": "3.0.0"
 			}
 		},
+		"vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
@@ -12261,7 +20834,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
 			"integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
-			"dev": true,
 			"requires": {
 				"clone": "2.1.2",
 				"clone-buffer": "1.0.0",
@@ -12275,7 +20847,6 @@
 			"version": "2.4.4",
 			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
 			"integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
-			"dev": true,
 			"requires": {
 				"duplexify": "3.5.4",
 				"glob-stream": "5.3.5",
@@ -12299,26 +20870,22 @@
 				"clone": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-					"dev": true
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
 				},
 				"clone-stats": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-					"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-					"dev": true
+					"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
 				},
 				"replace-ext": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-					"dev": true
+					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "0.2.1"
 					}
@@ -12327,7 +20894,6 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
 					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-					"dev": true,
 					"requires": {
 						"clone": "1.0.4",
 						"clone-stats": "0.0.1",
@@ -12340,16 +20906,54 @@
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
 			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-			"dev": true,
 			"requires": {
 				"indexof": "0.0.1"
+			}
+		},
+		"w3c-hr-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"requires": {
+				"browser-process-hrtime": "0.1.2"
+			}
+		},
+		"walker": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"requires": {
+				"makeerror": "1.0.11"
+			}
+		},
+		"warning": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+			"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+			"requires": {
+				"loose-envify": "1.3.1"
+			}
+		},
+		"watch": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+			"requires": {
+				"exec-sh": "0.2.1",
+				"minimist": "1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
 			}
 		},
 		"watchpack": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.5.0.tgz",
 			"integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
-			"dev": true,
 			"requires": {
 				"chokidar": "2.0.3",
 				"graceful-fs": "4.1.11",
@@ -12360,7 +20964,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-					"dev": true,
 					"requires": {
 						"micromatch": "3.1.10",
 						"normalize-path": "2.1.1"
@@ -12369,20 +20972,17 @@
 				"arr-diff": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 				},
 				"array-unique": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 				},
 				"braces": {
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
 					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "1.1.0",
 						"array-unique": "0.3.2",
@@ -12402,7 +21002,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "1.0.2"
 							}
@@ -12411,7 +21010,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "0.1.1"
 							}
@@ -12422,7 +21020,6 @@
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
 					"integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
-					"dev": true,
 					"requires": {
 						"anymatch": "2.0.0",
 						"async-each": "1.0.1",
@@ -12442,7 +21039,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -12451,7 +21047,6 @@
 					"version": "2.1.4",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
 					"requires": {
 						"debug": "2.6.9",
 						"define-property": "0.2.5",
@@ -12466,7 +21061,6 @@
 							"version": "0.2.5",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "0.1.6"
 							}
@@ -12475,7 +21069,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "0.1.1"
 							}
@@ -12484,7 +21077,6 @@
 							"version": "0.1.6",
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "0.1.6",
 								"is-data-descriptor": "0.1.4",
@@ -12494,8 +21086,7 @@
 						"kind-of": {
 							"version": "5.1.0",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 						}
 					}
 				},
@@ -12503,7 +21094,6 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-					"dev": true,
 					"requires": {
 						"assign-symbols": "1.0.0",
 						"is-extendable": "1.0.1"
@@ -12513,7 +21103,6 @@
 							"version": "1.0.1",
 							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-							"dev": true,
 							"requires": {
 								"is-plain-object": "2.0.4"
 							}
@@ -12524,7 +21113,6 @@
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"dev": true,
 					"requires": {
 						"array-unique": "0.3.2",
 						"define-property": "1.0.0",
@@ -12540,7 +21128,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "1.0.2"
 							}
@@ -12549,7 +21136,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "0.1.1"
 							}
@@ -12560,7 +21146,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
 					"requires": {
 						"extend-shallow": "2.0.1",
 						"is-number": "3.0.0",
@@ -12572,7 +21157,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "0.1.1"
 							}
@@ -12583,7 +21167,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"dev": true,
 					"requires": {
 						"is-glob": "3.1.0",
 						"path-dirname": "1.0.2"
@@ -12593,7 +21176,6 @@
 							"version": "3.1.0",
 							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-							"dev": true,
 							"requires": {
 								"is-extglob": "2.1.1"
 							}
@@ -12604,7 +21186,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -12613,7 +21194,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -12624,7 +21204,6 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -12633,7 +21212,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -12643,14 +21221,12 @@
 				"is-extglob": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 				},
 				"is-glob": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "2.1.1"
 					}
@@ -12659,7 +21235,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -12668,7 +21243,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -12678,20 +21252,17 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				},
 				"micromatch": {
 					"version": "3.1.10",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
 					"requires": {
 						"arr-diff": "4.0.0",
 						"array-unique": "0.3.2",
@@ -12711,25 +21282,35 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
+			}
+		},
+		"wbuf": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+			"integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+			"requires": {
+				"minimalistic-assert": "1.0.0"
 			}
 		},
 		"wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-			"dev": true,
 			"requires": {
 				"defaults": "1.0.3"
 			}
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"webpack": {
 			"version": "3.11.0",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
 			"integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
-			"dev": true,
 			"requires": {
 				"acorn": "5.5.3",
 				"acorn-dynamic-import": "2.0.2",
@@ -12759,7 +21340,6 @@
 					"version": "6.4.0",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
 					"integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
-					"dev": true,
 					"requires": {
 						"fast-deep-equal": "1.1.0",
 						"fast-json-stable-stringify": "2.0.0",
@@ -12771,7 +21351,6 @@
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
 					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-					"dev": true,
 					"requires": {
 						"lodash": "4.17.4"
 					}
@@ -12780,92 +21359,487 @@
 					"version": "4.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"dev": true,
 					"requires": {
 						"has-flag": "2.0.0"
 					}
 				}
 			}
 		},
-		"webpack-merge": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.1.2.tgz",
-			"integrity": "sha512-/0QYwW/H1N/CdXYA2PNPVbsxO3u2Fpz34vs72xm03SRfg6bMNGfMJIQEpQjKRvkG2JvT6oRJFpDtSrwbX8Jzvw==",
-			"dev": true,
+		"webpack-dev-middleware": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
+			"integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
 			"requires": {
-				"lodash": "4.17.5"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.5",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-					"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-					"dev": true
-				}
+				"memory-fs": "0.4.1",
+				"mime": "1.6.0",
+				"path-is-absolute": "1.0.1",
+				"range-parser": "1.2.0",
+				"time-stamp": "2.0.0"
 			}
 		},
-		"webpack-sources": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
-			"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
-			"dev": true,
+		"webpack-dev-server": {
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz",
+			"integrity": "sha512-zrPoX97bx47vZiAXfDrkw8pe9QjJ+lunQl3dypojyWwWr1M5I2h0VSrMPfTjopHQPRNn+NqfjcMmhoLcUJe2gA==",
 			"requires": {
-				"source-list-map": "2.0.0",
-				"source-map": "0.6.1"
+				"ansi-html": "0.0.7",
+				"array-includes": "3.0.3",
+				"bonjour": "3.5.0",
+				"chokidar": "2.0.3",
+				"compression": "1.7.2",
+				"connect-history-api-fallback": "1.5.0",
+				"debug": "3.1.0",
+				"del": "3.0.0",
+				"express": "4.16.3",
+				"html-entities": "1.2.1",
+				"http-proxy-middleware": "0.17.4",
+				"import-local": "1.0.0",
+				"internal-ip": "1.2.0",
+				"ip": "1.1.5",
+				"killable": "1.0.0",
+				"loglevel": "1.6.1",
+				"opn": "5.3.0",
+				"portfinder": "1.0.13",
+				"selfsigned": "1.10.3",
+				"serve-index": "1.9.1",
+				"sockjs": "0.3.19",
+				"sockjs-client": "1.1.4",
+				"spdy": "3.4.7",
+				"strip-ansi": "3.0.1",
+				"supports-color": "5.3.0",
+				"webpack-dev-middleware": "1.12.2",
+				"yargs": "6.6.0"
 			},
 			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
-		"well-known-symbols": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-1.0.0.tgz",
-			"integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg=",
-			"dev": true
-		},
-		"which": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-			"dev": true,
-			"requires": {
-				"isexe": "2.0.0"
-			}
-		},
-		"which-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-			"dev": true
-		},
-		"wide-align": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-			"dev": true,
-			"requires": {
-				"string-width": "1.0.2"
-			},
-			"dependencies": {
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"requires": {
+						"micromatch": "3.1.10",
+						"normalize-path": "2.1.1"
+					}
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"requires": {
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+				},
+				"chokidar": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
+					"integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+					"requires": {
+						"anymatch": "2.0.0",
+						"async-each": "1.0.1",
+						"braces": "2.3.2",
+						"fsevents": "1.1.3",
+						"glob-parent": "3.1.0",
+						"inherits": "2.0.3",
+						"is-binary-path": "1.0.1",
+						"is-glob": "4.0.0",
+						"normalize-path": "2.1.1",
+						"path-is-absolute": "1.0.1",
+						"readdirp": "2.1.0",
+						"upath": "1.0.4"
+					}
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"extend-shallow": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+					"requires": {
+						"assign-symbols": "1.0.0",
+						"is-extendable": "1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+							"requires": {
+								"is-plain-object": "2.0.4"
+							}
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"glob-parent": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+					"requires": {
+						"is-glob": "3.1.0",
+						"path-dirname": "1.0.2"
+					},
+					"dependencies": {
+						"is-glob": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+							"requires": {
+								"is-extglob": "2.1.1"
+							}
+						}
+					}
+				},
+				"import-local": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+					"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+					"requires": {
+						"pkg-dir": "2.0.0",
+						"resolve-cwd": "2.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-glob": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"requires": {
+						"is-extglob": "2.1.1"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"requires": {
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"os-locale": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+					"requires": {
+						"lcid": "1.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+					"requires": {
+						"pinkie": "2.0.4"
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"requires": {
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"requires": {
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
 					}
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -12876,7 +21850,174 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"which-module": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+				},
+				"yargs": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+					"requires": {
+						"camelcase": "3.0.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "1.4.0",
+						"read-pkg-up": "1.0.1",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "1.0.2",
+						"which-module": "1.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "4.2.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+					"requires": {
+						"camelcase": "3.0.0"
+					}
+				}
+			}
+		},
+		"webpack-merge": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.1.2.tgz",
+			"integrity": "sha512-/0QYwW/H1N/CdXYA2PNPVbsxO3u2Fpz34vs72xm03SRfg6bMNGfMJIQEpQjKRvkG2JvT6oRJFpDtSrwbX8Jzvw==",
+			"requires": {
+				"lodash": "4.17.5"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.5",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+					"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+				}
+			}
+		},
+		"webpack-sources": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+			"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+			"requires": {
+				"source-list-map": "2.0.0",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"websocket-driver": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+			"integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+			"requires": {
+				"http-parser-js": "0.4.12",
+				"websocket-extensions": "0.1.3"
+			}
+		},
+		"websocket-extensions": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
+		},
+		"well-known-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-1.0.0.tgz",
+			"integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg="
+		},
+		"whatwg-encoding": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"whatwg-fetch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+		},
+		"whatwg-mimetype": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
+			"integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew=="
+		},
+		"whatwg-url": {
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
+			"integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
+			"requires": {
+				"lodash.sortby": "4.7.0",
+				"tr46": "1.0.1",
+				"webidl-conversions": "4.0.2"
+			}
+		},
+		"which": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"requires": {
+				"isexe": "2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+		},
+		"wide-align": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+			"requires": {
+				"string-width": "1.0.2"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -12887,7 +22028,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
 			"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
-			"dev": true,
 			"requires": {
 				"string-width": "2.1.1"
 			}
@@ -12895,20 +22035,17 @@
 		"window-size": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-			"dev": true
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
 		},
 		"wordwrap": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-			"dev": true
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-			"dev": true,
 			"requires": {
 				"string-width": "1.0.2",
 				"strip-ansi": "3.0.1"
@@ -12918,7 +22055,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -12927,7 +22063,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -12938,7 +22073,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -12948,14 +22082,12 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write-file-atomic": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"imurmurhash": "0.1.4",
@@ -12966,7 +22098,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
 			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
-			"dev": true,
 			"requires": {
 				"detect-indent": "5.0.0",
 				"graceful-fs": "4.1.11",
@@ -12979,14 +22110,12 @@
 				"detect-indent": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-					"dev": true
+					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
 				},
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
@@ -12994,41 +22123,49 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.1.0.tgz",
 			"integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
-			"dev": true,
 			"requires": {
 				"sort-keys": "2.0.0",
 				"write-json-file": "2.3.0"
 			}
 		},
+		"ws": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+			"requires": {
+				"async-limiter": "1.0.0",
+				"safe-buffer": "5.1.1"
+			}
+		},
 		"xdg-basedir": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-			"dev": true
+			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+		},
+		"xml-name-validator": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
 		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-			"dev": true
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 		},
 		"y18n": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-			"dev": true
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 		},
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-			"dev": true
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
 			"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-			"dev": true,
 			"requires": {
 				"camelcase": "4.1.0",
 				"cliui": "3.2.0",
@@ -13048,14 +22185,12 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"cliui": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
 					"requires": {
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1",
@@ -13066,7 +22201,6 @@
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"dev": true,
 							"requires": {
 								"code-point-at": "1.1.0",
 								"is-fullwidth-code-point": "1.0.0",
@@ -13079,7 +22213,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -13088,7 +22221,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -13099,7 +22231,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
 			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-			"dev": true,
 			"requires": {
 				"camelcase": "4.1.0"
 			},
@@ -13107,10 +22238,14 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				}
 			}
+		},
+		"zone.js": {
+			"version": "0.8.26",
+			"resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.26.tgz",
+			"integrity": "sha512-W9Nj+UmBJG251wkCacIkETgra4QgBo/vgoEkb4a2uoLzpQG7qF9nzwoLXWU5xj3Fg2mxGvEDh47mg24vXccYjA=="
 		}
 	}
 }

--- a/packages/angular-material/package-lock.json
+++ b/packages/angular-material/package-lock.json
@@ -7,14 +7,14 @@
 			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.5.1.tgz",
 			"integrity": "sha512-OlTo6DYg0XfTKOF8eLf79wcHm4Ut10xU2cRBRPMW/NA5F9VMjZGTfRHWDIYC3s+1kObGYrBLshXWU1K0hILkNQ==",
 			"requires": {
-				"cacache": "10.0.4",
-				"find-cache-dir": "1.0.0",
-				"globby": "7.1.1",
-				"is-glob": "4.0.0",
-				"loader-utils": "1.1.0",
-				"minimatch": "3.0.4",
-				"p-limit": "1.2.0",
-				"serialize-javascript": "1.4.0"
+				"cacache": "^10.0.4",
+				"find-cache-dir": "^1.0.0",
+				"globby": "^7.1.1",
+				"is-glob": "^4.0.0",
+				"loader-utils": "^1.1.0",
+				"minimatch": "^3.0.4",
+				"p-limit": "^1.0.0",
+				"serialize-javascript": "^1.4.0"
 			},
 			"dependencies": {
 				"aproba": {
@@ -27,7 +27,7 @@
 					"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 					"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 					"requires": {
-						"array-uniq": "1.0.3"
+						"array-uniq": "^1.0.1"
 					}
 				},
 				"array-uniq": {
@@ -60,7 +60,7 @@
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -74,19 +74,19 @@
 					"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
 					"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
 					"requires": {
-						"bluebird": "3.5.1",
-						"chownr": "1.0.1",
-						"glob": "7.1.2",
-						"graceful-fs": "4.1.11",
-						"lru-cache": "4.1.2",
-						"mississippi": "2.0.0",
-						"mkdirp": "0.5.1",
-						"move-concurrently": "1.0.1",
-						"promise-inflight": "1.0.1",
-						"rimraf": "2.6.2",
-						"ssri": "5.3.0",
-						"unique-filename": "1.1.0",
-						"y18n": "4.0.0"
+						"bluebird": "^3.5.1",
+						"chownr": "^1.0.1",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.1.11",
+						"lru-cache": "^4.1.1",
+						"mississippi": "^2.0.0",
+						"mkdirp": "^0.5.1",
+						"move-concurrently": "^1.0.1",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"ssri": "^5.2.4",
+						"unique-filename": "^1.1.0",
+						"y18n": "^4.0.0"
 					}
 				},
 				"chownr": {
@@ -109,10 +109,10 @@
 					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 					"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 					"requires": {
-						"buffer-from": "1.0.0",
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.5",
-						"typedarray": "0.0.6"
+						"buffer-from": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.2.2",
+						"typedarray": "^0.0.6"
 					}
 				},
 				"copy-concurrently": {
@@ -120,12 +120,12 @@
 					"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
 					"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
 					"requires": {
-						"aproba": "1.2.0",
-						"fs-write-stream-atomic": "1.0.10",
-						"iferr": "0.1.5",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"run-queue": "1.0.3"
+						"aproba": "^1.1.1",
+						"fs-write-stream-atomic": "^1.0.8",
+						"iferr": "^0.1.5",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.5.4",
+						"run-queue": "^1.0.0"
 					}
 				},
 				"core-util-is": {
@@ -143,8 +143,8 @@
 					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
 					"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
 					"requires": {
-						"arrify": "1.0.1",
-						"path-type": "3.0.0"
+						"arrify": "^1.0.1",
+						"path-type": "^3.0.0"
 					}
 				},
 				"duplexify": {
@@ -152,10 +152,10 @@
 					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
 					"integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
 					"requires": {
-						"end-of-stream": "1.4.1",
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.5",
-						"stream-shift": "1.0.0"
+						"end-of-stream": "^1.0.0",
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.0",
+						"stream-shift": "^1.0.0"
 					}
 				},
 				"emojis-list": {
@@ -168,7 +168,7 @@
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
 					"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 					"requires": {
-						"once": "1.4.0"
+						"once": "^1.4.0"
 					}
 				},
 				"find-cache-dir": {
@@ -176,9 +176,9 @@
 					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
 					"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
 					"requires": {
-						"commondir": "1.0.1",
-						"make-dir": "1.2.0",
-						"pkg-dir": "2.0.0"
+						"commondir": "^1.0.1",
+						"make-dir": "^1.0.0",
+						"pkg-dir": "^2.0.0"
 					}
 				},
 				"find-up": {
@@ -186,7 +186,7 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"flush-write-stream": {
@@ -194,8 +194,8 @@
 					"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
 					"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
 					"requires": {
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.5"
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.4"
 					}
 				},
 				"from2": {
@@ -203,8 +203,8 @@
 					"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 					"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 					"requires": {
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.5"
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.0"
 					}
 				},
 				"fs-write-stream-atomic": {
@@ -212,10 +212,10 @@
 					"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
 					"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"iferr": "0.1.5",
-						"imurmurhash": "0.1.4",
-						"readable-stream": "2.3.5"
+						"graceful-fs": "^4.1.2",
+						"iferr": "^0.1.5",
+						"imurmurhash": "^0.1.4",
+						"readable-stream": "1 || 2"
 					}
 				},
 				"fs.realpath": {
@@ -228,12 +228,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"globby": {
@@ -241,12 +241,12 @@
 					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
 					"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
 					"requires": {
-						"array-union": "1.0.2",
-						"dir-glob": "2.0.0",
-						"glob": "7.1.2",
-						"ignore": "3.3.7",
-						"pify": "3.0.0",
-						"slash": "1.0.0"
+						"array-union": "^1.0.1",
+						"dir-glob": "^2.0.0",
+						"glob": "^7.1.2",
+						"ignore": "^3.3.5",
+						"pify": "^3.0.0",
+						"slash": "^1.0.0"
 					}
 				},
 				"graceful-fs": {
@@ -274,8 +274,8 @@
 					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -293,7 +293,7 @@
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"requires": {
-						"is-extglob": "2.1.1"
+						"is-extglob": "^2.1.1"
 					}
 				},
 				"isarray": {
@@ -311,9 +311,9 @@
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
 					"requires": {
-						"big.js": "3.2.0",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1"
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0"
 					}
 				},
 				"locate-path": {
@@ -321,8 +321,8 @@
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"lru-cache": {
@@ -330,8 +330,8 @@
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
 					"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"make-dir": {
@@ -339,7 +339,7 @@
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
 					"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"minimatch": {
@@ -347,7 +347,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -360,16 +360,16 @@
 					"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
 					"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
 					"requires": {
-						"concat-stream": "1.6.2",
-						"duplexify": "3.5.4",
-						"end-of-stream": "1.4.1",
-						"flush-write-stream": "1.0.3",
-						"from2": "2.3.0",
-						"parallel-transform": "1.1.0",
-						"pump": "2.0.1",
-						"pumpify": "1.4.0",
-						"stream-each": "1.2.2",
-						"through2": "2.0.3"
+						"concat-stream": "^1.5.0",
+						"duplexify": "^3.4.2",
+						"end-of-stream": "^1.1.0",
+						"flush-write-stream": "^1.0.0",
+						"from2": "^2.1.0",
+						"parallel-transform": "^1.1.0",
+						"pump": "^2.0.1",
+						"pumpify": "^1.3.3",
+						"stream-each": "^1.1.0",
+						"through2": "^2.0.0"
 					}
 				},
 				"mkdirp": {
@@ -385,12 +385,12 @@
 					"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
 					"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
 					"requires": {
-						"aproba": "1.2.0",
-						"copy-concurrently": "1.0.5",
-						"fs-write-stream-atomic": "1.0.10",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"run-queue": "1.0.3"
+						"aproba": "^1.1.1",
+						"copy-concurrently": "^1.0.0",
+						"fs-write-stream-atomic": "^1.0.8",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.5.4",
+						"run-queue": "^1.0.3"
 					}
 				},
 				"once": {
@@ -398,7 +398,7 @@
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"p-limit": {
@@ -406,7 +406,7 @@
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
 					"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
@@ -414,7 +414,7 @@
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"requires": {
-						"p-limit": "1.2.0"
+						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
@@ -427,9 +427,9 @@
 					"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
 					"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
 					"requires": {
-						"cyclist": "0.2.2",
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.5"
+						"cyclist": "~0.2.2",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.1.5"
 					}
 				},
 				"path-exists": {
@@ -447,7 +447,7 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"pify": {
@@ -460,7 +460,7 @@
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 					"requires": {
-						"find-up": "2.1.0"
+						"find-up": "^2.1.0"
 					}
 				},
 				"process-nextick-args": {
@@ -483,8 +483,8 @@
 					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
 					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 					"requires": {
-						"end-of-stream": "1.4.1",
-						"once": "1.4.0"
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
 					}
 				},
 				"pumpify": {
@@ -492,9 +492,9 @@
 					"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
 					"integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
 					"requires": {
-						"duplexify": "3.5.4",
-						"inherits": "2.0.3",
-						"pump": "2.0.1"
+						"duplexify": "^3.5.3",
+						"inherits": "^2.0.3",
+						"pump": "^2.0.0"
 					}
 				},
 				"readable-stream": {
@@ -502,13 +502,13 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
 					"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.0.3",
-						"util-deprecate": "1.0.2"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.0.3",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"rimraf": {
@@ -516,7 +516,7 @@
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"run-queue": {
@@ -524,7 +524,7 @@
 					"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
 					"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
 					"requires": {
-						"aproba": "1.2.0"
+						"aproba": "^1.1.1"
 					}
 				},
 				"safe-buffer": {
@@ -547,7 +547,7 @@
 					"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
 					"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "^5.1.1"
 					}
 				},
 				"stream-each": {
@@ -555,8 +555,8 @@
 					"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
 					"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
 					"requires": {
-						"end-of-stream": "1.4.1",
-						"stream-shift": "1.0.0"
+						"end-of-stream": "^1.1.0",
+						"stream-shift": "^1.0.0"
 					}
 				},
 				"stream-shift": {
@@ -569,7 +569,7 @@
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 					"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "~5.1.0"
 					}
 				},
 				"through2": {
@@ -577,8 +577,8 @@
 					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 					"requires": {
-						"readable-stream": "2.3.5",
-						"xtend": "4.0.1"
+						"readable-stream": "^2.1.5",
+						"xtend": "~4.0.1"
 					}
 				},
 				"typedarray": {
@@ -591,7 +591,7 @@
 					"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
 					"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
 					"requires": {
-						"unique-slug": "2.0.0"
+						"unique-slug": "^2.0.0"
 					}
 				},
 				"unique-slug": {
@@ -599,7 +599,7 @@
 					"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
 					"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
 					"requires": {
-						"imurmurhash": "0.1.4"
+						"imurmurhash": "^0.1.4"
 					}
 				},
 				"util-deprecate": {
@@ -635,30 +635,30 @@
 			"integrity": "sha512-zrPoX97bx47vZiAXfDrkw8pe9QjJ+lunQl3dypojyWwWr1M5I2h0VSrMPfTjopHQPRNn+NqfjcMmhoLcUJe2gA==",
 			"requires": {
 				"ansi-html": "0.0.7",
-				"array-includes": "3.0.3",
-				"bonjour": "3.5.0",
-				"chokidar": "2.0.3",
-				"compression": "1.7.2",
-				"connect-history-api-fallback": "1.5.0",
-				"debug": "3.1.0",
-				"del": "3.0.0",
-				"express": "4.16.3",
-				"html-entities": "1.2.1",
-				"http-proxy-middleware": "0.17.4",
-				"import-local": "1.0.0",
+				"array-includes": "^3.0.3",
+				"bonjour": "^3.5.0",
+				"chokidar": "^2.0.0",
+				"compression": "^1.5.2",
+				"connect-history-api-fallback": "^1.3.0",
+				"debug": "^3.1.0",
+				"del": "^3.0.0",
+				"express": "^4.16.2",
+				"html-entities": "^1.2.0",
+				"http-proxy-middleware": "~0.17.4",
+				"import-local": "^1.0.0",
 				"internal-ip": "1.2.0",
-				"ip": "1.1.5",
-				"killable": "1.0.0",
-				"loglevel": "1.6.1",
-				"opn": "5.3.0",
-				"portfinder": "1.0.13",
-				"selfsigned": "1.10.2",
-				"serve-index": "1.9.1",
+				"ip": "^1.1.5",
+				"killable": "^1.0.0",
+				"loglevel": "^1.4.1",
+				"opn": "^5.1.0",
+				"portfinder": "^1.0.9",
+				"selfsigned": "^1.9.1",
+				"serve-index": "^1.7.2",
 				"sockjs": "0.3.19",
 				"sockjs-client": "1.1.4",
-				"spdy": "3.4.7",
-				"strip-ansi": "3.0.1",
-				"supports-color": "5.3.0",
+				"spdy": "^3.4.1",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^5.1.0",
 				"webpack-dev-middleware": "1.12.2",
 				"yargs": "6.6.0"
 			},
@@ -668,7 +668,7 @@
 					"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
 					"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
 					"requires": {
-						"mime-types": "2.1.18",
+						"mime-types": "~2.1.18",
 						"negotiator": "0.6.1"
 					}
 				},
@@ -687,8 +687,8 @@
 					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 					"requires": {
-						"micromatch": "3.1.10",
-						"normalize-path": "2.1.1"
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
 					}
 				},
 				"arr-diff": {
@@ -721,8 +721,8 @@
 					"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
 					"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
 					"requires": {
-						"define-properties": "1.1.2",
-						"es-abstract": "1.11.0"
+						"define-properties": "^1.1.2",
+						"es-abstract": "^1.7.0"
 					}
 				},
 				"array-union": {
@@ -730,7 +730,7 @@
 					"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 					"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 					"requires": {
-						"array-uniq": "1.0.3"
+						"array-uniq": "^1.0.1"
 					}
 				},
 				"array-uniq": {
@@ -773,13 +773,13 @@
 					"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 					"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 					"requires": {
-						"cache-base": "1.0.1",
-						"class-utils": "0.3.6",
-						"component-emitter": "1.2.1",
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"mixin-deep": "1.3.1",
-						"pascalcase": "0.1.1"
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -787,7 +787,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						}
 					}
@@ -808,15 +808,15 @@
 					"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
 					"requires": {
 						"bytes": "3.0.0",
-						"content-type": "1.0.4",
+						"content-type": "~1.0.4",
 						"debug": "2.6.9",
-						"depd": "1.1.2",
-						"http-errors": "1.6.2",
+						"depd": "~1.1.1",
+						"http-errors": "~1.6.2",
 						"iconv-lite": "0.4.19",
-						"on-finished": "2.3.0",
+						"on-finished": "~2.3.0",
 						"qs": "6.5.1",
 						"raw-body": "2.3.2",
-						"type-is": "1.6.16"
+						"type-is": "~1.6.15"
 					},
 					"dependencies": {
 						"debug": {
@@ -834,12 +834,12 @@
 					"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
 					"integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
 					"requires": {
-						"array-flatten": "2.1.1",
-						"deep-equal": "1.0.1",
-						"dns-equal": "1.0.0",
-						"dns-txt": "2.0.2",
-						"multicast-dns": "6.2.3",
-						"multicast-dns-service-types": "1.1.0"
+						"array-flatten": "^2.1.0",
+						"deep-equal": "^1.0.1",
+						"dns-equal": "^1.0.0",
+						"dns-txt": "^2.0.2",
+						"multicast-dns": "^6.0.1",
+						"multicast-dns-service-types": "^1.1.0"
 					}
 				},
 				"brace-expansion": {
@@ -847,7 +847,7 @@
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -856,18 +856,18 @@
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
 					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"kind-of": "6.0.2",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"kind-of": "^6.0.2",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -875,7 +875,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -883,7 +883,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -908,15 +908,15 @@
 					"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 					"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 					"requires": {
-						"collection-visit": "1.0.0",
-						"component-emitter": "1.2.1",
-						"get-value": "2.0.6",
-						"has-value": "1.0.0",
-						"isobject": "3.0.1",
-						"set-value": "2.0.0",
-						"to-object-path": "0.3.0",
-						"union-value": "1.0.0",
-						"unset-value": "1.0.0"
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
 					}
 				},
 				"camelcase": {
@@ -929,8 +929,8 @@
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 					"requires": {
-						"camelcase": "2.1.1",
-						"map-obj": "1.0.1"
+						"camelcase": "^2.0.0",
+						"map-obj": "^1.0.0"
 					}
 				},
 				"chokidar": {
@@ -938,18 +938,18 @@
 					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
 					"integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
 					"requires": {
-						"anymatch": "2.0.0",
-						"async-each": "1.0.1",
-						"braces": "2.3.1",
-						"fsevents": "1.1.3",
-						"glob-parent": "3.1.0",
-						"inherits": "2.0.3",
-						"is-binary-path": "1.0.1",
-						"is-glob": "4.0.0",
-						"normalize-path": "2.1.1",
-						"path-is-absolute": "1.0.1",
-						"readdirp": "2.1.0",
-						"upath": "1.0.4"
+						"anymatch": "^2.0.0",
+						"async-each": "^1.0.0",
+						"braces": "^2.3.0",
+						"fsevents": "^1.1.2",
+						"glob-parent": "^3.1.0",
+						"inherits": "^2.0.1",
+						"is-binary-path": "^1.0.0",
+						"is-glob": "^4.0.0",
+						"normalize-path": "^2.1.1",
+						"path-is-absolute": "^1.0.0",
+						"readdirp": "^2.0.0",
+						"upath": "^1.0.0"
 					}
 				},
 				"class-utils": {
@@ -957,10 +957,10 @@
 					"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 					"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 					"requires": {
-						"arr-union": "3.1.0",
-						"define-property": "0.2.5",
-						"isobject": "3.0.1",
-						"static-extend": "0.1.2"
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -968,7 +968,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -976,7 +976,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -984,7 +984,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -994,7 +994,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -1002,7 +1002,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -1012,9 +1012,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -1029,9 +1029,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"code-point-at": {
@@ -1044,8 +1044,8 @@
 					"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 					"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 					"requires": {
-						"map-visit": "1.0.0",
-						"object-visit": "1.0.1"
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
 					}
 				},
 				"component-emitter": {
@@ -1058,7 +1058,7 @@
 					"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
 					"integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
 					"requires": {
-						"mime-db": "1.33.0"
+						"mime-db": ">= 1.33.0 < 2"
 					}
 				},
 				"compression": {
@@ -1066,13 +1066,13 @@
 					"resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
 					"integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
 					"requires": {
-						"accepts": "1.3.5",
+						"accepts": "~1.3.4",
 						"bytes": "3.0.0",
-						"compressible": "2.0.13",
+						"compressible": "~2.0.13",
 						"debug": "2.6.9",
-						"on-headers": "1.0.1",
+						"on-headers": "~1.0.1",
 						"safe-buffer": "5.1.1",
-						"vary": "1.1.2"
+						"vary": "~1.1.2"
 					},
 					"dependencies": {
 						"debug": {
@@ -1130,7 +1130,7 @@
 					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 					"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 					"requires": {
-						"array-find-index": "1.0.2"
+						"array-find-index": "^1.0.1"
 					}
 				},
 				"debug": {
@@ -1161,8 +1161,8 @@
 					"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 					"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 					"requires": {
-						"foreach": "2.0.5",
-						"object-keys": "1.0.11"
+						"foreach": "^2.0.5",
+						"object-keys": "^1.0.8"
 					}
 				},
 				"define-property": {
@@ -1170,8 +1170,8 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 					"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 					"requires": {
-						"is-descriptor": "1.0.2",
-						"isobject": "3.0.1"
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
 					}
 				},
 				"del": {
@@ -1179,12 +1179,12 @@
 					"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
 					"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
 					"requires": {
-						"globby": "6.1.0",
-						"is-path-cwd": "1.0.0",
-						"is-path-in-cwd": "1.0.1",
-						"p-map": "1.2.0",
-						"pify": "3.0.0",
-						"rimraf": "2.6.2"
+						"globby": "^6.1.0",
+						"is-path-cwd": "^1.0.0",
+						"is-path-in-cwd": "^1.0.0",
+						"p-map": "^1.1.1",
+						"pify": "^3.0.0",
+						"rimraf": "^2.2.8"
 					}
 				},
 				"depd": {
@@ -1212,8 +1212,8 @@
 					"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
 					"integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
 					"requires": {
-						"ip": "1.1.5",
-						"safe-buffer": "5.1.1"
+						"ip": "^1.1.0",
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"dns-txt": {
@@ -1221,7 +1221,7 @@
 					"resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
 					"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
 					"requires": {
-						"buffer-indexof": "1.1.1"
+						"buffer-indexof": "^1.0.0"
 					}
 				},
 				"ee-first": {
@@ -1239,7 +1239,7 @@
 					"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
 					"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 					"requires": {
-						"prr": "1.0.1"
+						"prr": "~1.0.1"
 					}
 				},
 				"error-ex": {
@@ -1247,7 +1247,7 @@
 					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 					"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 					"requires": {
-						"is-arrayish": "0.2.1"
+						"is-arrayish": "^0.2.1"
 					}
 				},
 				"es-abstract": {
@@ -1255,11 +1255,11 @@
 					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
 					"integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
 					"requires": {
-						"es-to-primitive": "1.1.1",
-						"function-bind": "1.1.1",
-						"has": "1.0.1",
-						"is-callable": "1.1.3",
-						"is-regex": "1.0.4"
+						"es-to-primitive": "^1.1.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.1",
+						"is-callable": "^1.1.3",
+						"is-regex": "^1.0.4"
 					}
 				},
 				"es-to-primitive": {
@@ -1267,9 +1267,9 @@
 					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 					"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 					"requires": {
-						"is-callable": "1.1.3",
-						"is-date-object": "1.0.1",
-						"is-symbol": "1.0.1"
+						"is-callable": "^1.1.1",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.1"
 					}
 				},
 				"escape-html": {
@@ -1292,7 +1292,7 @@
 					"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
 					"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
 					"requires": {
-						"original": "1.0.0"
+						"original": ">=0.0.5"
 					}
 				},
 				"expand-brackets": {
@@ -1300,13 +1300,13 @@
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"debug": {
@@ -1322,7 +1322,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -1330,7 +1330,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -1338,7 +1338,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -1346,7 +1346,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -1356,7 +1356,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -1364,7 +1364,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -1374,9 +1374,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -1391,7 +1391,7 @@
 					"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 					"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 					"requires": {
-						"fill-range": "2.2.3"
+						"fill-range": "^2.1.0"
 					},
 					"dependencies": {
 						"fill-range": {
@@ -1399,11 +1399,11 @@
 							"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 							"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
 							"requires": {
-								"is-number": "2.1.0",
-								"isobject": "2.1.0",
-								"randomatic": "1.1.7",
-								"repeat-element": "1.1.2",
-								"repeat-string": "1.6.1"
+								"is-number": "^2.1.0",
+								"isobject": "^2.0.0",
+								"randomatic": "^1.1.3",
+								"repeat-element": "^1.1.2",
+								"repeat-string": "^1.5.2"
 							}
 						},
 						"is-number": {
@@ -1411,7 +1411,7 @@
 							"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 							"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"isobject": {
@@ -1427,7 +1427,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -1437,36 +1437,36 @@
 					"resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
 					"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
 					"requires": {
-						"accepts": "1.3.5",
+						"accepts": "~1.3.5",
 						"array-flatten": "1.1.1",
 						"body-parser": "1.18.2",
 						"content-disposition": "0.5.2",
-						"content-type": "1.0.4",
+						"content-type": "~1.0.4",
 						"cookie": "0.3.1",
 						"cookie-signature": "1.0.6",
 						"debug": "2.6.9",
-						"depd": "1.1.2",
-						"encodeurl": "1.0.2",
-						"escape-html": "1.0.3",
-						"etag": "1.8.1",
+						"depd": "~1.1.2",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"etag": "~1.8.1",
 						"finalhandler": "1.1.1",
 						"fresh": "0.5.2",
 						"merge-descriptors": "1.0.1",
-						"methods": "1.1.2",
-						"on-finished": "2.3.0",
-						"parseurl": "1.3.2",
+						"methods": "~1.1.2",
+						"on-finished": "~2.3.0",
+						"parseurl": "~1.3.2",
 						"path-to-regexp": "0.1.7",
-						"proxy-addr": "2.0.3",
+						"proxy-addr": "~2.0.3",
 						"qs": "6.5.1",
-						"range-parser": "1.2.0",
+						"range-parser": "~1.2.0",
 						"safe-buffer": "5.1.1",
 						"send": "0.16.2",
 						"serve-static": "1.13.2",
 						"setprototypeof": "1.1.0",
-						"statuses": "1.4.0",
-						"type-is": "1.6.16",
+						"statuses": "~1.4.0",
+						"type-is": "~1.6.16",
 						"utils-merge": "1.0.1",
-						"vary": "1.1.2"
+						"vary": "~1.1.2"
 					},
 					"dependencies": {
 						"array-flatten": {
@@ -1489,8 +1489,8 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 					"requires": {
-						"assign-symbols": "1.0.0",
-						"is-extendable": "1.0.1"
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
@@ -1498,7 +1498,7 @@
 							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -1508,14 +1508,14 @@
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1523,7 +1523,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -1531,7 +1531,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1541,7 +1541,7 @@
 					"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
 					"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
 					"requires": {
-						"websocket-driver": "0.7.0"
+						"websocket-driver": ">=0.5.1"
 					}
 				},
 				"filename-regex": {
@@ -1554,10 +1554,10 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -1565,7 +1565,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1576,12 +1576,12 @@
 					"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
 					"requires": {
 						"debug": "2.6.9",
-						"encodeurl": "1.0.2",
-						"escape-html": "1.0.3",
-						"on-finished": "2.3.0",
-						"parseurl": "1.3.2",
-						"statuses": "1.4.0",
-						"unpipe": "1.0.0"
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"on-finished": "~2.3.0",
+						"parseurl": "~1.3.2",
+						"statuses": "~1.4.0",
+						"unpipe": "~1.0.0"
 					},
 					"dependencies": {
 						"debug": {
@@ -1599,7 +1599,7 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"for-in": {
@@ -1612,7 +1612,7 @@
 					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 					"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 					"requires": {
-						"for-in": "1.0.2"
+						"for-in": "^1.0.1"
 					}
 				},
 				"foreach": {
@@ -1630,7 +1630,7 @@
 					"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 					"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 					"requires": {
-						"map-cache": "0.2.2"
+						"map-cache": "^0.2.2"
 					}
 				},
 				"fresh": {
@@ -1649,8 +1649,8 @@
 					"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
 					"optional": true,
 					"requires": {
-						"nan": "2.10.0",
-						"node-pre-gyp": "0.6.39"
+						"nan": "^2.3.0",
+						"node-pre-gyp": "^0.6.39"
 					},
 					"dependencies": {
 						"abbrev": {
@@ -2457,12 +2457,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"glob-base": {
@@ -2470,8 +2470,8 @@
 					"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 					"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 					"requires": {
-						"glob-parent": "2.0.0",
-						"is-glob": "2.0.1"
+						"glob-parent": "^2.0.0",
+						"is-glob": "^2.0.0"
 					},
 					"dependencies": {
 						"glob-parent": {
@@ -2479,7 +2479,7 @@
 							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 							"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 							"requires": {
-								"is-glob": "2.0.1"
+								"is-glob": "^2.0.0"
 							}
 						},
 						"is-extglob": {
@@ -2492,7 +2492,7 @@
 							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 							"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 							"requires": {
-								"is-extglob": "1.0.0"
+								"is-extglob": "^1.0.0"
 							}
 						}
 					}
@@ -2502,8 +2502,8 @@
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 					"requires": {
-						"is-glob": "3.1.0",
-						"path-dirname": "1.0.2"
+						"is-glob": "^3.1.0",
+						"path-dirname": "^1.0.0"
 					},
 					"dependencies": {
 						"is-glob": {
@@ -2511,7 +2511,7 @@
 							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 							"requires": {
-								"is-extglob": "2.1.1"
+								"is-extglob": "^2.1.0"
 							}
 						}
 					}
@@ -2521,11 +2521,11 @@
 					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"requires": {
-						"array-union": "1.0.2",
-						"glob": "7.1.2",
-						"object-assign": "4.1.1",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					},
 					"dependencies": {
 						"pify": {
@@ -2550,7 +2550,7 @@
 					"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 					"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
 					"requires": {
-						"function-bind": "1.1.1"
+						"function-bind": "^1.0.2"
 					}
 				},
 				"has-flag": {
@@ -2563,9 +2563,9 @@
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 					"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "1.0.0",
-						"isobject": "3.0.1"
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
 					}
 				},
 				"has-values": {
@@ -2573,8 +2573,8 @@
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 					"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 					"requires": {
-						"is-number": "3.0.0",
-						"kind-of": "4.0.0"
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2582,7 +2582,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 							"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -2597,10 +2597,10 @@
 					"resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
 					"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
 					"requires": {
-						"inherits": "2.0.3",
-						"obuf": "1.1.2",
-						"readable-stream": "2.3.5",
-						"wbuf": "1.7.3"
+						"inherits": "^2.0.1",
+						"obuf": "^1.0.0",
+						"readable-stream": "^2.0.1",
+						"wbuf": "^1.1.0"
 					}
 				},
 				"html-entities": {
@@ -2621,7 +2621,7 @@
 						"depd": "1.1.1",
 						"inherits": "2.0.3",
 						"setprototypeof": "1.0.3",
-						"statuses": "1.4.0"
+						"statuses": ">= 1.3.1 < 2"
 					},
 					"dependencies": {
 						"depd": {
@@ -2646,8 +2646,8 @@
 					"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
 					"integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
 					"requires": {
-						"eventemitter3": "1.2.0",
-						"requires-port": "1.0.0"
+						"eventemitter3": "1.x.x",
+						"requires-port": "1.x.x"
 					}
 				},
 				"http-proxy-middleware": {
@@ -2655,10 +2655,10 @@
 					"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
 					"integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
 					"requires": {
-						"http-proxy": "1.16.2",
-						"is-glob": "3.1.0",
-						"lodash": "4.17.5",
-						"micromatch": "2.3.11"
+						"http-proxy": "^1.16.2",
+						"is-glob": "^3.1.0",
+						"lodash": "^4.17.2",
+						"micromatch": "^2.3.11"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -2666,7 +2666,7 @@
 							"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 							"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 							"requires": {
-								"arr-flatten": "1.1.0"
+								"arr-flatten": "^1.0.1"
 							}
 						},
 						"array-unique": {
@@ -2679,9 +2679,9 @@
 							"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 							"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 							"requires": {
-								"expand-range": "1.8.2",
-								"preserve": "0.2.0",
-								"repeat-element": "1.1.2"
+								"expand-range": "^1.8.1",
+								"preserve": "^0.2.0",
+								"repeat-element": "^1.1.2"
 							}
 						},
 						"expand-brackets": {
@@ -2689,7 +2689,7 @@
 							"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 							"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 							"requires": {
-								"is-posix-bracket": "0.1.1"
+								"is-posix-bracket": "^0.1.0"
 							}
 						},
 						"extglob": {
@@ -2697,7 +2697,7 @@
 							"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 							"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 							"requires": {
-								"is-extglob": "1.0.0"
+								"is-extglob": "^1.0.0"
 							},
 							"dependencies": {
 								"is-extglob": {
@@ -2712,7 +2712,7 @@
 							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 							"requires": {
-								"is-extglob": "2.1.1"
+								"is-extglob": "^2.1.0"
 							}
 						},
 						"kind-of": {
@@ -2720,7 +2720,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						},
 						"micromatch": {
@@ -2728,19 +2728,19 @@
 							"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 							"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 							"requires": {
-								"arr-diff": "2.0.0",
-								"array-unique": "0.2.1",
-								"braces": "1.8.5",
-								"expand-brackets": "0.1.5",
-								"extglob": "0.3.2",
-								"filename-regex": "2.0.1",
-								"is-extglob": "1.0.0",
-								"is-glob": "2.0.1",
-								"kind-of": "3.2.2",
-								"normalize-path": "2.1.1",
-								"object.omit": "2.0.1",
-								"parse-glob": "3.0.4",
-								"regex-cache": "0.4.4"
+								"arr-diff": "^2.0.0",
+								"array-unique": "^0.2.1",
+								"braces": "^1.8.2",
+								"expand-brackets": "^0.1.4",
+								"extglob": "^0.3.1",
+								"filename-regex": "^2.0.0",
+								"is-extglob": "^1.0.0",
+								"is-glob": "^2.0.1",
+								"kind-of": "^3.0.2",
+								"normalize-path": "^2.0.1",
+								"object.omit": "^2.0.0",
+								"parse-glob": "^3.0.4",
+								"regex-cache": "^0.4.2"
 							},
 							"dependencies": {
 								"is-extglob": {
@@ -2753,7 +2753,7 @@
 									"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 									"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 									"requires": {
-										"is-extglob": "1.0.0"
+										"is-extglob": "^1.0.0"
 									}
 								}
 							}
@@ -2770,8 +2770,8 @@
 					"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
 					"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 					"requires": {
-						"pkg-dir": "2.0.0",
-						"resolve-cwd": "2.0.0"
+						"pkg-dir": "^2.0.0",
+						"resolve-cwd": "^2.0.0"
 					}
 				},
 				"indent-string": {
@@ -2779,7 +2779,7 @@
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 					"requires": {
-						"repeating": "2.0.1"
+						"repeating": "^2.0.0"
 					}
 				},
 				"inflight": {
@@ -2787,8 +2787,8 @@
 					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -2801,7 +2801,7 @@
 					"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
 					"integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
 					"requires": {
-						"meow": "3.7.0"
+						"meow": "^3.3.0"
 					}
 				},
 				"invert-kv": {
@@ -2824,7 +2824,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-arrayish": {
@@ -2837,7 +2837,7 @@
 					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 					"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 					"requires": {
-						"binary-extensions": "1.11.0"
+						"binary-extensions": "^1.0.0"
 					}
 				},
 				"is-buffer": {
@@ -2850,7 +2850,7 @@
 					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 					"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 					"requires": {
-						"builtin-modules": "1.1.1"
+						"builtin-modules": "^1.0.0"
 					}
 				},
 				"is-callable": {
@@ -2863,7 +2863,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-date-object": {
@@ -2876,9 +2876,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"is-dotfile": {
@@ -2891,7 +2891,7 @@
 					"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 					"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 					"requires": {
-						"is-primitive": "2.0.0"
+						"is-primitive": "^2.0.0"
 					}
 				},
 				"is-extendable": {
@@ -2909,7 +2909,7 @@
 					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 					"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -2917,7 +2917,7 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-glob": {
@@ -2925,7 +2925,7 @@
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"requires": {
-						"is-extglob": "2.1.1"
+						"is-extglob": "^2.1.1"
 					}
 				},
 				"is-number": {
@@ -2933,7 +2933,7 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2941,7 +2941,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -2951,7 +2951,7 @@
 					"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
 					"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
 					"requires": {
-						"is-number": "4.0.0"
+						"is-number": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
@@ -2971,7 +2971,7 @@
 					"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
 					"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
 					"requires": {
-						"is-path-inside": "1.0.1"
+						"is-path-inside": "^1.0.0"
 					}
 				},
 				"is-path-inside": {
@@ -2979,7 +2979,7 @@
 					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 					"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 					"requires": {
-						"path-is-inside": "1.0.2"
+						"path-is-inside": "^1.0.1"
 					}
 				},
 				"is-plain-object": {
@@ -2987,7 +2987,7 @@
 					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					}
 				},
 				"is-posix-bracket": {
@@ -3005,7 +3005,7 @@
 					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 					"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 					"requires": {
-						"has": "1.0.1"
+						"has": "^1.0.1"
 					}
 				},
 				"is-symbol": {
@@ -3058,7 +3058,7 @@
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -3066,11 +3066,11 @@
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					},
 					"dependencies": {
 						"pify": {
@@ -3085,8 +3085,8 @@
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"lodash": {
@@ -3104,8 +3104,8 @@
 					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 					"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 					"requires": {
-						"currently-unhandled": "0.4.1",
-						"signal-exit": "3.0.2"
+						"currently-unhandled": "^0.4.1",
+						"signal-exit": "^3.0.0"
 					}
 				},
 				"map-cache": {
@@ -3123,7 +3123,7 @@
 					"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 					"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 					"requires": {
-						"object-visit": "1.0.1"
+						"object-visit": "^1.0.0"
 					}
 				},
 				"media-typer": {
@@ -3136,8 +3136,8 @@
 					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 					"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 					"requires": {
-						"errno": "0.1.7",
-						"readable-stream": "2.3.5"
+						"errno": "^0.1.3",
+						"readable-stream": "^2.0.1"
 					}
 				},
 				"meow": {
@@ -3145,16 +3145,16 @@
 					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 					"requires": {
-						"camelcase-keys": "2.1.0",
-						"decamelize": "1.2.0",
-						"loud-rejection": "1.6.0",
-						"map-obj": "1.0.1",
-						"minimist": "1.2.0",
-						"normalize-package-data": "2.4.0",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"redent": "1.0.0",
-						"trim-newlines": "1.0.0"
+						"camelcase-keys": "^2.0.0",
+						"decamelize": "^1.1.2",
+						"loud-rejection": "^1.0.0",
+						"map-obj": "^1.0.1",
+						"minimist": "^1.1.3",
+						"normalize-package-data": "^2.3.4",
+						"object-assign": "^4.0.1",
+						"read-pkg-up": "^1.0.1",
+						"redent": "^1.0.0",
+						"trim-newlines": "^1.0.0"
 					}
 				},
 				"merge-descriptors": {
@@ -3172,19 +3172,19 @@
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.1",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				},
 				"mime": {
@@ -3202,7 +3202,7 @@
 					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
 					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 					"requires": {
-						"mime-db": "1.33.0"
+						"mime-db": "~1.33.0"
 					}
 				},
 				"minimalistic-assert": {
@@ -3215,7 +3215,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -3228,8 +3228,8 @@
 					"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 					"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 					"requires": {
-						"for-in": "1.0.2",
-						"is-extendable": "1.0.1"
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
@@ -3237,7 +3237,7 @@
 							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -3267,8 +3267,8 @@
 					"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
 					"integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
 					"requires": {
-						"dns-packet": "1.3.1",
-						"thunky": "1.0.2"
+						"dns-packet": "^1.3.1",
+						"thunky": "^1.0.2"
 					}
 				},
 				"multicast-dns-service-types": {
@@ -3287,18 +3287,18 @@
 					"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
 					"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"fragment-cache": "0.2.1",
-						"is-odd": "2.0.0",
-						"is-windows": "1.0.2",
-						"kind-of": "6.0.2",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					}
 				},
 				"negotiator": {
@@ -3316,10 +3316,10 @@
 					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 					"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 					"requires": {
-						"hosted-git-info": "2.6.0",
-						"is-builtin-module": "1.0.0",
-						"semver": "5.5.0",
-						"validate-npm-package-license": "3.0.3"
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"normalize-path": {
@@ -3327,7 +3327,7 @@
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"requires": {
-						"remove-trailing-separator": "1.1.0"
+						"remove-trailing-separator": "^1.0.1"
 					}
 				},
 				"number-is-nan": {
@@ -3345,9 +3345,9 @@
 					"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 					"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 					"requires": {
-						"copy-descriptor": "0.1.1",
-						"define-property": "0.2.5",
-						"kind-of": "3.2.2"
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
 					},
 					"dependencies": {
 						"define-property": {
@@ -3355,7 +3355,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -3363,7 +3363,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"is-data-descriptor": {
@@ -3371,7 +3371,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"is-descriptor": {
@@ -3379,9 +3379,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -3396,7 +3396,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -3411,7 +3411,7 @@
 					"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 					"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.0"
 					}
 				},
 				"object.omit": {
@@ -3419,8 +3419,8 @@
 					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 					"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 					"requires": {
-						"for-own": "0.1.5",
-						"is-extendable": "0.1.1"
+						"for-own": "^0.1.4",
+						"is-extendable": "^0.1.1"
 					}
 				},
 				"object.pick": {
@@ -3428,7 +3428,7 @@
 					"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 					"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					}
 				},
 				"obuf": {
@@ -3454,7 +3454,7 @@
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"opn": {
@@ -3462,7 +3462,7 @@
 					"resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
 					"integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
 					"requires": {
-						"is-wsl": "1.1.0"
+						"is-wsl": "^1.1.0"
 					}
 				},
 				"original": {
@@ -3470,7 +3470,7 @@
 					"resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
 					"integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
 					"requires": {
-						"url-parse": "1.0.5"
+						"url-parse": "1.0.x"
 					},
 					"dependencies": {
 						"url-parse": {
@@ -3478,8 +3478,8 @@
 							"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
 							"integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
 							"requires": {
-								"querystringify": "0.0.4",
-								"requires-port": "1.0.0"
+								"querystringify": "0.0.x",
+								"requires-port": "1.0.x"
 							}
 						}
 					}
@@ -3489,7 +3489,7 @@
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"requires": {
-						"lcid": "1.0.0"
+						"lcid": "^1.0.0"
 					}
 				},
 				"p-limit": {
@@ -3497,7 +3497,7 @@
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
 					"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
@@ -3505,7 +3505,7 @@
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"requires": {
-						"p-limit": "1.2.0"
+						"p-limit": "^1.1.0"
 					}
 				},
 				"p-map": {
@@ -3523,10 +3523,10 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 					"requires": {
-						"glob-base": "0.3.0",
-						"is-dotfile": "1.0.3",
-						"is-extglob": "1.0.0",
-						"is-glob": "2.0.1"
+						"glob-base": "^0.3.0",
+						"is-dotfile": "^1.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.0"
 					},
 					"dependencies": {
 						"is-extglob": {
@@ -3539,7 +3539,7 @@
 							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 							"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 							"requires": {
-								"is-extglob": "1.0.0"
+								"is-extglob": "^1.0.0"
 							}
 						}
 					}
@@ -3549,7 +3549,7 @@
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 					"requires": {
-						"error-ex": "1.3.1"
+						"error-ex": "^1.2.0"
 					}
 				},
 				"parseurl": {
@@ -3592,9 +3592,9 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					},
 					"dependencies": {
 						"pify": {
@@ -3619,7 +3619,7 @@
 					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 					"requires": {
-						"pinkie": "2.0.4"
+						"pinkie": "^2.0.0"
 					}
 				},
 				"pkg-dir": {
@@ -3627,7 +3627,7 @@
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 					"requires": {
-						"find-up": "2.1.0"
+						"find-up": "^2.1.0"
 					}
 				},
 				"portfinder": {
@@ -3635,9 +3635,9 @@
 					"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
 					"integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
 					"requires": {
-						"async": "1.5.2",
-						"debug": "2.6.9",
-						"mkdirp": "0.5.1"
+						"async": "^1.5.2",
+						"debug": "^2.2.0",
+						"mkdirp": "0.5.x"
 					},
 					"dependencies": {
 						"debug": {
@@ -3670,7 +3670,7 @@
 					"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
 					"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
 					"requires": {
-						"forwarded": "0.1.2",
+						"forwarded": "~0.1.2",
 						"ipaddr.js": "1.6.0"
 					}
 				},
@@ -3694,8 +3694,8 @@
 					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 					"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
 					"requires": {
-						"is-number": "3.0.0",
-						"kind-of": "4.0.0"
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -3703,7 +3703,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 							"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -3729,9 +3729,9 @@
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -3739,8 +3739,8 @@
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
@@ -3748,8 +3748,8 @@
 							"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						},
 						"path-exists": {
@@ -3757,7 +3757,7 @@
 							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 							"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 							"requires": {
-								"pinkie-promise": "2.0.1"
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -3767,13 +3767,13 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
 					"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.0.3",
-						"util-deprecate": "1.0.2"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.0.3",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"readdirp": {
@@ -3781,10 +3781,10 @@
 					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 					"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"minimatch": "3.0.4",
-						"readable-stream": "2.3.5",
-						"set-immediate-shim": "1.0.1"
+						"graceful-fs": "^4.1.2",
+						"minimatch": "^3.0.2",
+						"readable-stream": "^2.0.2",
+						"set-immediate-shim": "^1.0.1"
 					}
 				},
 				"redent": {
@@ -3792,8 +3792,8 @@
 					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 					"requires": {
-						"indent-string": "2.1.0",
-						"strip-indent": "1.0.1"
+						"indent-string": "^2.1.0",
+						"strip-indent": "^1.0.1"
 					}
 				},
 				"regex-cache": {
@@ -3801,7 +3801,7 @@
 					"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 					"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 					"requires": {
-						"is-equal-shallow": "0.1.3"
+						"is-equal-shallow": "^0.1.3"
 					}
 				},
 				"regex-not": {
@@ -3809,8 +3809,8 @@
 					"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 					"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 					"requires": {
-						"extend-shallow": "3.0.2",
-						"safe-regex": "1.1.0"
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"remove-trailing-separator": {
@@ -3833,7 +3833,7 @@
 					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 					"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 					"requires": {
-						"is-finite": "1.0.2"
+						"is-finite": "^1.0.0"
 					}
 				},
 				"require-directory": {
@@ -3856,7 +3856,7 @@
 					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
 					"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 					"requires": {
-						"resolve-from": "3.0.0"
+						"resolve-from": "^3.0.0"
 					}
 				},
 				"resolve-from": {
@@ -3879,7 +3879,7 @@
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-buffer": {
@@ -3892,7 +3892,7 @@
 					"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 					"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 					"requires": {
-						"ret": "0.1.15"
+						"ret": "~0.1.10"
 					}
 				},
 				"select-hose": {
@@ -3919,18 +3919,18 @@
 					"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
 					"requires": {
 						"debug": "2.6.9",
-						"depd": "1.1.2",
-						"destroy": "1.0.4",
-						"encodeurl": "1.0.2",
-						"escape-html": "1.0.3",
-						"etag": "1.8.1",
+						"depd": "~1.1.2",
+						"destroy": "~1.0.4",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"etag": "~1.8.1",
 						"fresh": "0.5.2",
-						"http-errors": "1.6.2",
+						"http-errors": "~1.6.2",
 						"mime": "1.4.1",
 						"ms": "2.0.0",
-						"on-finished": "2.3.0",
-						"range-parser": "1.2.0",
-						"statuses": "1.4.0"
+						"on-finished": "~2.3.0",
+						"range-parser": "~1.2.0",
+						"statuses": "~1.4.0"
 					},
 					"dependencies": {
 						"debug": {
@@ -3948,13 +3948,13 @@
 					"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
 					"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
 					"requires": {
-						"accepts": "1.3.5",
+						"accepts": "~1.3.4",
 						"batch": "0.6.1",
 						"debug": "2.6.9",
-						"escape-html": "1.0.3",
-						"http-errors": "1.6.2",
-						"mime-types": "2.1.18",
-						"parseurl": "1.3.2"
+						"escape-html": "~1.0.3",
+						"http-errors": "~1.6.2",
+						"mime-types": "~2.1.17",
+						"parseurl": "~1.3.2"
 					},
 					"dependencies": {
 						"debug": {
@@ -3972,9 +3972,9 @@
 					"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
 					"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
 					"requires": {
-						"encodeurl": "1.0.2",
-						"escape-html": "1.0.3",
-						"parseurl": "1.3.2",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"parseurl": "~1.3.2",
 						"send": "0.16.2"
 					}
 				},
@@ -3993,10 +3993,10 @@
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 					"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"split-string": "3.1.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -4004,7 +4004,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -4024,14 +4024,14 @@
 					"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 					"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 					"requires": {
-						"base": "0.11.2",
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"map-cache": "0.2.2",
-						"source-map": "0.5.7",
-						"source-map-resolve": "0.5.1",
-						"use": "3.1.0"
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
 					},
 					"dependencies": {
 						"debug": {
@@ -4047,7 +4047,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -4055,7 +4055,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -4063,7 +4063,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -4071,7 +4071,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -4081,7 +4081,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -4089,7 +4089,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -4099,9 +4099,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -4116,9 +4116,9 @@
 					"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 					"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 					"requires": {
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"snapdragon-util": "3.0.1"
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -4126,7 +4126,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						}
 					}
@@ -4136,7 +4136,7 @@
 					"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 					"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.2.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -4144,7 +4144,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -4154,8 +4154,8 @@
 					"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
 					"integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
 					"requires": {
-						"faye-websocket": "0.10.0",
-						"uuid": "3.2.1"
+						"faye-websocket": "^0.10.0",
+						"uuid": "^3.0.1"
 					}
 				},
 				"sockjs-client": {
@@ -4163,12 +4163,12 @@
 					"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
 					"integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
 					"requires": {
-						"debug": "2.6.9",
+						"debug": "^2.6.6",
 						"eventsource": "0.1.6",
-						"faye-websocket": "0.11.1",
-						"inherits": "2.0.3",
-						"json3": "3.3.2",
-						"url-parse": "1.2.0"
+						"faye-websocket": "~0.11.0",
+						"inherits": "^2.0.1",
+						"json3": "^3.3.2",
+						"url-parse": "^1.1.8"
 					},
 					"dependencies": {
 						"debug": {
@@ -4184,7 +4184,7 @@
 							"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
 							"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
 							"requires": {
-								"websocket-driver": "0.7.0"
+								"websocket-driver": ">=0.5.1"
 							}
 						}
 					}
@@ -4199,11 +4199,11 @@
 					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
 					"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
 					"requires": {
-						"atob": "2.0.3",
-						"decode-uri-component": "0.2.0",
-						"resolve-url": "0.2.1",
-						"source-map-url": "0.4.0",
-						"urix": "0.1.0"
+						"atob": "^2.0.0",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
 					}
 				},
 				"source-map-url": {
@@ -4216,8 +4216,8 @@
 					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
 					"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 					"requires": {
-						"spdx-expression-parse": "3.0.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -4230,8 +4230,8 @@
 					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 					"requires": {
-						"spdx-exceptions": "2.1.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -4244,12 +4244,12 @@
 					"resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
 					"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
 					"requires": {
-						"debug": "2.6.9",
-						"handle-thing": "1.2.5",
-						"http-deceiver": "1.2.7",
-						"safe-buffer": "5.1.1",
-						"select-hose": "2.0.0",
-						"spdy-transport": "2.1.0"
+						"debug": "^2.6.8",
+						"handle-thing": "^1.2.5",
+						"http-deceiver": "^1.2.7",
+						"safe-buffer": "^5.0.1",
+						"select-hose": "^2.0.0",
+						"spdy-transport": "^2.0.18"
 					},
 					"dependencies": {
 						"debug": {
@@ -4267,13 +4267,13 @@
 					"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
 					"integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
 					"requires": {
-						"debug": "2.6.9",
-						"detect-node": "2.0.3",
-						"hpack.js": "2.1.6",
-						"obuf": "1.1.2",
-						"readable-stream": "2.3.5",
-						"safe-buffer": "5.1.1",
-						"wbuf": "1.7.3"
+						"debug": "^2.6.8",
+						"detect-node": "^2.0.3",
+						"hpack.js": "^2.1.6",
+						"obuf": "^1.1.1",
+						"readable-stream": "^2.2.9",
+						"safe-buffer": "^5.0.1",
+						"wbuf": "^1.7.2"
 					},
 					"dependencies": {
 						"debug": {
@@ -4291,7 +4291,7 @@
 					"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 					"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 					"requires": {
-						"extend-shallow": "3.0.2"
+						"extend-shallow": "^3.0.0"
 					}
 				},
 				"static-extend": {
@@ -4299,8 +4299,8 @@
 					"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 					"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 					"requires": {
-						"define-property": "0.2.5",
-						"object-copy": "0.1.0"
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
 					},
 					"dependencies": {
 						"define-property": {
@@ -4308,7 +4308,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -4316,7 +4316,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -4324,7 +4324,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -4334,7 +4334,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -4342,7 +4342,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -4352,9 +4352,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -4374,9 +4374,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"string_decoder": {
@@ -4384,7 +4384,7 @@
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 					"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "~5.1.0"
 					}
 				},
 				"strip-ansi": {
@@ -4392,7 +4392,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-bom": {
@@ -4400,7 +4400,7 @@
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"strip-indent": {
@@ -4408,7 +4408,7 @@
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 					"requires": {
-						"get-stdin": "4.0.1"
+						"get-stdin": "^4.0.1"
 					}
 				},
 				"supports-color": {
@@ -4416,7 +4416,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"thunky": {
@@ -4434,7 +4434,7 @@
 					"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 					"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -4442,7 +4442,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -4452,10 +4452,10 @@
 					"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 					"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 					"requires": {
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"regex-not": "1.0.2",
-						"safe-regex": "1.1.0"
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"to-regex-range": {
@@ -4463,8 +4463,8 @@
 					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 					"requires": {
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1"
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
 					}
 				},
 				"trim-newlines": {
@@ -4478,7 +4478,7 @@
 					"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
 					"requires": {
 						"media-typer": "0.3.0",
-						"mime-types": "2.1.18"
+						"mime-types": "~2.1.18"
 					}
 				},
 				"union-value": {
@@ -4486,10 +4486,10 @@
 					"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 					"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 					"requires": {
-						"arr-union": "3.1.0",
-						"get-value": "2.0.6",
-						"is-extendable": "0.1.1",
-						"set-value": "0.4.3"
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -4497,7 +4497,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"set-value": {
@@ -4505,10 +4505,10 @@
 							"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 							"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-extendable": "0.1.1",
-								"is-plain-object": "2.0.4",
-								"to-object-path": "0.3.0"
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
 							}
 						}
 					}
@@ -4523,8 +4523,8 @@
 					"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 					"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 					"requires": {
-						"has-value": "0.3.1",
-						"isobject": "3.0.1"
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"has-value": {
@@ -4532,9 +4532,9 @@
 							"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 							"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 							"requires": {
-								"get-value": "2.0.6",
-								"has-values": "0.1.4",
-								"isobject": "2.1.0"
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -4569,8 +4569,8 @@
 					"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
 					"integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
 					"requires": {
-						"querystringify": "1.0.0",
-						"requires-port": "1.0.0"
+						"querystringify": "~1.0.0",
+						"requires-port": "~1.0.0"
 					},
 					"dependencies": {
 						"querystringify": {
@@ -4585,7 +4585,7 @@
 					"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
 					"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.2"
 					}
 				},
 				"util-deprecate": {
@@ -4608,8 +4608,8 @@
 					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
 					"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
 					"requires": {
-						"spdx-correct": "3.0.0",
-						"spdx-expression-parse": "3.0.0"
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
 					}
 				},
 				"vary": {
@@ -4622,7 +4622,7 @@
 					"resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
 					"integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
 					"requires": {
-						"minimalistic-assert": "1.0.0"
+						"minimalistic-assert": "^1.0.0"
 					}
 				},
 				"webpack-dev-middleware": {
@@ -4630,11 +4630,11 @@
 					"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
 					"integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
 					"requires": {
-						"memory-fs": "0.4.1",
-						"mime": "1.6.0",
-						"path-is-absolute": "1.0.1",
-						"range-parser": "1.2.0",
-						"time-stamp": "2.0.0"
+						"memory-fs": "~0.4.1",
+						"mime": "^1.5.0",
+						"path-is-absolute": "^1.0.0",
+						"range-parser": "^1.0.3",
+						"time-stamp": "^2.0.0"
 					},
 					"dependencies": {
 						"mime": {
@@ -4649,8 +4649,8 @@
 					"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
 					"integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
 					"requires": {
-						"http-parser-js": "0.4.11",
-						"websocket-extensions": "0.1.3"
+						"http-parser-js": ">=0.4.0",
+						"websocket-extensions": ">=0.1.1"
 					}
 				},
 				"websocket-extensions": {
@@ -4668,8 +4668,8 @@
 					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					}
 				},
 				"wrappy": {
@@ -4687,19 +4687,19 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
 					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
 					"requires": {
-						"camelcase": "3.0.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "4.2.1"
+						"camelcase": "^3.0.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.2",
+						"which-module": "^1.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^4.2.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -4714,7 +4714,7 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
 					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
 					"requires": {
-						"camelcase": "3.0.0"
+						"camelcase": "^3.0.0"
 					},
 					"dependencies": {
 						"camelcase": {

--- a/packages/angular/package-lock.json
+++ b/packages/angular/package-lock.json
@@ -7,14 +7,14 @@
 			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.5.1.tgz",
 			"integrity": "sha512-OlTo6DYg0XfTKOF8eLf79wcHm4Ut10xU2cRBRPMW/NA5F9VMjZGTfRHWDIYC3s+1kObGYrBLshXWU1K0hILkNQ==",
 			"requires": {
-				"cacache": "10.0.4",
-				"find-cache-dir": "1.0.0",
-				"globby": "7.1.1",
-				"is-glob": "4.0.0",
-				"loader-utils": "1.1.0",
-				"minimatch": "3.0.4",
-				"p-limit": "1.2.0",
-				"serialize-javascript": "1.4.0"
+				"cacache": "^10.0.4",
+				"find-cache-dir": "^1.0.0",
+				"globby": "^7.1.1",
+				"is-glob": "^4.0.0",
+				"loader-utils": "^1.1.0",
+				"minimatch": "^3.0.4",
+				"p-limit": "^1.0.0",
+				"serialize-javascript": "^1.4.0"
 			},
 			"dependencies": {
 				"aproba": {
@@ -27,7 +27,7 @@
 					"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 					"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 					"requires": {
-						"array-uniq": "1.0.3"
+						"array-uniq": "^1.0.1"
 					}
 				},
 				"array-uniq": {
@@ -60,7 +60,7 @@
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -74,19 +74,19 @@
 					"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
 					"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
 					"requires": {
-						"bluebird": "3.5.1",
-						"chownr": "1.0.1",
-						"glob": "7.1.2",
-						"graceful-fs": "4.1.11",
-						"lru-cache": "4.1.2",
-						"mississippi": "2.0.0",
-						"mkdirp": "0.5.1",
-						"move-concurrently": "1.0.1",
-						"promise-inflight": "1.0.1",
-						"rimraf": "2.6.2",
-						"ssri": "5.3.0",
-						"unique-filename": "1.1.0",
-						"y18n": "4.0.0"
+						"bluebird": "^3.5.1",
+						"chownr": "^1.0.1",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.1.11",
+						"lru-cache": "^4.1.1",
+						"mississippi": "^2.0.0",
+						"mkdirp": "^0.5.1",
+						"move-concurrently": "^1.0.1",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"ssri": "^5.2.4",
+						"unique-filename": "^1.1.0",
+						"y18n": "^4.0.0"
 					}
 				},
 				"chownr": {
@@ -109,10 +109,10 @@
 					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 					"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 					"requires": {
-						"buffer-from": "1.0.0",
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.5",
-						"typedarray": "0.0.6"
+						"buffer-from": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.2.2",
+						"typedarray": "^0.0.6"
 					}
 				},
 				"copy-concurrently": {
@@ -120,12 +120,12 @@
 					"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
 					"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
 					"requires": {
-						"aproba": "1.2.0",
-						"fs-write-stream-atomic": "1.0.10",
-						"iferr": "0.1.5",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"run-queue": "1.0.3"
+						"aproba": "^1.1.1",
+						"fs-write-stream-atomic": "^1.0.8",
+						"iferr": "^0.1.5",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.5.4",
+						"run-queue": "^1.0.0"
 					}
 				},
 				"core-util-is": {
@@ -143,8 +143,8 @@
 					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
 					"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
 					"requires": {
-						"arrify": "1.0.1",
-						"path-type": "3.0.0"
+						"arrify": "^1.0.1",
+						"path-type": "^3.0.0"
 					}
 				},
 				"duplexify": {
@@ -152,10 +152,10 @@
 					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
 					"integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
 					"requires": {
-						"end-of-stream": "1.4.1",
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.5",
-						"stream-shift": "1.0.0"
+						"end-of-stream": "^1.0.0",
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.0",
+						"stream-shift": "^1.0.0"
 					}
 				},
 				"emojis-list": {
@@ -168,7 +168,7 @@
 					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
 					"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 					"requires": {
-						"once": "1.4.0"
+						"once": "^1.4.0"
 					}
 				},
 				"find-cache-dir": {
@@ -176,9 +176,9 @@
 					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
 					"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
 					"requires": {
-						"commondir": "1.0.1",
-						"make-dir": "1.2.0",
-						"pkg-dir": "2.0.0"
+						"commondir": "^1.0.1",
+						"make-dir": "^1.0.0",
+						"pkg-dir": "^2.0.0"
 					}
 				},
 				"find-up": {
@@ -186,7 +186,7 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"flush-write-stream": {
@@ -194,8 +194,8 @@
 					"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
 					"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
 					"requires": {
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.5"
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.4"
 					}
 				},
 				"from2": {
@@ -203,8 +203,8 @@
 					"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 					"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 					"requires": {
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.5"
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.0"
 					}
 				},
 				"fs-write-stream-atomic": {
@@ -212,10 +212,10 @@
 					"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
 					"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"iferr": "0.1.5",
-						"imurmurhash": "0.1.4",
-						"readable-stream": "2.3.5"
+						"graceful-fs": "^4.1.2",
+						"iferr": "^0.1.5",
+						"imurmurhash": "^0.1.4",
+						"readable-stream": "1 || 2"
 					}
 				},
 				"fs.realpath": {
@@ -228,12 +228,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"globby": {
@@ -241,12 +241,12 @@
 					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
 					"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
 					"requires": {
-						"array-union": "1.0.2",
-						"dir-glob": "2.0.0",
-						"glob": "7.1.2",
-						"ignore": "3.3.7",
-						"pify": "3.0.0",
-						"slash": "1.0.0"
+						"array-union": "^1.0.1",
+						"dir-glob": "^2.0.0",
+						"glob": "^7.1.2",
+						"ignore": "^3.3.5",
+						"pify": "^3.0.0",
+						"slash": "^1.0.0"
 					}
 				},
 				"graceful-fs": {
@@ -274,8 +274,8 @@
 					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -293,7 +293,7 @@
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"requires": {
-						"is-extglob": "2.1.1"
+						"is-extglob": "^2.1.1"
 					}
 				},
 				"isarray": {
@@ -311,9 +311,9 @@
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
 					"requires": {
-						"big.js": "3.2.0",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1"
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0"
 					}
 				},
 				"locate-path": {
@@ -321,8 +321,8 @@
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"lru-cache": {
@@ -330,8 +330,8 @@
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
 					"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
 					"requires": {
-						"pseudomap": "1.0.2",
-						"yallist": "2.1.2"
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
 					}
 				},
 				"make-dir": {
@@ -339,7 +339,7 @@
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
 					"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"minimatch": {
@@ -347,7 +347,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -360,16 +360,16 @@
 					"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
 					"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
 					"requires": {
-						"concat-stream": "1.6.2",
-						"duplexify": "3.5.4",
-						"end-of-stream": "1.4.1",
-						"flush-write-stream": "1.0.3",
-						"from2": "2.3.0",
-						"parallel-transform": "1.1.0",
-						"pump": "2.0.1",
-						"pumpify": "1.4.0",
-						"stream-each": "1.2.2",
-						"through2": "2.0.3"
+						"concat-stream": "^1.5.0",
+						"duplexify": "^3.4.2",
+						"end-of-stream": "^1.1.0",
+						"flush-write-stream": "^1.0.0",
+						"from2": "^2.1.0",
+						"parallel-transform": "^1.1.0",
+						"pump": "^2.0.1",
+						"pumpify": "^1.3.3",
+						"stream-each": "^1.1.0",
+						"through2": "^2.0.0"
 					}
 				},
 				"mkdirp": {
@@ -385,12 +385,12 @@
 					"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
 					"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
 					"requires": {
-						"aproba": "1.2.0",
-						"copy-concurrently": "1.0.5",
-						"fs-write-stream-atomic": "1.0.10",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"run-queue": "1.0.3"
+						"aproba": "^1.1.1",
+						"copy-concurrently": "^1.0.0",
+						"fs-write-stream-atomic": "^1.0.8",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.5.4",
+						"run-queue": "^1.0.3"
 					}
 				},
 				"once": {
@@ -398,7 +398,7 @@
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"p-limit": {
@@ -406,7 +406,7 @@
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
 					"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
@@ -414,7 +414,7 @@
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"requires": {
-						"p-limit": "1.2.0"
+						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
@@ -427,9 +427,9 @@
 					"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
 					"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
 					"requires": {
-						"cyclist": "0.2.2",
-						"inherits": "2.0.3",
-						"readable-stream": "2.3.5"
+						"cyclist": "~0.2.2",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.1.5"
 					}
 				},
 				"path-exists": {
@@ -447,7 +447,7 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"pify": {
@@ -460,7 +460,7 @@
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 					"requires": {
-						"find-up": "2.1.0"
+						"find-up": "^2.1.0"
 					}
 				},
 				"process-nextick-args": {
@@ -483,8 +483,8 @@
 					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
 					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 					"requires": {
-						"end-of-stream": "1.4.1",
-						"once": "1.4.0"
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
 					}
 				},
 				"pumpify": {
@@ -492,9 +492,9 @@
 					"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
 					"integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
 					"requires": {
-						"duplexify": "3.5.4",
-						"inherits": "2.0.3",
-						"pump": "2.0.1"
+						"duplexify": "^3.5.3",
+						"inherits": "^2.0.3",
+						"pump": "^2.0.0"
 					}
 				},
 				"readable-stream": {
@@ -502,13 +502,13 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
 					"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.0.3",
-						"util-deprecate": "1.0.2"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.0.3",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"rimraf": {
@@ -516,7 +516,7 @@
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"run-queue": {
@@ -524,7 +524,7 @@
 					"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
 					"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
 					"requires": {
-						"aproba": "1.2.0"
+						"aproba": "^1.1.1"
 					}
 				},
 				"safe-buffer": {
@@ -547,7 +547,7 @@
 					"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
 					"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "^5.1.1"
 					}
 				},
 				"stream-each": {
@@ -555,8 +555,8 @@
 					"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
 					"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
 					"requires": {
-						"end-of-stream": "1.4.1",
-						"stream-shift": "1.0.0"
+						"end-of-stream": "^1.1.0",
+						"stream-shift": "^1.0.0"
 					}
 				},
 				"stream-shift": {
@@ -569,7 +569,7 @@
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 					"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "~5.1.0"
 					}
 				},
 				"through2": {
@@ -577,8 +577,8 @@
 					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 					"requires": {
-						"readable-stream": "2.3.5",
-						"xtend": "4.0.1"
+						"readable-stream": "^2.1.5",
+						"xtend": "~4.0.1"
 					}
 				},
 				"typedarray": {
@@ -591,7 +591,7 @@
 					"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
 					"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
 					"requires": {
-						"unique-slug": "2.0.0"
+						"unique-slug": "^2.0.0"
 					}
 				},
 				"unique-slug": {
@@ -599,7 +599,7 @@
 					"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
 					"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
 					"requires": {
-						"imurmurhash": "0.1.4"
+						"imurmurhash": "^0.1.4"
 					}
 				},
 				"util-deprecate": {
@@ -635,30 +635,30 @@
 			"integrity": "sha512-zrPoX97bx47vZiAXfDrkw8pe9QjJ+lunQl3dypojyWwWr1M5I2h0VSrMPfTjopHQPRNn+NqfjcMmhoLcUJe2gA==",
 			"requires": {
 				"ansi-html": "0.0.7",
-				"array-includes": "3.0.3",
-				"bonjour": "3.5.0",
-				"chokidar": "2.0.3",
-				"compression": "1.7.2",
-				"connect-history-api-fallback": "1.5.0",
-				"debug": "3.1.0",
-				"del": "3.0.0",
-				"express": "4.16.3",
-				"html-entities": "1.2.1",
-				"http-proxy-middleware": "0.17.4",
-				"import-local": "1.0.0",
+				"array-includes": "^3.0.3",
+				"bonjour": "^3.5.0",
+				"chokidar": "^2.0.0",
+				"compression": "^1.5.2",
+				"connect-history-api-fallback": "^1.3.0",
+				"debug": "^3.1.0",
+				"del": "^3.0.0",
+				"express": "^4.16.2",
+				"html-entities": "^1.2.0",
+				"http-proxy-middleware": "~0.17.4",
+				"import-local": "^1.0.0",
 				"internal-ip": "1.2.0",
-				"ip": "1.1.5",
-				"killable": "1.0.0",
-				"loglevel": "1.6.1",
-				"opn": "5.3.0",
-				"portfinder": "1.0.13",
-				"selfsigned": "1.10.2",
-				"serve-index": "1.9.1",
+				"ip": "^1.1.5",
+				"killable": "^1.0.0",
+				"loglevel": "^1.4.1",
+				"opn": "^5.1.0",
+				"portfinder": "^1.0.9",
+				"selfsigned": "^1.9.1",
+				"serve-index": "^1.7.2",
 				"sockjs": "0.3.19",
 				"sockjs-client": "1.1.4",
-				"spdy": "3.4.7",
-				"strip-ansi": "3.0.1",
-				"supports-color": "5.3.0",
+				"spdy": "^3.4.1",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^5.1.0",
 				"webpack-dev-middleware": "1.12.2",
 				"yargs": "6.6.0"
 			},
@@ -668,7 +668,7 @@
 					"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
 					"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
 					"requires": {
-						"mime-types": "2.1.18",
+						"mime-types": "~2.1.18",
 						"negotiator": "0.6.1"
 					}
 				},
@@ -687,8 +687,8 @@
 					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 					"requires": {
-						"micromatch": "3.1.10",
-						"normalize-path": "2.1.1"
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
 					}
 				},
 				"arr-diff": {
@@ -721,8 +721,8 @@
 					"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
 					"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
 					"requires": {
-						"define-properties": "1.1.2",
-						"es-abstract": "1.11.0"
+						"define-properties": "^1.1.2",
+						"es-abstract": "^1.7.0"
 					}
 				},
 				"array-union": {
@@ -730,7 +730,7 @@
 					"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 					"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 					"requires": {
-						"array-uniq": "1.0.3"
+						"array-uniq": "^1.0.1"
 					}
 				},
 				"array-uniq": {
@@ -773,13 +773,13 @@
 					"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 					"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 					"requires": {
-						"cache-base": "1.0.1",
-						"class-utils": "0.3.6",
-						"component-emitter": "1.2.1",
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"mixin-deep": "1.3.1",
-						"pascalcase": "0.1.1"
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -787,7 +787,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						}
 					}
@@ -808,15 +808,15 @@
 					"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
 					"requires": {
 						"bytes": "3.0.0",
-						"content-type": "1.0.4",
+						"content-type": "~1.0.4",
 						"debug": "2.6.9",
-						"depd": "1.1.2",
-						"http-errors": "1.6.2",
+						"depd": "~1.1.1",
+						"http-errors": "~1.6.2",
 						"iconv-lite": "0.4.19",
-						"on-finished": "2.3.0",
+						"on-finished": "~2.3.0",
 						"qs": "6.5.1",
 						"raw-body": "2.3.2",
-						"type-is": "1.6.16"
+						"type-is": "~1.6.15"
 					},
 					"dependencies": {
 						"debug": {
@@ -834,12 +834,12 @@
 					"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
 					"integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
 					"requires": {
-						"array-flatten": "2.1.1",
-						"deep-equal": "1.0.1",
-						"dns-equal": "1.0.0",
-						"dns-txt": "2.0.2",
-						"multicast-dns": "6.2.3",
-						"multicast-dns-service-types": "1.1.0"
+						"array-flatten": "^2.1.0",
+						"deep-equal": "^1.0.1",
+						"dns-equal": "^1.0.0",
+						"dns-txt": "^2.0.2",
+						"multicast-dns": "^6.0.1",
+						"multicast-dns-service-types": "^1.1.0"
 					}
 				},
 				"brace-expansion": {
@@ -847,7 +847,7 @@
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -856,18 +856,18 @@
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
 					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"kind-of": "6.0.2",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"kind-of": "^6.0.2",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -875,7 +875,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -883,7 +883,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -908,15 +908,15 @@
 					"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 					"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 					"requires": {
-						"collection-visit": "1.0.0",
-						"component-emitter": "1.2.1",
-						"get-value": "2.0.6",
-						"has-value": "1.0.0",
-						"isobject": "3.0.1",
-						"set-value": "2.0.0",
-						"to-object-path": "0.3.0",
-						"union-value": "1.0.0",
-						"unset-value": "1.0.0"
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
 					}
 				},
 				"camelcase": {
@@ -929,8 +929,8 @@
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 					"requires": {
-						"camelcase": "2.1.1",
-						"map-obj": "1.0.1"
+						"camelcase": "^2.0.0",
+						"map-obj": "^1.0.0"
 					}
 				},
 				"chokidar": {
@@ -938,18 +938,18 @@
 					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
 					"integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
 					"requires": {
-						"anymatch": "2.0.0",
-						"async-each": "1.0.1",
-						"braces": "2.3.1",
-						"fsevents": "1.1.3",
-						"glob-parent": "3.1.0",
-						"inherits": "2.0.3",
-						"is-binary-path": "1.0.1",
-						"is-glob": "4.0.0",
-						"normalize-path": "2.1.1",
-						"path-is-absolute": "1.0.1",
-						"readdirp": "2.1.0",
-						"upath": "1.0.4"
+						"anymatch": "^2.0.0",
+						"async-each": "^1.0.0",
+						"braces": "^2.3.0",
+						"fsevents": "^1.1.2",
+						"glob-parent": "^3.1.0",
+						"inherits": "^2.0.1",
+						"is-binary-path": "^1.0.0",
+						"is-glob": "^4.0.0",
+						"normalize-path": "^2.1.1",
+						"path-is-absolute": "^1.0.0",
+						"readdirp": "^2.0.0",
+						"upath": "^1.0.0"
 					}
 				},
 				"class-utils": {
@@ -957,10 +957,10 @@
 					"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 					"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 					"requires": {
-						"arr-union": "3.1.0",
-						"define-property": "0.2.5",
-						"isobject": "3.0.1",
-						"static-extend": "0.1.2"
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -968,7 +968,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -976,7 +976,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -984,7 +984,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -994,7 +994,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -1002,7 +1002,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -1012,9 +1012,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -1029,9 +1029,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"code-point-at": {
@@ -1044,8 +1044,8 @@
 					"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 					"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 					"requires": {
-						"map-visit": "1.0.0",
-						"object-visit": "1.0.1"
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
 					}
 				},
 				"component-emitter": {
@@ -1058,7 +1058,7 @@
 					"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
 					"integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
 					"requires": {
-						"mime-db": "1.33.0"
+						"mime-db": ">= 1.33.0 < 2"
 					}
 				},
 				"compression": {
@@ -1066,13 +1066,13 @@
 					"resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
 					"integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
 					"requires": {
-						"accepts": "1.3.5",
+						"accepts": "~1.3.4",
 						"bytes": "3.0.0",
-						"compressible": "2.0.13",
+						"compressible": "~2.0.13",
 						"debug": "2.6.9",
-						"on-headers": "1.0.1",
+						"on-headers": "~1.0.1",
 						"safe-buffer": "5.1.1",
-						"vary": "1.1.2"
+						"vary": "~1.1.2"
 					},
 					"dependencies": {
 						"debug": {
@@ -1130,7 +1130,7 @@
 					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 					"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 					"requires": {
-						"array-find-index": "1.0.2"
+						"array-find-index": "^1.0.1"
 					}
 				},
 				"debug": {
@@ -1161,8 +1161,8 @@
 					"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 					"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 					"requires": {
-						"foreach": "2.0.5",
-						"object-keys": "1.0.11"
+						"foreach": "^2.0.5",
+						"object-keys": "^1.0.8"
 					}
 				},
 				"define-property": {
@@ -1170,8 +1170,8 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 					"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 					"requires": {
-						"is-descriptor": "1.0.2",
-						"isobject": "3.0.1"
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
 					}
 				},
 				"del": {
@@ -1179,12 +1179,12 @@
 					"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
 					"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
 					"requires": {
-						"globby": "6.1.0",
-						"is-path-cwd": "1.0.0",
-						"is-path-in-cwd": "1.0.1",
-						"p-map": "1.2.0",
-						"pify": "3.0.0",
-						"rimraf": "2.6.2"
+						"globby": "^6.1.0",
+						"is-path-cwd": "^1.0.0",
+						"is-path-in-cwd": "^1.0.0",
+						"p-map": "^1.1.1",
+						"pify": "^3.0.0",
+						"rimraf": "^2.2.8"
 					}
 				},
 				"depd": {
@@ -1212,8 +1212,8 @@
 					"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
 					"integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
 					"requires": {
-						"ip": "1.1.5",
-						"safe-buffer": "5.1.1"
+						"ip": "^1.1.0",
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"dns-txt": {
@@ -1221,7 +1221,7 @@
 					"resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
 					"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
 					"requires": {
-						"buffer-indexof": "1.1.1"
+						"buffer-indexof": "^1.0.0"
 					}
 				},
 				"ee-first": {
@@ -1239,7 +1239,7 @@
 					"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
 					"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 					"requires": {
-						"prr": "1.0.1"
+						"prr": "~1.0.1"
 					}
 				},
 				"error-ex": {
@@ -1247,7 +1247,7 @@
 					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 					"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 					"requires": {
-						"is-arrayish": "0.2.1"
+						"is-arrayish": "^0.2.1"
 					}
 				},
 				"es-abstract": {
@@ -1255,11 +1255,11 @@
 					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
 					"integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
 					"requires": {
-						"es-to-primitive": "1.1.1",
-						"function-bind": "1.1.1",
-						"has": "1.0.1",
-						"is-callable": "1.1.3",
-						"is-regex": "1.0.4"
+						"es-to-primitive": "^1.1.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.1",
+						"is-callable": "^1.1.3",
+						"is-regex": "^1.0.4"
 					}
 				},
 				"es-to-primitive": {
@@ -1267,9 +1267,9 @@
 					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 					"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 					"requires": {
-						"is-callable": "1.1.3",
-						"is-date-object": "1.0.1",
-						"is-symbol": "1.0.1"
+						"is-callable": "^1.1.1",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.1"
 					}
 				},
 				"escape-html": {
@@ -1292,7 +1292,7 @@
 					"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
 					"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
 					"requires": {
-						"original": "1.0.0"
+						"original": ">=0.0.5"
 					}
 				},
 				"expand-brackets": {
@@ -1300,13 +1300,13 @@
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"debug": {
@@ -1322,7 +1322,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -1330,7 +1330,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -1338,7 +1338,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -1346,7 +1346,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -1356,7 +1356,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -1364,7 +1364,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -1374,9 +1374,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -1391,7 +1391,7 @@
 					"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 					"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 					"requires": {
-						"fill-range": "2.2.3"
+						"fill-range": "^2.1.0"
 					},
 					"dependencies": {
 						"fill-range": {
@@ -1399,11 +1399,11 @@
 							"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 							"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
 							"requires": {
-								"is-number": "2.1.0",
-								"isobject": "2.1.0",
-								"randomatic": "1.1.7",
-								"repeat-element": "1.1.2",
-								"repeat-string": "1.6.1"
+								"is-number": "^2.1.0",
+								"isobject": "^2.0.0",
+								"randomatic": "^1.1.3",
+								"repeat-element": "^1.1.2",
+								"repeat-string": "^1.5.2"
 							}
 						},
 						"is-number": {
@@ -1411,7 +1411,7 @@
 							"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 							"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"isobject": {
@@ -1427,7 +1427,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -1437,36 +1437,36 @@
 					"resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
 					"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
 					"requires": {
-						"accepts": "1.3.5",
+						"accepts": "~1.3.5",
 						"array-flatten": "1.1.1",
 						"body-parser": "1.18.2",
 						"content-disposition": "0.5.2",
-						"content-type": "1.0.4",
+						"content-type": "~1.0.4",
 						"cookie": "0.3.1",
 						"cookie-signature": "1.0.6",
 						"debug": "2.6.9",
-						"depd": "1.1.2",
-						"encodeurl": "1.0.2",
-						"escape-html": "1.0.3",
-						"etag": "1.8.1",
+						"depd": "~1.1.2",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"etag": "~1.8.1",
 						"finalhandler": "1.1.1",
 						"fresh": "0.5.2",
 						"merge-descriptors": "1.0.1",
-						"methods": "1.1.2",
-						"on-finished": "2.3.0",
-						"parseurl": "1.3.2",
+						"methods": "~1.1.2",
+						"on-finished": "~2.3.0",
+						"parseurl": "~1.3.2",
 						"path-to-regexp": "0.1.7",
-						"proxy-addr": "2.0.3",
+						"proxy-addr": "~2.0.3",
 						"qs": "6.5.1",
-						"range-parser": "1.2.0",
+						"range-parser": "~1.2.0",
 						"safe-buffer": "5.1.1",
 						"send": "0.16.2",
 						"serve-static": "1.13.2",
 						"setprototypeof": "1.1.0",
-						"statuses": "1.4.0",
-						"type-is": "1.6.16",
+						"statuses": "~1.4.0",
+						"type-is": "~1.6.16",
 						"utils-merge": "1.0.1",
-						"vary": "1.1.2"
+						"vary": "~1.1.2"
 					},
 					"dependencies": {
 						"array-flatten": {
@@ -1489,8 +1489,8 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 					"requires": {
-						"assign-symbols": "1.0.0",
-						"is-extendable": "1.0.1"
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
@@ -1498,7 +1498,7 @@
 							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -1508,14 +1508,14 @@
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -1523,7 +1523,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -1531,7 +1531,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1541,7 +1541,7 @@
 					"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
 					"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
 					"requires": {
-						"websocket-driver": "0.7.0"
+						"websocket-driver": ">=0.5.1"
 					}
 				},
 				"filename-regex": {
@@ -1554,10 +1554,10 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -1565,7 +1565,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -1576,12 +1576,12 @@
 					"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
 					"requires": {
 						"debug": "2.6.9",
-						"encodeurl": "1.0.2",
-						"escape-html": "1.0.3",
-						"on-finished": "2.3.0",
-						"parseurl": "1.3.2",
-						"statuses": "1.4.0",
-						"unpipe": "1.0.0"
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"on-finished": "~2.3.0",
+						"parseurl": "~1.3.2",
+						"statuses": "~1.4.0",
+						"unpipe": "~1.0.0"
 					},
 					"dependencies": {
 						"debug": {
@@ -1599,7 +1599,7 @@
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"for-in": {
@@ -1612,7 +1612,7 @@
 					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 					"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 					"requires": {
-						"for-in": "1.0.2"
+						"for-in": "^1.0.1"
 					}
 				},
 				"foreach": {
@@ -1630,7 +1630,7 @@
 					"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 					"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 					"requires": {
-						"map-cache": "0.2.2"
+						"map-cache": "^0.2.2"
 					}
 				},
 				"fresh": {
@@ -1649,8 +1649,8 @@
 					"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
 					"optional": true,
 					"requires": {
-						"nan": "2.10.0",
-						"node-pre-gyp": "0.6.39"
+						"nan": "^2.3.0",
+						"node-pre-gyp": "^0.6.39"
 					},
 					"dependencies": {
 						"abbrev": {
@@ -2457,12 +2457,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"glob-base": {
@@ -2470,8 +2470,8 @@
 					"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 					"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 					"requires": {
-						"glob-parent": "2.0.0",
-						"is-glob": "2.0.1"
+						"glob-parent": "^2.0.0",
+						"is-glob": "^2.0.0"
 					},
 					"dependencies": {
 						"glob-parent": {
@@ -2479,7 +2479,7 @@
 							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 							"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 							"requires": {
-								"is-glob": "2.0.1"
+								"is-glob": "^2.0.0"
 							}
 						},
 						"is-extglob": {
@@ -2492,7 +2492,7 @@
 							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 							"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 							"requires": {
-								"is-extglob": "1.0.0"
+								"is-extglob": "^1.0.0"
 							}
 						}
 					}
@@ -2502,8 +2502,8 @@
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 					"requires": {
-						"is-glob": "3.1.0",
-						"path-dirname": "1.0.2"
+						"is-glob": "^3.1.0",
+						"path-dirname": "^1.0.0"
 					},
 					"dependencies": {
 						"is-glob": {
@@ -2511,7 +2511,7 @@
 							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 							"requires": {
-								"is-extglob": "2.1.1"
+								"is-extglob": "^2.1.0"
 							}
 						}
 					}
@@ -2521,11 +2521,11 @@
 					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"requires": {
-						"array-union": "1.0.2",
-						"glob": "7.1.2",
-						"object-assign": "4.1.1",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					},
 					"dependencies": {
 						"pify": {
@@ -2550,7 +2550,7 @@
 					"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 					"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
 					"requires": {
-						"function-bind": "1.1.1"
+						"function-bind": "^1.0.2"
 					}
 				},
 				"has-flag": {
@@ -2563,9 +2563,9 @@
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 					"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "1.0.0",
-						"isobject": "3.0.1"
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
 					}
 				},
 				"has-values": {
@@ -2573,8 +2573,8 @@
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 					"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 					"requires": {
-						"is-number": "3.0.0",
-						"kind-of": "4.0.0"
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2582,7 +2582,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 							"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -2597,10 +2597,10 @@
 					"resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
 					"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
 					"requires": {
-						"inherits": "2.0.3",
-						"obuf": "1.1.2",
-						"readable-stream": "2.3.5",
-						"wbuf": "1.7.3"
+						"inherits": "^2.0.1",
+						"obuf": "^1.0.0",
+						"readable-stream": "^2.0.1",
+						"wbuf": "^1.1.0"
 					}
 				},
 				"html-entities": {
@@ -2621,7 +2621,7 @@
 						"depd": "1.1.1",
 						"inherits": "2.0.3",
 						"setprototypeof": "1.0.3",
-						"statuses": "1.4.0"
+						"statuses": ">= 1.3.1 < 2"
 					},
 					"dependencies": {
 						"depd": {
@@ -2646,8 +2646,8 @@
 					"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
 					"integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
 					"requires": {
-						"eventemitter3": "1.2.0",
-						"requires-port": "1.0.0"
+						"eventemitter3": "1.x.x",
+						"requires-port": "1.x.x"
 					}
 				},
 				"http-proxy-middleware": {
@@ -2655,10 +2655,10 @@
 					"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
 					"integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
 					"requires": {
-						"http-proxy": "1.16.2",
-						"is-glob": "3.1.0",
-						"lodash": "4.17.5",
-						"micromatch": "2.3.11"
+						"http-proxy": "^1.16.2",
+						"is-glob": "^3.1.0",
+						"lodash": "^4.17.2",
+						"micromatch": "^2.3.11"
 					},
 					"dependencies": {
 						"arr-diff": {
@@ -2666,7 +2666,7 @@
 							"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 							"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 							"requires": {
-								"arr-flatten": "1.1.0"
+								"arr-flatten": "^1.0.1"
 							}
 						},
 						"array-unique": {
@@ -2679,9 +2679,9 @@
 							"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 							"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 							"requires": {
-								"expand-range": "1.8.2",
-								"preserve": "0.2.0",
-								"repeat-element": "1.1.2"
+								"expand-range": "^1.8.1",
+								"preserve": "^0.2.0",
+								"repeat-element": "^1.1.2"
 							}
 						},
 						"expand-brackets": {
@@ -2689,7 +2689,7 @@
 							"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 							"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 							"requires": {
-								"is-posix-bracket": "0.1.1"
+								"is-posix-bracket": "^0.1.0"
 							}
 						},
 						"extglob": {
@@ -2697,7 +2697,7 @@
 							"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 							"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 							"requires": {
-								"is-extglob": "1.0.0"
+								"is-extglob": "^1.0.0"
 							},
 							"dependencies": {
 								"is-extglob": {
@@ -2712,7 +2712,7 @@
 							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 							"requires": {
-								"is-extglob": "2.1.1"
+								"is-extglob": "^2.1.0"
 							}
 						},
 						"kind-of": {
@@ -2720,7 +2720,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						},
 						"micromatch": {
@@ -2728,19 +2728,19 @@
 							"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 							"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 							"requires": {
-								"arr-diff": "2.0.0",
-								"array-unique": "0.2.1",
-								"braces": "1.8.5",
-								"expand-brackets": "0.1.5",
-								"extglob": "0.3.2",
-								"filename-regex": "2.0.1",
-								"is-extglob": "1.0.0",
-								"is-glob": "2.0.1",
-								"kind-of": "3.2.2",
-								"normalize-path": "2.1.1",
-								"object.omit": "2.0.1",
-								"parse-glob": "3.0.4",
-								"regex-cache": "0.4.4"
+								"arr-diff": "^2.0.0",
+								"array-unique": "^0.2.1",
+								"braces": "^1.8.2",
+								"expand-brackets": "^0.1.4",
+								"extglob": "^0.3.1",
+								"filename-regex": "^2.0.0",
+								"is-extglob": "^1.0.0",
+								"is-glob": "^2.0.1",
+								"kind-of": "^3.0.2",
+								"normalize-path": "^2.0.1",
+								"object.omit": "^2.0.0",
+								"parse-glob": "^3.0.4",
+								"regex-cache": "^0.4.2"
 							},
 							"dependencies": {
 								"is-extglob": {
@@ -2753,7 +2753,7 @@
 									"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 									"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 									"requires": {
-										"is-extglob": "1.0.0"
+										"is-extglob": "^1.0.0"
 									}
 								}
 							}
@@ -2770,8 +2770,8 @@
 					"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
 					"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 					"requires": {
-						"pkg-dir": "2.0.0",
-						"resolve-cwd": "2.0.0"
+						"pkg-dir": "^2.0.0",
+						"resolve-cwd": "^2.0.0"
 					}
 				},
 				"indent-string": {
@@ -2779,7 +2779,7 @@
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 					"requires": {
-						"repeating": "2.0.1"
+						"repeating": "^2.0.0"
 					}
 				},
 				"inflight": {
@@ -2787,8 +2787,8 @@
 					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -2801,7 +2801,7 @@
 					"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
 					"integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
 					"requires": {
-						"meow": "3.7.0"
+						"meow": "^3.3.0"
 					}
 				},
 				"invert-kv": {
@@ -2824,7 +2824,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-arrayish": {
@@ -2837,7 +2837,7 @@
 					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 					"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 					"requires": {
-						"binary-extensions": "1.11.0"
+						"binary-extensions": "^1.0.0"
 					}
 				},
 				"is-buffer": {
@@ -2850,7 +2850,7 @@
 					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 					"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 					"requires": {
-						"builtin-modules": "1.1.1"
+						"builtin-modules": "^1.0.0"
 					}
 				},
 				"is-callable": {
@@ -2863,7 +2863,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-date-object": {
@@ -2876,9 +2876,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"is-dotfile": {
@@ -2891,7 +2891,7 @@
 					"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 					"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 					"requires": {
-						"is-primitive": "2.0.0"
+						"is-primitive": "^2.0.0"
 					}
 				},
 				"is-extendable": {
@@ -2909,7 +2909,7 @@
 					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 					"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -2917,7 +2917,7 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-glob": {
@@ -2925,7 +2925,7 @@
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"requires": {
-						"is-extglob": "2.1.1"
+						"is-extglob": "^2.1.1"
 					}
 				},
 				"is-number": {
@@ -2933,7 +2933,7 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2941,7 +2941,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -2951,7 +2951,7 @@
 					"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
 					"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
 					"requires": {
-						"is-number": "4.0.0"
+						"is-number": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
@@ -2971,7 +2971,7 @@
 					"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
 					"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
 					"requires": {
-						"is-path-inside": "1.0.1"
+						"is-path-inside": "^1.0.0"
 					}
 				},
 				"is-path-inside": {
@@ -2979,7 +2979,7 @@
 					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 					"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 					"requires": {
-						"path-is-inside": "1.0.2"
+						"path-is-inside": "^1.0.1"
 					}
 				},
 				"is-plain-object": {
@@ -2987,7 +2987,7 @@
 					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					}
 				},
 				"is-posix-bracket": {
@@ -3005,7 +3005,7 @@
 					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 					"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 					"requires": {
-						"has": "1.0.1"
+						"has": "^1.0.1"
 					}
 				},
 				"is-symbol": {
@@ -3058,7 +3058,7 @@
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 					"requires": {
-						"invert-kv": "1.0.0"
+						"invert-kv": "^1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -3066,11 +3066,11 @@
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					},
 					"dependencies": {
 						"pify": {
@@ -3085,8 +3085,8 @@
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"requires": {
-						"p-locate": "2.0.0",
-						"path-exists": "3.0.0"
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"lodash": {
@@ -3104,8 +3104,8 @@
 					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 					"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 					"requires": {
-						"currently-unhandled": "0.4.1",
-						"signal-exit": "3.0.2"
+						"currently-unhandled": "^0.4.1",
+						"signal-exit": "^3.0.0"
 					}
 				},
 				"map-cache": {
@@ -3123,7 +3123,7 @@
 					"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 					"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 					"requires": {
-						"object-visit": "1.0.1"
+						"object-visit": "^1.0.0"
 					}
 				},
 				"media-typer": {
@@ -3136,8 +3136,8 @@
 					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 					"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 					"requires": {
-						"errno": "0.1.7",
-						"readable-stream": "2.3.5"
+						"errno": "^0.1.3",
+						"readable-stream": "^2.0.1"
 					}
 				},
 				"meow": {
@@ -3145,16 +3145,16 @@
 					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 					"requires": {
-						"camelcase-keys": "2.1.0",
-						"decamelize": "1.2.0",
-						"loud-rejection": "1.6.0",
-						"map-obj": "1.0.1",
-						"minimist": "1.2.0",
-						"normalize-package-data": "2.4.0",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"redent": "1.0.0",
-						"trim-newlines": "1.0.0"
+						"camelcase-keys": "^2.0.0",
+						"decamelize": "^1.1.2",
+						"loud-rejection": "^1.0.0",
+						"map-obj": "^1.0.1",
+						"minimist": "^1.1.3",
+						"normalize-package-data": "^2.3.4",
+						"object-assign": "^4.0.1",
+						"read-pkg-up": "^1.0.1",
+						"redent": "^1.0.0",
+						"trim-newlines": "^1.0.0"
 					}
 				},
 				"merge-descriptors": {
@@ -3172,19 +3172,19 @@
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.1",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				},
 				"mime": {
@@ -3202,7 +3202,7 @@
 					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
 					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 					"requires": {
-						"mime-db": "1.33.0"
+						"mime-db": "~1.33.0"
 					}
 				},
 				"minimalistic-assert": {
@@ -3215,7 +3215,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -3228,8 +3228,8 @@
 					"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 					"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 					"requires": {
-						"for-in": "1.0.2",
-						"is-extendable": "1.0.1"
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
@@ -3237,7 +3237,7 @@
 							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 							"requires": {
-								"is-plain-object": "2.0.4"
+								"is-plain-object": "^2.0.4"
 							}
 						}
 					}
@@ -3267,8 +3267,8 @@
 					"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
 					"integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
 					"requires": {
-						"dns-packet": "1.3.1",
-						"thunky": "1.0.2"
+						"dns-packet": "^1.3.1",
+						"thunky": "^1.0.2"
 					}
 				},
 				"multicast-dns-service-types": {
@@ -3287,18 +3287,18 @@
 					"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
 					"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"fragment-cache": "0.2.1",
-						"is-odd": "2.0.0",
-						"is-windows": "1.0.2",
-						"kind-of": "6.0.2",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					}
 				},
 				"negotiator": {
@@ -3316,10 +3316,10 @@
 					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 					"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 					"requires": {
-						"hosted-git-info": "2.6.0",
-						"is-builtin-module": "1.0.0",
-						"semver": "5.5.0",
-						"validate-npm-package-license": "3.0.3"
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"normalize-path": {
@@ -3327,7 +3327,7 @@
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"requires": {
-						"remove-trailing-separator": "1.1.0"
+						"remove-trailing-separator": "^1.0.1"
 					}
 				},
 				"number-is-nan": {
@@ -3345,9 +3345,9 @@
 					"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 					"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 					"requires": {
-						"copy-descriptor": "0.1.1",
-						"define-property": "0.2.5",
-						"kind-of": "3.2.2"
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
 					},
 					"dependencies": {
 						"define-property": {
@@ -3355,7 +3355,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -3363,7 +3363,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"is-data-descriptor": {
@@ -3371,7 +3371,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							}
 						},
 						"is-descriptor": {
@@ -3379,9 +3379,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -3396,7 +3396,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -3411,7 +3411,7 @@
 					"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 					"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.0"
 					}
 				},
 				"object.omit": {
@@ -3419,8 +3419,8 @@
 					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 					"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 					"requires": {
-						"for-own": "0.1.5",
-						"is-extendable": "0.1.1"
+						"for-own": "^0.1.4",
+						"is-extendable": "^0.1.1"
 					}
 				},
 				"object.pick": {
@@ -3428,7 +3428,7 @@
 					"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 					"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 					"requires": {
-						"isobject": "3.0.1"
+						"isobject": "^3.0.1"
 					}
 				},
 				"obuf": {
@@ -3454,7 +3454,7 @@
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"opn": {
@@ -3462,7 +3462,7 @@
 					"resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
 					"integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
 					"requires": {
-						"is-wsl": "1.1.0"
+						"is-wsl": "^1.1.0"
 					}
 				},
 				"original": {
@@ -3470,7 +3470,7 @@
 					"resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
 					"integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
 					"requires": {
-						"url-parse": "1.0.5"
+						"url-parse": "1.0.x"
 					},
 					"dependencies": {
 						"url-parse": {
@@ -3478,8 +3478,8 @@
 							"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
 							"integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
 							"requires": {
-								"querystringify": "0.0.4",
-								"requires-port": "1.0.0"
+								"querystringify": "0.0.x",
+								"requires-port": "1.0.x"
 							}
 						}
 					}
@@ -3489,7 +3489,7 @@
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"requires": {
-						"lcid": "1.0.0"
+						"lcid": "^1.0.0"
 					}
 				},
 				"p-limit": {
@@ -3497,7 +3497,7 @@
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
 					"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 					"requires": {
-						"p-try": "1.0.0"
+						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
@@ -3505,7 +3505,7 @@
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"requires": {
-						"p-limit": "1.2.0"
+						"p-limit": "^1.1.0"
 					}
 				},
 				"p-map": {
@@ -3523,10 +3523,10 @@
 					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 					"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 					"requires": {
-						"glob-base": "0.3.0",
-						"is-dotfile": "1.0.3",
-						"is-extglob": "1.0.0",
-						"is-glob": "2.0.1"
+						"glob-base": "^0.3.0",
+						"is-dotfile": "^1.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.0"
 					},
 					"dependencies": {
 						"is-extglob": {
@@ -3539,7 +3539,7 @@
 							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 							"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 							"requires": {
-								"is-extglob": "1.0.0"
+								"is-extglob": "^1.0.0"
 							}
 						}
 					}
@@ -3549,7 +3549,7 @@
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 					"requires": {
-						"error-ex": "1.3.1"
+						"error-ex": "^1.2.0"
 					}
 				},
 				"parseurl": {
@@ -3592,9 +3592,9 @@
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					},
 					"dependencies": {
 						"pify": {
@@ -3619,7 +3619,7 @@
 					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 					"requires": {
-						"pinkie": "2.0.4"
+						"pinkie": "^2.0.0"
 					}
 				},
 				"pkg-dir": {
@@ -3627,7 +3627,7 @@
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 					"requires": {
-						"find-up": "2.1.0"
+						"find-up": "^2.1.0"
 					}
 				},
 				"portfinder": {
@@ -3635,9 +3635,9 @@
 					"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
 					"integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
 					"requires": {
-						"async": "1.5.2",
-						"debug": "2.6.9",
-						"mkdirp": "0.5.1"
+						"async": "^1.5.2",
+						"debug": "^2.2.0",
+						"mkdirp": "0.5.x"
 					},
 					"dependencies": {
 						"debug": {
@@ -3670,7 +3670,7 @@
 					"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
 					"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
 					"requires": {
-						"forwarded": "0.1.2",
+						"forwarded": "~0.1.2",
 						"ipaddr.js": "1.6.0"
 					}
 				},
@@ -3694,8 +3694,8 @@
 					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 					"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
 					"requires": {
-						"is-number": "3.0.0",
-						"kind-of": "4.0.0"
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -3703,7 +3703,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 							"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -3729,9 +3729,9 @@
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -3739,8 +3739,8 @@
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
@@ -3748,8 +3748,8 @@
 							"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 							"requires": {
-								"path-exists": "2.1.0",
-								"pinkie-promise": "2.0.1"
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
 							}
 						},
 						"path-exists": {
@@ -3757,7 +3757,7 @@
 							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 							"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 							"requires": {
-								"pinkie-promise": "2.0.1"
+								"pinkie-promise": "^2.0.0"
 							}
 						}
 					}
@@ -3767,13 +3767,13 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
 					"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.0.3",
-						"util-deprecate": "1.0.2"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.0.3",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"readdirp": {
@@ -3781,10 +3781,10 @@
 					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 					"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"minimatch": "3.0.4",
-						"readable-stream": "2.3.5",
-						"set-immediate-shim": "1.0.1"
+						"graceful-fs": "^4.1.2",
+						"minimatch": "^3.0.2",
+						"readable-stream": "^2.0.2",
+						"set-immediate-shim": "^1.0.1"
 					}
 				},
 				"redent": {
@@ -3792,8 +3792,8 @@
 					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 					"requires": {
-						"indent-string": "2.1.0",
-						"strip-indent": "1.0.1"
+						"indent-string": "^2.1.0",
+						"strip-indent": "^1.0.1"
 					}
 				},
 				"regex-cache": {
@@ -3801,7 +3801,7 @@
 					"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 					"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 					"requires": {
-						"is-equal-shallow": "0.1.3"
+						"is-equal-shallow": "^0.1.3"
 					}
 				},
 				"regex-not": {
@@ -3809,8 +3809,8 @@
 					"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 					"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 					"requires": {
-						"extend-shallow": "3.0.2",
-						"safe-regex": "1.1.0"
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"remove-trailing-separator": {
@@ -3833,7 +3833,7 @@
 					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 					"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 					"requires": {
-						"is-finite": "1.0.2"
+						"is-finite": "^1.0.0"
 					}
 				},
 				"require-directory": {
@@ -3856,7 +3856,7 @@
 					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
 					"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 					"requires": {
-						"resolve-from": "3.0.0"
+						"resolve-from": "^3.0.0"
 					}
 				},
 				"resolve-from": {
@@ -3879,7 +3879,7 @@
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-buffer": {
@@ -3892,7 +3892,7 @@
 					"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 					"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 					"requires": {
-						"ret": "0.1.15"
+						"ret": "~0.1.10"
 					}
 				},
 				"select-hose": {
@@ -3919,18 +3919,18 @@
 					"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
 					"requires": {
 						"debug": "2.6.9",
-						"depd": "1.1.2",
-						"destroy": "1.0.4",
-						"encodeurl": "1.0.2",
-						"escape-html": "1.0.3",
-						"etag": "1.8.1",
+						"depd": "~1.1.2",
+						"destroy": "~1.0.4",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"etag": "~1.8.1",
 						"fresh": "0.5.2",
-						"http-errors": "1.6.2",
+						"http-errors": "~1.6.2",
 						"mime": "1.4.1",
 						"ms": "2.0.0",
-						"on-finished": "2.3.0",
-						"range-parser": "1.2.0",
-						"statuses": "1.4.0"
+						"on-finished": "~2.3.0",
+						"range-parser": "~1.2.0",
+						"statuses": "~1.4.0"
 					},
 					"dependencies": {
 						"debug": {
@@ -3948,13 +3948,13 @@
 					"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
 					"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
 					"requires": {
-						"accepts": "1.3.5",
+						"accepts": "~1.3.4",
 						"batch": "0.6.1",
 						"debug": "2.6.9",
-						"escape-html": "1.0.3",
-						"http-errors": "1.6.2",
-						"mime-types": "2.1.18",
-						"parseurl": "1.3.2"
+						"escape-html": "~1.0.3",
+						"http-errors": "~1.6.2",
+						"mime-types": "~2.1.17",
+						"parseurl": "~1.3.2"
 					},
 					"dependencies": {
 						"debug": {
@@ -3972,9 +3972,9 @@
 					"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
 					"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
 					"requires": {
-						"encodeurl": "1.0.2",
-						"escape-html": "1.0.3",
-						"parseurl": "1.3.2",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"parseurl": "~1.3.2",
 						"send": "0.16.2"
 					}
 				},
@@ -3993,10 +3993,10 @@
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 					"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"split-string": "3.1.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -4004,7 +4004,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -4024,14 +4024,14 @@
 					"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 					"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 					"requires": {
-						"base": "0.11.2",
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"map-cache": "0.2.2",
-						"source-map": "0.5.7",
-						"source-map-resolve": "0.5.1",
-						"use": "3.1.0"
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
 					},
 					"dependencies": {
 						"debug": {
@@ -4047,7 +4047,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -4055,7 +4055,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -4063,7 +4063,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -4071,7 +4071,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -4081,7 +4081,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -4089,7 +4089,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -4099,9 +4099,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -4116,9 +4116,9 @@
 					"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 					"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 					"requires": {
-						"define-property": "1.0.0",
-						"isobject": "3.0.1",
-						"snapdragon-util": "3.0.1"
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -4126,7 +4126,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						}
 					}
@@ -4136,7 +4136,7 @@
 					"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 					"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.2.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -4144,7 +4144,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -4154,8 +4154,8 @@
 					"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
 					"integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
 					"requires": {
-						"faye-websocket": "0.10.0",
-						"uuid": "3.2.1"
+						"faye-websocket": "^0.10.0",
+						"uuid": "^3.0.1"
 					}
 				},
 				"sockjs-client": {
@@ -4163,12 +4163,12 @@
 					"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
 					"integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
 					"requires": {
-						"debug": "2.6.9",
+						"debug": "^2.6.6",
 						"eventsource": "0.1.6",
-						"faye-websocket": "0.11.1",
-						"inherits": "2.0.3",
-						"json3": "3.3.2",
-						"url-parse": "1.2.0"
+						"faye-websocket": "~0.11.0",
+						"inherits": "^2.0.1",
+						"json3": "^3.3.2",
+						"url-parse": "^1.1.8"
 					},
 					"dependencies": {
 						"debug": {
@@ -4184,7 +4184,7 @@
 							"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
 							"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
 							"requires": {
-								"websocket-driver": "0.7.0"
+								"websocket-driver": ">=0.5.1"
 							}
 						}
 					}
@@ -4199,11 +4199,11 @@
 					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
 					"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
 					"requires": {
-						"atob": "2.0.3",
-						"decode-uri-component": "0.2.0",
-						"resolve-url": "0.2.1",
-						"source-map-url": "0.4.0",
-						"urix": "0.1.0"
+						"atob": "^2.0.0",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
 					}
 				},
 				"source-map-url": {
@@ -4216,8 +4216,8 @@
 					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
 					"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 					"requires": {
-						"spdx-expression-parse": "3.0.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-exceptions": {
@@ -4230,8 +4230,8 @@
 					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 					"requires": {
-						"spdx-exceptions": "2.1.0",
-						"spdx-license-ids": "3.0.0"
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
 					}
 				},
 				"spdx-license-ids": {
@@ -4244,12 +4244,12 @@
 					"resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
 					"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
 					"requires": {
-						"debug": "2.6.9",
-						"handle-thing": "1.2.5",
-						"http-deceiver": "1.2.7",
-						"safe-buffer": "5.1.1",
-						"select-hose": "2.0.0",
-						"spdy-transport": "2.1.0"
+						"debug": "^2.6.8",
+						"handle-thing": "^1.2.5",
+						"http-deceiver": "^1.2.7",
+						"safe-buffer": "^5.0.1",
+						"select-hose": "^2.0.0",
+						"spdy-transport": "^2.0.18"
 					},
 					"dependencies": {
 						"debug": {
@@ -4267,13 +4267,13 @@
 					"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
 					"integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
 					"requires": {
-						"debug": "2.6.9",
-						"detect-node": "2.0.3",
-						"hpack.js": "2.1.6",
-						"obuf": "1.1.2",
-						"readable-stream": "2.3.5",
-						"safe-buffer": "5.1.1",
-						"wbuf": "1.7.3"
+						"debug": "^2.6.8",
+						"detect-node": "^2.0.3",
+						"hpack.js": "^2.1.6",
+						"obuf": "^1.1.1",
+						"readable-stream": "^2.2.9",
+						"safe-buffer": "^5.0.1",
+						"wbuf": "^1.7.2"
 					},
 					"dependencies": {
 						"debug": {
@@ -4291,7 +4291,7 @@
 					"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 					"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 					"requires": {
-						"extend-shallow": "3.0.2"
+						"extend-shallow": "^3.0.0"
 					}
 				},
 				"static-extend": {
@@ -4299,8 +4299,8 @@
 					"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 					"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 					"requires": {
-						"define-property": "0.2.5",
-						"object-copy": "0.1.0"
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
 					},
 					"dependencies": {
 						"define-property": {
@@ -4308,7 +4308,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -4316,7 +4316,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -4324,7 +4324,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -4334,7 +4334,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"requires": {
-								"kind-of": "3.2.2"
+								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -4342,7 +4342,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "1.1.6"
+										"is-buffer": "^1.1.5"
 									}
 								}
 							}
@@ -4352,9 +4352,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -4374,9 +4374,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"string_decoder": {
@@ -4384,7 +4384,7 @@
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 					"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "~5.1.0"
 					}
 				},
 				"strip-ansi": {
@@ -4392,7 +4392,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-bom": {
@@ -4400,7 +4400,7 @@
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"strip-indent": {
@@ -4408,7 +4408,7 @@
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 					"requires": {
-						"get-stdin": "4.0.1"
+						"get-stdin": "^4.0.1"
 					}
 				},
 				"supports-color": {
@@ -4416,7 +4416,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"thunky": {
@@ -4434,7 +4434,7 @@
 					"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 					"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -4442,7 +4442,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -4452,10 +4452,10 @@
 					"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 					"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 					"requires": {
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"regex-not": "1.0.2",
-						"safe-regex": "1.1.0"
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
 					}
 				},
 				"to-regex-range": {
@@ -4463,8 +4463,8 @@
 					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 					"requires": {
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1"
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
 					}
 				},
 				"trim-newlines": {
@@ -4478,7 +4478,7 @@
 					"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
 					"requires": {
 						"media-typer": "0.3.0",
-						"mime-types": "2.1.18"
+						"mime-types": "~2.1.18"
 					}
 				},
 				"union-value": {
@@ -4486,10 +4486,10 @@
 					"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 					"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 					"requires": {
-						"arr-union": "3.1.0",
-						"get-value": "2.0.6",
-						"is-extendable": "0.1.1",
-						"set-value": "0.4.3"
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -4497,7 +4497,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"set-value": {
@@ -4505,10 +4505,10 @@
 							"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 							"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 							"requires": {
-								"extend-shallow": "2.0.1",
-								"is-extendable": "0.1.1",
-								"is-plain-object": "2.0.4",
-								"to-object-path": "0.3.0"
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
 							}
 						}
 					}
@@ -4523,8 +4523,8 @@
 					"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 					"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 					"requires": {
-						"has-value": "0.3.1",
-						"isobject": "3.0.1"
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"has-value": {
@@ -4532,9 +4532,9 @@
 							"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 							"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 							"requires": {
-								"get-value": "2.0.6",
-								"has-values": "0.1.4",
-								"isobject": "2.1.0"
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
 							},
 							"dependencies": {
 								"isobject": {
@@ -4569,8 +4569,8 @@
 					"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
 					"integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
 					"requires": {
-						"querystringify": "1.0.0",
-						"requires-port": "1.0.0"
+						"querystringify": "~1.0.0",
+						"requires-port": "~1.0.0"
 					},
 					"dependencies": {
 						"querystringify": {
@@ -4585,7 +4585,7 @@
 					"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
 					"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.2"
 					}
 				},
 				"util-deprecate": {
@@ -4608,8 +4608,8 @@
 					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
 					"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
 					"requires": {
-						"spdx-correct": "3.0.0",
-						"spdx-expression-parse": "3.0.0"
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
 					}
 				},
 				"vary": {
@@ -4622,7 +4622,7 @@
 					"resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
 					"integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
 					"requires": {
-						"minimalistic-assert": "1.0.0"
+						"minimalistic-assert": "^1.0.0"
 					}
 				},
 				"webpack-dev-middleware": {
@@ -4630,11 +4630,11 @@
 					"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
 					"integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
 					"requires": {
-						"memory-fs": "0.4.1",
-						"mime": "1.6.0",
-						"path-is-absolute": "1.0.1",
-						"range-parser": "1.2.0",
-						"time-stamp": "2.0.0"
+						"memory-fs": "~0.4.1",
+						"mime": "^1.5.0",
+						"path-is-absolute": "^1.0.0",
+						"range-parser": "^1.0.3",
+						"time-stamp": "^2.0.0"
 					},
 					"dependencies": {
 						"mime": {
@@ -4649,8 +4649,8 @@
 					"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
 					"integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
 					"requires": {
-						"http-parser-js": "0.4.11",
-						"websocket-extensions": "0.1.3"
+						"http-parser-js": ">=0.4.0",
+						"websocket-extensions": ">=0.1.1"
 					}
 				},
 				"websocket-extensions": {
@@ -4668,8 +4668,8 @@
 					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
 					}
 				},
 				"wrappy": {
@@ -4687,19 +4687,19 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
 					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
 					"requires": {
-						"camelcase": "3.0.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "4.2.1"
+						"camelcase": "^3.0.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.2",
+						"which-module": "^1.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^4.2.0"
 					},
 					"dependencies": {
 						"camelcase": {
@@ -4714,7 +4714,7 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
 					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
 					"requires": {
-						"camelcase": "3.0.0"
+						"camelcase": "^3.0.0"
 					},
 					"dependencies": {
 						"camelcase": {

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -29,18 +29,15 @@
 				"json-stable-stringify": "1.0.1"
 			}
 		},
-		"argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"requires": {
-				"sprintf-js": "1.0.3"
-			}
-		},
 		"array-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
 		"asn1": {
 			"version": "0.2.3",
@@ -112,20 +109,10 @@
 				"delayed-stream": "1.0.0"
 			}
 		},
-		"commander": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
-		},
-		"component-emitter": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-		},
-		"cookiejar": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-			"integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
+		"core-js": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -181,14 +168,6 @@
 				"whatwg-url": "6.4.1"
 			}
 		},
-		"debug": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-			"requires": {
-				"ms": "2.0.0"
-			}
-		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -222,6 +201,14 @@
 			"optional": true,
 			"requires": {
 				"jsbn": "0.1.1"
+			}
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "0.4.19"
 			}
 		},
 		"escodegen": {
@@ -276,6 +263,20 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
+		"fbjs": {
+			"version": "0.8.16",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+			"requires": {
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.17"
+			}
+		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -291,25 +292,12 @@
 				"mime-types": "2.1.18"
 			}
 		},
-		"formidable": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
-			"integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
-		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
 				"assert-plus": "1.0.0"
-			}
-		},
-		"graphlib": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
-			"integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
-			"requires": {
-				"lodash": "4.17.4"
 			}
 		},
 		"har-schema": {
@@ -378,20 +366,24 @@
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
 			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
 		},
-		"inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.4"
+			}
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -403,22 +395,6 @@
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
 			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
-		"js-yaml": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
-			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.0"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
-				}
-			}
-		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -426,9 +402,9 @@
 			"optional": true
 		},
 		"jsdom": {
-			"version": "11.10.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.10.0.tgz",
-			"integrity": "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
+			"version": "11.9.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.9.0.tgz",
+			"integrity": "sha512-sb3omwJTJ+HwAltLZevM/KQBusY+l2Ar5UfnTCWk9oUVBiDnQPBNiG1BaTAKttCnneonYbNo7vi4EFDY2lBfNA==",
 			"requires": {
 				"abab": "1.0.4",
 				"acorn": "5.5.3",
@@ -462,21 +438,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
 			"integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk="
-		},
-		"json-refs": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/json-refs/-/json-refs-3.0.4.tgz",
-			"integrity": "sha512-UFnB5j1C7XrUWQIlFGrjerFVuc04TZAyoEavfb0VofdjguWWN97aCtWsv1uX6pXylJiLw+agsyTPCnNjL6W4ag==",
-			"requires": {
-				"commander": "2.11.0",
-				"graphlib": "2.1.5",
-				"js-yaml": "3.11.0",
-				"lodash": "4.17.4",
-				"native-promise-only": "0.8.1",
-				"path-loader": "1.0.4",
-				"slash": "1.0.0",
-				"uri-js": "3.0.2"
-			}
 		},
 		"json-schema": {
 			"version": "0.2.3",
@@ -564,16 +525,6 @@
 				"js-tokens": "3.0.2"
 			}
 		},
-		"methods": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-		},
-		"mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-		},
 		"mime-db": {
 			"version": "1.33.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
@@ -587,15 +538,14 @@
 				"mime-db": "1.33.0"
 			}
 		},
-		"ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-		},
-		"native-promise-only": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-			"integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
+			}
 		},
 		"nwmatcher": {
 			"version": "1.4.4",
@@ -606,6 +556,11 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
 			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"optionator": {
 			"version": "0.8.2",
@@ -625,15 +580,6 @@
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
 			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
 		},
-		"path-loader": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/path-loader/-/path-loader-1.0.4.tgz",
-			"integrity": "sha512-k/IPo9OWyofATP5gwIehHHQoFShS37zsSIsejKe6fjI+tqK+FnRpiSg4ZfWUpxb0g2PfCreWPqBD4ayjqjqkdQ==",
-			"requires": {
-				"native-promise-only": "0.8.1",
-				"superagent": "3.8.3"
-			}
-		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -649,10 +595,23 @@
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
-		"process-nextick-args": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "2.0.6"
+			}
+		},
+		"prop-types": {
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"requires": {
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			}
 		},
 		"punycode": {
 			"version": "2.1.0",
@@ -664,18 +623,15 @@
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
 			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
 		},
-		"readable-stream": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+		"react-dom": {
+			"version": "16.3.2",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
+			"integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.2",
-				"string_decoder": "1.1.1",
-				"util-deprecate": "1.0.2"
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
 			}
 		},
 		"redux": {
@@ -754,10 +710,10 @@
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
-		"slash": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"sntp": {
 			"version": "2.1.0",
@@ -772,11 +728,6 @@
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"optional": true
-		},
-		"sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
 			"version": "1.14.1",
@@ -798,35 +749,10 @@
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
 		},
-		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"requires": {
-				"safe-buffer": "5.1.2"
-			}
-		},
 		"stringstream": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
 			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-		},
-		"superagent": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
-			"integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
-			"requires": {
-				"component-emitter": "1.2.1",
-				"cookiejar": "2.1.1",
-				"debug": "3.1.0",
-				"extend": "3.0.1",
-				"form-data": "2.3.2",
-				"formidable": "1.2.1",
-				"methods": "1.1.2",
-				"mime": "1.6.0",
-				"qs": "6.5.1",
-				"readable-stream": "2.3.6"
-			}
 		},
 		"symbol-observable": {
 			"version": "1.2.0",
@@ -883,18 +809,10 @@
 				"prelude-ls": "1.1.2"
 			}
 		},
-		"uri-js": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
-			"integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
-			"requires": {
-				"punycode": "2.1.0"
-			}
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		"ua-parser-js": {
+			"version": "0.7.17",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
 		},
 		"uuid": {
 			"version": "3.2.1",
@@ -931,6 +849,11 @@
 			"requires": {
 				"iconv-lite": "0.4.19"
 			}
+		},
+		"whatwg-fetch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
 		},
 		"whatwg-mimetype": {
 			"version": "2.1.0",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -2,528 +2,229 @@
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
-		"abab": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
-		},
-		"acorn": {
-			"version": "5.5.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
-		},
-		"acorn-globals": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
-			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
-			"requires": {
-				"acorn": "5.5.3"
-			}
-		},
-		"ajv": {
-			"version": "4.11.8",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-			"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-			"requires": {
-				"co": "4.6.0",
-				"json-stable-stringify": "1.0.1"
-			}
-		},
-		"array-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
-		},
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-		},
-		"asn1": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-		},
-		"assert-plus": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-		},
-		"async-limiter": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
-		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-		},
-		"aws-sign2": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-		},
-		"aws4": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
-		},
-		"bcrypt-pbkdf": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-			"optional": true,
-			"requires": {
-				"tweetnacl": "0.14.5"
-			}
-		},
-		"boom": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-			"requires": {
-				"hoek": "4.2.1"
-			}
-		},
-		"browser-process-hrtime": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
-			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
-		},
-		"caseless": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-		},
-		"co": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
 		},
 		"combined-stream": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
-		},
-		"core-js": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
-		"cryptiles": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-			"requires": {
-				"boom": "5.2.0"
-			},
-			"dependencies": {
-				"boom": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-					"requires": {
-						"hoek": "4.2.1"
-					}
-				}
-			}
-		},
-		"cssom": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
-		},
-		"cssstyle": {
-			"version": "0.2.37",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-			"requires": {
-				"cssom": "0.3.2"
-			}
-		},
-		"dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"requires": {
-				"assert-plus": "1.0.0"
-			}
-		},
-		"data-urls": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
-			"integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
-			"requires": {
-				"abab": "1.0.4",
-				"whatwg-mimetype": "2.1.0",
-				"whatwg-url": "6.4.1"
-			}
-		},
-		"deep-is": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
-		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-		},
-		"document-register-element": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.8.1.tgz",
-			"integrity": "sha512-WqUnZzRZByeur0YsQBDHG9mYWJR83Un4LeSRhZNfXZ0hlqDwP6WuxPK+a/tLIX/r5BCp+UAv/b0Z73KkCsdPjQ==",
-			"requires": {
-				"lightercollective": "0.0.0"
-			}
-		},
-		"domexception": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
-			"requires": {
-				"webidl-conversions": "4.0.2"
-			}
-		},
-		"ecc-jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-			"optional": true,
-			"requires": {
-				"jsbn": "0.1.1"
-			}
-		},
-		"encoding": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"requires": {
-				"iconv-lite": "0.4.19"
-			}
-		},
-		"escodegen": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
-			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
-			"requires": {
-				"esprima": "3.1.3",
-				"estraverse": "4.2.0",
-				"esutils": "2.0.2",
-				"optionator": "0.8.2",
-				"source-map": "0.6.1"
-			}
-		},
-		"esprima": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-		},
-		"estraverse": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
-		},
-		"esutils": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
 		"extend": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
 			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
 		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-		},
-		"fast-deep-equal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-		},
-		"fast-json-stable-stringify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-		},
-		"fast-levenshtein": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-		},
-		"fbjs": {
-			"version": "0.8.16",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
-			"requires": {
-				"core-js": "1.2.7",
-				"isomorphic-fetch": "2.2.1",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"promise": "7.3.1",
-				"setimmediate": "1.0.5",
-				"ua-parser-js": "0.7.17"
-			}
-		},
-		"forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-		},
 		"form-data": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
-				"asynckit": "0.4.0",
+				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "2.1.18"
+				"mime-types": "^2.1.12"
 			}
 		},
-		"getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+		"json-refs": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/json-refs/-/json-refs-3.0.4.tgz",
+			"integrity": "sha512-UFnB5j1C7XrUWQIlFGrjerFVuc04TZAyoEavfb0VofdjguWWN97aCtWsv1uX6pXylJiLw+agsyTPCnNjL6W4ag==",
 			"requires": {
-				"assert-plus": "1.0.0"
-			}
-		},
-		"har-schema": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-		},
-		"har-validator": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
+				"commander": "~2.11.0",
+				"graphlib": "^2.1.1",
+				"js-yaml": "^3.10.0",
+				"lodash": "^4.17.4",
+				"native-promise-only": "^0.8.1",
+				"path-loader": "^1.0.4",
+				"slash": "^1.0.0",
+				"uri-js": "^3.0.2"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "5.5.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+				"argparse": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 					"requires": {
-						"co": "4.6.0",
-						"fast-deep-equal": "1.1.0",
-						"fast-json-stable-stringify": "2.0.0",
-						"json-schema-traverse": "0.3.1"
+						"sprintf-js": "~1.0.2"
 					}
+				},
+				"commander": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+				},
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+				},
+				"cookiejar": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
+					"integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"esprima": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+				},
+				"formidable": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+					"integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+				},
+				"graphlib": {
+					"version": "2.1.5",
+					"resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
+					"integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
+					"requires": {
+						"lodash": "^4.11.1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"js-yaml": {
+					"version": "3.11.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+					"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
+				"methods": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+					"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+				},
+				"mime": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"native-promise-only": {
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+					"integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+				},
+				"path-loader": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/path-loader/-/path-loader-1.0.4.tgz",
+					"integrity": "sha512-k/IPo9OWyofATP5gwIehHHQoFShS37zsSIsejKe6fjI+tqK+FnRpiSg4ZfWUpxb0g2PfCreWPqBD4ayjqjqkdQ==",
+					"requires": {
+						"native-promise-only": "^0.8.1",
+						"superagent": "^3.6.3"
+					}
+				},
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"slash": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+				},
+				"sprintf-js": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				},
+				"superagent": {
+					"version": "3.8.3",
+					"resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+					"integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+					"requires": {
+						"component-emitter": "^1.2.0",
+						"cookiejar": "^2.1.0",
+						"debug": "^3.1.0",
+						"extend": "^3.0.0",
+						"form-data": "^2.3.1",
+						"formidable": "^1.2.0",
+						"methods": "^1.1.1",
+						"mime": "^1.4.1",
+						"qs": "^6.5.1",
+						"readable-stream": "^2.3.5"
+					}
+				},
+				"uri-js": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+					"integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+					"requires": {
+						"punycode": "^2.1.0"
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 				}
 			}
-		},
-		"hawk": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-			"requires": {
-				"boom": "4.3.1",
-				"cryptiles": "3.1.2",
-				"hoek": "4.2.1",
-				"sntp": "2.1.0"
-			}
-		},
-		"hoek": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-		},
-		"html-encoding-sniffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-			"requires": {
-				"whatwg-encoding": "1.0.3"
-			}
-		},
-		"http-signature": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.14.1"
-			}
-		},
-		"iconv-lite": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-		},
-		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-		},
-		"is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-		},
-		"isomorphic-fetch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"requires": {
-				"node-fetch": "1.7.3",
-				"whatwg-fetch": "2.0.4"
-			}
-		},
-		"isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-		},
-		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-		},
-		"jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"optional": true
-		},
-		"jsdom": {
-			"version": "11.9.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.9.0.tgz",
-			"integrity": "sha512-sb3omwJTJ+HwAltLZevM/KQBusY+l2Ar5UfnTCWk9oUVBiDnQPBNiG1BaTAKttCnneonYbNo7vi4EFDY2lBfNA==",
-			"requires": {
-				"abab": "1.0.4",
-				"acorn": "5.5.3",
-				"acorn-globals": "4.1.0",
-				"array-equal": "1.0.0",
-				"cssom": "0.3.2",
-				"cssstyle": "0.2.37",
-				"data-urls": "1.0.0",
-				"domexception": "1.0.1",
-				"escodegen": "1.9.1",
-				"html-encoding-sniffer": "1.0.2",
-				"left-pad": "1.3.0",
-				"nwmatcher": "1.4.4",
-				"parse5": "4.0.0",
-				"pn": "1.1.0",
-				"request": "2.85.0",
-				"request-promise-native": "1.0.5",
-				"sax": "1.2.4",
-				"symbol-tree": "3.2.2",
-				"tough-cookie": "2.3.4",
-				"w3c-hr-time": "1.0.1",
-				"webidl-conversions": "4.0.2",
-				"whatwg-encoding": "1.0.3",
-				"whatwg-mimetype": "2.1.0",
-				"whatwg-url": "6.4.1",
-				"ws": "4.1.0",
-				"xml-name-validator": "3.0.0"
-			}
-		},
-		"jsdom-global": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
-			"integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk="
-		},
-		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-		},
-		"json-schema-traverse": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-		},
-		"json-stable-stringify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"requires": {
-				"jsonify": "0.0.0"
-			}
-		},
-		"json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-		},
-		"jsonify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-		},
-		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
-				"verror": "1.10.0"
-			}
-		},
-		"left-pad": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
-		},
-		"levn": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
-			}
-		},
-		"lightercollective": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/lightercollective/-/lightercollective-0.0.0.tgz",
-			"integrity": "sha512-4SdGgHgQjlqhk90QxAYsltGEI6HHt30xy9fOIPKi+c3vcGRcpPDtzm6+kxr1N9ixkrx/ngMhTCe/VpBc/HmNBQ=="
 		},
 		"lodash": {
 			"version": "4.17.4",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
 			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-		},
-		"lodash-es": {
-			"version": "4.17.10",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
-			"integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
-		},
-		"lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-		},
-		"lodash.sortby": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
-		},
-		"loose-envify": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-			"requires": {
-				"js-tokens": "3.0.2"
-			}
 		},
 		"mime-db": {
 			"version": "1.33.0",
@@ -535,82 +236,7 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
 			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"requires": {
-				"mime-db": "1.33.0"
-			}
-		},
-		"node-fetch": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-			"requires": {
-				"encoding": "0.1.12",
-				"is-stream": "1.1.0"
-			}
-		},
-		"nwmatcher": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-			"integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
-		},
-		"oauth-sign": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-		},
-		"optionator": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
-			}
-		},
-		"parse5": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
-		},
-		"performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-		},
-		"pn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
-		},
-		"prelude-ls": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"requires": {
-				"asap": "2.0.6"
-			}
-		},
-		"prop-types": {
-			"version": "15.6.1",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
-			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1"
+				"mime-db": "~1.33.0"
 			}
 		},
 		"punycode": {
@@ -623,271 +249,15 @@
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
 			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
 		},
-		"react-dom": {
-			"version": "16.3.2",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
-			"integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
-			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.1"
-			}
-		},
-		"redux": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
-			"requires": {
-				"lodash": "4.17.4",
-				"lodash-es": "4.17.10",
-				"loose-envify": "1.3.1",
-				"symbol-observable": "1.2.0"
-			}
-		},
-		"redux-mock-store": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.4.0.tgz",
-			"integrity": "sha512-y+SGh/SONWwqs4DiyHjd0H6NMgz368wXDiUjSHuOnMEr4dN9PmjV6N3bNvxoILaIQ7zeVKclLyxsCQ2TwGZfEw==",
-			"requires": {
-				"lodash.isplainobject": "4.0.6"
-			}
-		},
-		"request": {
-			"version": "2.85.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-			"integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
-			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.7.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.6",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.2",
-				"har-validator": "5.0.3",
-				"hawk": "6.0.2",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.18",
-				"oauth-sign": "0.8.2",
-				"performance-now": "2.1.0",
-				"qs": "6.5.1",
-				"safe-buffer": "5.1.2",
-				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.4",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.2.1"
-			}
-		},
-		"request-promise-core": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-			"requires": {
-				"lodash": "4.17.4"
-			}
-		},
-		"request-promise-native": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
-			"requires": {
-				"request-promise-core": "1.1.1",
-				"stealthy-require": "1.1.1",
-				"tough-cookie": "2.3.4"
-			}
-		},
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
-		"sax": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-		},
-		"sntp": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-			"requires": {
-				"hoek": "4.2.1"
-			}
-		},
-		"source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"optional": true
-		},
-		"sshpk": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
-			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"tweetnacl": "0.14.5"
-			}
-		},
-		"stealthy-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
-		},
-		"stringstream": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-		},
-		"symbol-observable": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-		},
-		"symbol-tree": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
-		},
-		"tough-cookie": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-			"requires": {
-				"punycode": "1.4.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-				}
-			}
-		},
-		"tr46": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-			"requires": {
-				"punycode": "2.1.0"
-			}
-		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"requires": {
-				"safe-buffer": "5.1.2"
-			}
-		},
-		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"optional": true
-		},
-		"type-check": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"requires": {
-				"prelude-ls": "1.1.2"
-			}
-		},
-		"ua-parser-js": {
-			"version": "0.7.17",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
-		},
 		"uuid": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
 			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-		},
-		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"requires": {
-				"assert-plus": "1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
-			}
-		},
-		"w3c-hr-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
-			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
-			"requires": {
-				"browser-process-hrtime": "0.1.2"
-			}
-		},
-		"webidl-conversions": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-		},
-		"whatwg-encoding": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
-			"requires": {
-				"iconv-lite": "0.4.19"
-			}
-		},
-		"whatwg-fetch": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
-		},
-		"whatwg-mimetype": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
-			"integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew=="
-		},
-		"whatwg-url": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
-			"integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
-			"requires": {
-				"lodash.sortby": "4.7.0",
-				"tr46": "1.0.1",
-				"webidl-conversions": "4.0.2"
-			}
-		},
-		"wordwrap": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-		},
-		"ws": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-			"requires": {
-				"async-limiter": "1.0.0",
-				"safe-buffer": "5.1.2"
-			}
-		},
-		"xml-name-validator": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
 		}
 	}
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,9 +41,9 @@
   "dependencies": {
     "ajv": "^4.11.2",
     "json-refs": "^3.0.4",
-    "lodash": "4.17.4",
+    "lodash": "^4.17.4",
     "redux": "^3.7.2",
-    "uuid": "^3.1.0"
+    "uuid": "^3.2.1"
   },
   "devDependencies": {
     "document-register-element": "^1.7.0",

--- a/packages/core/src/generators/uischema.ts
+++ b/packages/core/src/generators/uischema.ts
@@ -26,7 +26,7 @@ import * as _ from 'lodash';
 
 import { JsonSchema } from '../models/jsonSchema';
 import { ControlElement, LabelElement, Layout, UISchemaElement } from '../models/uischema';
-import { resolveSchema } from "../util/resolvers";
+import { resolveSchema } from '../util/resolvers';
 
 /**
  * Creates a new ILayout.
@@ -85,7 +85,7 @@ const isLayout = (uischema: UISchemaElement): uischema is Layout =>
 
 /**
  * Wraps the given {@code uiSchema} in a Layout if there is none already.
- * @param uiSchema The ui schema to wrap in a layout.
+ * @param uischema The ui schema to wrap in a layout.
  * @param layoutType The type of the layout to create.
  * @returns the wrapped uiSchema.
  */

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -76,7 +76,7 @@ export const coreReducer = (
         return state;
       } else if (action.path === '') {
         // empty path is ok
-        const result = action.updater(state.data);
+        const result = action.updater(_.cloneDeep(state.data));
 
         if (result === undefined || result === null) {
           return {

--- a/packages/core/src/testers/index.ts
+++ b/packages/core/src/testers/index.ts
@@ -337,6 +337,10 @@ export const isPrimitiveArrayControl = and(
     && schema.type === 'array'
     && !_.isEmpty(schema.items)
     && !Array.isArray(schema.items) // we don't care about tuples
+  ),
+  schemaSubPathMatches(
+    'items',
+    schema => _.includes(['integer', 'number', 'boolean', 'string'], schema.type)
   )
 );
 

--- a/packages/core/src/testers/index.ts
+++ b/packages/core/src/testers/index.ts
@@ -309,7 +309,7 @@ export const isDateTimeControl = and(uiTypeIs('Control'), formatIs('date-time'))
  * is an array of objects.
  * @type {Tester}
  */
-export const isArrayObjectControl = and(
+export const isObjectArrayControl = and(
   uiTypeIs('Control'),
   schemaMatches(schema =>
     !_.isEmpty(schema)
@@ -317,8 +317,26 @@ export const isArrayObjectControl = and(
     && !_.isEmpty(schema.items)
     && !Array.isArray(schema.items) // we don't care about tuples
   ),
-  schemaSubPathMatches('items', schema =>
-    schema.type === 'object'
+  schemaSubPathMatches('items', schema => schema.type === 'object')
+);
+
+/**
+ * Synonym for isObjectArrayControl
+ */
+export const isArrayObjectControl = isObjectArrayControl;
+
+/**
+ * Tests whether the given UI schema is of type Control and if the schema
+ * is an array of a primitive type.
+ * @type {Tester}
+ */
+export const isPrimitiveArrayControl = and(
+  uiTypeIs('Control'),
+  schemaMatches(schema =>
+    !_.isEmpty(schema)
+    && schema.type === 'array'
+    && !_.isEmpty(schema.items)
+    && !Array.isArray(schema.items) // we don't care about tuples
   )
 );
 

--- a/packages/core/test/testers.test.ts
+++ b/packages/core/test/testers.test.ts
@@ -266,10 +266,24 @@ test('tester isPrimitiveArrayControl', t => {
         }
       }
     ),
-    'Array Schema Type with wrong item type not checked!'
+    `Primitive array tester was not triggered for 'integer' schema type`
+  );
+  t.false(
+    isPrimitiveArrayControl(
+      control,
+      {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'array',
+            items: {type: 'object'}
+          }
+        }
+      }
+    ),
+    `Primitive array tester was not triggered for 'object' schema type`
   );
 });
-
 
 test('tester isObjectArrayControl', t => {
   t.false(isObjectArrayControl({type: 'Foo'}, null));

--- a/packages/core/test/testers.test.ts
+++ b/packages/core/test/testers.test.ts
@@ -26,7 +26,8 @@ import test from 'ava';
 import {
   and,
   formatIs,
-  isArrayObjectControl,
+  isPrimitiveArrayControl,
+  isObjectArrayControl,
   isBooleanControl,
   isDateControl,
   isEnumControl,
@@ -246,30 +247,54 @@ test('or should allow to compose multiple testers', t => {
     optionIs('slider', true)
   )(uischema, schema));
 });
-test('tester isArrayObjectControl', t => {
-  t.false(isArrayObjectControl({type: 'Foo'}, null));
+
+test('tester isPrimitiveArrayControl', t => {
   const control: ControlElement = {
     type: 'Control',
     scope: '#/properties/foo'
   };
-  t.false(isArrayObjectControl(control, undefined), 'No Schema not checked!');
+  t.true(
+    isPrimitiveArrayControl(
+      control,
+      {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'array',
+            items: {type: 'integer'}
+          }
+        }
+      }
+    ),
+    'Array Schema Type with wrong item type not checked!'
+  );
+});
+
+
+test('tester isObjectArrayControl', t => {
+  t.false(isObjectArrayControl({type: 'Foo'}, null));
+  const control: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/foo'
+  };
+  t.false(isObjectArrayControl(control, undefined), 'No Schema not checked!');
 
   t.false(
-    isArrayObjectControl(
+    isObjectArrayControl(
       control,
       {type: 'object', properties: {bar: {type: 'integer'}}}
     ),
     'Wrong Schema Type not checked!'
   );
   t.false(
-    isArrayObjectControl(
+    isObjectArrayControl(
       control,
       {type: 'object', properties: {foo: {type: 'array'}}}
     ),
     'Array Schema Type without items not checked!'
   );
   t.false(
-    isArrayObjectControl(
+    isObjectArrayControl(
       control,
       {
         type: 'object',
@@ -287,7 +312,7 @@ test('tester isArrayObjectControl', t => {
     'Array Schema Type with tuples not checked!'
   );
   t.false(
-    isArrayObjectControl(
+    isObjectArrayControl(
       control,
       {
         type: 'object',
@@ -316,7 +341,7 @@ test('tester isArrayObjectControl', t => {
       }
     }
   };
-  t.true(isArrayObjectControl(control, schema));
+  t.true(isObjectArrayControl(control, schema));
 });
 
 test('isBooleanControl', t => {

--- a/packages/core/test/util/renderer.test.ts
+++ b/packages/core/test/util/renderer.test.ts
@@ -24,7 +24,11 @@
 */
 import test from 'ava';
 import * as _ from 'lodash';
-import { mapDispatchToControlProps, mapStateToControlProps } from '../../src/util';
+import {
+  createDefaultValue,
+  mapDispatchToControlProps,
+  mapStateToControlProps
+} from '../../src/util';
 import configureStore from 'redux-mock-store';
 import { UPDATE_DATA, UpdateAction } from '../../src/actions';
 
@@ -256,4 +260,39 @@ test('mapDispatchToControlProps', t => {
   t.is(updateAction.type, UPDATE_DATA);
   t.is(updateAction.path, 'foo');
   t.is(updateAction.updater(), 42);
+});
+
+test('createDefaultValue', t => {
+  t.true(
+    _.isDate(createDefaultValue(
+      {
+        type: 'string',
+        format: 'date'
+      }
+    ))
+  );
+  t.true(
+    _.isDate(
+      createDefaultValue({
+        type: 'string',
+        format: 'date-time'
+      })
+    )
+  );
+  t.true(
+    _.isDate(createDefaultValue(
+      {
+        type: 'string',
+        format: 'time'
+      }
+    ))
+  );
+  t.is(createDefaultValue({ type: 'string' }), '');
+  t.is(createDefaultValue({ type: 'number' }), 0);
+  t.falsy(createDefaultValue({ type: 'boolean' }));
+  t.is(createDefaultValue({ type: 'integer' }), 0);
+  t.deepEqual(createDefaultValue({ type: 'array' }), []);
+  t.is(createDefaultValue({ type: 'null' }), null);
+  t.deepEqual(createDefaultValue({ type: 'object' }), {});
+  t.deepEqual(createDefaultValue({ type: 'something' }), {});
 });

--- a/packages/editor/package-lock.json
+++ b/packages/editor/package-lock.json
@@ -1,0 +1,8863 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"copy-webpack-plugin": {
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.5.1.tgz",
+			"integrity": "sha512-OlTo6DYg0XfTKOF8eLf79wcHm4Ut10xU2cRBRPMW/NA5F9VMjZGTfRHWDIYC3s+1kObGYrBLshXWU1K0hILkNQ==",
+			"requires": {
+				"cacache": "^10.0.4",
+				"find-cache-dir": "^1.0.0",
+				"globby": "^7.1.1",
+				"is-glob": "^4.0.0",
+				"loader-utils": "^1.1.0",
+				"minimatch": "^3.0.4",
+				"p-limit": "^1.0.0",
+				"serialize-javascript": "^1.4.0"
+			},
+			"dependencies": {
+				"aproba": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+				},
+				"array-union": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+					"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+					"requires": {
+						"array-uniq": "^1.0.1"
+					}
+				},
+				"array-uniq": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+					"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+				},
+				"arrify": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+				},
+				"big.js": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+					"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+				},
+				"bluebird": {
+					"version": "3.5.1",
+					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+					"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"buffer-from": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+					"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+				},
+				"cacache": {
+					"version": "10.0.4",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+					"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+					"requires": {
+						"bluebird": "^3.5.1",
+						"chownr": "^1.0.1",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.1.11",
+						"lru-cache": "^4.1.1",
+						"mississippi": "^2.0.0",
+						"mkdirp": "^0.5.1",
+						"move-concurrently": "^1.0.1",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"ssri": "^5.2.4",
+						"unique-filename": "^1.1.0",
+						"y18n": "^4.0.0"
+					}
+				},
+				"chownr": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+					"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+				},
+				"commondir": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+					"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+				},
+				"concat-stream": {
+					"version": "1.6.2",
+					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+					"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.2.2",
+						"typedarray": "^0.0.6"
+					}
+				},
+				"copy-concurrently": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+					"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+					"requires": {
+						"aproba": "^1.1.1",
+						"fs-write-stream-atomic": "^1.0.8",
+						"iferr": "^0.1.5",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.5.4",
+						"run-queue": "^1.0.0"
+					}
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+				},
+				"cyclist": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+					"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
+				},
+				"dir-glob": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+					"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+					"requires": {
+						"arrify": "^1.0.1",
+						"path-type": "^3.0.0"
+					}
+				},
+				"duplexify": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+					"integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
+					"requires": {
+						"end-of-stream": "^1.0.0",
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.0",
+						"stream-shift": "^1.0.0"
+					}
+				},
+				"emojis-list": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+					"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+				},
+				"end-of-stream": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+					"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+					"requires": {
+						"once": "^1.4.0"
+					}
+				},
+				"find-cache-dir": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+					"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^1.0.0",
+						"pkg-dir": "^2.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"flush-write-stream": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+					"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+					"requires": {
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.4"
+					}
+				},
+				"from2": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+					"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+					"requires": {
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.0"
+					}
+				},
+				"fs-write-stream-atomic": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+					"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"iferr": "^0.1.5",
+						"imurmurhash": "^0.1.4",
+						"readable-stream": "1 || 2"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"globby": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+					"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+					"requires": {
+						"array-union": "^1.0.1",
+						"dir-glob": "^2.0.0",
+						"glob": "^7.1.2",
+						"ignore": "^3.3.5",
+						"pify": "^3.0.0",
+						"slash": "^1.0.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+				},
+				"iferr": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+					"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+				},
+				"ignore": {
+					"version": "3.3.8",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
+					"integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg=="
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+				},
+				"is-glob": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"json5": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+				},
+				"loader-utils": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+					"requires": {
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+					"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"make-dir": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
+					"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+				},
+				"mississippi": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+					"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+					"requires": {
+						"concat-stream": "^1.5.0",
+						"duplexify": "^3.4.2",
+						"end-of-stream": "^1.1.0",
+						"flush-write-stream": "^1.0.0",
+						"from2": "^2.1.0",
+						"parallel-transform": "^1.1.0",
+						"pump": "^2.0.1",
+						"pumpify": "^1.3.3",
+						"stream-each": "^1.1.0",
+						"through2": "^2.0.0"
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"move-concurrently": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+					"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+					"requires": {
+						"aproba": "^1.1.1",
+						"copy-concurrently": "^1.0.0",
+						"fs-write-stream-atomic": "^1.0.8",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.5.4",
+						"run-queue": "^1.0.3"
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"p-limit": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+					"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+				},
+				"parallel-transform": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+					"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+					"requires": {
+						"cyclist": "~0.2.2",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.1.5"
+					}
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+				},
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				},
+				"pkg-dir": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+					"requires": {
+						"find-up": "^2.1.0"
+					}
+				},
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+				},
+				"promise-inflight": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+					"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+				},
+				"pump": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				},
+				"pumpify": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.0.tgz",
+					"integrity": "sha512-UWi0klDoq8xtVzlMRgENV9F7iCTZExaJQSQL187UXsxpk9NnrKGqTqqUNYAKGOzucSOxs2+jUnRNI+rLviPhJg==",
+					"requires": {
+						"duplexify": "^3.6.0",
+						"inherits": "^2.0.3",
+						"pump": "^2.0.0"
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+					"requires": {
+						"glob": "^7.0.5"
+					}
+				},
+				"run-queue": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+					"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+					"requires": {
+						"aproba": "^1.1.1"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				},
+				"serialize-javascript": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
+					"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
+				},
+				"slash": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+				},
+				"ssri": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+					"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+					"requires": {
+						"safe-buffer": "^5.1.1"
+					}
+				},
+				"stream-each": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+					"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"stream-shift": "^1.0.0"
+					}
+				},
+				"stream-shift": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+					"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				},
+				"through2": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"requires": {
+						"readable-stream": "^2.1.5",
+						"xtend": "~4.0.1"
+					}
+				},
+				"typedarray": {
+					"version": "0.0.6",
+					"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+					"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+				},
+				"unique-filename": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+					"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+					"requires": {
+						"unique-slug": "^2.0.0"
+					}
+				},
+				"unique-slug": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+					"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+					"requires": {
+						"imurmurhash": "^0.1.4"
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+				},
+				"xtend": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+					"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+				}
+			}
+		},
+		"json-refs": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/json-refs/-/json-refs-2.1.7.tgz",
+			"integrity": "sha1-uesB/in16j6Sh48VrqEK04taz4k=",
+			"requires": {
+				"commander": "^2.9.0",
+				"graphlib": "^2.1.1",
+				"js-yaml": "^3.8.3",
+				"native-promise-only": "^0.8.1",
+				"path-loader": "^1.0.2",
+				"slash": "^1.0.0",
+				"uri-js": "^3.0.2"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"requires": {
+						"sprintf-js": "~1.0.2"
+					}
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+				},
+				"combined-stream": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+					"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+					"requires": {
+						"delayed-stream": "~1.0.0"
+					}
+				},
+				"commander": {
+					"version": "2.15.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+				},
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+				},
+				"cookiejar": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
+					"integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+				},
+				"esprima": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+				},
+				"extend": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+					"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+				},
+				"form-data": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+					"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "1.0.6",
+						"mime-types": "^2.1.12"
+					}
+				},
+				"formidable": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+					"integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+				},
+				"graphlib": {
+					"version": "2.1.5",
+					"resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
+					"integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
+					"requires": {
+						"lodash": "^4.11.1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"js-yaml": {
+					"version": "3.11.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+					"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
+				"methods": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+					"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+				},
+				"mime": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+				},
+				"mime-db": {
+					"version": "1.33.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+					"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+				},
+				"mime-types": {
+					"version": "2.1.18",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+					"requires": {
+						"mime-db": "~1.33.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"native-promise-only": {
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+					"integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+				},
+				"path-loader": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/path-loader/-/path-loader-1.0.4.tgz",
+					"integrity": "sha512-k/IPo9OWyofATP5gwIehHHQoFShS37zsSIsejKe6fjI+tqK+FnRpiSg4ZfWUpxb0g2PfCreWPqBD4ayjqjqkdQ==",
+					"requires": {
+						"native-promise-only": "^0.8.1",
+						"superagent": "^3.6.3"
+					}
+				},
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+				},
+				"punycode": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+				},
+				"qs": {
+					"version": "6.5.2",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				},
+				"slash": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+				},
+				"sprintf-js": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				},
+				"superagent": {
+					"version": "3.8.3",
+					"resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+					"integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+					"requires": {
+						"component-emitter": "^1.2.0",
+						"cookiejar": "^2.1.0",
+						"debug": "^3.1.0",
+						"extend": "^3.0.0",
+						"form-data": "^2.3.1",
+						"formidable": "^1.2.0",
+						"methods": "^1.1.1",
+						"mime": "^1.4.1",
+						"qs": "^6.5.1",
+						"readable-stream": "^2.3.5"
+					}
+				},
+				"uri-js": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+					"integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+					"requires": {
+						"punycode": "^2.1.0"
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+				}
+			}
+		},
+		"lodash": {
+			"version": "4.17.10",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+		},
+		"ts-jest": {
+			"version": "22.4.5",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-22.4.5.tgz",
+			"integrity": "sha512-3LkEkPzKutk+klOxtAhvTdYc9ZK7lHugyPg4VNj+l8jg7CCOBgAHqp009MWdT6WllYeSoWHcQaB3aJ6/JbTMJg==",
+			"requires": {
+				"babel-core": "^6.26.3",
+				"babel-plugin-istanbul": "^4.1.6",
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
+				"babel-preset-jest": "^22.4.3",
+				"cpx": "^1.5.0",
+				"fs-extra": "6.0.0",
+				"jest-config": "^22.4.3",
+				"lodash": "^4.17.10",
+				"pkg-dir": "^2.0.0",
+				"yargs": "^11.0.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.46",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz",
+					"integrity": "sha512-7BKRkmYaPZm3Yff5HGZJKCz7RqZ5jUjknsXT6Gz5YKG23J3uq9hAj0epncCB0rlqmnZ8Q+UUpQB2tCR5mT37vw==",
+					"requires": {
+						"@babel/highlight": "7.0.0-beta.46"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0-beta.46",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.46.tgz",
+					"integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"abab": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+					"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+				},
+				"acorn": {
+					"version": "5.5.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+					"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
+				},
+				"acorn-globals": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+					"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+					"requires": {
+						"acorn": "^5.0.0"
+					}
+				},
+				"ajv": {
+					"version": "5.5.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+					"requires": {
+						"co": "^4.6.0",
+						"fast-deep-equal": "^1.0.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.3.0"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"anymatch": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+					"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+					"requires": {
+						"micromatch": "^2.1.5",
+						"normalize-path": "^2.0.0"
+					},
+					"dependencies": {
+						"arr-diff": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+							"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+							"requires": {
+								"arr-flatten": "^1.0.1"
+							}
+						},
+						"array-unique": {
+							"version": "0.2.1",
+							"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+							"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+						},
+						"braces": {
+							"version": "1.8.5",
+							"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+							"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+							"requires": {
+								"expand-range": "^1.8.1",
+								"preserve": "^0.2.0",
+								"repeat-element": "^1.1.2"
+							}
+						},
+						"expand-brackets": {
+							"version": "0.1.5",
+							"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+							"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+							"requires": {
+								"is-posix-bracket": "^0.1.0"
+							}
+						},
+						"extglob": {
+							"version": "0.3.2",
+							"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+							"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+							"requires": {
+								"is-extglob": "^1.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						},
+						"micromatch": {
+							"version": "2.3.11",
+							"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+							"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+							"requires": {
+								"arr-diff": "^2.0.0",
+								"array-unique": "^0.2.1",
+								"braces": "^1.8.2",
+								"expand-brackets": "^0.1.4",
+								"extglob": "^0.3.1",
+								"filename-regex": "^2.0.0",
+								"is-extglob": "^1.0.0",
+								"is-glob": "^2.0.1",
+								"kind-of": "^3.0.2",
+								"normalize-path": "^2.0.1",
+								"object.omit": "^2.0.0",
+								"parse-glob": "^3.0.4",
+								"regex-cache": "^0.4.2"
+							}
+						}
+					}
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"arr-flatten": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+					"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+				},
+				"arr-union": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+					"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+				},
+				"array-equal": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+					"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+				},
+				"array-filter": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+					"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
+				},
+				"array-map": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+					"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+				},
+				"array-reduce": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+					"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"arrify": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+				},
+				"asn1": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+					"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+				},
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				},
+				"assign-symbols": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+					"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+				},
+				"async-each": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+					"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+				},
+				"async-limiter": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+					"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+				},
+				"atob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+					"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
+				},
+				"aws-sign2": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+					"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+				},
+				"aws4": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+					"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+				},
+				"babel-code-frame": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+					"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+					"requires": {
+						"chalk": "^1.1.3",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.2"
+					}
+				},
+				"babel-core": {
+					"version": "6.26.3",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+					"requires": {
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.1",
+						"debug": "^2.6.9",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.8",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.7"
+					}
+				},
+				"babel-generator": {
+					"version": "6.26.1",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+					"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+					"requires": {
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"detect-indent": "^4.0.0",
+						"jsesc": "^1.3.0",
+						"lodash": "^4.17.4",
+						"source-map": "^0.5.7",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"babel-helpers": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+					"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+					"requires": {
+						"babel-runtime": "^6.22.0",
+						"babel-template": "^6.24.1"
+					}
+				},
+				"babel-messages": {
+					"version": "6.23.0",
+					"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+					"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+					"requires": {
+						"babel-runtime": "^6.22.0"
+					}
+				},
+				"babel-plugin-istanbul": {
+					"version": "4.1.6",
+					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+					"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
+					"requires": {
+						"babel-plugin-syntax-object-rest-spread": "^6.13.0",
+						"find-up": "^2.1.0",
+						"istanbul-lib-instrument": "^1.10.1",
+						"test-exclude": "^4.2.1"
+					}
+				},
+				"babel-plugin-jest-hoist": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz",
+					"integrity": "sha512-zhvv4f6OTWy2bYevcJftwGCWXMFe7pqoz41IhMi4xna7xNsX5NygdagsrE0y6kkfuXq8UalwvPwKTyAxME2E/g=="
+				},
+				"babel-plugin-syntax-object-rest-spread": {
+					"version": "6.13.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+					"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+				},
+				"babel-plugin-transform-es2015-modules-commonjs": {
+					"version": "6.26.2",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+					"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+					"requires": {
+						"babel-plugin-transform-strict-mode": "^6.24.1",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-types": "^6.26.0"
+					}
+				},
+				"babel-plugin-transform-strict-mode": {
+					"version": "6.24.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+					"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+					"requires": {
+						"babel-runtime": "^6.22.0",
+						"babel-types": "^6.24.1"
+					}
+				},
+				"babel-preset-jest": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz",
+					"integrity": "sha512-a+M3LTEXTq3gxv0uBN9Qm6ahUl7a8pj923nFbCUdqFUSsf3YrX8Uc+C3MEwji5Af3LiQjSC7w4ooYewlz8HRTA==",
+					"requires": {
+						"babel-plugin-jest-hoist": "^22.4.3",
+						"babel-plugin-syntax-object-rest-spread": "^6.13.0"
+					}
+				},
+				"babel-register": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+					"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+					"requires": {
+						"babel-core": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"core-js": "^2.5.0",
+						"home-or-tmp": "^2.0.0",
+						"lodash": "^4.17.4",
+						"mkdirp": "^0.5.1",
+						"source-map-support": "^0.4.15"
+					}
+				},
+				"babel-runtime": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+					"requires": {
+						"core-js": "^2.4.0",
+						"regenerator-runtime": "^0.11.0"
+					}
+				},
+				"babel-template": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+					"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+					"requires": {
+						"babel-runtime": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"lodash": "^4.17.4"
+					}
+				},
+				"babel-traverse": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+					"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+					"requires": {
+						"babel-code-frame": "^6.26.0",
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"debug": "^2.6.8",
+						"globals": "^9.18.0",
+						"invariant": "^2.2.2",
+						"lodash": "^4.17.4"
+					}
+				},
+				"babel-types": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+					"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+					"requires": {
+						"babel-runtime": "^6.26.0",
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.4",
+						"to-fast-properties": "^1.0.3"
+					}
+				},
+				"babylon": {
+					"version": "6.18.0",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+				},
+				"base": {
+					"version": "0.11.2",
+					"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+					"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+					"requires": {
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						}
+					}
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+					"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+					"optional": true,
+					"requires": {
+						"tweetnacl": "^0.14.3"
+					}
+				},
+				"binary-extensions": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+					"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+				},
+				"boom": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+					"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+					"requires": {
+						"hoek": "4.x.x"
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"browser-process-hrtime": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+					"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
+				},
+				"browser-resolve": {
+					"version": "1.11.2",
+					"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+					"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+					"requires": {
+						"resolve": "1.1.7"
+					},
+					"dependencies": {
+						"resolve": {
+							"version": "1.1.7",
+							"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+							"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+						}
+					}
+				},
+				"buffer-from": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+					"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+				},
+				"builtin-modules": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+					"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+				},
+				"cache-base": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+					"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+					"requires": {
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
+					}
+				},
+				"callsites": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"chokidar": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+					"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+					"requires": {
+						"anymatch": "^1.3.0",
+						"async-each": "^1.0.0",
+						"fsevents": "^1.0.0",
+						"glob-parent": "^2.0.0",
+						"inherits": "^2.0.1",
+						"is-binary-path": "^1.0.0",
+						"is-glob": "^2.0.0",
+						"path-is-absolute": "^1.0.0",
+						"readdirp": "^2.0.0"
+					}
+				},
+				"ci-info": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
+					"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg=="
+				},
+				"class-utils": {
+					"version": "0.3.6",
+					"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+					"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+					"requires": {
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"cliui": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+					"requires": {
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				},
+				"co": {
+					"version": "4.6.0",
+					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+				},
+				"collection-visit": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+					"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+					"requires": {
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+					"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+					"requires": {
+						"color-name": "^1.1.1"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+				},
+				"combined-stream": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+					"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+					"requires": {
+						"delayed-stream": "~1.0.0"
+					}
+				},
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+					"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+				},
+				"copy-descriptor": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+					"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+				},
+				"core-js": {
+					"version": "2.5.6",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+					"integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+				},
+				"cpx": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/cpx/-/cpx-1.5.0.tgz",
+					"integrity": "sha1-GFvgGFEdhycN7czCkxceN2VauI8=",
+					"requires": {
+						"babel-runtime": "^6.9.2",
+						"chokidar": "^1.6.0",
+						"duplexer": "^0.1.1",
+						"glob": "^7.0.5",
+						"glob2base": "^0.0.12",
+						"minimatch": "^3.0.2",
+						"mkdirp": "^0.5.1",
+						"resolve": "^1.1.7",
+						"safe-buffer": "^5.0.1",
+						"shell-quote": "^1.6.1",
+						"subarg": "^1.0.0"
+					}
+				},
+				"cross-spawn": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"cryptiles": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+					"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+					"requires": {
+						"boom": "5.x.x"
+					},
+					"dependencies": {
+						"boom": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+							"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+							"requires": {
+								"hoek": "4.x.x"
+							}
+						}
+					}
+				},
+				"cssom": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+					"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+				},
+				"cssstyle": {
+					"version": "0.2.37",
+					"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+					"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+					"requires": {
+						"cssom": "0.3.x"
+					}
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+					"requires": {
+						"assert-plus": "^1.0.0"
+					}
+				},
+				"data-urls": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
+					"integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+					"requires": {
+						"abab": "^1.0.4",
+						"whatwg-mimetype": "^2.0.0",
+						"whatwg-url": "^6.4.0"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+				},
+				"decode-uri-component": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+					"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+				},
+				"deep-is": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+					"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+				},
+				"define-property": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+					"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+					"requires": {
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
+					},
+					"dependencies": {
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						}
+					}
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+				},
+				"detect-indent": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+					"requires": {
+						"repeating": "^2.0.0"
+					}
+				},
+				"diff": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+				},
+				"domexception": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+					"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+					"requires": {
+						"webidl-conversions": "^4.0.2"
+					}
+				},
+				"duplexer": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+					"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+				},
+				"ecc-jsbn": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+					"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+					"optional": true,
+					"requires": {
+						"jsbn": "~0.1.0"
+					}
+				},
+				"error-ex": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+					"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+					"requires": {
+						"is-arrayish": "^0.2.1"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+				},
+				"escodegen": {
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+					"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+					"requires": {
+						"esprima": "^3.1.3",
+						"estraverse": "^4.2.0",
+						"esutils": "^2.0.2",
+						"optionator": "^0.8.1",
+						"source-map": "~0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+							"optional": true
+						}
+					}
+				},
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+				},
+				"estraverse": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+					"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+					"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+				},
+				"execa": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+					"requires": {
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"expand-range": {
+					"version": "1.8.2",
+					"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+					"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+					"requires": {
+						"fill-range": "^2.1.0"
+					},
+					"dependencies": {
+						"fill-range": {
+							"version": "2.2.4",
+							"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+							"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+							"requires": {
+								"is-number": "^2.1.0",
+								"isobject": "^2.0.0",
+								"randomatic": "^3.0.0",
+								"repeat-element": "^1.1.2",
+								"repeat-string": "^1.5.2"
+							}
+						},
+						"is-number": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+							"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							}
+						},
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"expect": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
+					"integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"jest-diff": "^22.4.3",
+						"jest-get-type": "^22.4.3",
+						"jest-matcher-utils": "^22.4.3",
+						"jest-message-util": "^22.4.3",
+						"jest-regex-util": "^22.4.3"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						}
+					}
+				},
+				"extend": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+					"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+				},
+				"extend-shallow": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+					"requires": {
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						}
+					}
+				},
+				"extsprintf": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+					"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+				},
+				"fast-deep-equal": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+				},
+				"fast-json-stable-stringify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+					"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+				},
+				"fast-levenshtein": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+					"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+				},
+				"filename-regex": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+					"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"find-index": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+					"integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ="
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"for-in": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+				},
+				"for-own": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+					"requires": {
+						"for-in": "^1.0.1"
+					}
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+				},
+				"form-data": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+					"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "1.0.6",
+						"mime-types": "^2.1.12"
+					}
+				},
+				"fragment-cache": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+					"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+					"requires": {
+						"map-cache": "^0.2.2"
+					}
+				},
+				"fs-extra": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.0.tgz",
+					"integrity": "sha512-lk2cUCo8QzbiEWEbt7Cw3m27WMiRG321xsssbcIpfMhpRjrlC08WBOVQqj1/nQYYNnPtyIhP1oqLO3QwT2tPCw==",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+				},
+				"fsevents": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
+					"integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
+					"optional": true,
+					"requires": {
+						"nan": "^2.9.2",
+						"node-pre-gyp": "^0.9.0"
+					},
+					"dependencies": {
+						"abbrev": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true
+						},
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"optional": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.4",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^2.0.6"
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"chownr": {
+							"version": "1.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"debug": {
+							"version": "2.6.9",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"deep-extend": {
+							"version": "0.4.2",
+							"bundled": true,
+							"optional": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"detect-libc": {
+							"version": "1.0.3",
+							"bundled": true,
+							"optional": true
+						},
+						"fs-minipass": {
+							"version": "1.2.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"aproba": "^1.0.3",
+								"console-control-strings": "^1.0.0",
+								"has-unicode": "^2.0.0",
+								"object-assign": "^4.1.0",
+								"signal-exit": "^3.0.0",
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1",
+								"wide-align": "^1.1.0"
+							}
+						},
+						"glob": {
+							"version": "7.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"iconv-lite": {
+							"version": "0.4.21",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safer-buffer": "^2.1.0"
+							}
+						},
+						"ignore-walk": {
+							"version": "3.0.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minimatch": "^3.0.4"
+							}
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.3",
+							"bundled": true
+						},
+						"ini": {
+							"version": "1.3.5",
+							"bundled": true,
+							"optional": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true
+						},
+						"minipass": {
+							"version": "2.2.4",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "^5.1.1",
+								"yallist": "^3.0.0"
+							}
+						},
+						"minizlib": {
+							"version": "1.1.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"requires": {
+								"minimist": "0.0.8"
+							}
+						},
+						"ms": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"needle": {
+							"version": "2.2.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"debug": "^2.1.2",
+								"iconv-lite": "^0.4.4",
+								"sax": "^1.2.4"
+							}
+						},
+						"node-pre-gyp": {
+							"version": "0.9.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"detect-libc": "^1.0.2",
+								"mkdirp": "^0.5.1",
+								"needle": "^2.2.0",
+								"nopt": "^4.0.1",
+								"npm-packlist": "^1.1.6",
+								"npmlog": "^4.0.2",
+								"rc": "^1.1.7",
+								"rimraf": "^2.6.1",
+								"semver": "^5.3.0",
+								"tar": "^4"
+							}
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"abbrev": "1",
+								"osenv": "^0.1.4"
+							}
+						},
+						"npm-bundled": {
+							"version": "1.0.3",
+							"bundled": true,
+							"optional": true
+						},
+						"npm-packlist": {
+							"version": "1.1.10",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ignore-walk": "^3.0.1",
+								"npm-bundled": "^1.0.1"
+							}
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"are-we-there-yet": "~1.1.2",
+								"console-control-strings": "~1.1.0",
+								"gauge": "~2.7.3",
+								"set-blocking": "~2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"osenv": {
+							"version": "0.1.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"os-homedir": "^1.0.0",
+								"os-tmpdir": "^1.0.0"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"rc": {
+							"version": "1.2.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"deep-extend": "~0.4.0",
+								"ini": "~1.3.0",
+								"minimist": "^1.2.0",
+								"strip-json-comments": "~2.0.1"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "1.2.0",
+									"bundled": true,
+									"optional": true
+								}
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"rimraf": {
+							"version": "2.6.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"glob": "^7.0.5"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.1",
+							"bundled": true
+						},
+						"safer-buffer": {
+							"version": "2.1.2",
+							"bundled": true,
+							"optional": true
+						},
+						"sax": {
+							"version": "1.2.4",
+							"bundled": true,
+							"optional": true
+						},
+						"semver": {
+							"version": "5.5.0",
+							"bundled": true,
+							"optional": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"tar": {
+							"version": "4.4.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"chownr": "^1.0.1",
+								"fs-minipass": "^1.2.5",
+								"minipass": "^2.2.4",
+								"minizlib": "^1.1.0",
+								"mkdirp": "^0.5.0",
+								"safe-buffer": "^5.1.1",
+								"yallist": "^3.0.2"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"wide-align": {
+							"version": "1.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"string-width": "^1.0.2"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"yallist": {
+							"version": "3.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"get-caller-file": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+				},
+				"get-value": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+					"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+					"requires": {
+						"assert-plus": "^1.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"glob-base": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+					"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+					"requires": {
+						"glob-parent": "^2.0.0",
+						"is-glob": "^2.0.0"
+					}
+				},
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"requires": {
+						"is-glob": "^2.0.0"
+					}
+				},
+				"glob2base": {
+					"version": "0.0.12",
+					"resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+					"integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
+					"requires": {
+						"find-index": "^0.1.1"
+					}
+				},
+				"globals": {
+					"version": "9.18.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+				},
+				"har-schema": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+					"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+				},
+				"har-validator": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+					"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+					"requires": {
+						"ajv": "^5.1.0",
+						"har-schema": "^2.0.0"
+					}
+				},
+				"has-ansi": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+					"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"has-value": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+					"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+					"requires": {
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
+					}
+				},
+				"has-values": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+					"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+					"requires": {
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+							"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"hawk": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+					"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+					"requires": {
+						"boom": "4.x.x",
+						"cryptiles": "3.x.x",
+						"hoek": "4.x.x",
+						"sntp": "2.x.x"
+					}
+				},
+				"hoek": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+					"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+				},
+				"home-or-tmp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+					"requires": {
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.1"
+					}
+				},
+				"hosted-git-info": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+					"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+				},
+				"html-encoding-sniffer": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+					"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+					"requires": {
+						"whatwg-encoding": "^1.0.1"
+					}
+				},
+				"http-signature": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+					"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+					"requires": {
+						"assert-plus": "^1.0.0",
+						"jsprim": "^1.2.2",
+						"sshpk": "^1.7.0"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+				},
+				"invariant": {
+					"version": "2.2.4",
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+					"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+					"requires": {
+						"loose-envify": "^1.0.0"
+					}
+				},
+				"invert-kv": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-arrayish": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+					"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+				},
+				"is-binary-path": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+					"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+					"requires": {
+						"binary-extensions": "^1.0.0"
+					}
+				},
+				"is-buffer": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+				},
+				"is-builtin-module": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+					"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+					"requires": {
+						"builtin-modules": "^1.0.0"
+					}
+				},
+				"is-ci": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+					"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+					"requires": {
+						"ci-info": "^1.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"is-dotfile": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+					"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+				},
+				"is-equal-shallow": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+					"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+					"requires": {
+						"is-primitive": "^2.0.0"
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-finite": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+					"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"is-generator-fn": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+					"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-odd": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+					"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+					"requires": {
+						"is-number": "^4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+							"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+						}
+					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"is-posix-bracket": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+					"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+				},
+				"is-primitive": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+					"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+				},
+				"is-utf8": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+					"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+				},
+				"is-windows": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+					"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+				},
+				"istanbul-lib-coverage": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
+					"integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A=="
+				},
+				"istanbul-lib-instrument": {
+					"version": "1.10.1",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
+					"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
+					"requires": {
+						"babel-generator": "^6.18.0",
+						"babel-template": "^6.16.0",
+						"babel-traverse": "^6.18.0",
+						"babel-types": "^6.18.0",
+						"babylon": "^6.18.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"semver": "^5.3.0"
+					}
+				},
+				"jest-config": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.3.tgz",
+					"integrity": "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
+					"requires": {
+						"chalk": "^2.0.1",
+						"glob": "^7.1.1",
+						"jest-environment-jsdom": "^22.4.3",
+						"jest-environment-node": "^22.4.3",
+						"jest-get-type": "^22.4.3",
+						"jest-jasmine2": "^22.4.3",
+						"jest-regex-util": "^22.4.3",
+						"jest-resolve": "^22.4.3",
+						"jest-util": "^22.4.3",
+						"jest-validate": "^22.4.3",
+						"pretty-format": "^22.4.3"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"jest-diff": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
+					"integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+					"requires": {
+						"chalk": "^2.0.1",
+						"diff": "^3.2.0",
+						"jest-get-type": "^22.4.3",
+						"pretty-format": "^22.4.3"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"jest-environment-jsdom": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
+					"integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
+					"requires": {
+						"jest-mock": "^22.4.3",
+						"jest-util": "^22.4.3",
+						"jsdom": "^11.5.1"
+					}
+				},
+				"jest-environment-node": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
+					"integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
+					"requires": {
+						"jest-mock": "^22.4.3",
+						"jest-util": "^22.4.3"
+					}
+				},
+				"jest-get-type": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+					"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
+				},
+				"jest-jasmine2": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.3.tgz",
+					"integrity": "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
+					"requires": {
+						"chalk": "^2.0.1",
+						"co": "^4.6.0",
+						"expect": "^22.4.3",
+						"graceful-fs": "^4.1.11",
+						"is-generator-fn": "^1.0.0",
+						"jest-diff": "^22.4.3",
+						"jest-matcher-utils": "^22.4.3",
+						"jest-message-util": "^22.4.3",
+						"jest-snapshot": "^22.4.3",
+						"jest-util": "^22.4.3",
+						"source-map-support": "^0.5.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+						},
+						"source-map-support": {
+							"version": "0.5.5",
+							"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
+							"integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
+							"requires": {
+								"buffer-from": "^1.0.0",
+								"source-map": "^0.6.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"jest-matcher-utils": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+					"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-get-type": "^22.4.3",
+						"pretty-format": "^22.4.3"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"jest-message-util": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+					"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
+					"requires": {
+						"@babel/code-frame": "^7.0.0-beta.35",
+						"chalk": "^2.0.1",
+						"micromatch": "^2.3.11",
+						"slash": "^1.0.0",
+						"stack-utils": "^1.0.1"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"arr-diff": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+							"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+							"requires": {
+								"arr-flatten": "^1.0.1"
+							}
+						},
+						"array-unique": {
+							"version": "0.2.1",
+							"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+							"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+						},
+						"braces": {
+							"version": "1.8.5",
+							"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+							"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+							"requires": {
+								"expand-range": "^1.8.1",
+								"preserve": "^0.2.0",
+								"repeat-element": "^1.1.2"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"expand-brackets": {
+							"version": "0.1.5",
+							"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+							"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+							"requires": {
+								"is-posix-bracket": "^0.1.0"
+							}
+						},
+						"extglob": {
+							"version": "0.3.2",
+							"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+							"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+							"requires": {
+								"is-extglob": "^1.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						},
+						"micromatch": {
+							"version": "2.3.11",
+							"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+							"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+							"requires": {
+								"arr-diff": "^2.0.0",
+								"array-unique": "^0.2.1",
+								"braces": "^1.8.2",
+								"expand-brackets": "^0.1.4",
+								"extglob": "^0.3.1",
+								"filename-regex": "^2.0.0",
+								"is-extglob": "^1.0.0",
+								"is-glob": "^2.0.1",
+								"kind-of": "^3.0.2",
+								"normalize-path": "^2.0.1",
+								"object.omit": "^2.0.0",
+								"parse-glob": "^3.0.4",
+								"regex-cache": "^0.4.2"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"jest-mock": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
+					"integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q=="
+				},
+				"jest-regex-util": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
+					"integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg=="
+				},
+				"jest-resolve": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
+					"integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
+					"requires": {
+						"browser-resolve": "^1.11.2",
+						"chalk": "^2.0.1"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"jest-snapshot": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
+					"integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-diff": "^22.4.3",
+						"jest-matcher-utils": "^22.4.3",
+						"mkdirp": "^0.5.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^22.4.3"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"jest-util": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
+					"integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
+					"requires": {
+						"callsites": "^2.0.0",
+						"chalk": "^2.0.1",
+						"graceful-fs": "^4.1.11",
+						"is-ci": "^1.0.10",
+						"jest-message-util": "^22.4.3",
+						"mkdirp": "^0.5.1",
+						"source-map": "^0.6.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"jest-validate": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.3.tgz",
+					"integrity": "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-config": "^22.4.3",
+						"jest-get-type": "^22.4.3",
+						"leven": "^2.1.0",
+						"pretty-format": "^22.4.3"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.4.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+							"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+					"optional": true
+				},
+				"jsdom": {
+					"version": "11.10.0",
+					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.10.0.tgz",
+					"integrity": "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
+					"requires": {
+						"abab": "^1.0.4",
+						"acorn": "^5.3.0",
+						"acorn-globals": "^4.1.0",
+						"array-equal": "^1.0.0",
+						"cssom": ">= 0.3.2 < 0.4.0",
+						"cssstyle": ">= 0.2.37 < 0.3.0",
+						"data-urls": "^1.0.0",
+						"domexception": "^1.0.0",
+						"escodegen": "^1.9.0",
+						"html-encoding-sniffer": "^1.0.2",
+						"left-pad": "^1.2.0",
+						"nwmatcher": "^1.4.3",
+						"parse5": "4.0.0",
+						"pn": "^1.1.0",
+						"request": "^2.83.0",
+						"request-promise-native": "^1.0.5",
+						"sax": "^1.2.4",
+						"symbol-tree": "^3.2.2",
+						"tough-cookie": "^2.3.3",
+						"w3c-hr-time": "^1.0.1",
+						"webidl-conversions": "^4.0.2",
+						"whatwg-encoding": "^1.0.3",
+						"whatwg-mimetype": "^2.1.0",
+						"whatwg-url": "^6.4.0",
+						"ws": "^4.0.0",
+						"xml-name-validator": "^3.0.0"
+					}
+				},
+				"jsesc": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+				},
+				"json-schema-traverse": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+					"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+				},
+				"json5": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+				},
+				"jsonfile": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
+				},
+				"jsonify": {
+					"version": "0.0.0",
+					"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+					"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+				},
+				"jsprim": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+					"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.3.0",
+						"json-schema": "0.2.3",
+						"verror": "1.10.0"
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"lcid": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+					"requires": {
+						"invert-kv": "^1.0.0"
+					}
+				},
+				"left-pad": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+					"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+				},
+				"leven": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+					"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+				},
+				"levn": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+					"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+					"requires": {
+						"prelude-ls": "~1.1.2",
+						"type-check": "~0.3.2"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"lodash.sortby": {
+					"version": "4.7.0",
+					"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+					"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+				},
+				"loose-envify": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+					"requires": {
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+					"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"map-cache": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+					"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+				},
+				"map-visit": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+					"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+					"requires": {
+						"object-visit": "^1.0.0"
+					}
+				},
+				"math-random": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+					"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+				},
+				"mem": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+					"requires": {
+						"mimic-fn": "^1.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"mime-db": {
+					"version": "1.33.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+					"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+				},
+				"mime-types": {
+					"version": "2.1.18",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+					"requires": {
+						"mime-db": "~1.33.0"
+					}
+				},
+				"mimic-fn": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+				},
+				"mixin-deep": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+					"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+					"requires": {
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"nan": {
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+					"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+					"optional": true
+				},
+				"nanomatch": {
+					"version": "1.2.9",
+					"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+					"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					}
+				},
+				"natural-compare": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+					"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+					"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+					"requires": {
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
+					}
+				},
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+					"requires": {
+						"path-key": "^2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+				},
+				"nwmatcher": {
+					"version": "1.4.4",
+					"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+					"integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
+				},
+				"oauth-sign": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				},
+				"object-copy": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+					"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+					"requires": {
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"object-visit": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+					"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+					"requires": {
+						"isobject": "^3.0.0"
+					}
+				},
+				"object.omit": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+					"requires": {
+						"for-own": "^0.1.4",
+						"is-extendable": "^0.1.1"
+					}
+				},
+				"object.pick": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+					"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"optionator": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+					"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+					"requires": {
+						"deep-is": "~0.1.3",
+						"fast-levenshtein": "~2.0.4",
+						"levn": "~0.3.0",
+						"prelude-ls": "~1.1.2",
+						"type-check": "~0.3.2",
+						"wordwrap": "~1.0.0"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+				},
+				"p-finally": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+				},
+				"p-limit": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+					"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+				},
+				"parse-glob": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+					"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+					"requires": {
+						"glob-base": "^0.3.0",
+						"is-dotfile": "^1.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"parse5": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+				},
+				"pascalcase": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+					"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+				},
+				"path-parse": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+					"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"performance-now": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+					"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+					"requires": {
+						"pinkie": "^2.0.0"
+					}
+				},
+				"pkg-dir": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+					"requires": {
+						"find-up": "^2.1.0"
+					}
+				},
+				"pn": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+					"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+				},
+				"posix-character-classes": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+					"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+				},
+				"prelude-ls": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+					"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+				},
+				"preserve": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+					"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+				},
+				"pretty-format": {
+					"version": "22.4.3",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+					"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+					"requires": {
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+						},
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						}
+					}
+				},
+				"private": {
+					"version": "0.1.8",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+					"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+				},
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+				},
+				"punycode": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+				},
+				"qs": {
+					"version": "6.5.2",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+				},
+				"randomatic": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+					"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+					"requires": {
+						"is-number": "^4.0.0",
+						"kind-of": "^6.0.0",
+						"math-random": "^1.0.1"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+							"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+						}
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"requires": {
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"requires": {
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+							"requires": {
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
+							}
+						},
+						"path-exists": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+							"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+							"requires": {
+								"pinkie-promise": "^2.0.0"
+							}
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"readdirp": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+					"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"minimatch": "^3.0.2",
+						"readable-stream": "^2.0.2",
+						"set-immediate-shim": "^1.0.1"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+				},
+				"regex-cache": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+					"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+					"requires": {
+						"is-equal-shallow": "^0.1.3"
+					}
+				},
+				"regex-not": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+					"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+					"requires": {
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
+					}
+				},
+				"remove-trailing-separator": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+					"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+				},
+				"repeat-element": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+					"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+				},
+				"repeat-string": {
+					"version": "1.6.1",
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+				},
+				"repeating": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+					"requires": {
+						"is-finite": "^1.0.0"
+					}
+				},
+				"request": {
+					"version": "2.85.0",
+					"resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+					"integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+					"requires": {
+						"aws-sign2": "~0.7.0",
+						"aws4": "^1.6.0",
+						"caseless": "~0.12.0",
+						"combined-stream": "~1.0.5",
+						"extend": "~3.0.1",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.3.1",
+						"har-validator": "~5.0.3",
+						"hawk": "~6.0.2",
+						"http-signature": "~1.2.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.17",
+						"oauth-sign": "~0.8.2",
+						"performance-now": "^2.1.0",
+						"qs": "~6.5.1",
+						"safe-buffer": "^5.1.1",
+						"stringstream": "~0.0.5",
+						"tough-cookie": "~2.3.3",
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.1.0"
+					}
+				},
+				"request-promise-core": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+					"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+					"requires": {
+						"lodash": "^4.13.1"
+					}
+				},
+				"request-promise-native": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+					"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+					"requires": {
+						"request-promise-core": "1.1.1",
+						"stealthy-require": "^1.1.0",
+						"tough-cookie": ">=2.3.3"
+					}
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+				},
+				"resolve": {
+					"version": "1.7.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+					"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+					"requires": {
+						"path-parse": "^1.0.5"
+					}
+				},
+				"resolve-url": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+					"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+				},
+				"ret": {
+					"version": "0.1.15",
+					"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+					"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				},
+				"safe-regex": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+					"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+					"requires": {
+						"ret": "~0.1.10"
+					}
+				},
+				"sax": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+				},
+				"semver": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+				},
+				"set-immediate-shim": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+					"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+				},
+				"set-value": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+					"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+				},
+				"shell-quote": {
+					"version": "1.6.1",
+					"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+					"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+					"requires": {
+						"array-filter": "~0.0.0",
+						"array-map": "~0.0.0",
+						"array-reduce": "~0.0.0",
+						"jsonify": "~0.0.0"
+					}
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+				},
+				"slash": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+				},
+				"snapdragon": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+					"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+					"requires": {
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"snapdragon-node": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+					"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+					"requires": {
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						}
+					}
+				},
+				"snapdragon-util": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+					"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+					"requires": {
+						"kind-of": "^3.2.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"sntp": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+					"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+					"requires": {
+						"hoek": "4.x.x"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				},
+				"source-map-resolve": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+					"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+					"requires": {
+						"atob": "^2.0.0",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
+					}
+				},
+				"source-map-support": {
+					"version": "0.4.18",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+					"requires": {
+						"source-map": "^0.5.6"
+					}
+				},
+				"source-map-url": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+					"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+				},
+				"spdx-correct": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+					"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+					"requires": {
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-exceptions": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+					"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+				},
+				"spdx-expression-parse": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+					"requires": {
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-license-ids": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+					"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+				},
+				"split-string": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+					"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+					"requires": {
+						"extend-shallow": "^3.0.0"
+					}
+				},
+				"sshpk": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+					"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+					"requires": {
+						"asn1": "~0.2.3",
+						"assert-plus": "^1.0.0",
+						"bcrypt-pbkdf": "^1.0.0",
+						"dashdash": "^1.12.0",
+						"ecc-jsbn": "~0.1.1",
+						"getpass": "^0.1.1",
+						"jsbn": "~0.1.0",
+						"tweetnacl": "~0.14.0"
+					}
+				},
+				"stack-utils": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+					"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
+				},
+				"static-extend": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+					"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+					"requires": {
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"stealthy-require": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+					"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				},
+				"stringstream": {
+					"version": "0.0.5",
+					"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+					"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"requires": {
+						"is-utf8": "^0.2.0"
+					}
+				},
+				"strip-eof": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+				},
+				"subarg": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+					"integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+					"requires": {
+						"minimist": "^1.1.0"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+						}
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				},
+				"symbol-tree": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+					"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+				},
+				"test-exclude": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
+					"integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
+					"requires": {
+						"arrify": "^1.0.1",
+						"micromatch": "^3.1.8",
+						"object-assign": "^4.1.0",
+						"read-pkg-up": "^1.0.1",
+						"require-main-filename": "^1.0.1"
+					}
+				},
+				"to-fast-properties": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+				},
+				"to-object-path": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+					"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"to-regex": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+					"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+					"requires": {
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
+				},
+				"tough-cookie": {
+					"version": "2.3.4",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+					"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+					"requires": {
+						"punycode": "^1.4.1"
+					},
+					"dependencies": {
+						"punycode": {
+							"version": "1.4.1",
+							"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+							"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+						}
+					}
+				},
+				"tr46": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+					"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+					"requires": {
+						"punycode": "^2.1.0"
+					}
+				},
+				"trim-right": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+					"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+					"requires": {
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+					"optional": true
+				},
+				"type-check": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+					"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+					"requires": {
+						"prelude-ls": "~1.1.2"
+					}
+				},
+				"union-value": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+					"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+					"requires": {
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"set-value": {
+							"version": "0.4.3",
+							"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+							"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+							"requires": {
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
+							}
+						}
+					}
+				},
+				"universalify": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+					"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+				},
+				"unset-value": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+					"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+					"requires": {
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
+					},
+					"dependencies": {
+						"has-value": {
+							"version": "0.3.1",
+							"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+							"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+							"requires": {
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
+							},
+							"dependencies": {
+								"isobject": {
+									"version": "2.1.0",
+									"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+									"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+									"requires": {
+										"isarray": "1.0.0"
+									}
+								}
+							}
+						},
+						"has-values": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+							"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+						}
+					}
+				},
+				"urix": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+					"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+				},
+				"use": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+					"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+					"requires": {
+						"kind-of": "^6.0.2"
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+				},
+				"uuid": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+					"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+					"requires": {
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
+					}
+				},
+				"verror": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+					"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+					"requires": {
+						"assert-plus": "^1.0.0",
+						"core-util-is": "1.0.2",
+						"extsprintf": "^1.2.0"
+					}
+				},
+				"w3c-hr-time": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+					"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+					"requires": {
+						"browser-process-hrtime": "^0.1.2"
+					}
+				},
+				"webidl-conversions": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+					"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+				},
+				"whatwg-encoding": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+					"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+					"requires": {
+						"iconv-lite": "0.4.19"
+					}
+				},
+				"whatwg-mimetype": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
+					"integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew=="
+				},
+				"whatwg-url": {
+					"version": "6.4.1",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
+					"integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				},
+				"which": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+					"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+				},
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
+					},
+					"dependencies": {
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+				},
+				"ws": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+					"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+					"requires": {
+						"async-limiter": "~1.0.0",
+						"safe-buffer": "~5.1.0"
+					}
+				},
+				"xml-name-validator": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+					"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+				},
+				"yargs": {
+					"version": "11.0.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "9.0.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+					"requires": {
+						"camelcase": "^4.1.0"
+					}
+				}
+			}
+		},
+		"webpack-dev-server": {
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz",
+			"integrity": "sha512-zrPoX97bx47vZiAXfDrkw8pe9QjJ+lunQl3dypojyWwWr1M5I2h0VSrMPfTjopHQPRNn+NqfjcMmhoLcUJe2gA==",
+			"requires": {
+				"ansi-html": "0.0.7",
+				"array-includes": "^3.0.3",
+				"bonjour": "^3.5.0",
+				"chokidar": "^2.0.0",
+				"compression": "^1.5.2",
+				"connect-history-api-fallback": "^1.3.0",
+				"debug": "^3.1.0",
+				"del": "^3.0.0",
+				"express": "^4.16.2",
+				"html-entities": "^1.2.0",
+				"http-proxy-middleware": "~0.17.4",
+				"import-local": "^1.0.0",
+				"internal-ip": "1.2.0",
+				"ip": "^1.1.5",
+				"killable": "^1.0.0",
+				"loglevel": "^1.4.1",
+				"opn": "^5.1.0",
+				"portfinder": "^1.0.9",
+				"selfsigned": "^1.9.1",
+				"serve-index": "^1.7.2",
+				"sockjs": "0.3.19",
+				"sockjs-client": "1.1.4",
+				"spdy": "^3.4.1",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^5.1.0",
+				"webpack-dev-middleware": "1.12.2",
+				"yargs": "6.6.0"
+			},
+			"dependencies": {
+				"accepts": {
+					"version": "1.3.5",
+					"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+					"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+					"requires": {
+						"mime-types": "~2.1.18",
+						"negotiator": "0.6.1"
+					}
+				},
+				"ansi-html": {
+					"version": "0.0.7",
+					"resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+					"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"requires": {
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
+					}
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"arr-flatten": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+					"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+				},
+				"arr-union": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+					"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+				},
+				"array-find-index": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+					"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+				},
+				"array-flatten": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
+					"integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
+				},
+				"array-includes": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+					"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+					"requires": {
+						"define-properties": "^1.1.2",
+						"es-abstract": "^1.7.0"
+					}
+				},
+				"array-union": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+					"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+					"requires": {
+						"array-uniq": "^1.0.1"
+					}
+				},
+				"array-uniq": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+					"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"assign-symbols": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+					"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+				},
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+				},
+				"async-each": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+					"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+				},
+				"atob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+					"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+				},
+				"base": {
+					"version": "0.11.2",
+					"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+					"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+					"requires": {
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						}
+					}
+				},
+				"batch": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+					"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
+				},
+				"binary-extensions": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+					"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+				},
+				"body-parser": {
+					"version": "1.18.2",
+					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+					"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+					"requires": {
+						"bytes": "3.0.0",
+						"content-type": "~1.0.4",
+						"debug": "2.6.9",
+						"depd": "~1.1.1",
+						"http-errors": "~1.6.2",
+						"iconv-lite": "0.4.19",
+						"on-finished": "~2.3.0",
+						"qs": "6.5.1",
+						"raw-body": "2.3.2",
+						"type-is": "~1.6.15"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						}
+					}
+				},
+				"bonjour": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+					"integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+					"requires": {
+						"array-flatten": "^2.1.0",
+						"deep-equal": "^1.0.1",
+						"dns-equal": "^1.0.0",
+						"dns-txt": "^2.0.2",
+						"multicast-dns": "^6.0.1",
+						"multicast-dns-service-types": "^1.1.0"
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"buffer-indexof": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+					"integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
+				},
+				"builtin-modules": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+					"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+				},
+				"bytes": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+					"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+				},
+				"cache-base": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+					"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+					"requires": {
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
+					}
+				},
+				"camelcase": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+				},
+				"camelcase-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+					"requires": {
+						"camelcase": "^2.0.0",
+						"map-obj": "^1.0.0"
+					}
+				},
+				"chokidar": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
+					"integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+					"requires": {
+						"anymatch": "^2.0.0",
+						"async-each": "^1.0.0",
+						"braces": "^2.3.0",
+						"fsevents": "^1.1.2",
+						"glob-parent": "^3.1.0",
+						"inherits": "^2.0.1",
+						"is-binary-path": "^1.0.0",
+						"is-glob": "^4.0.0",
+						"normalize-path": "^2.1.1",
+						"path-is-absolute": "^1.0.0",
+						"readdirp": "^2.0.0",
+						"upath": "^1.0.0"
+					}
+				},
+				"class-utils": {
+					"version": "0.3.6",
+					"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+					"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+					"requires": {
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
+					}
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+				},
+				"collection-visit": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+					"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+					"requires": {
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
+					}
+				},
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+				},
+				"compressible": {
+					"version": "2.0.13",
+					"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
+					"integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
+					"requires": {
+						"mime-db": ">= 1.33.0 < 2"
+					}
+				},
+				"compression": {
+					"version": "1.7.2",
+					"resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+					"integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
+					"requires": {
+						"accepts": "~1.3.4",
+						"bytes": "3.0.0",
+						"compressible": "~2.0.13",
+						"debug": "2.6.9",
+						"on-headers": "~1.0.1",
+						"safe-buffer": "5.1.1",
+						"vary": "~1.1.2"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.1",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+							"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+						}
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+				},
+				"connect-history-api-fallback": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
+					"integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
+				},
+				"content-disposition": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+					"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+				},
+				"content-type": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+					"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+				},
+				"cookie": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+					"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+				},
+				"cookie-signature": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+					"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+				},
+				"copy-descriptor": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+					"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+				},
+				"currently-unhandled": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+					"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+					"requires": {
+						"array-find-index": "^1.0.1"
+					}
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+				},
+				"decode-uri-component": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+					"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+				},
+				"deep-equal": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+					"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+				},
+				"define-properties": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+					"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+					"requires": {
+						"foreach": "^2.0.5",
+						"object-keys": "^1.0.8"
+					}
+				},
+				"define-property": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+					"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+					"requires": {
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
+					},
+					"dependencies": {
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						}
+					}
+				},
+				"del": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+					"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+					"requires": {
+						"globby": "^6.1.0",
+						"is-path-cwd": "^1.0.0",
+						"is-path-in-cwd": "^1.0.0",
+						"p-map": "^1.1.1",
+						"pify": "^3.0.0",
+						"rimraf": "^2.2.8"
+					}
+				},
+				"depd": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+					"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+				},
+				"destroy": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+					"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+				},
+				"detect-node": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
+					"integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
+				},
+				"dns-equal": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+					"integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
+				},
+				"dns-packet": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
+					"integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+					"requires": {
+						"ip": "^1.1.0",
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"dns-txt": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+					"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+					"requires": {
+						"buffer-indexof": "^1.0.0"
+					}
+				},
+				"ee-first": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+					"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+				},
+				"encodeurl": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+					"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+				},
+				"errno": {
+					"version": "0.1.7",
+					"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+					"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+					"requires": {
+						"prr": "~1.0.1"
+					}
+				},
+				"error-ex": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+					"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+					"requires": {
+						"is-arrayish": "^0.2.1"
+					}
+				},
+				"es-abstract": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+					"integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
+					"requires": {
+						"es-to-primitive": "^1.1.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.1",
+						"is-callable": "^1.1.3",
+						"is-regex": "^1.0.4"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+					"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+					"requires": {
+						"is-callable": "^1.1.1",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.1"
+					}
+				},
+				"escape-html": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+					"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+				},
+				"etag": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+					"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+				},
+				"eventemitter3": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+					"integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+				},
+				"eventsource": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+					"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+					"requires": {
+						"original": ">=0.0.5"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"expand-range": {
+					"version": "1.8.2",
+					"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+					"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+					"requires": {
+						"fill-range": "^2.1.0"
+					},
+					"dependencies": {
+						"fill-range": {
+							"version": "2.2.4",
+							"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+							"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+							"requires": {
+								"is-number": "^2.1.0",
+								"isobject": "^2.0.0",
+								"randomatic": "^3.0.0",
+								"repeat-element": "^1.1.2",
+								"repeat-string": "^1.5.2"
+							}
+						},
+						"is-number": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+							"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							}
+						},
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"express": {
+					"version": "4.16.3",
+					"resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+					"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+					"requires": {
+						"accepts": "~1.3.5",
+						"array-flatten": "1.1.1",
+						"body-parser": "1.18.2",
+						"content-disposition": "0.5.2",
+						"content-type": "~1.0.4",
+						"cookie": "0.3.1",
+						"cookie-signature": "1.0.6",
+						"debug": "2.6.9",
+						"depd": "~1.1.2",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"etag": "~1.8.1",
+						"finalhandler": "1.1.1",
+						"fresh": "0.5.2",
+						"merge-descriptors": "1.0.1",
+						"methods": "~1.1.2",
+						"on-finished": "~2.3.0",
+						"parseurl": "~1.3.2",
+						"path-to-regexp": "0.1.7",
+						"proxy-addr": "~2.0.3",
+						"qs": "6.5.1",
+						"range-parser": "~1.2.0",
+						"safe-buffer": "5.1.1",
+						"send": "0.16.2",
+						"serve-static": "1.13.2",
+						"setprototypeof": "1.1.0",
+						"statuses": "~1.4.0",
+						"type-is": "~1.6.16",
+						"utils-merge": "1.0.1",
+						"vary": "~1.1.2"
+					},
+					"dependencies": {
+						"array-flatten": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+							"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+						},
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.1",
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+							"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+						}
+					}
+				},
+				"extend-shallow": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+					"requires": {
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						}
+					}
+				},
+				"faye-websocket": {
+					"version": "0.10.0",
+					"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+					"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+					"requires": {
+						"websocket-driver": ">=0.5.1"
+					}
+				},
+				"filename-regex": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+					"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"finalhandler": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+					"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+					"requires": {
+						"debug": "2.6.9",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"on-finished": "~2.3.0",
+						"parseurl": "~1.3.2",
+						"statuses": "~1.4.0",
+						"unpipe": "~1.0.0"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						}
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"follow-redirects": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+					"integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+					"requires": {
+						"debug": "^3.1.0"
+					}
+				},
+				"for-in": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+					"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+				},
+				"for-own": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+					"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+					"requires": {
+						"for-in": "^1.0.1"
+					}
+				},
+				"foreach": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+					"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+				},
+				"forwarded": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+					"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+				},
+				"fragment-cache": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+					"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+					"requires": {
+						"map-cache": "^0.2.2"
+					}
+				},
+				"fresh": {
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+					"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+				},
+				"fsevents": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
+					"integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
+					"optional": true,
+					"requires": {
+						"nan": "^2.9.2",
+						"node-pre-gyp": "^0.9.0"
+					},
+					"dependencies": {
+						"abbrev": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true
+						},
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"optional": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.4",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^2.0.6"
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"chownr": {
+							"version": "1.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"debug": {
+							"version": "2.6.9",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"deep-extend": {
+							"version": "0.4.2",
+							"bundled": true,
+							"optional": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"detect-libc": {
+							"version": "1.0.3",
+							"bundled": true,
+							"optional": true
+						},
+						"fs-minipass": {
+							"version": "1.2.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"aproba": "^1.0.3",
+								"console-control-strings": "^1.0.0",
+								"has-unicode": "^2.0.0",
+								"object-assign": "^4.1.0",
+								"signal-exit": "^3.0.0",
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1",
+								"wide-align": "^1.1.0"
+							}
+						},
+						"glob": {
+							"version": "7.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"iconv-lite": {
+							"version": "0.4.21",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safer-buffer": "^2.1.0"
+							}
+						},
+						"ignore-walk": {
+							"version": "3.0.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minimatch": "^3.0.4"
+							}
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.3",
+							"bundled": true
+						},
+						"ini": {
+							"version": "1.3.5",
+							"bundled": true,
+							"optional": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true
+						},
+						"minipass": {
+							"version": "2.2.4",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "^5.1.1",
+								"yallist": "^3.0.0"
+							}
+						},
+						"minizlib": {
+							"version": "1.1.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"requires": {
+								"minimist": "0.0.8"
+							}
+						},
+						"ms": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"needle": {
+							"version": "2.2.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"debug": "^2.1.2",
+								"iconv-lite": "^0.4.4",
+								"sax": "^1.2.4"
+							}
+						},
+						"node-pre-gyp": {
+							"version": "0.9.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"detect-libc": "^1.0.2",
+								"mkdirp": "^0.5.1",
+								"needle": "^2.2.0",
+								"nopt": "^4.0.1",
+								"npm-packlist": "^1.1.6",
+								"npmlog": "^4.0.2",
+								"rc": "^1.1.7",
+								"rimraf": "^2.6.1",
+								"semver": "^5.3.0",
+								"tar": "^4"
+							}
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"abbrev": "1",
+								"osenv": "^0.1.4"
+							}
+						},
+						"npm-bundled": {
+							"version": "1.0.3",
+							"bundled": true,
+							"optional": true
+						},
+						"npm-packlist": {
+							"version": "1.1.10",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ignore-walk": "^3.0.1",
+								"npm-bundled": "^1.0.1"
+							}
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"are-we-there-yet": "~1.1.2",
+								"console-control-strings": "~1.1.0",
+								"gauge": "~2.7.3",
+								"set-blocking": "~2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"osenv": {
+							"version": "0.1.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"os-homedir": "^1.0.0",
+								"os-tmpdir": "^1.0.0"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"rc": {
+							"version": "1.2.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"deep-extend": "~0.4.0",
+								"ini": "~1.3.0",
+								"minimist": "^1.2.0",
+								"strip-json-comments": "~2.0.1"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "1.2.0",
+									"bundled": true,
+									"optional": true
+								}
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"rimraf": {
+							"version": "2.6.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"glob": "^7.0.5"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.1",
+							"bundled": true
+						},
+						"safer-buffer": {
+							"version": "2.1.2",
+							"bundled": true,
+							"optional": true
+						},
+						"sax": {
+							"version": "1.2.4",
+							"bundled": true,
+							"optional": true
+						},
+						"semver": {
+							"version": "5.5.0",
+							"bundled": true,
+							"optional": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"tar": {
+							"version": "4.4.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"chownr": "^1.0.1",
+								"fs-minipass": "^1.2.5",
+								"minipass": "^2.2.4",
+								"minizlib": "^1.1.0",
+								"mkdirp": "^0.5.0",
+								"safe-buffer": "^5.1.1",
+								"yallist": "^3.0.2"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"wide-align": {
+							"version": "1.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"string-width": "^1.0.2"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true
+						},
+						"yallist": {
+							"version": "3.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"function-bind": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+					"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+				},
+				"get-caller-file": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+				},
+				"get-stdin": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+					"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+				},
+				"get-value": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+					"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"glob-base": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+					"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+					"requires": {
+						"glob-parent": "^2.0.0",
+						"is-glob": "^2.0.0"
+					},
+					"dependencies": {
+						"glob-parent": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+							"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+							"requires": {
+								"is-glob": "^2.0.0"
+							}
+						},
+						"is-extglob": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+							"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+						},
+						"is-glob": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+							"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+							"requires": {
+								"is-extglob": "^1.0.0"
+							}
+						}
+					}
+				},
+				"glob-parent": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+					"requires": {
+						"is-glob": "^3.1.0",
+						"path-dirname": "^1.0.0"
+					},
+					"dependencies": {
+						"is-glob": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+							"requires": {
+								"is-extglob": "^2.1.0"
+							}
+						}
+					}
+				},
+				"globby": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+					"requires": {
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+						}
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+				},
+				"handle-thing": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+					"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
+				},
+				"has": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+					"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+					"requires": {
+						"function-bind": "^1.0.2"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"has-value": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+					"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+					"requires": {
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
+					}
+				},
+				"has-values": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+					"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+					"requires": {
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+							"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"hosted-git-info": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+					"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+				},
+				"hpack.js": {
+					"version": "2.1.6",
+					"resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+					"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+					"requires": {
+						"inherits": "^2.0.1",
+						"obuf": "^1.0.0",
+						"readable-stream": "^2.0.1",
+						"wbuf": "^1.1.0"
+					}
+				},
+				"html-entities": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+					"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+				},
+				"http-deceiver": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+					"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
+				},
+				"http-errors": {
+					"version": "1.6.3",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+					"requires": {
+						"depd": "~1.1.2",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.1.0",
+						"statuses": ">= 1.4.0 < 2"
+					}
+				},
+				"http-parser-js": {
+					"version": "0.4.12",
+					"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.12.tgz",
+					"integrity": "sha1-uc+/Sizybw/DSxDKFImid3HjR08="
+				},
+				"http-proxy": {
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+					"integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+					"requires": {
+						"eventemitter3": "^3.0.0",
+						"follow-redirects": "^1.0.0",
+						"requires-port": "^1.0.0"
+					}
+				},
+				"http-proxy-middleware": {
+					"version": "0.17.4",
+					"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+					"integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+					"requires": {
+						"http-proxy": "^1.16.2",
+						"is-glob": "^3.1.0",
+						"lodash": "^4.17.2",
+						"micromatch": "^2.3.11"
+					},
+					"dependencies": {
+						"arr-diff": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+							"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+							"requires": {
+								"arr-flatten": "^1.0.1"
+							}
+						},
+						"array-unique": {
+							"version": "0.2.1",
+							"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+							"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+						},
+						"braces": {
+							"version": "1.8.5",
+							"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+							"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+							"requires": {
+								"expand-range": "^1.8.1",
+								"preserve": "^0.2.0",
+								"repeat-element": "^1.1.2"
+							}
+						},
+						"expand-brackets": {
+							"version": "0.1.5",
+							"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+							"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+							"requires": {
+								"is-posix-bracket": "^0.1.0"
+							}
+						},
+						"extglob": {
+							"version": "0.3.2",
+							"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+							"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+							"requires": {
+								"is-extglob": "^1.0.0"
+							},
+							"dependencies": {
+								"is-extglob": {
+									"version": "1.0.0",
+									"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+									"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+								}
+							}
+						},
+						"is-glob": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+							"requires": {
+								"is-extglob": "^2.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						},
+						"micromatch": {
+							"version": "2.3.11",
+							"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+							"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+							"requires": {
+								"arr-diff": "^2.0.0",
+								"array-unique": "^0.2.1",
+								"braces": "^1.8.2",
+								"expand-brackets": "^0.1.4",
+								"extglob": "^0.3.1",
+								"filename-regex": "^2.0.0",
+								"is-extglob": "^1.0.0",
+								"is-glob": "^2.0.1",
+								"kind-of": "^3.0.2",
+								"normalize-path": "^2.0.1",
+								"object.omit": "^2.0.0",
+								"parse-glob": "^3.0.4",
+								"regex-cache": "^0.4.2"
+							},
+							"dependencies": {
+								"is-extglob": {
+									"version": "1.0.0",
+									"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+									"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+								},
+								"is-glob": {
+									"version": "2.0.1",
+									"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+									"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+									"requires": {
+										"is-extglob": "^1.0.0"
+									}
+								}
+							}
+						}
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+				},
+				"import-local": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+					"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+					"requires": {
+						"pkg-dir": "^2.0.0",
+						"resolve-cwd": "^2.0.0"
+					}
+				},
+				"indent-string": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+					"requires": {
+						"repeating": "^2.0.0"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+				},
+				"internal-ip": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
+					"integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
+					"requires": {
+						"meow": "^3.3.0"
+					}
+				},
+				"invert-kv": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+				},
+				"ip": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+					"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+				},
+				"ipaddr.js": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+					"integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-arrayish": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+					"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+				},
+				"is-binary-path": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+					"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+					"requires": {
+						"binary-extensions": "^1.0.0"
+					}
+				},
+				"is-buffer": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+				},
+				"is-builtin-module": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+					"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+					"requires": {
+						"builtin-modules": "^1.0.0"
+					}
+				},
+				"is-callable": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+					"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-date-object": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+					"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"requires": {
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"is-dotfile": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+					"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+				},
+				"is-equal-shallow": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+					"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+					"requires": {
+						"is-primitive": "^2.0.0"
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+				},
+				"is-finite": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+					"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"is-glob": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"is-odd": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+					"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+					"requires": {
+						"is-number": "^4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+							"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+						}
+					}
+				},
+				"is-path-cwd": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+					"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+				},
+				"is-path-in-cwd": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+					"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+					"requires": {
+						"is-path-inside": "^1.0.0"
+					}
+				},
+				"is-path-inside": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+					"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+					"requires": {
+						"path-is-inside": "^1.0.1"
+					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"is-posix-bracket": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+					"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+				},
+				"is-primitive": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+					"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+				},
+				"is-regex": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+					"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+					"requires": {
+						"has": "^1.0.1"
+					}
+				},
+				"is-symbol": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+					"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+				},
+				"is-utf8": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+					"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+				},
+				"is-windows": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+					"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+				},
+				"is-wsl": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"json3": {
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+					"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+				},
+				"killable": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz",
+					"integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"lcid": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+					"requires": {
+						"invert-kv": "^1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+						}
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"loglevel": {
+					"version": "1.6.1",
+					"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
+					"integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
+				},
+				"loud-rejection": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+					"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+					"requires": {
+						"currently-unhandled": "^0.4.1",
+						"signal-exit": "^3.0.0"
+					}
+				},
+				"map-cache": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+					"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+				},
+				"map-obj": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+				},
+				"map-visit": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+					"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+					"requires": {
+						"object-visit": "^1.0.0"
+					}
+				},
+				"math-random": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+					"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+				},
+				"media-typer": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+					"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+				},
+				"memory-fs": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+					"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+					"requires": {
+						"errno": "^0.1.3",
+						"readable-stream": "^2.0.1"
+					}
+				},
+				"meow": {
+					"version": "3.7.0",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+					"requires": {
+						"camelcase-keys": "^2.0.0",
+						"decamelize": "^1.1.2",
+						"loud-rejection": "^1.0.0",
+						"map-obj": "^1.0.1",
+						"minimist": "^1.1.3",
+						"normalize-package-data": "^2.3.4",
+						"object-assign": "^4.0.1",
+						"read-pkg-up": "^1.0.1",
+						"redent": "^1.0.0",
+						"trim-newlines": "^1.0.0"
+					}
+				},
+				"merge-descriptors": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+					"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+				},
+				"methods": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+					"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"mime": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+					"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+				},
+				"mime-db": {
+					"version": "1.33.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+					"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+				},
+				"mime-types": {
+					"version": "2.1.18",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+					"requires": {
+						"mime-db": "~1.33.0"
+					}
+				},
+				"minimalistic-assert": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+					"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"mixin-deep": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+					"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+					"requires": {
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"requires": {
+						"minimist": "0.0.8"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "0.0.8",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+						}
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"multicast-dns": {
+					"version": "6.2.3",
+					"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
+					"integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+					"requires": {
+						"dns-packet": "^1.3.1",
+						"thunky": "^1.0.2"
+					}
+				},
+				"multicast-dns-service-types": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+					"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+				},
+				"nan": {
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+					"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+					"optional": true
+				},
+				"nanomatch": {
+					"version": "1.2.9",
+					"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+					"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					}
+				},
+				"negotiator": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+					"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+				},
+				"node-forge": {
+					"version": "0.7.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+					"integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+					"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+					"requires": {
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
+					}
+				},
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				},
+				"object-copy": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+					"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+					"requires": {
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"object-keys": {
+					"version": "1.0.11",
+					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+					"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+				},
+				"object-visit": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+					"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+					"requires": {
+						"isobject": "^3.0.0"
+					}
+				},
+				"object.omit": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+					"requires": {
+						"for-own": "^0.1.4",
+						"is-extendable": "^0.1.1"
+					}
+				},
+				"object.pick": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+					"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"obuf": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+					"integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
+				},
+				"on-finished": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+					"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+					"requires": {
+						"ee-first": "1.1.1"
+					}
+				},
+				"on-headers": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+					"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+				},
+				"once": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"opn": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+					"integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+					"requires": {
+						"is-wsl": "^1.1.0"
+					}
+				},
+				"original": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
+					"integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
+					"requires": {
+						"url-parse": "1.0.x"
+					},
+					"dependencies": {
+						"url-parse": {
+							"version": "1.0.5",
+							"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
+							"integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
+							"requires": {
+								"querystringify": "0.0.x",
+								"requires-port": "1.0.x"
+							}
+						}
+					}
+				},
+				"os-locale": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+					"requires": {
+						"lcid": "^1.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+					"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-map": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+					"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+				},
+				"parse-glob": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+					"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+					"requires": {
+						"glob-base": "^0.3.0",
+						"is-dotfile": "^1.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.0"
+					},
+					"dependencies": {
+						"is-extglob": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+							"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+						},
+						"is-glob": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+							"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+							"requires": {
+								"is-extglob": "^1.0.0"
+							}
+						}
+					}
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"parseurl": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+					"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+				},
+				"pascalcase": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+					"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+				},
+				"path-dirname": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+				},
+				"path-is-inside": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+					"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+				},
+				"path-to-regexp": {
+					"version": "0.1.7",
+					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+					"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+						}
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+					"requires": {
+						"pinkie": "^2.0.0"
+					}
+				},
+				"pkg-dir": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+					"requires": {
+						"find-up": "^2.1.0"
+					}
+				},
+				"portfinder": {
+					"version": "1.0.13",
+					"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
+					"integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+					"requires": {
+						"async": "^1.5.2",
+						"debug": "^2.2.0",
+						"mkdirp": "0.5.x"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						}
+					}
+				},
+				"posix-character-classes": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+					"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+				},
+				"preserve": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+					"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+				},
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+				},
+				"proxy-addr": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+					"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+					"requires": {
+						"forwarded": "~0.1.2",
+						"ipaddr.js": "1.6.0"
+					}
+				},
+				"prr": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+					"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+				},
+				"qs": {
+					"version": "6.5.1",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+				},
+				"querystringify": {
+					"version": "0.0.4",
+					"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+					"integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw="
+				},
+				"randomatic": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+					"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+					"requires": {
+						"is-number": "^4.0.0",
+						"kind-of": "^6.0.0",
+						"math-random": "^1.0.1"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+							"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+						}
+					}
+				},
+				"range-parser": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+					"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+				},
+				"raw-body": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+					"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+					"requires": {
+						"bytes": "3.0.0",
+						"http-errors": "1.6.2",
+						"iconv-lite": "0.4.19",
+						"unpipe": "1.0.0"
+					},
+					"dependencies": {
+						"depd": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+							"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+						},
+						"http-errors": {
+							"version": "1.6.2",
+							"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+							"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+							"requires": {
+								"depd": "1.1.1",
+								"inherits": "2.0.3",
+								"setprototypeof": "1.0.3",
+								"statuses": ">= 1.3.1 < 2"
+							}
+						},
+						"setprototypeof": {
+							"version": "1.0.3",
+							"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+							"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+						}
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"requires": {
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"requires": {
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+							"requires": {
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
+							}
+						},
+						"path-exists": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+							"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+							"requires": {
+								"pinkie-promise": "^2.0.0"
+							}
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"readdirp": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+					"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"minimatch": "^3.0.2",
+						"readable-stream": "^2.0.2",
+						"set-immediate-shim": "^1.0.1"
+					}
+				},
+				"redent": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+					"requires": {
+						"indent-string": "^2.1.0",
+						"strip-indent": "^1.0.1"
+					}
+				},
+				"regex-cache": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+					"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+					"requires": {
+						"is-equal-shallow": "^0.1.3"
+					}
+				},
+				"regex-not": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+					"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+					"requires": {
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
+					}
+				},
+				"remove-trailing-separator": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+					"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+				},
+				"repeat-element": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+					"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+				},
+				"repeat-string": {
+					"version": "1.6.1",
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+				},
+				"repeating": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+					"requires": {
+						"is-finite": "^1.0.0"
+					}
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+				},
+				"requires-port": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+					"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+				},
+				"resolve-cwd": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+					"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+					"requires": {
+						"resolve-from": "^3.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+				},
+				"resolve-url": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+					"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+				},
+				"ret": {
+					"version": "0.1.15",
+					"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+					"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+					"requires": {
+						"glob": "^7.0.5"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				},
+				"safe-regex": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+					"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+					"requires": {
+						"ret": "~0.1.10"
+					}
+				},
+				"select-hose": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+					"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
+				},
+				"selfsigned": {
+					"version": "1.10.3",
+					"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.3.tgz",
+					"integrity": "sha512-vmZenZ+8Al3NLHkWnhBQ0x6BkML1eCP2xEi3JE+f3D9wW9fipD9NNJHYtE9XJM4TsPaHGZJIamrSI6MTg1dU2Q==",
+					"requires": {
+						"node-forge": "0.7.5"
+					}
+				},
+				"semver": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+				},
+				"send": {
+					"version": "0.16.2",
+					"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+					"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+					"requires": {
+						"debug": "2.6.9",
+						"depd": "~1.1.2",
+						"destroy": "~1.0.4",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"etag": "~1.8.1",
+						"fresh": "0.5.2",
+						"http-errors": "~1.6.2",
+						"mime": "1.4.1",
+						"ms": "2.0.0",
+						"on-finished": "~2.3.0",
+						"range-parser": "~1.2.0",
+						"statuses": "~1.4.0"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						}
+					}
+				},
+				"serve-index": {
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+					"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+					"requires": {
+						"accepts": "~1.3.4",
+						"batch": "0.6.1",
+						"debug": "2.6.9",
+						"escape-html": "~1.0.3",
+						"http-errors": "~1.6.2",
+						"mime-types": "~2.1.17",
+						"parseurl": "~1.3.2"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						}
+					}
+				},
+				"serve-static": {
+					"version": "1.13.2",
+					"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+					"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+					"requires": {
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"parseurl": "~1.3.2",
+						"send": "0.16.2"
+					}
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+				},
+				"set-immediate-shim": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+					"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+				},
+				"set-value": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+					"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"setprototypeof": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+				},
+				"snapdragon": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+					"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+					"requires": {
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"snapdragon-node": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+					"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+					"requires": {
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						}
+					}
+				},
+				"snapdragon-util": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+					"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+					"requires": {
+						"kind-of": "^3.2.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"sockjs": {
+					"version": "0.3.19",
+					"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
+					"integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
+					"requires": {
+						"faye-websocket": "^0.10.0",
+						"uuid": "^3.0.1"
+					}
+				},
+				"sockjs-client": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+					"integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+					"requires": {
+						"debug": "^2.6.6",
+						"eventsource": "0.1.6",
+						"faye-websocket": "~0.11.0",
+						"inherits": "^2.0.1",
+						"json3": "^3.3.2",
+						"url-parse": "^1.1.8"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"faye-websocket": {
+							"version": "0.11.1",
+							"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+							"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+							"requires": {
+								"websocket-driver": ">=0.5.1"
+							}
+						}
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				},
+				"source-map-resolve": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+					"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+					"requires": {
+						"atob": "^2.0.0",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
+					}
+				},
+				"source-map-url": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+					"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+				},
+				"spdx-correct": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+					"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+					"requires": {
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-exceptions": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+					"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+				},
+				"spdx-expression-parse": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+					"requires": {
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-license-ids": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+					"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+				},
+				"spdy": {
+					"version": "3.4.7",
+					"resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
+					"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+					"requires": {
+						"debug": "^2.6.8",
+						"handle-thing": "^1.2.5",
+						"http-deceiver": "^1.2.7",
+						"safe-buffer": "^5.0.1",
+						"select-hose": "^2.0.0",
+						"spdy-transport": "^2.0.18"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						}
+					}
+				},
+				"spdy-transport": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
+					"integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
+					"requires": {
+						"debug": "^2.6.8",
+						"detect-node": "^2.0.3",
+						"hpack.js": "^2.1.6",
+						"obuf": "^1.1.1",
+						"readable-stream": "^2.2.9",
+						"safe-buffer": "^5.0.1",
+						"wbuf": "^1.7.2"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							}
+						}
+					}
+				},
+				"split-string": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+					"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+					"requires": {
+						"extend-shallow": "^3.0.0"
+					}
+				},
+				"static-extend": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+					"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+					"requires": {
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"statuses": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"requires": {
+						"is-utf8": "^0.2.0"
+					}
+				},
+				"strip-indent": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+					"requires": {
+						"get-stdin": "^4.0.1"
+					}
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"thunky": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz",
+					"integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E="
+				},
+				"time-stamp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
+					"integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c="
+				},
+				"to-object-path": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+					"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"to-regex": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+					"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+					"requires": {
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
+				},
+				"trim-newlines": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+				},
+				"type-is": {
+					"version": "1.6.16",
+					"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+					"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+					"requires": {
+						"media-typer": "0.3.0",
+						"mime-types": "~2.1.18"
+					}
+				},
+				"union-value": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+					"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+					"requires": {
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"set-value": {
+							"version": "0.4.3",
+							"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+							"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+							"requires": {
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
+							}
+						}
+					}
+				},
+				"unpipe": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+					"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+				},
+				"unset-value": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+					"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+					"requires": {
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
+					},
+					"dependencies": {
+						"has-value": {
+							"version": "0.3.1",
+							"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+							"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+							"requires": {
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
+							},
+							"dependencies": {
+								"isobject": {
+									"version": "2.1.0",
+									"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+									"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+									"requires": {
+										"isarray": "1.0.0"
+									}
+								}
+							}
+						},
+						"has-values": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+							"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+						}
+					}
+				},
+				"upath": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/upath/-/upath-1.0.5.tgz",
+					"integrity": "sha512-qbKn90aDQ0YEwvXoLqj0oiuUYroLX2lVHZ+b+xwjozFasAOC4GneDq5+OaIG5Zj+jFmbz/uO+f7a9qxjktJQww=="
+				},
+				"urix": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+					"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+				},
+				"url-parse": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
+					"integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
+					"requires": {
+						"querystringify": "^2.0.0",
+						"requires-port": "^1.0.0"
+					},
+					"dependencies": {
+						"querystringify": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+							"integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
+						}
+					}
+				},
+				"use": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+					"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+					"requires": {
+						"kind-of": "^6.0.2"
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+				},
+				"utils-merge": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+					"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+				},
+				"uuid": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+					"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+					"requires": {
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
+					}
+				},
+				"vary": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+					"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+				},
+				"wbuf": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+					"integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+					"requires": {
+						"minimalistic-assert": "^1.0.0"
+					}
+				},
+				"webpack-dev-middleware": {
+					"version": "1.12.2",
+					"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
+					"integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
+					"requires": {
+						"memory-fs": "~0.4.1",
+						"mime": "^1.5.0",
+						"path-is-absolute": "^1.0.0",
+						"range-parser": "^1.0.3",
+						"time-stamp": "^2.0.0"
+					},
+					"dependencies": {
+						"mime": {
+							"version": "1.6.0",
+							"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+							"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+						}
+					}
+				},
+				"websocket-driver": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+					"integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+					"requires": {
+						"http-parser-js": ">=0.4.0",
+						"websocket-extensions": ">=0.1.1"
+					}
+				},
+				"websocket-extensions": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+					"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
+				},
+				"which-module": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+				},
+				"yargs": {
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+					"requires": {
+						"camelcase": "^3.0.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.2",
+						"which-module": "^1.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^4.2.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+							"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+						}
+					}
+				},
+				"yargs-parser": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+					"requires": {
+						"camelcase": "^3.0.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+							"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -56,7 +56,7 @@
     "@jsonforms/react": "2.0.0",
     "@jsonforms/webcomponent": "2.0.0",
     "ajv": "^4.11.2",
-    "json-refs": "^2.1.7",
+    "json-refs": "^3.0.4",
     "lodash": "^4.17.4",
     "react": "^16.2.0",
     "react-dnd": "^2.5.4",
@@ -69,10 +69,10 @@
     "@jsonforms/material-renderers": "2.0.0",
     "@jsonforms/vanilla-renderers": "2.0.0",
     "awesome-typescript-loader": "^3.1.3",
-    "copy-webpack-plugin": "^4.0.1",
+    "copy-webpack-plugin": "^4.5.1",
     "jest": "^22.4.2",
     "ncp": "^2.0.0",
-    "ts-jest": "^22.4.1",
-    "webpack-dev-server": "^2.7.1"
+    "ts-jest": "^22.4.4",
+    "webpack-dev-server": "^2.11.2"
   }
 }

--- a/packages/examples/package-lock.json
+++ b/packages/examples/package-lock.json
@@ -1,0 +1,143 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"moment": {
+			"version": "2.22.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
+			"integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
+		},
+		"react": {
+			"version": "16.3.2",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz",
+			"integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
+			"requires": {
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.0"
+			},
+			"dependencies": {
+				"asap": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+					"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+				},
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				},
+				"encoding": {
+					"version": "0.1.12",
+					"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+					"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+					"requires": {
+						"iconv-lite": "~0.4.13"
+					}
+				},
+				"fbjs": {
+					"version": "0.8.16",
+					"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+					"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+					"requires": {
+						"core-js": "^1.0.0",
+						"isomorphic-fetch": "^2.1.1",
+						"loose-envify": "^1.0.0",
+						"object-assign": "^4.1.0",
+						"promise": "^7.1.1",
+						"setimmediate": "^1.0.5",
+						"ua-parser-js": "^0.7.9"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.23",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+				},
+				"isomorphic-fetch": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+					"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+					"requires": {
+						"node-fetch": "^1.0.1",
+						"whatwg-fetch": ">=0.10.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+				},
+				"loose-envify": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+					"requires": {
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"node-fetch": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+					"requires": {
+						"encoding": "^0.1.11",
+						"is-stream": "^1.0.1"
+					}
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				},
+				"promise": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+					"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+					"requires": {
+						"asap": "~2.0.3"
+					}
+				},
+				"prop-types": {
+					"version": "15.6.1",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+					"requires": {
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
+					}
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+				},
+				"setimmediate": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+					"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+				},
+				"ua-parser-js": {
+					"version": "0.7.18",
+					"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+					"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+				},
+				"whatwg-fetch": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+					"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+				}
+			}
+		}
+	}
+}

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -29,8 +29,8 @@
     "@jsonforms/core": "^2.0.0",
     "@jsonforms/react": "^2.0.0",
     "@jsonforms/webcomponent": "^2.0.0",
-    "moment": "^2.22.1",
-    "react": "^16.3.2",
+    "moment": "^2.20.1",
+    "react": "^16.2.0",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2"
   }

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -23,6 +23,7 @@
   THE SOFTWARE.
 */
 import * as array from './arrays';
+import * as stringArray from './stringArray';
 import * as categorization from './categorization';
 import * as day1 from './day1';
 import * as day2 from './day2';
@@ -45,6 +46,7 @@ import * as text from './text';
 import * as numbers from './numbers';
 
 export {
+  stringArray,
   array,
   categorization,
   day1,

--- a/packages/examples/src/stringArray.ts
+++ b/packages/examples/src/stringArray.ts
@@ -1,0 +1,39 @@
+import { registerExamples } from './register';
+
+export const schema = {
+  type: 'object',
+  properties: {
+    comments:
+      {
+        type: 'array',
+        items: {
+          type: 'string',
+          maxLength: 5
+        }
+      }
+  }
+};
+
+export const uischema = {
+  type: 'VerticalLayout',
+  elements: [
+    {
+      type: 'Control',
+      scope: '#/properties/comments'
+    }
+  ]
+};
+
+export const data = {
+  comments: ['one string', 'two strings']
+};
+
+registerExamples([
+  {
+    name: 'stringArray',
+    label: 'Array of Strings',
+    data,
+    schema,
+    uiSchema: uischema
+  },
+]);

--- a/packages/i18n/package-lock.json
+++ b/packages/i18n/package-lock.json
@@ -1,0 +1,702 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"jsdom": {
+			"version": "11.10.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.10.0.tgz",
+			"integrity": "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
+			"requires": {
+				"abab": "^1.0.4",
+				"acorn": "^5.3.0",
+				"acorn-globals": "^4.1.0",
+				"array-equal": "^1.0.0",
+				"cssom": ">= 0.3.2 < 0.4.0",
+				"cssstyle": ">= 0.2.37 < 0.3.0",
+				"data-urls": "^1.0.0",
+				"domexception": "^1.0.0",
+				"escodegen": "^1.9.0",
+				"html-encoding-sniffer": "^1.0.2",
+				"left-pad": "^1.2.0",
+				"nwmatcher": "^1.4.3",
+				"parse5": "4.0.0",
+				"pn": "^1.1.0",
+				"request": "^2.83.0",
+				"request-promise-native": "^1.0.5",
+				"sax": "^1.2.4",
+				"symbol-tree": "^3.2.2",
+				"tough-cookie": "^2.3.3",
+				"w3c-hr-time": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"whatwg-encoding": "^1.0.3",
+				"whatwg-mimetype": "^2.1.0",
+				"whatwg-url": "^6.4.0",
+				"ws": "^4.0.0",
+				"xml-name-validator": "^3.0.0"
+			},
+			"dependencies": {
+				"abab": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+					"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+				},
+				"acorn": {
+					"version": "5.5.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+					"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
+				},
+				"acorn-globals": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+					"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+					"requires": {
+						"acorn": "^5.0.0"
+					}
+				},
+				"ajv": {
+					"version": "5.5.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+					"requires": {
+						"co": "^4.6.0",
+						"fast-deep-equal": "^1.0.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.3.0"
+					}
+				},
+				"array-equal": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+					"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+				},
+				"asn1": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+					"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+				},
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				},
+				"async-limiter": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+					"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+				},
+				"aws-sign2": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+					"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+				},
+				"aws4": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+					"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+					"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+					"optional": true,
+					"requires": {
+						"tweetnacl": "^0.14.3"
+					}
+				},
+				"boom": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+					"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+					"requires": {
+						"hoek": "4.x.x"
+					}
+				},
+				"browser-process-hrtime": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+					"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+				},
+				"co": {
+					"version": "4.6.0",
+					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+				},
+				"combined-stream": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+					"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+					"requires": {
+						"delayed-stream": "~1.0.0"
+					}
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+				},
+				"cryptiles": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+					"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+					"requires": {
+						"boom": "5.x.x"
+					},
+					"dependencies": {
+						"boom": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+							"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+							"requires": {
+								"hoek": "4.x.x"
+							}
+						}
+					}
+				},
+				"cssom": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+					"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+				},
+				"cssstyle": {
+					"version": "0.2.37",
+					"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+					"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+					"requires": {
+						"cssom": "0.3.x"
+					}
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+					"requires": {
+						"assert-plus": "^1.0.0"
+					}
+				},
+				"data-urls": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
+					"integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+					"requires": {
+						"abab": "^1.0.4",
+						"whatwg-mimetype": "^2.0.0",
+						"whatwg-url": "^6.4.0"
+					}
+				},
+				"deep-is": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+					"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+				},
+				"domexception": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+					"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+					"requires": {
+						"webidl-conversions": "^4.0.2"
+					}
+				},
+				"ecc-jsbn": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+					"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+					"optional": true,
+					"requires": {
+						"jsbn": "~0.1.0"
+					}
+				},
+				"escodegen": {
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+					"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+					"requires": {
+						"esprima": "^3.1.3",
+						"estraverse": "^4.2.0",
+						"esutils": "^2.0.2",
+						"optionator": "^0.8.1",
+						"source-map": "~0.6.1"
+					}
+				},
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+				},
+				"estraverse": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+					"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+					"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+				},
+				"extend": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+					"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+				},
+				"extsprintf": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+					"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+				},
+				"fast-deep-equal": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+				},
+				"fast-json-stable-stringify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+					"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+				},
+				"fast-levenshtein": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+					"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+				},
+				"form-data": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+					"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "1.0.6",
+						"mime-types": "^2.1.12"
+					}
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+					"requires": {
+						"assert-plus": "^1.0.0"
+					}
+				},
+				"har-schema": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+					"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+				},
+				"har-validator": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+					"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+					"requires": {
+						"ajv": "^5.1.0",
+						"har-schema": "^2.0.0"
+					}
+				},
+				"hawk": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+					"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+					"requires": {
+						"boom": "4.x.x",
+						"cryptiles": "3.x.x",
+						"hoek": "4.x.x",
+						"sntp": "2.x.x"
+					}
+				},
+				"hoek": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+					"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+				},
+				"html-encoding-sniffer": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+					"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+					"requires": {
+						"whatwg-encoding": "^1.0.1"
+					}
+				},
+				"http-signature": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+					"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+					"requires": {
+						"assert-plus": "^1.0.0",
+						"jsprim": "^1.2.2",
+						"sshpk": "^1.7.0"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+					"optional": true
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+				},
+				"json-schema-traverse": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+					"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+				},
+				"jsprim": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+					"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.3.0",
+						"json-schema": "0.2.3",
+						"verror": "1.10.0"
+					}
+				},
+				"left-pad": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+					"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+				},
+				"levn": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+					"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+					"requires": {
+						"prelude-ls": "~1.1.2",
+						"type-check": "~0.3.2"
+					}
+				},
+				"lodash": {
+					"version": "4.17.10",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+				},
+				"lodash.sortby": {
+					"version": "4.7.0",
+					"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+					"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+				},
+				"mime-db": {
+					"version": "1.33.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+					"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+				},
+				"mime-types": {
+					"version": "2.1.18",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+					"requires": {
+						"mime-db": "~1.33.0"
+					}
+				},
+				"nwmatcher": {
+					"version": "1.4.4",
+					"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+					"integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
+				},
+				"oauth-sign": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+				},
+				"optionator": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+					"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+					"requires": {
+						"deep-is": "~0.1.3",
+						"fast-levenshtein": "~2.0.4",
+						"levn": "~0.3.0",
+						"prelude-ls": "~1.1.2",
+						"type-check": "~0.3.2",
+						"wordwrap": "~1.0.0"
+					}
+				},
+				"parse5": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+				},
+				"performance-now": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+					"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+				},
+				"pn": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+					"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+				},
+				"prelude-ls": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+					"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+				},
+				"punycode": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+				},
+				"qs": {
+					"version": "6.5.2",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+				},
+				"request": {
+					"version": "2.85.0",
+					"resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+					"integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+					"requires": {
+						"aws-sign2": "~0.7.0",
+						"aws4": "^1.6.0",
+						"caseless": "~0.12.0",
+						"combined-stream": "~1.0.5",
+						"extend": "~3.0.1",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.3.1",
+						"har-validator": "~5.0.3",
+						"hawk": "~6.0.2",
+						"http-signature": "~1.2.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.17",
+						"oauth-sign": "~0.8.2",
+						"performance-now": "^2.1.0",
+						"qs": "~6.5.1",
+						"safe-buffer": "^5.1.1",
+						"stringstream": "~0.0.5",
+						"tough-cookie": "~2.3.3",
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.1.0"
+					}
+				},
+				"request-promise-core": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+					"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+					"requires": {
+						"lodash": "^4.13.1"
+					}
+				},
+				"request-promise-native": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+					"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+					"requires": {
+						"request-promise-core": "1.1.1",
+						"stealthy-require": "^1.1.0",
+						"tough-cookie": ">=2.3.3"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				},
+				"sax": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+				},
+				"sntp": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+					"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+					"requires": {
+						"hoek": "4.x.x"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"optional": true
+				},
+				"sshpk": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+					"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+					"requires": {
+						"asn1": "~0.2.3",
+						"assert-plus": "^1.0.0",
+						"bcrypt-pbkdf": "^1.0.0",
+						"dashdash": "^1.12.0",
+						"ecc-jsbn": "~0.1.1",
+						"getpass": "^0.1.1",
+						"jsbn": "~0.1.0",
+						"tweetnacl": "~0.14.0"
+					}
+				},
+				"stealthy-require": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+					"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+				},
+				"stringstream": {
+					"version": "0.0.5",
+					"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+					"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+				},
+				"symbol-tree": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+					"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+				},
+				"tough-cookie": {
+					"version": "2.3.4",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+					"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+					"requires": {
+						"punycode": "^1.4.1"
+					},
+					"dependencies": {
+						"punycode": {
+							"version": "1.4.1",
+							"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+							"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+						}
+					}
+				},
+				"tr46": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+					"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+					"requires": {
+						"punycode": "^2.1.0"
+					}
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+					"requires": {
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+					"optional": true
+				},
+				"type-check": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+					"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+					"requires": {
+						"prelude-ls": "~1.1.2"
+					}
+				},
+				"uuid": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+				},
+				"verror": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+					"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+					"requires": {
+						"assert-plus": "^1.0.0",
+						"core-util-is": "1.0.2",
+						"extsprintf": "^1.2.0"
+					}
+				},
+				"w3c-hr-time": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+					"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+					"requires": {
+						"browser-process-hrtime": "^0.1.2"
+					}
+				},
+				"webidl-conversions": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+					"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+				},
+				"whatwg-encoding": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+					"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+					"requires": {
+						"iconv-lite": "0.4.19"
+					}
+				},
+				"whatwg-mimetype": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
+					"integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew=="
+				},
+				"whatwg-url": {
+					"version": "6.4.1",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
+					"integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				},
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+				},
+				"ws": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+					"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+					"requires": {
+						"async-limiter": "~1.0.0",
+						"safe-buffer": "~5.1.0"
+					}
+				},
+				"xml-name-validator": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+					"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+				}
+			}
+		}
+	}
+}

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@jsonforms/core": "^2.0.0",
     "es6-shim": "^0.35.3",
-    "json-refs": "^2.1.6",
+    "json-refs": "^3.0.4",
     "moment": "^2.20.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
@@ -51,7 +51,7 @@
     "@jsonforms/vanilla-renderers": "^2.0.0",
     "@jsonforms/webcomponent": "^2.0.0",
     "document-register-element": "^1.7.0",
-    "jsdom": "^11.5.1",
+    "jsdom": "^11.9.0",
     "jsdom-global": "^3.0.2"
   }
 }

--- a/packages/material/package-lock.json
+++ b/packages/material/package-lock.json
@@ -89,39 +89,6 @@
 				"arrify": "1.0.1"
 			}
 		},
-		"@material-ui/icons": {
-			"version": "1.0.0-beta.43",
-			"resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-1.0.0-beta.43.tgz",
-			"integrity": "sha512-t6Fhq7t6LuZsFH1TtbjcVJiqmdc/vgk1X9pdannBHuWN9tuIaPBkEBhb/YRRn6VpNJIww92uIuyw0xHyaKcsHg==",
-			"requires": {
-				"recompose": "0.26.0"
-			}
-		},
-		"@types/jss": {
-			"version": "9.5.2",
-			"resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.5.2.tgz",
-			"integrity": "sha512-EX87yNYcisXO5BU9tT7stB7OGuDJyV3JwtMwhfUprrmHwYKWh9a3vchAy6DYzUSbmTA7bD46h8qata5jP1V7Zw==",
-			"requires": {
-				"csstype": "2.4.2",
-				"indefinite-observable": "1.0.1"
-			}
-		},
-		"@types/react": {
-			"version": "16.3.13",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.13.tgz",
-			"integrity": "sha512-YMFH/E9ryjUm2AoOy8KdTuG1SufaMuYmO/5xACROl0pm9dRmE2RN3d2zjv/eHALF6LGRZPVb7G9kqP0n5dWttQ==",
-			"requires": {
-				"csstype": "2.4.2"
-			}
-		},
-		"@types/react-transition-group": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.0.9.tgz",
-			"integrity": "sha512-Id2MtQcmOgLymqqLqg1VjzNpN7O5vGoF47h3s7jxhzqWdMCtk2GwxFUqcKbGrRmHzzQGyRatfG8yahonIys74Q==",
-			"requires": {
-				"@types/react": "16.3.13"
-			}
-		},
 		"abab": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -375,9 +342,9 @@
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"atob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-			"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+			"integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw=="
 		},
 		"auto-bind": {
 			"version": "1.2.0",
@@ -730,6 +697,13 @@
 				"espower-location-detector": "1.0.0",
 				"espurify": "1.7.0",
 				"estraverse": "4.2.0"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.5.5",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+					"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+				}
 			}
 		},
 		"babel-plugin-istanbul": {
@@ -890,6 +864,11 @@
 				"source-map-support": "0.4.18"
 			},
 			"dependencies": {
+				"core-js": {
+					"version": "2.5.5",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+					"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+				},
 				"source-map-support": {
 					"version": "0.4.18",
 					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
@@ -907,6 +886,13 @@
 			"requires": {
 				"core-js": "2.5.5",
 				"regenerator-runtime": "0.11.1"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.5.5",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+					"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+				}
 			}
 		},
 		"babel-template": {
@@ -1086,6 +1072,11 @@
 					"requires": {
 						"ms": "2.0.0"
 					}
+				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
 				},
 				"ms": {
 					"version": "2.0.0",
@@ -1288,6 +1279,13 @@
 				"deep-equal": "1.0.1",
 				"espurify": "1.7.0",
 				"estraverse": "4.2.0"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.5.5",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+					"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+				}
 			}
 		},
 		"call-signature": {
@@ -1738,9 +1736,9 @@
 			}
 		},
 		"core-js": {
-			"version": "2.5.5",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-			"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -1827,11 +1825,6 @@
 				"cssom": "0.3.2"
 			}
 		},
-		"csstype": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.4.2.tgz",
-			"integrity": "sha512-1TnkyZwDy0oUl//6685j2bTMNe61SzntWntijNdmmEzvpYbGmVMZkj204gv4glcQp6z/ypg+YRziT91XVFmOyg=="
-		},
 		"currently-unhandled": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -1844,6 +1837,14 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
 			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
+		},
+		"d": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+			"requires": {
+				"es5-ext": "0.10.42"
+			}
 		},
 		"dashdash": {
 			"version": "1.14.1",
@@ -2175,6 +2176,13 @@
 			"requires": {
 				"call-signature": "0.0.2",
 				"core-js": "2.5.5"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.5.5",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+					"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+				}
 			}
 		},
 		"encodeurl": {
@@ -2187,7 +2195,7 @@
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 			"requires": {
-				"iconv-lite": "0.4.19"
+				"iconv-lite": "0.4.21"
 			}
 		},
 		"end-of-stream": {
@@ -2252,10 +2260,39 @@
 				"is-symbol": "1.0.1"
 			}
 		},
+		"es5-ext": {
+			"version": "0.10.42",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+			"integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
+			"requires": {
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1",
+				"next-tick": "1.0.0"
+			}
+		},
 		"es6-error": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
 			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+		},
+		"es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.42",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"es6-symbol": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.42"
+			}
 		},
 		"escape-html": {
 			"version": "1.0.3",
@@ -2314,6 +2351,13 @@
 			"integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
 			"requires": {
 				"core-js": "2.5.5"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.5.5",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+					"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+				}
 			}
 		},
 		"estraverse": {
@@ -2547,13 +2591,6 @@
 				"promise": "7.3.1",
 				"setimmediate": "1.0.5",
 				"ua-parser-js": "0.7.17"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-				}
 			}
 		},
 		"figures": {
@@ -2762,25 +2799,21 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+					"bundled": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"bundled": true
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+					"bundled": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"delegates": "1.0.0",
@@ -2789,13 +2822,11 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+					"bundled": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"bundled": true,
 					"requires": {
 						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
@@ -2803,35 +2834,29 @@
 				},
 				"chownr": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-					"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+					"bundled": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+					"bundled": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+					"bundled": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+					"bundled": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+					"bundled": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -2839,26 +2864,22 @@
 				},
 				"deep-extend": {
 					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+					"bundled": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+					"bundled": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+					"bundled": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-					"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"minipass": "2.2.4"
@@ -2866,14 +2887,12 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+					"bundled": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"aproba": "1.2.0",
@@ -2888,8 +2907,7 @@
 				},
 				"glob": {
 					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
@@ -2902,14 +2920,12 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+					"bundled": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.21",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-					"integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"safer-buffer": "2.1.2"
@@ -2917,8 +2933,7 @@
 				},
 				"ignore-walk": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-					"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"minimatch": "3.0.4"
@@ -2926,8 +2941,7 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"once": "1.4.0",
@@ -2936,46 +2950,39 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+					"bundled": true
 				},
 				"ini": {
 					"version": "1.3.5",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+					"bundled": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"bundled": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"bundled": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"bundled": true,
 					"requires": {
 						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+					"bundled": true
 				},
 				"minipass": {
 					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-					"integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+					"bundled": true,
 					"requires": {
 						"safe-buffer": "5.1.1",
 						"yallist": "3.0.2"
@@ -2983,8 +2990,7 @@
 				},
 				"minizlib": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-					"integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"minipass": "2.2.4"
@@ -2992,22 +2998,19 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"bundled": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"bundled": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
-					"integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"debug": "2.6.9",
@@ -3017,8 +3020,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.9.1",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz",
-					"integrity": "sha1-8RwHUW3ZL4cZnbx+GDjqt81WyeA=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "1.0.3",
@@ -3035,8 +3037,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1.1.1",
@@ -3045,14 +3046,12 @@
 				},
 				"npm-bundled": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-					"integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+					"bundled": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.1.10",
-					"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
-					"integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"ignore-walk": "3.0.1",
@@ -3061,8 +3060,7 @@
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "1.1.4",
@@ -3073,39 +3071,33 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+					"bundled": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"bundled": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+					"bundled": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+					"bundled": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "1.0.2",
@@ -3114,20 +3106,17 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+					"bundled": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+					"bundled": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.6",
-					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
-					"integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "0.4.2",
@@ -3138,16 +3127,14 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+							"bundled": true,
 							"optional": true
 						}
 					}
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"core-util-is": "1.0.2",
@@ -3161,8 +3148,7 @@
 				},
 				"rimraf": {
 					"version": "2.6.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"glob": "7.1.2"
@@ -3170,43 +3156,36 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+					"bundled": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+					"bundled": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
-					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+					"bundled": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+					"bundled": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+					"bundled": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+					"bundled": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"bundled": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -3215,8 +3194,7 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "5.1.1"
@@ -3224,22 +3202,19 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"bundled": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"bundled": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.1",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
-					"integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"chownr": "1.0.1",
@@ -3253,14 +3228,12 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+					"bundled": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"string-width": "1.0.2"
@@ -3268,13 +3241,11 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+					"bundled": true
 				},
 				"yallist": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+					"bundled": true
 				}
 			}
 		},
@@ -3719,9 +3690,12 @@
 			"integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
 		},
 		"iconv-lite": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+			"version": "0.4.21",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+			"integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+			"requires": {
+				"safer-buffer": "2.1.2"
+			}
 		},
 		"iferr": {
 			"version": "0.1.5",
@@ -3756,21 +3730,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-		},
-		"indefinite-observable": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-1.0.1.tgz",
-			"integrity": "sha1-CZFUI8yNb36xy3iCrRNGM8mm7cM=",
-			"requires": {
-				"symbol-observable": "1.0.4"
-			},
-			"dependencies": {
-				"symbol-observable": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-					"integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
-				}
-			}
 		},
 		"indent-string": {
 			"version": "3.2.0",
@@ -5071,12 +5030,10 @@
 			}
 		},
 		"material-ui": {
-			"version": "1.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.44.tgz",
-			"integrity": "sha512-m5SJxvDz77bVKcjyZG/AyG6RBR+UUwkPgvHHLJa2jyAHBNtJMCQ5GVouTXOxaUKlvD5cbO/mcH0YtzugyQTAVg==",
+			"version": "1.0.0-beta.25",
+			"resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.25.tgz",
+			"integrity": "sha512-c31uPg4h9VP1Udn//wSqSRwrWryCT9kaUlOdpVvHCL0i5dNqD1eU9dYQNUihwO3P//DXEzOYwmbEHFR8ZeYjbw==",
 			"requires": {
-				"@types/jss": "9.5.2",
-				"@types/react-transition-group": "2.0.9",
 				"babel-runtime": "6.26.0",
 				"brcast": "3.0.1",
 				"classnames": "2.2.5",
@@ -5084,20 +5041,14 @@
 				"dom-helpers": "3.3.1",
 				"hoist-non-react-statics": "2.5.0",
 				"jss": "9.8.1",
-				"jss-camel-case": "6.1.0",
-				"jss-default-unit": "8.0.2",
-				"jss-global": "3.0.0",
-				"jss-nested": "6.0.1",
-				"jss-props-sort": "6.0.0",
-				"jss-vendor-prefixer": "7.0.0",
+				"jss-preset-default": "4.3.0",
 				"keycode": "2.2.0",
 				"lodash": "4.17.10",
 				"normalize-scroll-left": "0.1.2",
 				"prop-types": "15.6.1",
 				"react-event-listener": "0.5.3",
 				"react-jss": "8.4.0",
-				"react-lifecycles-compat": "2.0.2",
-				"react-popper": "0.10.4",
+				"react-popper": "0.7.5",
 				"react-scrollbar-size": "2.1.0",
 				"react-transition-group": "2.3.1",
 				"recompose": "0.26.0",
@@ -5105,12 +5056,20 @@
 				"warning": "3.0.0"
 			}
 		},
-		"material-ui-pickers": {
-			"version": "1.0.0-rc.7",
-			"resolved": "https://registry.npmjs.org/material-ui-pickers/-/material-ui-pickers-1.0.0-rc.7.tgz",
-			"integrity": "sha512-DVEkymZM+yKdE0088Ny1T+Ylr9tlcMHhOdeAMN0afXEq8xHnawxma3TYa304mWMt1dVzBQY5543FVLlo3aXZ+w==",
+		"material-ui-icons": {
+			"version": "1.0.0-beta.36",
+			"resolved": "https://registry.npmjs.org/material-ui-icons/-/material-ui-icons-1.0.0-beta.36.tgz",
+			"integrity": "sha512-7rS6b2EV5QXCB/gTi/Ac9Wbxd+h9EZv1Td3rLLJe4IER8mVHRgdqZccB3EsjW2DrJ7opdY1+8X3/vyrS7CQNpg==",
 			"requires": {
-				"babel-runtime": "6.26.0",
+				"recompose": "0.26.0"
+			}
+		},
+		"material-ui-pickers": {
+			"version": "1.0.0-beta.12",
+			"resolved": "https://registry.npmjs.org/material-ui-pickers/-/material-ui-pickers-1.0.0-beta.12.tgz",
+			"integrity": "sha512-eNRy183HRJ7xahxCv+eOhDG5uRAGxMjQxK15zkG8ZtgNmDQhJS8MlZ/ZJPljDelypozKxRJUIq1DRVwO5ux+FA==",
+			"requires": {
+				"moment-range": "3.1.1",
 				"react-text-mask": "5.4.0"
 			}
 		},
@@ -5393,6 +5352,14 @@
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
 			"integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
 		},
+		"moment-range": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/moment-range/-/moment-range-3.1.1.tgz",
+			"integrity": "sha1-XFLPn6sp253ZvNhtN+UrBKenJxo=",
+			"requires": {
+				"es6-symbol": "3.1.1"
+			}
+		},
 		"move-concurrently": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -5487,6 +5454,11 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
 			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+		},
+		"next-tick": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
 		},
 		"node-fetch": {
 			"version": "1.7.3",
@@ -6257,6 +6229,11 @@
 						"statuses": "1.4.0"
 					}
 				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+				},
 				"setprototypeof": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
@@ -6327,15 +6304,10 @@
 				"theming": "1.3.0"
 			}
 		},
-		"react-lifecycles-compat": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-2.0.2.tgz",
-			"integrity": "sha512-BPksUj7VMAAFhcCw79sZA0Ow/LTAEjs3Sio1AQcuwLeOP+ua0f/08Su2wyiW+JjDDH6fRqNy3h5CLXh21u1mVg=="
-		},
 		"react-popper": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.10.4.tgz",
-			"integrity": "sha1-rypBXqIike3VBGeNev2opu4ylao=",
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.7.5.tgz",
+			"integrity": "sha512-ya9dhhGCf74JTOB2uyksEHhIGw7w9tNZRUJF73lEq2h4H5JT6MBa4PdT4G+sx6fZwq+xKZAL/sVNAIuojPn7Dg==",
 			"requires": {
 				"popper.js": "1.14.3",
 				"prop-types": "15.6.1"
@@ -6723,6 +6695,11 @@
 			"requires": {
 				"ret": "0.1.15"
 			}
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sane": {
 			"version": "2.5.0",
@@ -7437,7 +7414,7 @@
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
 			"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
 			"requires": {
-				"atob": "2.1.1",
+				"atob": "2.1.0",
 				"decode-uri-component": "0.2.0",
 				"resolve-url": "0.2.1",
 				"source-map-url": "0.4.0",
@@ -8868,9 +8845,9 @@
 			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
 		},
 		"upath": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-1.0.5.tgz",
-			"integrity": "sha512-qbKn90aDQ0YEwvXoLqj0oiuUYroLX2lVHZ+b+xwjozFasAOC4GneDq5+OaIG5Zj+jFmbz/uO+f7a9qxjktJQww=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
+			"integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw=="
 		},
 		"update-notifier": {
 			"version": "2.5.0",
@@ -9154,7 +9131,7 @@
 						"normalize-path": "2.1.1",
 						"path-is-absolute": "1.0.1",
 						"readdirp": "2.1.0",
-						"upath": "1.0.5"
+						"upath": "1.0.4"
 					}
 				},
 				"cliui": {
@@ -9610,6 +9587,13 @@
 			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
 			"requires": {
 				"iconv-lite": "0.4.19"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+				}
 			}
 		},
 		"whatwg-fetch": {

--- a/packages/material/package.json
+++ b/packages/material/package.json
@@ -58,7 +58,7 @@
     "@jsonforms/core": "^2.0.0",
     "@jsonforms/react": "^2.0.0",
     "@material-ui/icons": "^1.0.0-beta.43",
-    "material-ui": "^1.0.0-beta.43",
+    "material-ui": "1.0.0-beta.45",
     "material-ui-pickers": "^1.0.0-rc.6",
     "moment": "^2.20.1",
     "react": "^16.2.0",
@@ -68,7 +68,7 @@
     "@jsonforms/test": "^2.0.0",
     "@jsonforms/webcomponent": "^2.0.0",
     "ava": "^0.24.0",
-    "copy-webpack-plugin": "^4.2.3",
+    "copy-webpack-plugin": "^4.5.1",
     "document-register-element": "^1.7.0",
     "jest": "^22.4.2",
     "jsdom": "^11.9.0",
@@ -80,6 +80,6 @@
     "ts-jest": "^22.4.4",
     "ts-loader": "^3.2.0",
     "tslint-loader": "^3.5.3",
-    "webpack-dev-server": "^2.9.5"
+    "webpack-dev-server": "^2.11.2"
   }
 }

--- a/packages/material/src/complex/MaterialArrayControlRenderer.tsx
+++ b/packages/material/src/complex/MaterialArrayControlRenderer.tsx
@@ -53,25 +53,22 @@ export class MaterialArrayControlRenderer extends RendererComponent<TableControl
   render() {
     const { visible } = this.props;
     const numSelected = this.state.selected ? _.filter(this.state.selected, v => v).length : 0;
+
     const tableProps = {
       selectAll: this.selectAll,
       select: this.select,
       isSelected: this.isSelected,
       numSelected,
+      openConfirmDeleteDialog: this.openConfirmDeleteDialog,
       ...this.props
     };
 
-    const toolbarProps = {
-      openConfirmDeleteDialog: this.openConfirmDeleteDialog,
-      numSelected,
-      ...this.props
-    };
     const selectedCount = _.filter(this.state.selected, v => v).length;
 
     return (
       <Grid container direction='column' hidden={{ xsUp: !visible }} spacing={0}>
-        <Grid item>
-          <TableToolbar {...toolbarProps}/>
+        <Grid item hidden={{ xsUp: this.props.scopedSchema.type !== 'object' }}>
+          <TableToolbar {...tableProps} />
         </Grid>
         <Grid item>
           <MaterialTableControl {...tableProps}/>

--- a/packages/material/src/complex/index.ts
+++ b/packages/material/src/complex/index.ts
@@ -23,11 +23,16 @@
   THE SOFTWARE.
 */
 import {
-  isArrayObjectControl,
+  isObjectArrayControl,
+  isPrimitiveArrayControl,
+  or,
   RankedTester,
   rankWith,
 } from '@jsonforms/core';
 import MaterialArrayControlRenderer from './MaterialArrayControlRenderer';
 
-export const materialArrayControlTester: RankedTester = rankWith(3, isArrayObjectControl);
+export const materialArrayControlTester: RankedTester = rankWith(
+  3,
+  or(isObjectArrayControl, isPrimitiveArrayControl)
+);
 export { MaterialArrayControlRenderer };

--- a/packages/material/test/renderers/MaterialArrayControl.test.tsx
+++ b/packages/material/test/renderers/MaterialArrayControl.test.tsx
@@ -93,6 +93,36 @@ describe('Material array control', () => {
     expect(rows.length).toBe(3);
   });
 
+  it('should render primitives', () => {
+    const store = initJsonFormsStore();
+    // re-init
+    const data = { test: ["foo", "bar"] };
+    const schema = {
+      type: 'object',
+      properties: {
+        test: {
+          type: 'array',
+          items: { type: 'string' }
+        }
+      }
+    };
+    const uischema = {
+      type: 'Control',
+      scope: '#/properties/test'
+    };
+    store.dispatch(Actions.init(data, schema, uischema));
+
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialArrayControlRenderer schema={schema} uischema={uischema}/>
+      </Provider>
+    );
+
+    const rows = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'tr');
+    // header + 2 data entries
+    expect(rows.length).toBe(3);
+  });
+
   it('should delete an item', () => {
     const store = initJsonFormsStore();
     const tree = TestUtils.renderIntoDocument(
@@ -137,6 +167,7 @@ describe('Material array control', () => {
     // select all
     TestUtils.Simulate.change(cboxes[0], {'target': {'checked': true}});
 
+    expect(cboxes.length).toBe(5);
     expect(_.filter(cboxes, cbox => cbox.checked).length).toBe(4);
     TestUtils.Simulate.change(currentlyChecked, {'target': {'checked': false}});
     // keep select all state

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@jsonforms/core": "^2.0.0",
-    "lodash": "4.17.4",
+    "lodash": "^4.17.4",
     "react": "^16.2.0",
     "react-redux": "^5.0.6"
   },

--- a/packages/vanilla/package-lock.json
+++ b/packages/vanilla/package-lock.json
@@ -1,0 +1,270 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"react": {
+			"version": "16.3.2",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz",
+			"integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
+			"requires": {
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.0"
+			},
+			"dependencies": {
+				"asap": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+					"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+				},
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				},
+				"encoding": {
+					"version": "0.1.12",
+					"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+					"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+					"requires": {
+						"iconv-lite": "~0.4.13"
+					}
+				},
+				"fbjs": {
+					"version": "0.8.16",
+					"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+					"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+					"requires": {
+						"core-js": "^1.0.0",
+						"isomorphic-fetch": "^2.1.1",
+						"loose-envify": "^1.0.0",
+						"object-assign": "^4.1.0",
+						"promise": "^7.1.1",
+						"setimmediate": "^1.0.5",
+						"ua-parser-js": "^0.7.9"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.23",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+				},
+				"isomorphic-fetch": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+					"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+					"requires": {
+						"node-fetch": "^1.0.1",
+						"whatwg-fetch": ">=0.10.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+				},
+				"loose-envify": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+					"requires": {
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"node-fetch": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+					"requires": {
+						"encoding": "^0.1.11",
+						"is-stream": "^1.0.1"
+					}
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				},
+				"promise": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+					"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+					"requires": {
+						"asap": "~2.0.3"
+					}
+				},
+				"prop-types": {
+					"version": "15.6.1",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+					"requires": {
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
+					}
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+				},
+				"setimmediate": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+					"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+				},
+				"ua-parser-js": {
+					"version": "0.7.18",
+					"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+					"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+				},
+				"whatwg-fetch": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+					"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+				}
+			}
+		},
+		"react-dom": {
+			"version": "16.3.2",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
+			"integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
+			"requires": {
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.0"
+			},
+			"dependencies": {
+				"asap": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+					"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+				},
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				},
+				"encoding": {
+					"version": "0.1.12",
+					"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+					"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+					"requires": {
+						"iconv-lite": "~0.4.13"
+					}
+				},
+				"fbjs": {
+					"version": "0.8.16",
+					"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+					"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+					"requires": {
+						"core-js": "^1.0.0",
+						"isomorphic-fetch": "^2.1.1",
+						"loose-envify": "^1.0.0",
+						"object-assign": "^4.1.0",
+						"promise": "^7.1.1",
+						"setimmediate": "^1.0.5",
+						"ua-parser-js": "^0.7.9"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.23",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+				},
+				"isomorphic-fetch": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+					"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+					"requires": {
+						"node-fetch": "^1.0.1",
+						"whatwg-fetch": ">=0.10.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+				},
+				"loose-envify": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+					"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+					"requires": {
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"node-fetch": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+					"requires": {
+						"encoding": "^0.1.11",
+						"is-stream": "^1.0.1"
+					}
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+				},
+				"promise": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+					"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+					"requires": {
+						"asap": "~2.0.3"
+					}
+				},
+				"prop-types": {
+					"version": "15.6.1",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+					"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+					"requires": {
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.3.1",
+						"object-assign": "^4.1.1"
+					}
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+				},
+				"setimmediate": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+					"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+				},
+				"ua-parser-js": {
+					"version": "0.7.18",
+					"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+					"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+				},
+				"whatwg-fetch": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+					"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+				}
+			}
+		}
+	}
+}

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -18,23 +18,23 @@
   "dependencies": {
     "@jsonforms/core": "^2.0.0",
     "@jsonforms/react": "^2.0.0",
-    "react": "^16.3.2",
+    "react": "^16.2.0",
     "redux": "^3.7.2"
   },
   "devDependencies": {
     "@jsonforms/test": "^2.0.0",
     "@jsonforms/webcomponent": "^2.0.0",
     "ava": "^0.24.0",
-    "copy-webpack-plugin": "^4.2.3",
+    "copy-webpack-plugin": "^4.5.1",
     "document-register-element": "^1.7.0",
     "jsdom": "^11.9.0",
     "jsdom-global": "^3.0.2",
-    "react-dom": "^16.3.2",
+    "react-dom": "^16.2.0",
     "react-redux": "^5.0.6",
     "source-map-loader": "^0.2.3",
     "ts-loader": "^3.2.0",
     "tslint-loader": "^3.5.3",
-    "webpack-dev-server": "^2.9.5"
+    "webpack-dev-server": "^2.11.2"
   },
   "ava": {
     "verbose": true,

--- a/packages/vanilla/src/complex/TableArrayControl.tsx
+++ b/packages/vanilla/src/complex/TableArrayControl.tsx
@@ -87,7 +87,7 @@ class TableArrayControl extends RendererComponent<VanillaTableProps, void> {
     const buttonClass = getStyleAsClassName('array.table.button');
     const controlClass = [getStyleAsClassName('array.table'),
       convertToValidClassName(controlElement.scope)].join(' ');
-    const createControlElement = (key = ''): ControlElement => ({
+    const createControlElement = (key?: string): ControlElement => ({
       type: 'Control',
       label: false,
       scope: scopedSchema.type === 'object' ? `#/properties/${key}` : '#'
@@ -170,7 +170,7 @@ class TableArrayControl extends RendererComponent<VanillaTableProps, void> {
                     <td>
                       {
                         errorsPerEntry ?
-                          <span style={{ color: 'red'}}>
+                          <span className={getStyleAsClassName('array.validation.error')}>
                             {_.join(errorsPerEntry.map(e => e.message), ' and ')}
                           </span> :
                           <span>OK</span>

--- a/packages/vanilla/src/complex/array/index.ts
+++ b/packages/vanilla/src/complex/array/index.ts
@@ -23,7 +23,7 @@
   THE SOFTWARE.
 */
 import {
-  isArrayObjectControl,
+  isObjectArrayControl,
   RankedTester,
   rankWith,
 } from '@jsonforms/core';
@@ -35,6 +35,6 @@ export {
   ArrayControlRenderer
 };
 
-export const arrayControlTester: RankedTester = rankWith(2, isArrayObjectControl);
+export const arrayControlTester: RankedTester = rankWith(2, isObjectArrayControl);
 
 export default ArrayControlRenderer;

--- a/packages/vanilla/test/renderers/ArrayControl.test.tsx
+++ b/packages/vanilla/test/renderers/ArrayControl.test.tsx
@@ -1,0 +1,91 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2018 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import '@jsonforms/test';
+import * as React from 'react';
+import test from 'ava';
+import { Provider } from 'react-redux';
+import ArrayControl from '../../src/complex/array/ArrayControlRenderer';
+import { vanillaRenderers } from '../../src/index';
+import * as TestUtils from 'react-dom/test-utils';
+import { initJsonFormsVanillaStore } from '../vanillaStore';
+import IntegerField, { integerFieldTester } from '../../src/fields/IntegerField';
+
+test.beforeEach(t => {
+
+  t.context.schema = {
+    type: 'object',
+    properties: {
+      test: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            x: { type: 'integer' },
+            y: { type: 'integer' }
+          }
+        }
+      }
+    }
+  };
+  t.context.uischema = {
+    type: 'Control',
+    scope: '#/properties/test'
+  };
+  t.context.data = {
+    test: [{ x: 1, y: 3 }]
+  };
+  t.context.styles = [
+    {
+      name: 'array.table',
+      classNames: ['array-table-layout', 'control']
+    }
+  ];
+});
+
+test('render two children', t => {
+  const store = initJsonFormsVanillaStore({
+    data: t.context.data,
+    schema: t.context.schema,
+    uischema: t.context.uischema,
+    renderers: vanillaRenderers,
+    fields: [
+      {
+        tester: integerFieldTester, field: IntegerField
+      }
+    ]
+  });
+  const tree = TestUtils.renderIntoDocument(
+    <Provider store={store}>
+      <ArrayControl schema={t.context.schema} uischema={t.context.uischema}/>
+    </Provider>
+  );
+
+  const controls = TestUtils.scryRenderedDOMComponentsWithClass(
+    tree,
+    'control'
+  ) as HTMLDivElement[];
+
+  t.is(controls.length, 3);
+});

--- a/packages/webcomponent/package.json
+++ b/packages/webcomponent/package.json
@@ -43,7 +43,7 @@
     "@jsonforms/react": "^2.0.0",
     "@webcomponents/webcomponentsjs": "^1.0.20",
     "es6-shim": "^0.35.3",
-    "json-refs": "^2.1.6",
+    "json-refs": "^3.0.4",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-redux": "^5.0.6",


### PR DESCRIPTION
Adds support for primitive array types. Following changes have been made:
* Refactor typings of vanilla table controls
* Adds basic test case for vanilla `ArrayControl`
* Fix signature of `addItem` of table dispathc props
* Adds missing clone in core reducer if target path is empty
* Adds new example for demo purposes
