### PR TITLE
Add reducer for registering default data

### DIFF
--- a/packages/core/src/actions/index.ts
+++ b/packages/core/src/actions/index.ts
@@ -38,6 +38,9 @@ export const SET_CONFIG : 'jsonforms/SET_CONFIG' = 'jsonforms/SET_CONFIG';
 export const ADD_UI_SCHEMA: 'jsonforms/ADD_UI_SCHEMA' = `jsonforms/ADD_UI_SCHEMA`;
 export const REMOVE_UI_SCHEMA: 'jsonforms/REMOVE_UI_SCHEMA' = `jsonforms/REMOVE_UI_SCHEMA`;
 
+export const ADD_DEFAULT_DATA: 'jsonforms/ADD_DEFAULT_DATA' = `jsonforms/ADD_DEFAULT_DATA`;
+export const REMOVE_DEFAULT_DATA: 'jsonforms/REMOVE_DEFAULT_DATA' = `jsonforms/REMOVE_DEFAULT_DATA`;
+
 export interface UpdateAction {
   type: 'jsonforms/UPDATE';
   path: string;
@@ -55,6 +58,20 @@ export const init = (
       schema,
       uischema
     });
+
+export const registerDefaultData = (
+    schemaPath: string,
+    data: any
+) => ({
+    type: ADD_DEFAULT_DATA,
+    schemaPath,
+    data
+});
+
+export const unregisterDefaultData = (schemaPath: string) => ({
+    type: REMOVE_DEFAULT_DATA,
+    schemaPath
+});
 
 export const update =
   (path: string, updater: (any) => any): UpdateAction => ({

--- a/packages/core/src/reducers/default-data.ts
+++ b/packages/core/src/reducers/default-data.ts
@@ -1,0 +1,40 @@
+/*
+  The MIT License
+
+  Copyright (c) 2018 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import { ADD_DEFAULT_DATA, REMOVE_DEFAULT_DATA } from '../actions';
+
+export const defaultDataReducer = (
+    state: { schemaPath: string, data: any }[] = [],
+    { type, schemaPath, data }) => {
+    switch (type) {
+        case ADD_DEFAULT_DATA:
+            return state.concat([{ schemaPath, data }]);
+        case REMOVE_DEFAULT_DATA:
+            return state.filter(t => t.schemaPath !== schemaPath);
+        default:
+            return state;
+    }
+};
+
+export const extractDefaultData = state => state;

--- a/packages/core/src/reducers/index.ts
+++ b/packages/core/src/reducers/index.ts
@@ -26,13 +26,14 @@ import { combineReducers, Reducer } from 'redux';
 import { rendererReducer } from './renderers';
 import { fieldReducer } from './fields';
 import { configReducer } from './config';
+import { defaultDataReducer, extractDefaultData } from './default-data';
 import {
-  coreReducer,
-  errorAt,
-  extractData,
-  extractSchema,
-  extractUiSchema,
-  subErrorsAt
+    coreReducer,
+    errorAt,
+    extractData,
+    extractSchema,
+    extractUiSchema,
+    subErrorsAt
 } from './core';
 import { JsonFormsState } from '../store';
 import { findMatchingUISchema, uischemaRegistryReducer, UISchemaTester } from './uischemas';
@@ -52,12 +53,14 @@ export const jsonformsReducer = (additionalReducers = {}): Reducer<JsonFormsStat
     fields: fieldReducer,
     config: configReducer,
     uischemas: uischemaRegistryReducer,
+    defaultData: defaultDataReducer,
     ...additionalReducers
   });
 
 export const getData = state => extractData(state.jsonforms.core);
 export const getSchema = state => extractSchema(state.jsonforms.core);
 export const getUiSchema = state => extractUiSchema(state.jsonforms.core);
+export const getDefaultData = state => extractDefaultData(state.jsonforms.defaultData);
 
 export const findUISchema = state =>
   (schema: JsonSchema, schemaPath: string, path: string): UISchemaElement => {

--- a/packages/material-tree-renderer/example/index.ts
+++ b/packages/material-tree-renderer/example/index.ts
@@ -105,6 +105,13 @@ const store: Store<any> = createStore(
 );
 
 store.dispatch(Actions.init({}, taskSchema, uischema));
+store.dispatch(
+    Actions.registerDefaultData(
+        'properties.users.items',
+        { name: 'Test user' }
+    )
+);
+
 
 detailSchemata.forEach(({ tester, uischema: detailedUiSchema }) =>
   store.dispatch(Actions.registerUISchema(tester, detailedUiSchema))

--- a/packages/material-tree-renderer/src/services/property.util.ts
+++ b/packages/material-tree-renderer/src/services/property.util.ts
@@ -205,7 +205,7 @@ const findContainerProps = (property: string,
             findContainerProps(
               currentProp,
               currentProp,
-              `${schemaPath}.properties.${currentProp}`,
+              `${schemaPath.length > 0 ? schemaPath + '.' : ''}properties.${currentProp}`,
               schema.properties[currentProp],
               rootSchema,
               false,

--- a/packages/material-tree-renderer/src/tree/AddItemDialog.tsx
+++ b/packages/material-tree-renderer/src/tree/AddItemDialog.tsx
@@ -4,12 +4,12 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import {
-  getData,
-  getSchema,
-  JsonSchema,
-  Paths,
-  Resolve,
-  update
+    getData,
+    getSchema,
+    JsonSchema,
+    Paths,
+    Resolve,
+    update
 } from '@jsonforms/core';
 import { findContainerProperties, findPropertyLabel, Property } from '../services/property.util';
 import Button from '@material-ui/core/Button';
@@ -23,128 +23,150 @@ import ListItemText from '@material-ui/core/ListItemText';
 import { ListItemIcon } from '@material-ui/core';
 import { wrapImageIfNecessary } from '../helpers/image-provider.util';
 import { SchemaLabelProvider } from '../helpers/LabelProvider';
+import { getDefaultData } from '../../../core/src/reducers';
 
 export interface AddItemDialogProps {
-  rootData: any;
-  containerProperties: Property[];
-  rootSchema: any;
-  path: string;
-  schema: JsonSchema;
-  closeDialog: any;
-  dialogProps: any;
-  setSelection: any;
-  add?: any;
-  labelProvider?: SchemaLabelProvider;
-  imageProvider(JsonSchema): string;
+    rootData: any;
+    containerProperties: Property[];
+    rootSchema: any;
+    path: string;
+    schema: JsonSchema;
+    closeDialog: any;
+    dialogProps: any;
+    setSelection: any;
+    add?: any;
+    labelProvider?: SchemaLabelProvider;
+    defaultData: { schemaPath: string, data: any}[];
+    imageProvider(JsonSchema): string;
 }
+
+const createData = (defaultData: any, prop: Property) => {
+    const foundData = _.find(defaultData, d => {
+        return d.schemaPath === prop.schemaPath;
+    });
+
+    // default behavior is to read default property from schemas
+    const predefined = _.keys(prop.schema.properties).reduce(
+        (acc, key) => {
+            if (prop.schema.properties[key].default) {
+                acc[key] = prop.schema.properties[key].default;
+            }
+
+            // FIXME generate id if identifying property
+            // is set in editor to allow id refs
+            return acc;
+        },
+        {}
+    );
+
+    return _.merge(foundData ? foundData.data : {}, predefined);
+};
+
+const createPropLabel = (prop, labelProvider) => {
+    let label = prop.label;
+    if (labelProvider) {
+        label = labelProvider(prop.schema, prop.schemaPath);
+    }
+    return `${prop.property} [${label}]`;
+};
 
 class AddItemDialog extends React.Component<AddItemDialogProps, {}> {
 
-  render() {
-    const {
-      add,
-      path,
-      closeDialog,
-      dialogProps,
-      setSelection,
-      rootData,
-      /**
-       * Self contained schemas of the corresponding schema
-       */
-      containerProperties,
-      imageProvider,
-      labelProvider
-    } = this.props;
+    onClick = (prop: Property) => {
+        const { add, closeDialog, defaultData, path, rootData, setSelection } = this.props;
+        const newData = createData(defaultData, prop);
 
-    return (
-      <Dialog id='dialog' {...dialogProps}>
-        <DialogTitle id='dialog-title'>
-          Select item to create
-        </DialogTitle>
-        <DialogContent>
-          <List>
-            {
-              containerProperties
-                .map((prop, index) =>
-                  <ListItem
-                    button
-                    key={`${findPropertyLabel(prop)}-button-${index}`}
-                    onClick={() => {
-                      const newData = _.keys(prop.schema.properties).reduce(
-                        (d, key) => {
-                          if (prop.schema.properties[key].default) {
-                            d[key] = prop.schema.properties[key].default;
-                          }
+        const arrayPath = Paths.compose(path, prop.property);
+        const array = Resolve.data(rootData, arrayPath) as any[];
+        const selectionIndex = _.isEmpty(array) ? 0 : array.length;
+        const selectionPath = Paths.compose(arrayPath, selectionIndex.toString());
 
-                          // FIXME generate id if identifying property
-                          // is set in editor to allow id refs
-                          return d;
-                        },
-                        {}
-                      );
+        add(path, prop, newData);
+        setSelection(prop.schema, newData, selectionPath)();
+        closeDialog();
+    }
 
-                      const arrayPath = Paths.compose(path, prop.property);
-                      const array = Resolve.data(rootData, arrayPath) as any[];
-                      const selectionIndex = _.isEmpty(array) ? 0 : array.length;
-                      const selectionPath = Paths.compose(arrayPath, selectionIndex.toString());
+    render() {
+        const {
+            closeDialog,
+            dialogProps,
+            /**
+             * Self contained schemas of the corresponding schema
+             */
+            containerProperties,
+            imageProvider,
+            labelProvider,
+        } = this.props;
 
-                      add(path, prop, newData);
-                      setSelection(prop.schema, newData, selectionPath)();
-                      closeDialog();
-                    }}
-                  >
-                    <ListItemIcon>
-                        {wrapImageIfNecessary(imageProvider(prop.schema))}
-                    </ListItemIcon>
-                     <ListItemText
-                        primary={`${prop.property} [${(labelProvider && labelProvider(prop.schema, prop.schemaPath)) || prop.label}]`}
-                    />
-                  </ListItem>
-                )
-            }
-          </List>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={closeDialog} variant='outlined' color='primary'>
-            Close
-          </Button>
-        </DialogActions>
-      </Dialog>
-    );
-  }
+        return (
+            <Dialog id='dialog' {...dialogProps}>
+                <DialogTitle id='dialog-title'>
+                    Select item to create
+                </DialogTitle>
+                <DialogContent>
+                    <List>
+                        {
+                            containerProperties
+                                .map((prop, index) => {
+                                    const label = createPropLabel(prop, labelProvider);
+                                    return (
+                                        <ListItem
+                                            button
+                                            key={`${findPropertyLabel(prop)}-button-${index}`}
+                                            onClick={() => this.onClick(prop)}
+                                        >
+                                            <ListItemIcon>
+                                                {wrapImageIfNecessary(imageProvider(prop.schema))}
+                                            </ListItemIcon>
+                                            <ListItemText primary={label} />
+                                        </ListItem>
+                                    );
+                                })
+                        }
+                    </List>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={closeDialog} variant='outlined' color='primary'>
+                        Close
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        );
+    }
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const containerProperties = findContainerProperties(ownProps.schema, getSchema(state), false);
+    const containerProperties = findContainerProperties(ownProps.schema, getSchema(state), false);
 
