### PR TITLE
Generate UI schema if schema ownProps is available

### DIFF
--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -43,6 +43,7 @@ import {
 } from '../reducers';
 import { update } from '../actions';
 import { ErrorObject } from 'ajv';
+import { generateDefaultUISchema } from '../generators';
 
 export interface Labels {
   default: string;
@@ -221,11 +222,22 @@ export interface DispatchPropsOfControl {
   handleChange(path: string, value: any);
 }
 
-export const mapStateToDispatchRendererProps = (state, ownProps) => ({
-  renderers: state.jsonforms.renderers || [],
-  schema: ownProps.schema || getSchema(state),
-  uischema: ownProps.uischema || getUiSchema(state)
-});
+export const mapStateToDispatchRendererProps = (state, ownProps) => {
+  let uischema = ownProps.uischema;
+  if (uischema === undefined) {
+    if (ownProps.schema) {
+      uischema = generateDefaultUISchema(ownProps.schema);
+    } else {
+      uischema = getUiSchema(state);
+    }
+  }
+
+  return {
+    renderers: state.jsonforms.renderers || [],
+    schema: ownProps.schema || getSchema(state),
+    uischema
+  };
+};
 
 /**
  * Map state to layout props.

--- a/packages/core/test/util/renderer.test.ts
+++ b/packages/core/test/util/renderer.test.ts
@@ -27,7 +27,8 @@ import * as _ from 'lodash';
 import {
   createDefaultValue,
   mapDispatchToControlProps,
-  mapStateToControlProps, mapStateToDispatchRendererProps
+  mapStateToControlProps,
+  mapStateToDispatchRendererProps
 } from '../../src/util';
 import configureStore from 'redux-mock-store';
 import { UPDATE_DATA, UpdateAction } from '../../src/actions';
@@ -321,4 +322,29 @@ test(`mapStateToDispatchRendererProps should use registered UI schema given no o
     {}
   );
   t.deepEqual(props.uischema, coreUISchema);
+});
+
+test(`mapStateToDispatchRendererProps should use UI schema if given via ownProps`, t => {
+  const store = mockStore(createState(coreUISchema));
+  const schema = {
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'string'
+      },
+      bar: {
+        type: 'number'
+      }
+    }
+  };
+  const uischema = {
+    type: 'Control',
+    scope: '#/properties/foo'
+  };
+
+  const props = mapStateToDispatchRendererProps(
+    store.getState(),
+    { schema, uischema }
+  );
+  t.deepEqual(props.uischema, uischema);
 });

--- a/packages/core/test/util/renderer.test.ts
+++ b/packages/core/test/util/renderer.test.ts
@@ -27,10 +27,12 @@ import * as _ from 'lodash';
 import {
   createDefaultValue,
   mapDispatchToControlProps,
-  mapStateToControlProps
+  mapStateToControlProps, mapStateToDispatchRendererProps
 } from '../../src/util';
 import configureStore from 'redux-mock-store';
 import { UPDATE_DATA, UpdateAction } from '../../src/actions';
+import { generateDefaultUISchema } from '../../src/generators';
+import { ControlElement } from '../../src';
 
 const middlewares = [];
 const mockStore = configureStore(middlewares);
@@ -53,7 +55,7 @@ const disableRule = {
   }
 };
 
-const coreUISchema = {
+const coreUISchema: ControlElement = {
   type: 'Control',
   scope: '#/properties/firstName',
 };
@@ -73,9 +75,6 @@ const createState = uischema => ({
       },
       uischema,
       errors: []
-    },
-    i18n: {
-      locale: 'en-US'
     }
   }
 });
@@ -295,4 +294,31 @@ test('createDefaultValue', t => {
   t.is(createDefaultValue({ type: 'null' }), null);
   t.deepEqual(createDefaultValue({ type: 'object' }), {});
   t.deepEqual(createDefaultValue({ type: 'something' }), {});
+});
+
+test(`mapStateToDispatchRendererProps should generate UI schema given ownProps schema`, t => {
+  const store = mockStore(createState(coreUISchema));
+  const schema = {
+    type: 'object',
+    properties: {
+      bar: {
+        type: 'number'
+      }
+    }
+  };
+
+  const props = mapStateToDispatchRendererProps(
+    store.getState(),
+    { schema }
+  );
+  t.deepEqual(props.uischema, generateDefaultUISchema(schema));
+});
+
+test(`mapStateToDispatchRendererProps should use registered UI schema given no ownProps`, t => {
+  const store = mockStore(createState(coreUISchema));
+  const props = mapStateToDispatchRendererProps(
+    store.getState(),
+    {}
+  );
+  t.deepEqual(props.uischema, coreUISchema);
 });

--- a/packages/react/test/renderers/JsonForms.test.tsx
+++ b/packages/react/test/renderers/JsonForms.test.tsx
@@ -45,7 +45,6 @@ import {
 import * as TestUtils from 'react-dom/test-utils';
 
 import { JsonForms, StatelessRenderer } from '../../src';
-
 /**
  * Describes the initial state of the JSON Form's store.
  */


### PR DESCRIPTION
If the schema prop is available on the `JsonForms` component generate an UI schema accordingly instead of using the one from the store.