### PR TITLE
Unique ID support in Core, React and Material

### DIFF
--- a/packages/core/src/util/field.ts
+++ b/packages/core/src/util/field.ts
@@ -45,6 +45,10 @@ import {
 export interface StatePropsOfField extends StatePropsOfScopedRenderer {
   className?: string;
   isValid: boolean;
+  /**
+   * An optional unique ID that can be used to identify the rendered field.
+   */
+  id?: string;
 }
 
 /**
@@ -93,7 +97,7 @@ export const mapStateToFieldProps = (state, ownProps): StatePropsOfField => {
   const errors = getErrorAt(path)(state).map(error => error.message);
   const isValid = _.isEmpty(errors);
   const controlElement = ownProps.uischema as ControlElement;
-  const id = controlElement.scope || '';
+  const id = ownProps.id;
   const inputClassName = ['validate'].concat(isValid ? 'valid' : 'invalid');
   const defaultConfig = _.cloneDeep(getConfig(state));
   const config = _.merge(

--- a/packages/core/src/util/ids.ts
+++ b/packages/core/src/util/ids.ts
@@ -1,0 +1,26 @@
+const usedIDs: Set<string> = new Set<string>();
+
+export const createId = (proposedID: string) => {
+  if (proposedID === undefined) {
+    // failsafe to avoid endless loops in error cases
+    proposedID = 'undefined';
+  }
+  let tries = 1;
+  while (!isUniqueId(proposedID, tries)) {
+    tries++;
+  }
+  const newID = makeId(proposedID, tries);
+  usedIDs.add(newID);
+  return newID;
+};
+
+export const removeId = id => usedIDs.delete(id);
+
+const isUniqueId = (idBase: string, iteration: number) => {
+  const newID = makeId(idBase, iteration);
+  return !usedIDs.has(newID);
+};
+
+const makeId = (idBase: string, iteration: number) => iteration <= 1 ? idBase : idBase + iteration;
+
+export const clearAllIds = () => usedIDs.clear();

--- a/packages/core/src/util/index.ts
+++ b/packages/core/src/util/index.ts
@@ -81,3 +81,4 @@ export * from './renderer';
 export * from './field';
 export * from './runtime';
 export * from './Formatted';
+export * from './ids';

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -120,11 +120,6 @@ export interface StatePropsOfScopedRenderer extends StatePropsOfRenderer {
    */
   scopedSchema: JsonSchema;
 
-  /**
-   * An unique ID that can be used to identify the rendered element.
-   */
-  id: string;
-
   findUISchema(schema: JsonSchema, schemaPath: string, path: string);
 }
 /**
@@ -158,9 +153,9 @@ export interface StatePropsOfControl extends StatePropsOfScopedRenderer {
   required: boolean;
 
   /**
-   * The schema that corresponds to the data the control is bound to.
+   * An ID that can be used to identify the rendered element. May not be unique.
    */