-  return {
-    rootData: getData(state),
-    containerProperties,
-    rootSchema: getSchema(state),
-    path: ownProps.path,
-    schema: ownProps.schema,
-    closeDialog: ownProps.closeDialog,
-    dialogProps: ownProps.dialogProps,
-    setSelection: ownProps.setSelection,
-    labelProvider: ownProps.labelProvider
-  };
+    return {
+        rootData: getData(state),
+        defaultData: getDefaultData(state),
+        containerProperties,
+        rootSchema: getSchema(state),
+        path: ownProps.path,
+        schema: ownProps.schema,
+        closeDialog: ownProps.closeDialog,
+        dialogProps: ownProps.dialogProps,
+        setSelection: ownProps.setSelection,
+        labelProvider: ownProps.labelProvider
+    };
 };
 
 const mapDispatchToProps = dispatch => ({
     add(path, prop, newData) {
-      dispatch(
-        update(
-          Paths.compose(path, prop.property),
-          array => {
-            if (_.isEmpty(array)) {
-              return [newData];
-            }
-            array.push(newData);
+        dispatch(
+            update(
+                Paths.compose(path, prop.property),
+                array => {
+                    if (_.isEmpty(array)) {
+                        return [newData];
+                    }
+                    array.push(newData);
 
-            return array;
-          }
-        )
-      );
+                    return array;
+                }
+            )
+        );
     }
 });
 


### PR DESCRIPTION
Introduce a new reducer for adding a substate that keeps track of any pre-defined data that can be queried by clients. Currently, the only such client is the `AddItemDialog` which reads the registry and merges any result with any default values found in the schema, if such.
Registration is happening via a given schema path and a JSON value. No validation of the registered data or whatsoever is taking place.
The material-tree-renderer example has been updated to demonstrate this new feature.