### PR TITLE
Fix react/MUI related warnings

### DIFF
--- a/packages/material/src/complex/TableToolbar.tsx
+++ b/packages/material/src/complex/TableToolbar.tsx
@@ -79,14 +79,16 @@ export const TableToolbar = (
             </Grid>
             <Grid item>
               <Tooltip title='Delete'>
-                <Button
-                  variant='fab'
-                  aria-label={`Delete`}
-                  disabled={numSelected === 0}
-                  onClick={openConfirmDeleteDialog}
-                >
-                  <DeleteIcon />
-                </Button>
+                <div>
+                  <Button
+                    variant='fab'
+                    aria-label={`Delete`}
+                    disabled={numSelected === 0}
+                    onClick={openConfirmDeleteDialog}
+                  >
+                    <DeleteIcon />
+                  </Button>
+                </div>
               </Tooltip>
             </Grid>
           </Grid>

--- a/packages/material/src/controls/MaterialInputControl.tsx
+++ b/packages/material/src/controls/MaterialInputControl.tsx
@@ -61,11 +61,11 @@ export class MaterialInputControl extends Control<ControlProps, ControlState> {
       style.display = 'none';
     }
     const inputLabelStyle: {[x: string]: any} = {
-      'white-space': 'nowrap',
-      'overflow' : 'hidden',
-      'text-overflow': 'ellipsis',
+      whiteSpace: 'nowrap',
+      overflow : 'hidden',
+      textOverflow: 'ellipsis',
       // magic width as the label is transformed to 75% of its size
-      'width': '125%'
+      width: '125%'
     };
 
     const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused);


### PR DESCRIPTION
Fix warnings that appeared in the console:

* Wrap disabled button in div within `TableToolbar`
* Fix stylenames in input control