-  scopedSchema: JsonSchema;
+  id: string;
 }
 /**
  * Props of a Control.
@@ -315,7 +310,7 @@ export const mapStateToControlProps = (state, ownProps): StatePropsOfControl => 
   const label = labelDesc.show ? labelDesc.text : '';
   const errors = _.union(getErrorAt(path)(state).map(error => error.message));
   const controlElement = ownProps.uischema as ControlElement;
-  const id = controlElement.scope || '';
+  const id = ownProps.id;
   const required =
       controlElement.scope !== undefined && isRequired(ownProps.schema, controlElement.scope);
   const resolvedSchema = Resolve.schema(ownProps.schema, controlElement.scope);

--- a/packages/core/test/util/field.test.ts
+++ b/packages/core/test/util/field.test.ts
@@ -25,6 +25,7 @@
 import test from 'ava';
 import * as _ from 'lodash';
 import {
+  clearAllIds,
   defaultMapDispatchToControlProps,
   defaultMapStateToEnumFieldProps,
   mapStateToFieldProps
@@ -211,8 +212,10 @@ test('mapStateToFieldProps - data', t => {
 });
 
 test('mapStateToFieldProps - id', t => {
+  clearAllIds();
   const ownProps = {
-    uischema: coreUISchema
+    uischema: coreUISchema,
+    id: '#/properties/firstName'
   };
   const props = mapStateToFieldProps(createState(coreUISchema), ownProps);
   t.is(props.id, '#/properties/firstName');

--- a/packages/core/test/util/renderer.test.ts
+++ b/packages/core/test/util/renderer.test.ts
@@ -25,6 +25,7 @@
 import test from 'ava';
 import * as _ from 'lodash';
 import {
+  clearAllIds,
   createDefaultValue,
   mapDispatchToControlProps,
   mapStateToControlProps,
@@ -267,8 +268,10 @@ test('mapStateToControlProps - no duplicate error messages', t => {
 });
 
 test('mapStateToControlProps - id', t => {
+  clearAllIds();
   const ownProps = {
-    uischema: coreUISchema
+    uischema: coreUISchema,
+    id: '#/properties/firstName'
   };
   const props = mapStateToControlProps(createState(coreUISchema), ownProps);
   t.is(props.id, '#/properties/firstName');

--- a/packages/material/src/complex/MaterialTableControl.tsx
+++ b/packages/material/src/complex/MaterialTableControl.tsx
@@ -25,8 +25,8 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import Checkbox from '@material-ui/core/Checkbox';
-import {Grid, Hidden} from '@material-ui/core';
-import {Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core';
+import { Grid, Hidden } from '@material-ui/core';
+import { Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core';
 import {
   ControlElement,
   Paths

--- a/packages/material/src/controls/MaterialBooleanControl.tsx
+++ b/packages/material/src/controls/MaterialBooleanControl.tsx
@@ -37,7 +37,7 @@ import { FormControlLabel } from '@material-ui/core';
 import MaterialBooleanField from '../fields/MaterialBooleanField';
 
 export const MaterialBooleanControl =
-  ({  label, uischema, schema, visible, parentPath }: ControlProps) => {
+  ({  label, uischema, schema, visible, parentPath, id }: ControlProps) => {
     let style = {};
     if (!visible) {
       style = {display: 'none'};
@@ -47,7 +47,15 @@ export const MaterialBooleanControl =
       <FormControlLabel
         style={style}
         label={label}
-        control={<MaterialBooleanField uischema={uischema} schema={schema} path={parentPath}/>}
+        id={id}
+        control={
+          <MaterialBooleanField
+            uischema={uischema}
+            schema={schema}
+            path={parentPath}
+            id={id + '-input'}
+          />
+          }
       />
     );
   };

--- a/packages/material/src/controls/MaterialDateControl.tsx
+++ b/packages/material/src/controls/MaterialDateControl.tsx
@@ -95,7 +95,7 @@ export class MaterialDateControl extends Control<ControlProps & DateControl, Con
     return (
       <MuiPickersUtilsProvider utils={MomentUtils}>
         <DatePicker
-          id={id}
+          id={id + '-input'}
           label={computeLabel(labelText, required)}
           error={!isValid}
           style={style}

--- a/packages/material/src/controls/MaterialDateTimeControl.tsx
+++ b/packages/material/src/controls/MaterialDateTimeControl.tsx
@@ -71,7 +71,7 @@ export class MaterialDateTimeControl extends Control<ControlProps, ControlState>
     return (
       <MuiPickersUtilsProvider utils={MomentUtils}>
         <DateTimePicker
-          id={id}
+          id={id + '-input'}
           label={computeLabel(isPlainLabel(label) ? label : label.default, required)}
           error={!isValid}
           style={style}

--- a/packages/material/src/controls/MaterialInputControl.tsx
+++ b/packages/material/src/controls/MaterialInputControl.tsx
@@ -84,11 +84,12 @@ export class MaterialInputControl extends Control<ControlProps, ControlState> {
           fullWidth={!trim}
           onFocus={this.onFocus}
           onBlur={this.onBlur}
+          id={id}
         >
-          <InputLabel htmlFor={id} error={!isValid} style={inputLabelStyle}>
+          <InputLabel htmlFor={id + '-input'} error={!isValid} style={inputLabelStyle}>
             {computeLabel(isPlainLabel(label) ? label : label.default, required)}
           </InputLabel>
-          <DispatchField uischema={uischema} schema={schema} path={parentPath} />
+          <DispatchField uischema={uischema} schema={schema} path={parentPath} id={id + '-input'} />
           <FormHelperText error={!isValid}>
             {!isValid ? formatErrorMessage(errors) : showDescription ? description : null}
           </FormHelperText>

--- a/packages/material/src/controls/MaterialNativeControl.tsx
+++ b/packages/material/src/controls/MaterialNativeControl.tsx
@@ -68,7 +68,7 @@ export class MaterialNativeControl extends Control<ControlProps, ControlState> {
 
     return (
       <TextField
-        id={id}
+        id={id + '-input'}
         label={computeLabel(isPlainLabel(label) ? label : label.default, required)}
         type={fieldType}
         error={!isValid}

--- a/packages/material/src/controls/MaterialSliderControl.tsx
+++ b/packages/material/src/controls/MaterialSliderControl.tsx
@@ -87,8 +87,9 @@ export class MaterialSliderControl extends Control<ControlProps, ControlState> {
         fullWidth={!trim}
         onFocus={this.onFocus}
         onBlur={this.onBlur}
+        id={id}
       >
-        <Typography id={id} style={labelStyle} variant='caption'>
+        <Typography id={id + '-typo'} style={labelStyle} variant='caption'>
           {computeLabel(isPlainLabel(label) ? label : label.default, required)}
         </Typography>
         <div style={rangeContainerStyle}>
@@ -108,7 +109,7 @@ export class MaterialSliderControl extends Control<ControlProps, ControlState> {
             handleChange(path, Number(value));
           }
           }
-          id={id}
+          id={id + '-input'}
           disabled={!enabled}
           autoFocus={uischema.options && uischema.options.focus}
           step={scopedSchema.multipleOf || 1}

--- a/packages/material/test/renderers/MaterialBooleanField.test.tsx
+++ b/packages/material/test/renderers/MaterialBooleanField.test.tsx
@@ -38,6 +38,7 @@ import BooleanField, { materialBooleanFieldTester } from '../../src/fields/Mater
 import HorizontalLayoutRenderer from '../../src/layouts/MaterialHorizontalLayout';
 import { Provider } from 'react-redux';
 import * as TestUtils from 'react-dom/test-utils';
+import * as ReactDOM from 'react-dom';
 import { combineReducers, createStore, Store } from 'redux';
 import { materialFields, materialRenderers } from '../../src';
 
@@ -125,6 +126,13 @@ describe('Material boolean field tester', () => {
 
 describe('Material boolean field', () => {
 
+  /** Use this container to render components */
+  const container = document.createElement('div');
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container);
+  });
+
   it('should autofocus first element', () => {
     const jsonSchema: JsonSchema = {
       type: 'object',
@@ -162,10 +170,11 @@ describe('Material boolean field', () => {
       schema,
       layout
     );
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <HorizontalLayoutRenderer schema={jsonSchema} uischema={layout}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const inputs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
     expect(document.activeElement).not.toBe(inputs[0]);
@@ -182,10 +191,11 @@ describe('Material boolean field', () => {
       }
     };
     const store = initJsonFormsStore(data, schema, control);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <BooleanField schema={schema} uischema={control}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     expect(document.activeElement).toBe(input);
@@ -200,10 +210,11 @@ describe('Material boolean field', () => {
       }
     };
     const store = initJsonFormsStore(data, schema, control);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <BooleanField schema={schema} uischema={control}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     expect(input.autofocus).toBe(false);
@@ -215,10 +226,11 @@ describe('Material boolean field', () => {
       scope: '#/properties/foo',
     };
     const store = initJsonFormsStore(data, schema, control);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <BooleanField schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     expect(document.activeElement).not.toBe(input);
@@ -226,10 +238,11 @@ describe('Material boolean field', () => {
 
   it('should render', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <BooleanField schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
 
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -239,10 +252,11 @@ describe('Material boolean field', () => {
 
   it('should update via input event', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <BooleanField schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
 
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -253,10 +267,11 @@ describe('Material boolean field', () => {
 
   it('should update via action', () => {
     const store = initJsonFormsStore({'foo': false}, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <BooleanField schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     store.dispatch(update('foo', () => false));
@@ -266,10 +281,11 @@ describe('Material boolean field', () => {
 
   it('should update with undefined value', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <BooleanField schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     store.dispatch(update('foo', () => undefined));
@@ -278,10 +294,11 @@ describe('Material boolean field', () => {
 
   it('should update with null value', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <BooleanField schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     store.dispatch(update('foo', () => null));
@@ -290,10 +307,11 @@ describe('Material boolean field', () => {
 
   it('should not update with wrong ref', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <BooleanField schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     store.dispatch(update('bar', () => 11));
@@ -302,10 +320,11 @@ describe('Material boolean field', () => {
 
   it('should not update with null ref', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <BooleanField schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     store.dispatch(update(null, () => false));
@@ -314,10 +333,11 @@ describe('Material boolean field', () => {
 
   it('should not update with an undefined ref', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <BooleanField schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     store.dispatch(update(undefined, () => false));
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -326,10 +346,11 @@ describe('Material boolean field', () => {
 
   it('can be disabled', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <BooleanField schema={schema} uischema={uischema} enabled={false}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     expect(input.disabled).toBeTruthy();
@@ -337,12 +358,25 @@ describe('Material boolean field', () => {
 
   it('should be enabled by default', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <BooleanField schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     expect(input.disabled).toBeFalsy();
+  });
+
+  it('id should be present in output', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = ReactDOM.render(
+      <Provider store={store}>
+        <BooleanField schema={schema} uischema={uischema} id='myid'/>
+      </Provider>,
+      container
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.id).toBe('myid');
   });
 });

--- a/packages/material/test/renderers/MaterialDateControl.test.tsx
+++ b/packages/material/test/renderers/MaterialDateControl.test.tsx
@@ -39,6 +39,7 @@ import MaterialDateControl, {
 } from '../../src/controls/MaterialDateControl';
 import * as React from 'react';
 import * as TestUtils from 'react-dom/test-utils';
+import * as ReactDOM from 'react-dom';
 import { combineReducers, createStore, Store } from 'redux';
 import { materialFields, materialRenderers } from '../../src';
 
@@ -127,6 +128,13 @@ describe('Material date control tester', () => {
 
 describe('Material date control', () => {
 
+  /** Use this container to render components */
+  const container = document.createElement('div');
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container);
+  });
+
   it('should autofocus first element', () => {
     const jsonSchema: JsonSchema = {
       type: 'object',
@@ -164,10 +172,11 @@ describe('Material date control', () => {
       schema,
       uischema
     );
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <HorizontalLayoutRenderer schema={jsonSchema} uischema={layout}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const inputs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
     expect(document.activeElement).not.toBe(inputs[0]);
@@ -183,10 +192,11 @@ describe('Material date control', () => {
       }
     };
     const store = initJsonFormsStore(data, schema, control);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateControl schema={schema} uischema={control}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     expect(document.activeElement).toBe(input);
@@ -201,10 +211,11 @@ describe('Material date control', () => {
       }
     };
     const store = initJsonFormsStore(data, schema, control);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateControl schema={schema} uischema={control}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     expect(input.autofocus).toBeFalsy();
@@ -216,10 +227,11 @@ describe('Material date control', () => {
       scope: '#/properties/foo'
     };
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateControl schema={schema} uischema={control}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     expect(input.autofocus).toBeFalsy();
@@ -227,10 +239,11 @@ describe('Material date control', () => {
 
   it('should render', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
 
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -240,10 +253,11 @@ describe('Material date control', () => {
 
   it('should update via event', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     input.value = '1961-04-12';
@@ -253,10 +267,11 @@ describe('Material date control', () => {
 
   it('should update via action', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     store.dispatch(Actions.update('foo', () => '1961-04-12'));
@@ -265,10 +280,11 @@ describe('Material date control', () => {
 
   it('should update with null value', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     store.dispatch(Actions.update('foo', () => null));
@@ -277,10 +293,11 @@ describe('Material date control', () => {
 
   it('should update with undefined value', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     store.dispatch(Actions.update('foo', () => undefined));
@@ -289,10 +306,11 @@ describe('Material date control', () => {
 
   it('should not update with wrong ref', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     store.dispatch(Actions.update('bar', () => 'Bar'));
@@ -301,10 +319,11 @@ describe('Material date control', () => {
 
   it('should not update with null ref', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     store.dispatch(Actions.update(null, () => '1961-04-12'));
@@ -313,10 +332,11 @@ describe('Material date control', () => {
 
   it('should not update with undefined ref', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     store.dispatch(Actions.update(undefined, () => '1961-04-12'));
@@ -325,10 +345,11 @@ describe('Material date control', () => {
 
   it('can be disabled', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateControl schema={schema} uischema={uischema} enabled={false}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     expect(input.disabled).toBeTruthy();
@@ -336,12 +357,26 @@ describe('Material date control', () => {
 
   it('should be enabled by default', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     expect(input.disabled).toBeFalsy();
+  });
+
+  it('should render input id', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = ReactDOM.render(
+      <Provider store={store}>
+        <MaterialDateControl schema={schema} uischema={uischema} id='#/properties/foo'/>
+      </Provider>,
+      container
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    // there is only input id at the moment
+    expect(input.id).toBe('#/properties/foo-input');
   });
 });

--- a/packages/material/test/renderers/MaterialDateTimeControl.test.tsx
+++ b/packages/material/test/renderers/MaterialDateTimeControl.test.tsx
@@ -40,6 +40,7 @@ import MaterialDateTimeControl, {
 } from '../../src/controls/MaterialDateTimeControl';
 import { Provider } from 'react-redux';
 import * as TestUtils from 'react-dom/test-utils';
+import * as ReactDOM from 'react-dom';
 import * as moment from 'moment';
 import { combineReducers, createStore, Store } from 'redux';
 import { materialFields, materialRenderers } from '../../src';
@@ -129,6 +130,13 @@ describe('Material date time control tester', () => {
 
 describe('Material date time control', () => {
 
+  /** Use this container to render components */
+  const container = document.createElement('div');
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container);
+  });
+
   it('should autofocus first element', () => {
     const jsonSchema: JsonSchema = {
       type: 'object',
@@ -166,10 +174,11 @@ describe('Material date time control', () => {
       jsonSchema,
       layout
     );
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <HorizontalLayoutRenderer schema={jsonSchema} uischema={layout}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const inputs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
     expect(document.activeElement).not.toBe(inputs[0]);
@@ -185,10 +194,11 @@ describe('Material date time control', () => {
       }
     };
     const store = initJsonFormsStore(data, schema, control);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateTimeControl schema={schema} uischema={control}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     expect(document.activeElement).toBe(input);
@@ -203,10 +213,11 @@ describe('Material date time control', () => {
       }
     };
     const store = initJsonFormsStore(data, schema, control);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateTimeControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     expect(input.autofocus).toBeFalsy();
@@ -218,10 +229,11 @@ describe('Material date time control', () => {
       scope: '#/properties/foo'
     };
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateTimeControl schema={schema} uischema={control}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     expect(input.autofocus).toBeFalsy();
@@ -229,10 +241,11 @@ describe('Material date time control', () => {
 
   it('should render', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateTimeControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
 
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -242,10 +255,11 @@ describe('Material date time control', () => {
 
   it('should update via event', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateTimeControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     input.value = '04/12/1961 8:15 pm';
@@ -255,10 +269,11 @@ describe('Material date time control', () => {
 
   it('should update via action', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateTimeControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     store.dispatch(update('foo', () => moment('1961-04-12 20:15').format()));
@@ -267,10 +282,11 @@ describe('Material date time control', () => {
 
   it('should update with null value', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateTimeControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     store.dispatch(update('foo', () => null));
@@ -279,10 +295,11 @@ describe('Material date time control', () => {
 
   it('should not update with undefined value', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateTimeControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     store.dispatch(update('foo', () => undefined));
@@ -291,10 +308,11 @@ describe('Material date time control', () => {
 
   it('should not update with wrong ref', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateTimeControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     store.dispatch(update('bar', () => 'Bar'));
@@ -303,10 +321,11 @@ describe('Material date time control', () => {
 
   it('should not update with null ref', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateTimeControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     store.dispatch(update(null, () => '12.04.1961 20:15'));
@@ -315,10 +334,11 @@ describe('Material date time control', () => {
 
   it('should not update with undefined ref', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateTimeControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     store.dispatch(update(undefined, () => '12.04.1961 20:15'));
@@ -327,14 +347,15 @@ describe('Material date time control', () => {
 
   it('can be disabled', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateTimeControl
           schema={schema}
           uischema={uischema}
           enabled={false}
         />
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     expect(input.disabled).toBeTruthy();
@@ -342,12 +363,26 @@ describe('Material date time control', () => {
 
   it('should be enabled by default', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialDateTimeControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
     expect(input.disabled).toBeFalsy();
+  });
+
+  it('should render input id', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = ReactDOM.render(
+      <Provider store={store}>
+        <MaterialDateTimeControl schema={schema} uischema={uischema} id='#/properties/foo'/>
+      </Provider>,
+      container
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    // there is only input id at the moment
+    expect(input.id).toBe('#/properties/foo-input');
   });
 });

--- a/packages/material/test/renderers/MaterialInputControl.test.tsx
+++ b/packages/material/test/renderers/MaterialInputControl.test.tsx
@@ -25,6 +25,7 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
 import * as TestUtils from 'react-dom/test-utils';
+import * as ReactDOM from 'react-dom';
 import {
   Actions,
   ControlElement,
@@ -86,6 +87,13 @@ describe('Material input control tester', () => {
 
 describe('Material input control', () => {
 
+  /** Use this container to render components */
+  const container = document.createElement('div');
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container);
+  });
+
   it('should autofocus the first element', () => {
     const jsonSchema: JsonSchema = {
       type: 'object',
@@ -123,10 +131,11 @@ describe('Material input control', () => {
       schema,
       uischema
     );
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialHorizontalLayoutRenderer schema={jsonSchema} uischema={layout}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const inputs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
     expect(document.activeElement).not.toBe(inputs[0]);
@@ -135,10 +144,11 @@ describe('Material input control', () => {
 
   it('render', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialInputControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
 
     const control = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'div')[0];
@@ -165,10 +175,11 @@ describe('Material input control', () => {
       label: false
     };
     const store = initJsonFormsStore(data, schema, control);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialInputControl schema={schema} uischema={control}/>
-      </Provider>
+      </Provider>,
+      container
     );
 
     const div = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'div')[0];
@@ -190,14 +201,15 @@ describe('Material input control', () => {
 
   it('can be hidden', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialInputControl
           schema={schema}
           uischema={uischema}
           visible={false}
         />
-      </Provider>
+      </Provider>,
+      container
     );
     const control = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'div')[0] as HTMLElement;
     expect(getComputedStyle(control).display).toBe('none');
@@ -205,10 +217,11 @@ describe('Material input control', () => {
 
   it('should be shown by default', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialInputControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const control = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'div')[0] as HTMLElement;
     expect(control.hidden).toBeFalsy();
@@ -216,10 +229,11 @@ describe('Material input control', () => {
 
   it('should display a single error', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialInputControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
 
     const validation = TestUtils.findRenderedDOMComponentWithTag(tree, 'p');
@@ -229,10 +243,11 @@ describe('Material input control', () => {
 
   it('should display multiple errors', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialInputControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const validation = TestUtils.findRenderedDOMComponentWithTag(tree, 'p');
     store.dispatch(Actions.update('foo', () => 3));
@@ -241,10 +256,11 @@ describe('Material input control', () => {
 
   it('should not show any errors', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialInputControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const validation = TestUtils.findRenderedDOMComponentWithTag(tree, 'p');
     expect(validation.textContent).toBe('');
@@ -252,10 +268,11 @@ describe('Material input control', () => {
 
   it('should handle validation updates', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialInputControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const validation = TestUtils.findRenderedDOMComponentWithTag(tree, 'p');
     store.dispatch(Actions.update('foo', () => 3));
@@ -313,10 +330,11 @@ describe('Material input control', () => {
       jsonSchema,
       layout
     );
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialHorizontalLayoutRenderer schema={jsonSchema} uischema={layout}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const validation = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'p');
     expect(validation[0].textContent).toBe('');
@@ -341,10 +359,11 @@ describe('Material input control', () => {
     };
 
     const store = initJsonFormsStore({}, jsonSchema, control);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialInputControl schema={jsonSchema} uischema={control}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const label = TestUtils.findRenderedDOMComponentWithTag(tree, 'label');
     expect(label.textContent).toBe('Date Field*');
@@ -366,10 +385,11 @@ describe('Material input control', () => {
     };
 
     const store = initJsonFormsStore({}, jsonSchema, control);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialInputControl schema={jsonSchema} uischema={control}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const label = TestUtils.findRenderedDOMComponentWithTag(tree, 'label');
     expect(label.textContent).toBe('Date Field');
@@ -388,10 +408,11 @@ describe('Material input control', () => {
       options: {format: 'password'}
     };
     const store = initJsonFormsStore({}, jsonSchema, control);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialInputControl schema={jsonSchema} uischema={control}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input');
     expect(input.type).toBe('password');
@@ -417,12 +438,41 @@ describe('Material input control', () => {
       scope: '#/properties/expectedValue'
     };
     const store = initJsonFormsStore({}, jsonSchema, control);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <MaterialInputControl schema={jsonSchema} uischema={control}/>
-      </Provider>
+      </Provider>,
+      container
     );
-    const control = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'div')[0] as HTMLElement;
-    expect(control).toBe(undefined);
+    const rendered = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'div')[0] as HTMLElement;
+    expect(rendered).toBe(undefined);
+  });
+
+  it('should render own id and create/use input id', () => {
+    const jsonSchema = {
+      type: 'object',
+      properties: {
+        name: {type: 'string'}
+      }
+    };
+    const control = {
+      type: 'Control',
+      scope: '#/properties/name'
+    };
+    const store = initJsonFormsStore({}, jsonSchema, control);
+    const tree = ReactDOM.render(
+      <Provider store={store}>
+        <MaterialInputControl schema={jsonSchema} uischema={control} id={control.scope}/>
+      </Provider>,
+      container
+    );
+    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
+    expect(input.id).toBe('#/properties/name-input');
+
+    const label = TestUtils.findRenderedDOMComponentWithTag(tree, 'label') as HTMLLabelElement;
+    expect(label.htmlFor).toBe('#/properties/name-input');
+
+    const rootDiv = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'div')[0] as HTMLElement;
+    expect(rootDiv.id).toBe('#/properties/name');
   });
 });

--- a/packages/material/test/renderers/MaterialSliderControl.test.tsx
+++ b/packages/material/test/renderers/MaterialSliderControl.test.tsx
@@ -34,10 +34,11 @@ import {
   NOT_APPLICABLE,
   update
 } from '@jsonforms/core';
-import SliderControl, { materialSliderControlTester, MaterialSliderControl } from '../../src/controls/MaterialSliderControl';
-import HorizontalLayoutRenderer from '../../src/layouts/MaterialHorizontalLayout';
+import SliderControl,
+ { materialSliderControlTester } from '../../src/controls/MaterialSliderControl';
 import { Provider } from 'react-redux';
 import * as TestUtils from 'react-dom/test-utils';
+import * as ReactDOM from 'react-dom';
 import { materialFields, materialRenderers } from '../../src';
 import { combineReducers, createStore, Store } from 'redux';
 import Slider from '@material-ui/lab/Slider';
@@ -218,6 +219,16 @@ describe('Material slider tester', () => {
       )
     ).toBe(4);
   });
+});
+
+describe('Material slider control', () => {
+
+  /** Use this container to render components */
+  const container = document.createElement('div');
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container);
+  });
 
   it('should render', () => {
     const jsonSchema: JsonSchema = {
@@ -232,10 +243,11 @@ describe('Material slider tester', () => {
       }
     };
     const store = initJsonFormsStore({ foo: 5 }, jsonSchema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <SliderControl schema={jsonSchema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
 
     const input = TestUtils.findRenderedComponentWithType(tree, Slider) as Slider;
@@ -244,10 +256,11 @@ describe('Material slider tester', () => {
 
   it('should update via action', () => {
     const store = initJsonFormsStore({ foo: 3 }, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <SliderControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedComponentWithType(tree, Slider) as Slider;
     expect(input.props.value).toBe(3);
@@ -269,10 +282,11 @@ describe('Material slider tester', () => {
       },
     };
     const store = initJsonFormsStore({ foo: 6 }, schemaWithMultipleOf, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <SliderControl schema={schemaWithMultipleOf} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedComponentWithType(tree, Slider) as Slider;
     expect(input.props.step).toBe(2);
@@ -280,10 +294,11 @@ describe('Material slider tester', () => {
 
   it('should not update with undefined value', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <SliderControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedComponentWithType(tree, Slider) as Slider;
     store.dispatch(update('foo', () => undefined));
@@ -292,10 +307,11 @@ describe('Material slider tester', () => {
 
   it('should not update with null value', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <SliderControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedComponentWithType(tree, Slider) as Slider;
     store.dispatch(update('foo', () => null));
@@ -304,10 +320,11 @@ describe('Material slider tester', () => {
 
   it('should not update with wrong ref', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <SliderControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedComponentWithType(tree, Slider) as Slider;
     store.dispatch(update('bar', () => 11));
@@ -316,10 +333,11 @@ describe('Material slider tester', () => {
 
   it('should not update with null ref', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <SliderControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedComponentWithType(tree, Slider) as Slider;
     store.dispatch(update(null, () => 3));
@@ -328,10 +346,11 @@ describe('Material slider tester', () => {
 
   it('should not update with undefined ref', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <SliderControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     store.dispatch(update(undefined, () => 13));
     const input = TestUtils.findRenderedComponentWithType(tree, Slider) as Slider;
@@ -340,10 +359,11 @@ describe('Material slider tester', () => {
 
   it('can be disabled', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <SliderControl schema={schema} uischema={uischema} enabled={false}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedComponentWithType(tree, Slider) as Slider;
     expect(input.props.disabled).toBeTruthy();
@@ -351,12 +371,28 @@ describe('Material slider tester', () => {
 
   it('should be enabled by default', () => {
     const store = initJsonFormsStore(data, schema, uischema);
-    const tree = TestUtils.renderIntoDocument(
+    const tree = ReactDOM.render(
       <Provider store={store}>
         <SliderControl schema={schema} uischema={uischema}/>
-      </Provider>
+      </Provider>,
+      container
     );
     const input = TestUtils.findRenderedComponentWithType(tree, Slider) as Slider;
     expect(input.props.disabled).toBeFalsy();
+  });
+
+  it('should render id and input id', () => {
+    const store = initJsonFormsStore(data, schema, uischema);
+    const tree = ReactDOM.render(
+      <Provider store={store}>
+        <SliderControl schema={schema} uischema={uischema} id='#/properties/foo'/>
+      </Provider>,
+      container
+    );
+    const divs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'div') as HTMLElement[];
+    // id
+    expect(divs.find(d => d.id === '#/properties/foo')).toBeDefined();
+    // input id
+    expect(divs.find(d => d.id === '#/properties/foo-input')).toBeDefined();
   });
 });

--- a/packages/react/src/DispatchField.tsx
+++ b/packages/react/src/DispatchField.tsx
@@ -27,31 +27,30 @@ import { connect } from 'react-redux';
 import * as _ from 'lodash';
 import { UnknownRenderer } from './UnknownRenderer';
 import { DispatchFieldProps, mapStateToDispatchFieldProps } from '@jsonforms/core';
+
 /**
- * Props of the {@link DispatchField} renderer.
+ * Dispatch renderer component for fields.
  */
-  /**
-   * The available field renderers.
-   */
+class Dispatch extends React.Component<DispatchFieldProps> {
+  render() {
+    const { uischema, schema, path, fields, id } = this.props as DispatchFieldProps;
+    const field = _.maxBy(fields, r => r.tester(uischema, schema));
 
-const Dispatch = (dispatchFieldProps: DispatchFieldProps) => {
-  const uischema = dispatchFieldProps.uischema;
-  const schema = dispatchFieldProps.schema;
-  const field = _.maxBy(dispatchFieldProps.fields, r => r.tester(uischema, schema));
+    if (field === undefined || field.tester(uischema, schema) === -1) {
+      return <UnknownRenderer type={'field'}/>;
+    } else {
+      const Field = field.field;
 
-  if (field === undefined || field.tester(uischema, schema) === -1) {
-    return <UnknownRenderer type={'field'}/>;
-  } else {
-    const Field = field.field;
-
-    return (
-      <Field
-        schema={schema}
-        uischema={uischema}
-        path={dispatchFieldProps.path}
-      />
-    );
+      return (
+        <Field
+          uischema={uischema}
+          schema={schema}
+          path={path}
+          id={id}
+        />
+      );
+    }
   }
-};
+}
 
 export const DispatchField = connect(mapStateToDispatchFieldProps)(Dispatch);

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -26,26 +26,57 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { connect } from 'react-redux';
 import { UnknownRenderer } from './UnknownRenderer';
-import { JsonFormsProps, mapStateToDispatchRendererProps } from '@jsonforms/core';
+import {
+  createId,
+  JsonFormsProps,
+  mapStateToDispatchRendererProps,
+  removeId
+} from '@jsonforms/core';
 
-const JsonFormsDispatchRenderer =
-  ({ uischema, schema, path, renderers }: JsonFormsProps) => {
-  const renderer = _.maxBy(renderers, r => r.tester(uischema, schema));
-  if (renderer === undefined || renderer.tester(uischema, schema) === -1) {
-    return <UnknownRenderer type={'renderer'}/>;
-  } else {
-    const Render = renderer.renderer;
+class JsonFormsDispatchRenderer extends React.Component<JsonFormsProps, { id: string }> {
 
-    return (
-      <Render
-        uischema={uischema}
-        schema={schema}
-        path={path}
-        renderers={renderers}
-      />
-    );
+  constructor(props) {
+    super(props);
+    if (this.isManageOwnID(props)) {
+      this.state = {
+        id: createId(props.uischema.scope)
+      };
+    } else {
+      this.state = {
+        id: undefined
+      };
+    }
   }
-};
+
+  isManageOwnID(props) {
+    return props.uischema.type === 'Control';
+  }
+
+  componentWillUnmount() {
+    if (this.isManageOwnID(this.props)) {
+      removeId(this.state.id);
+    }
+  }
+
+  render() {
+    const { uischema, schema, path, renderers } = this.props as JsonFormsProps;
+    const renderer = _.maxBy(renderers, r => r.tester(uischema, schema));
+    if (renderer === undefined || renderer.tester(uischema, schema) === -1) {
+      return <UnknownRenderer type={'renderer'} />;
+    } else {
+      const Render = renderer.renderer;
+      return (
+        <Render
+          uischema={uischema}
+          schema={schema}
+          path={path}
+          renderers={renderers}
+          id={this.state.id}
+        />
+      );
+    }
+  }
+}
 
 export const JsonForms = connect(
   mapStateToDispatchRendererProps,

--- a/packages/react/src/util.ts
+++ b/packages/react/src/util.ts
@@ -23,9 +23,9 @@
   THE SOFTWARE.
 */
 import {
-    mapDispatchToControlProps,
-    mapStateToControlProps
-    } from '@jsonforms/core';
+  mapDispatchToControlProps,
+  mapStateToControlProps
+} from '@jsonforms/core';
 import { connect } from 'react-redux';
 /**
  * JSONForms specific connect function. This is a wrapper
@@ -57,3 +57,4 @@ export const connectToJsonForms = (
     mapDispatchToProps
   )(Component);
 };
+

--- a/packages/react/test/renderers/JsonForms.test.tsx
+++ b/packages/react/test/renderers/JsonForms.test.tsx
@@ -23,10 +23,6 @@
   THE SOFTWARE.
 */
 import 'jsdom-global/register';
-import * as installCE from 'document-register-element/pony';
-declare let global;
-installCE(global, 'force');
-global.requestAnimationFrame = cb => setTimeout(cb, 0);
 
 import * as React from 'react';
 import { test } from 'ava';
@@ -37,14 +33,19 @@ import {
   jsonformsReducer,
   JsonFormsStore,
   JsonSchema,
+  Layout,
+  rankWith,
   registerRenderer,
   RendererProps,
   UISchemaElement,
+  uiTypeIs,
   unregisterRenderer
 } from '@jsonforms/core';
 import * as TestUtils from 'react-dom/test-utils';
+import * as ReactDOM from 'react-dom';
+import { JsonForms } from '../../src/JsonForms';
+import { StatelessRenderer } from '../../src/Renderer';
 
-import { JsonForms, StatelessRenderer } from '../../src';
 /**
  * Describes the initial state of the JSON Form's store.
  */
@@ -71,11 +72,11 @@ export interface JsonFormsInitialState {
 }
 
 export const initJsonFormsStore = ({
-                                     data,
-                                     schema,
-                                     uischema,
-                                     ...props
-                                   }: JsonFormsInitialState): JsonFormsStore => {
+  data,
+  schema,
+  uischema,
+  ...props
+}: JsonFormsInitialState): JsonFormsStore => {
   return createStore(
     combineReducers({ jsonforms: jsonformsReducer() }),
     {
@@ -101,6 +102,19 @@ test.beforeEach(t => {
     type: 'Control',
     scope: '#/properties/foo'
   };
+  t.context.uischema2 = {
+    type: 'HorizontalLayout',
+    elements: [
+      {
+        type: 'Control',
+        scope: '#/properties/foo'
+      },
+      {
+        type: 'Control',
+        scope: '#/properties/foo'
+      }
+    ]
+  };
   t.context.schema = {
     type: 'object',
     properties: {
@@ -109,25 +123,33 @@ test.beforeEach(t => {
       }
     }
   };
+  t.context.container = document.createElement('div');
+});
+
+test.afterEach(t => {
+  ReactDOM.unmountComponentAtNode(t.context.container);
 });
 
 test('JsonForms renderer should report about missing renderer', t => {
   const data = { foo: 'John Doe' };
   const uischema = { type: 'Foo' };
-  const schema: JsonSchema = { type: 'object', properties: { foo: { type: 'string'} } };
+  const schema: JsonSchema = { type: 'object', properties: { foo: { type: 'string' } } };
   const store = initJsonFormsStore({
     data,
     schema,
     uischema
   });
 
+  const component = (
+    <Provider store={store}>
+      <JsonForms uischema={uischema} schema={schema} />
+    </Provider>
+  );
+  const tree = ReactDOM.render(component, t.context.container);
+
   const div = _.head(
     TestUtils.scryRenderedDOMComponentsWithTag(
-      TestUtils.renderIntoDocument(
-        <Provider store={store}>
-          <JsonForms uischema={uischema} schema={schema} />
-        </Provider>
-      ),
+      tree,
       'div'
     )
   ) as HTMLDivElement;
@@ -142,11 +164,12 @@ test('JsonForms renderer should pick most applicable renderer', t => {
   });
   store.dispatch(registerRenderer(() => 10, CustomRenderer1));
   store.dispatch(registerRenderer(() => 5, CustomRenderer1));
-  const tree = TestUtils.renderIntoDocument(
+  const component = (
     <Provider store={store}>
       <JsonForms uischema={t.context.uischema} schema={t.context.schema} />
     </Provider>
   );
+  const tree = ReactDOM.render(component, t.context.container);
 
   t.not(TestUtils.findRenderedDOMComponentWithTag(tree, 'h1'), undefined);
 });
@@ -164,11 +187,12 @@ test('JsonForms renderer should not consider any de-registered renderers', t => 
   store.dispatch(registerRenderer(tester2, CustomRenderer2));
   store.dispatch(registerRenderer(tester3, CustomRenderer3));
   store.dispatch(unregisterRenderer(tester3, CustomRenderer2));
-  const tree = TestUtils.renderIntoDocument(
-  <Provider store={store}>
-    <JsonForms uischema={t.context.uischema} schema={t.context.schema}/>
-  </Provider>
-);
+  const component = (
+    <Provider store={store}>
+      <JsonForms uischema={t.context.uischema} schema={t.context.schema} />
+    </Provider>
+  );
+  const tree = ReactDOM.render(component, t.context.container);
 
   t.not(TestUtils.findRenderedDOMComponentWithTag(tree, 'h1'), undefined);
 });
@@ -185,4 +209,62 @@ test('deregister an unregistered renderer should be a no-op', t => {
   const nrOfRenderers = store.getState().jsonforms.renderers.length;
   store.dispatch(unregisterRenderer(tester, CustomRenderer3));
   t.is(store.getState().jsonforms.renderers.length, nrOfRenderers);
+});
+
+test('ids should be unique within the same form', t => {
+
+  const FakeLayout = (props: RendererProps) => {
+    const { uischema, schema, path } = props;
+    const layout = uischema as Layout;
+    const children = layout.elements.map((e, idx) => (
+      <JsonForms
+        uischema={e}
+        schema={schema}
+        path={path}
+        key={`${path}-${idx}`}
+      />)
+    );
+    return (
+      <div className='layout'>
+        {children}
+      </div>
+    );
+  };
+
+  const store = initJsonFormsStore(
+    {
+      data: t.context.data,
+      schema: t.context.schema,
+      uischema: t.context.uischema2,
+      renderers: [{
+        tester: rankWith(10, uiTypeIs('HorizontalLayout')),
+        renderer: FakeLayout
+      }]
+    }
+  );
+
+  const ids = [];
+  const MyCustomRenderer: StatelessRenderer<any> = props => {
+    ids.push(props.id);
+    return (<div>Custom</div>);
+  };
+  store.dispatch(registerRenderer(() => 10, MyCustomRenderer));
+
+  ReactDOM.render(
+    <Provider store={store}>
+      <JsonForms uischema={t.context.uischema2} schema={t.context.schema} />
+    </Provider>,
+    t.context.container
+  );
+
+  t.is(
+    ids.indexOf('#/properties/foo') > -1,
+    true,
+    'Generated DOM should contain id: ' + '#/properties/foo'
+  );
+  t.is(
+    ids.indexOf('#/properties/foo2') > -1,
+    true,
+    'Generated DOM should contain id: ' + '#/properties/foo2'
+  );
 });

--- a/packages/vanilla/src/controls/InputControl.tsx
+++ b/packages/vanilla/src/controls/InputControl.tsx
@@ -71,11 +71,12 @@ export class InputControl extends Control<VanillaControlProps, ControlState> {
           hidden={!visible}
           onFocus={this.onFocus}
           onBlur={this.onBlur}
+          id={id}
         >
-          <label htmlFor={id} className={classNames.label}>
+          <label htmlFor={id + '-input'} className={classNames.label}>
             {computeLabel(labelText, required)}
           </label>
-          <DispatchField uischema={uischema} schema={schema} path={parentPath}/>
+          <DispatchField uischema={uischema} schema={schema} path={parentPath} id={id + '-input'}/>
           <div className={divClassNames}>
             {!isValid ? formatErrorMessage(errors) : showDescription ? description : null}
           </div>

--- a/packages/vanilla/test/renderers/TableArrayControl.test.tsx
+++ b/packages/vanilla/test/renderers/TableArrayControl.test.tsx
@@ -128,9 +128,9 @@ test('render two children', t => {
   const tds = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'td');
   t.is(tds.length, 3);
   t.is(tds[0].children.length, 1);
-  t.is(tds[0].children[0].id, '#/properties/x');
+  t.is(tds[0].children[0].id, '');
   t.is(tds[1].children.length, 1);
-  t.is(tds[1].children[0].id, '#/properties/y');
+  t.is(tds[1].children[0].id, '');
 });
 
 test('render empty data', t => {


### PR DESCRIPTION
Fixes #691 

Content:
 * Adds unique ID support in ```core```
 * Uses unique ID support in ```react``` to provide IDs
 * Uses generated IDs in ```react``` to derive unique IDs for HTML elements in Material renderers

Open Tasks:
 * Implement tests for ALL material fields
 * Add unique ID support for arrays