### PR TITLE
Avoid rendering unknown fields and empty layouts

### DIFF
--- a/packages/core/src/generators/uischema.ts
+++ b/packages/core/src/generators/uischema.ts
@@ -129,24 +129,23 @@ const generateUISchema =
         case 'object':
             const layout: Layout = createLayout(layoutType);
             schemaElements.push(layout);
-
             addLabel(layout, schemaName);
 
             if (!_.isEmpty(jsonSchema.properties)) {
-                // traverse properties
-                const nextRef: string = currentRef + '/properties';
-                Object.keys(jsonSchema.properties).map(propName => {
-                    let value = jsonSchema.properties[propName];
-                    const ref = `${nextRef}/${propName}`;
-                    if (value.$ref !== undefined) {
-                        value = resolveSchema(rootSchema, value.$ref);
-                    }
-                    generateUISchema(
-                        value,
-                        layout.elements,
-                        ref, propName, layoutType, rootSchema
-                    );
-                });
+              // traverse properties
+              const nextRef: string = currentRef + '/properties';
+              Object.keys(jsonSchema.properties).map(propName => {
+                let value = jsonSchema.properties[propName];
+                const ref = `${nextRef}/${propName}`;
+                if (value.$ref !== undefined) {
+                  value = resolveSchema(rootSchema, value.$ref);
+                }
+                generateUISchema(
+                  value,
+                  layout.elements,
+                  ref, propName, layoutType, rootSchema
+                );
+              });
             }
 
             return layout;

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -133,7 +133,7 @@ export interface RendererProps extends StatePropsOfRenderer { }
  * State-based props of a Control
  */
 export interface StatePropsOfControl extends StatePropsOfScopedRenderer {
-
+  fields?: { tester: RankedTester, field: any }[];
   /**
    * Any validation errors that are caused by the data to be rendered.
    */
@@ -337,7 +337,8 @@ export const mapStateToControlProps = (state, ownProps): StatePropsOfControl => 
     scopedSchema: resolvedSchema,
     uischema: ownProps.uischema,
     schema: ownProps.schema,
-    config
+    config,
+    fields: state.jsonforms.fields
   };
 };
 

--- a/packages/editor/src/helpers/NonEmptyLayout.tsx
+++ b/packages/editor/src/helpers/NonEmptyLayout.tsx
@@ -1,0 +1,49 @@
+import {
+  Layout,
+  mapStateToLayoutProps,
+  RankedTester,
+  rankWith,
+  RendererProps,
+  Tester,
+} from '@jsonforms/core';
+import { connectToJsonForms } from '@jsonforms/react';
+import * as _ from 'lodash';
+
+/**
+ * Checks whether the given UI schema contains only label field or not.
+ */
+export const isInstanceOfLayout: Tester =
+  (uischema: Layout): boolean => {
+      if (_.isEmpty(uischema)) {
+        return false;
+      }
+      if (!uischema.hasOwnProperty('elements')) {
+        return false;
+      }
+      return _.isEmpty(uischema.elements) ||
+        (
+             uischema.elements.length === 1 &&
+             _.some(uischema.elements, element => element.type === 'Label')
+        );
+    };
+/**
+ * Tester for empty layouts
+ * @type {RankedTester}
+ */
+export const nonEmptyLayoutTester: RankedTester =
+  rankWith(3, isInstanceOfLayout);
+
+/**
+ * NonEmptyLayoutRenderer is a custom layout renderer to prevent rendering empty layouts
+ *
+ * @returns null
+ * @constructor
+ */
+export const NonEmptyLayoutRenderer = (
+  {}: RendererProps) => {
+  return null;
+};
+
+export default connectToJsonForms(
+  mapStateToLayoutProps
+)(NonEmptyLayoutRenderer);

--- a/packages/material/src/controls/MaterialInputControl.tsx
+++ b/packages/material/src/controls/MaterialInputControl.tsx
@@ -23,6 +23,7 @@
   THE SOFTWARE.
 */
 import * as React from 'react';
+import * as _ from 'lodash';
 import {
   computeLabel,
   ControlProps,
@@ -52,7 +53,8 @@ export class MaterialInputControl extends Control<ControlProps, ControlState> {
       visible,
       required,
       parentPath,
-      config
+      config,
+      fields
     } = this.props;
     const isValid = errors.length === 0;
     const trim = config.trim;
@@ -61,23 +63,27 @@ export class MaterialInputControl extends Control<ControlProps, ControlState> {
       style.display = 'none';
     }
     const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused);
-
-    return (
-      <FormControl
-        style={style}
-        fullWidth={!trim}
-        onFocus={this.onFocus}
-        onBlur={this.onBlur}
-      >
-        <InputLabel htmlFor={id} error={!isValid}>
-          {computeLabel(isPlainLabel(label) ? label : label.default, required)}
-        </InputLabel>
-        <DispatchField uischema={uischema} schema={schema} path={parentPath} />
-        <FormHelperText error={!isValid}>
-          {!isValid ? formatErrorMessage(errors) : showDescription ? description : null}
-        </FormHelperText>
-      </FormControl>
-    );
+    const field = _.maxBy(fields, r => r.tester(uischema, schema));
+    if (field === undefined || field.tester(uischema, schema) === -1) {
+      return null;
+    } else {
+      return (
+        <FormControl
+          style={style}
+          fullWidth={!trim}
+          onFocus={this.onFocus}
+          onBlur={this.onBlur}
+        >
+          <InputLabel htmlFor={id} error={!isValid}>
+            {computeLabel(isPlainLabel(label) ? label : label.default, required)}
+          </InputLabel>
+          <DispatchField uischema={uischema} schema={schema} path={parentPath} />
+          <FormHelperText error={!isValid}>
+            {!isValid ? formatErrorMessage(errors) : showDescription ? description : null}
+          </FormHelperText>
+        </FormControl>
+      );
+    }
   }
 }
 export const materialInputControlTester: RankedTester = rankWith(1, isControl);


### PR DESCRIPTION
Return null if an unknown field is rendered
Set the layout as null if the type of field is object with empty properties when generating uischema