### PR TITLE
Various minor improvements for ionic renderer set

### DIFF
--- a/packages/angular/src/control.ts
+++ b/packages/angular/src/control.ts
@@ -20,7 +20,7 @@ import { JsonFormsBaseRenderer } from './base.renderer';
 
 export class JsonFormsControl extends JsonFormsBaseRenderer implements OnInit, OnDestroy {
 
-    form;
+    form: FormControl;
     subscription: Subscription;
 
     data: any;

--- a/packages/core/src/testers/index.ts
+++ b/packages/core/src/testers/index.ts
@@ -24,7 +24,7 @@
 */
 import * as _ from 'lodash';
 import { JsonSchema } from '../models/jsonSchema';
-import { ControlElement, UISchemaElement } from '../models/uischema';
+import { Categorization, ControlElement, UISchemaElement } from '../models/uischema';
 import { resolveSchema } from '../util/resolvers';
 
 /**
@@ -411,3 +411,22 @@ export const isNumberFormatControl = and(
   schemaTypeIs('integer'),
   optionIs('format', true)
 );
+
+export const isCategorization = (category: UISchemaElement): category is Categorization =>
+    category.type === 'Categorization';
+
+export const isCategory = (uischema: UISchemaElement): boolean =>
+    uischema.type === 'Category';
+
+const hasCategory = (categorization: Categorization): boolean => {
+    if (_.isEmpty(categorization.elements)) {
+        return false;
+    }
+    // all children of the categorization have to be categories
+    return categorization.elements
+        .map(elem => isCategorization(elem) ? hasCategory(elem) : isCategory(elem))
+        .reduce((prev, curr) => prev && curr, true);
+};
+
+export const categorizationHasCategory = uischema =>
+    hasCategory(uischema as Categorization);

--- a/packages/ionic/src/controls/boolean/boolean-control.ts
+++ b/packages/ionic/src/controls/boolean/boolean-control.ts
@@ -8,7 +8,7 @@ import { JsonFormsControl } from '@jsonforms/angular';
   template: `
       <ion-item>
           <ion-label>{{label}}</ion-label>
-          <ion-label stacked *ngIf="error" style="color: red">{{error}}</ion-label>
+          <ion-label stacked *ngIf="error" color="error">{{error}}</ion-label>
           <ion-checkbox [ngModel]="data" (ionChange)="onChange($event)"></ion-checkbox>
       </ion-item>
   `

--- a/packages/ionic/src/controls/boolean/boolean-control.ts
+++ b/packages/ionic/src/controls/boolean/boolean-control.ts
@@ -9,7 +9,7 @@ import { JsonFormsControl } from '@jsonforms/angular';
       <ion-item>
           <ion-label>{{label}}</ion-label>
           <ion-label stacked *ngIf="error" style="color: red">{{error}}</ion-label>
-          <ion-checkbox [ngModel]="value" (ionChange)="onChange($event)"></ion-checkbox>
+          <ion-checkbox [ngModel]="data" (ionChange)="onChange($event)"></ion-checkbox>
       </ion-item>
   `
 })

--- a/packages/ionic/src/controls/date/date-control.ts
+++ b/packages/ionic/src/controls/date/date-control.ts
@@ -8,9 +8,10 @@ import { JsonFormsControl } from '@jsonforms/angular';
   template: `
       <ion-item>
           <ion-label floating>{{label}}</ion-label>
+          <ion-label stacked *ngIf="error" style="color: red">{{error}}</ion-label>
           <ion-datetime
                   displayFormat="MM/DD/YYYY"
-                  [ngModel]="value"
+                  [ngModel]="data"
                   (ionChange)="onChange($event)"
           ></ion-datetime>
       </ion-item>

--- a/packages/ionic/src/controls/date/date-control.ts
+++ b/packages/ionic/src/controls/date/date-control.ts
@@ -8,7 +8,7 @@ import { JsonFormsControl } from '@jsonforms/angular';
   template: `
       <ion-item>
           <ion-label floating>{{label}}</ion-label>
-          <ion-label stacked *ngIf="error" style="color: red">{{error}}</ion-label>
+          <ion-label stacked *ngIf="error" color="error">{{error}}</ion-label>
           <ion-datetime
                   displayFormat="MM/DD/YYYY"
                   [ngModel]="data"

--- a/packages/ionic/src/controls/enum/enum-control.ts
+++ b/packages/ionic/src/controls/enum/enum-control.ts
@@ -8,7 +8,7 @@ import { JsonFormsControl } from '@jsonforms/angular';
   template: `
       <ion-item>
           <ion-label>{{label}}</ion-label>
-          <ion-label stacked *ngIf="error" style="color: red">{{error}}</ion-label>
+          <ion-label stacked *ngIf="error" color="errora">{{error}}</ion-label>
           <ion-select [ngModel]="data" (ionChange)="onChange($event)">
               <ion-option *ngFor="let option of options" value="{{option}}">
                   {{option}}

--- a/packages/ionic/src/controls/enum/enum-control.ts
+++ b/packages/ionic/src/controls/enum/enum-control.ts
@@ -8,7 +8,8 @@ import { JsonFormsControl } from '@jsonforms/angular';
   template: `
       <ion-item>
           <ion-label>{{label}}</ion-label>
-          <ion-select [ngModel]="value" (ionChange)="onChange($event)">
+          <ion-label stacked *ngIf="error" style="color: red">{{error}}</ion-label>
+          <ion-select [ngModel]="data" (ionChange)="onChange($event)">
               <ion-option *ngFor="let option of options" value="{{option}}">
                   {{option}}
               </ion-option>
@@ -18,14 +19,13 @@ import { JsonFormsControl } from '@jsonforms/angular';
 })
 export class EnumControlRenderer extends JsonFormsControl {
 
-  options;
+  options: any[];
 
   constructor(ngRedux: NgRedux<JsonFormsState>) {
     super(ngRedux);
   }
 
-  ngOnInit() {
-    super.ngOnInit();
+  mapAdditionalProps() {
     this.options = this.scopedSchema.enum;
   }
 }

--- a/packages/ionic/src/controls/number/number-control.ts
+++ b/packages/ionic/src/controls/number/number-control.ts
@@ -8,7 +8,7 @@ import { JsonFormsControl } from '@jsonforms/angular';
   template: `
       <ion-item>
           <ion-label floating>{{label}}</ion-label>
-          <ion-label stacked *ngIf="error" style="color: red">{{error}}</ion-label>
+          <ion-label stacked *ngIf="error" color="error">{{error}}</ion-label>
           <ion-input
                   type="number"
                   placeholder="{{ description }}"

--- a/packages/ionic/src/controls/number/number-control.ts
+++ b/packages/ionic/src/controls/number/number-control.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { NgRedux } from '@angular-redux/store';
-import { JsonFormsState, isNumberControl, RankedTester, rankWith } from '@jsonforms/core';
+import { isNumberControl, JsonFormsState, RankedTester, rankWith } from '@jsonforms/core';
 import { JsonFormsControl } from '@jsonforms/angular';
 
 @Component({
@@ -8,13 +8,14 @@ import { JsonFormsControl } from '@jsonforms/angular';
   template: `
       <ion-item>
           <ion-label floating>{{label}}</ion-label>
+          <ion-label stacked *ngIf="error" style="color: red">{{error}}</ion-label>
           <ion-input
                   type="number"
                   placeholder="{{ description }}"
                   [min]="min"
                   [max]="max"
                   [step]="multipleOf"
-                  [value]="value"
+                  [value]="data"
                   (ionChange)="onChange($event)"
           >
           </ion-input>
@@ -31,11 +32,10 @@ export class NumberControlRenderer extends JsonFormsControl {
     super(ngRedux);
   }
 
-  ngOnInit() {
-    super.ngOnInit();
-    this.min = this.scopedSchema.minimum || null;
-    this.max = this.scopedSchema.maximum || null;
-    this.multipleOf = this.scopedSchema.multipleOf || null;
+  mapAdditionalProps() {
+    this.min = this.scopedSchema.maximum;
+    this.max = this.scopedSchema.minimum;
+    this.multipleOf = this.scopedSchema.multipleOf;
   }
 }
 

--- a/packages/ionic/src/controls/string/string-control.ts
+++ b/packages/ionic/src/controls/string/string-control.ts
@@ -9,7 +9,7 @@ import { JsonFormsControl } from '@jsonforms/angular';
       <ion-item>
           <ion-label floating>{{label}}</ion-label>
           <!-- TODO: displays the actual error, question is where we want to actually display it -->
-          <ion-label stacked *ngIf="error" style="color: red">{{error}}</ion-label>
+          <ion-label stacked *ngIf="error" color="error">{{error}}</ion-label>
           <ion-input
                   type="text"
                   (ionChange)="onChange($event)"

--- a/packages/ionic/src/controls/string/string-control.ts
+++ b/packages/ionic/src/controls/string/string-control.ts
@@ -9,12 +9,11 @@ import { JsonFormsControl } from '@jsonforms/angular';
       <ion-item>
           <ion-label floating>{{label}}</ion-label>
           <!-- TODO: displays the actual error, question is where we want to actually display it -->
-          <!-- TODO: needs to be added for other controls as well -->
           <ion-label stacked *ngIf="error" style="color: red">{{error}}</ion-label>
           <ion-input
                   type="text"
                   (ionChange)="onChange($event)"
-                  [value]="value"
+                  [value]="data"
                   placeholder="{{ description }}"
                   [formControl]="form"
           >

--- a/packages/ionic/src/layouts/categorization/categorization-layout.ts
+++ b/packages/ionic/src/layouts/categorization/categorization-layout.ts
@@ -1,13 +1,11 @@
-import * as _ from 'lodash';
 import {
     and,
-    Categorization,
     Category,
+    categorizationHasCategory,
     JsonFormsState,
     Layout,
     RankedTester,
     rankWith,
-    UISchemaElement,
     uiTypeIs
 } from '@jsonforms/core';
 import { Component, ViewChild } from '@angular/core';
@@ -93,27 +91,9 @@ export class CategorizationLayoutRenderer extends JsonFormsIonicLayout {
     }
 }
 
-export const isCategorization = (category: Category | Categorization): category is Categorization =>
-    category.type === 'Categorization';
-
-export const isCategory = (uischema: UISchemaElement): boolean =>
-    uischema.type === 'Category';
-
 export const categorizationTester: RankedTester = rankWith(
     1,
     and(
         uiTypeIs('Categorization'),
-        uischema => {
-            const hasCategory = (categorization: Categorization): boolean => {
-                if (_.isEmpty(categorization.elements)) {
-                    return false;
-                }
-                // all children of the categorization have to be categories
-                return categorization.elements
-                    .map(elem => isCategorization(elem) ? hasCategory(elem) : isCategory(elem))
-                    .reduce((prev, curr) => prev && curr, true);
-            };
-
-            return hasCategory(uischema as Categorization);
-        }
+        categorizationHasCategory
     ));

--- a/packages/ionic/src/layouts/categorization/category/category.ts
+++ b/packages/ionic/src/layouts/categorization/category/category.ts
@@ -4,8 +4,8 @@ import { NavParams } from 'ionic-angular';
 @Component({
   selector: 'jsonforms-category',
   template: `
-      <div *ngFor="let uischema of elements">
-          <jsonforms-outlet [uischema]="uischema"></jsonforms-outlet>
+      <div *ngFor="let element of elements">
+          <jsonforms-outlet [uischema]="element"></jsonforms-outlet>
       </div>
   `
 })

--- a/packages/ionic/src/layouts/group/group-layout.ts
+++ b/packages/ionic/src/layouts/group/group-layout.ts
@@ -3,7 +3,6 @@ import {
   JsonFormsState,
   RankedTester,
   rankWith,
-  StatePropsOfLayout,
   uiTypeIs
 } from '@jsonforms/core';
 import { Component } from '@angular/core';
@@ -18,9 +17,9 @@ import { JsonFormsIonicLayout } from '../JsonFormsIonicLayout';
               {{label}}
           </ion-card-header>
           <ion-card-content>
-              <div *ngFor="let uischema of stateProps.uischema.elements">
+              <div *ngFor="let element of uischema?.elements">
                   <jsonforms-outlet
-                          [uischema]="uischema"
+                          [uischema]="element"
                           [path]="path"
                           [schema]="schema"
                   ></jsonforms-outlet>
@@ -33,19 +32,13 @@ import { JsonFormsIonicLayout } from '../JsonFormsIonicLayout';
 export class GroupLayoutRenderer extends JsonFormsIonicLayout {
 
   label: string;
-  stateProps: StatePropsOfLayout;
 
   constructor(ngRedux: NgRedux<JsonFormsState>) {
     super(ngRedux);
   }
 
-  ngOnInit() {
-    const ownProps = this.getOwnProps()
-    const state$ = this.connectLayoutToJsonForms(this.ngRedux, ownProps);
-    this.subscription = state$.subscribe(state => {
-      this.stateProps = state;
-      this.label = (ownProps.uischema as GroupLayout).label;
-    });
+  mapAdditionalProps() {
+      this.label = (this.uischema as GroupLayout).label;
   }
 }
 

--- a/packages/ionic/src/layouts/horizontal/horizontal-layout.ts
+++ b/packages/ionic/src/layouts/horizontal/horizontal-layout.ts
@@ -8,9 +8,9 @@ import { NgRedux } from '@angular-redux/store';
   template: `
       <ion-grid>
           <ion-row>
-              <ion-col *ngFor="let uischema of elements">
+              <ion-col *ngFor="let element of uischema?.elements">
                   <jsonforms-outlet
-                          [uischema]="uischema"
+                          [uischema]="element"
                           [schema]="schema"
                           [path]="path"
                   ></jsonforms-outlet>

--- a/packages/ionic/src/layouts/vertical/vertical-layout.ts
+++ b/packages/ionic/src/layouts/vertical/vertical-layout.ts
@@ -6,9 +6,9 @@ import { NgRedux } from '@angular-redux/store';
 @Component({
   selector: 'jsonforms-vertical-layout',
   template: `
-      <div *ngFor="let child of uischema.elements">
+      <div *ngFor="let element of uischema?.elements">
           <jsonforms-outlet
-                  [uischema]="child"
+                  [uischema]="element"
                   [path]="path"
                   [schema]="schema"
           ></jsonforms-outlet>

--- a/packages/ionic/src/other/label/label.ts
+++ b/packages/ionic/src/other/label/label.ts
@@ -1,11 +1,11 @@
 import { Component } from '@angular/core';
-import { JsonFormsState, RankedTester, rankWith, uiTypeIs } from '@jsonforms/core';
+import { JsonFormsState, LabelElement, RankedTester, rankWith, uiTypeIs } from '@jsonforms/core';
 import { NgRedux } from '@angular-redux/store';
 import { JsonFormsIonicLayout } from '../../layouts/JsonFormsIonicLayout';
 
 @Component({
-  selector: 'label',
-  template: `
+    selector: 'label',
+    template: `
       <div>
           {{label}}
       </div>
@@ -13,26 +13,18 @@ import { JsonFormsIonicLayout } from '../../layouts/JsonFormsIonicLayout';
 })
 export class LabelRenderer extends JsonFormsIonicLayout {
 
-  label: string;
+    label: string;
 
-  constructor(ngRedux: NgRedux<JsonFormsState>) {
-    super(ngRedux);
-  }
+    constructor(ngRedux: NgRedux<JsonFormsState>) {
+        super(ngRedux);
+    }
 
-  ngOnInit() {
-    // TODO: this is using connectLayoutToJsonForms
-    const state$ = this.connectLayoutToJsonForms(this.ngRedux, this.getOwnProps());
-    this.subscription = state$.subscribe(state => {
-      this.label = state.uischema.label;
-    });
-  }
-
-  ngOnDestroy() {
-    this.subscription.unsubscribe();
-  }
+    mapAdditionalProps() {
+        this.label = (this.uischema as LabelElement).text;
+    }
 }
 
 export const labelTester: RankedTester = rankWith(
-  4,
-  uiTypeIs('Label')
+    4,
+    uiTypeIs('Label')
 );

--- a/packages/ionic/src/other/master-detail/master-detail.ts
+++ b/packages/ionic/src/other/master-detail/master-detail.ts
@@ -1,14 +1,17 @@
 import * as _ from 'lodash';
 import { Component, ViewChild } from '@angular/core';
 import {
-  ControlElement,
-  Generate,
-  JsonFormsState,
-  RankedTester,
-  rankWith,
-  resolveSchema,
-  toDataPath,
-  uiTypeIs,
+    composeWithUi,
+    ControlElement,
+    Generate,
+    JsonFormsState,
+    JsonSchema,
+    RankedTester,
+    rankWith,
+    resolveSchema,
+    toDataPath,
+    UISchemaElement,
+    uiTypeIs,
 } from '@jsonforms/core';
 import { JsonFormsControl } from '@jsonforms/angular';
 import { Nav, Platform } from 'ionic-angular';
@@ -16,11 +19,18 @@ import { MasterDetailNavService } from './master-detail-nav.service';
 import { MasterPage } from './pages/master/master';
 import { removeSchemaKeywords } from '../../common';
 import { NgRedux } from '@angular-redux/store';
-import { DetailPage } from './pages/detail/detail';
+
+export interface MasterItem {
+    label: string;
+    data: any;
+    path: string;
+    schema: JsonSchema;
+    uischema: UISchemaElement;
+}
 
 @Component({
-  selector: 'jsonforms-master-detail',
-  template: `
+    selector: 'jsonforms-master-detail',
+    template: `
       <ion-split-pane (ionChange)="onSplitPaneChange($event)">
           <ion-nav [root]="masterPage" #masterNav ></ion-nav>
           <ion-nav [root]="detailPage" #detailNav main></ion-nav>
@@ -29,89 +39,77 @@ import { DetailPage } from './pages/detail/detail';
 })
 export class MasterDetailComponent extends JsonFormsControl {
 
-  @ViewChild('masterNav') masterNav: Nav;
-  @ViewChild('detailNav') detailNav: Nav;
+    @ViewChild('masterNav') masterNav: Nav;
+    @ViewChild('detailNav') detailNav: Nav;
+    masterItems: MasterItem[];
 
-  private masterItems: any[];
-
-  constructor(
-    private parentNav: Nav,
-    private platform: Platform,
-    ngRedux: NgRedux<JsonFormsState>,
-    private masterDetailService: MasterDetailNavService
-  ) {
-    super(ngRedux);
-  }
-
-  ngOnInit() {
-
-    this.masterDetailService.masterNav = this.masterNav;
-    this.masterDetailService.detailNav = this.detailNav;
-    this.masterDetailService.parentNav = this.parentNav;
-
-    const state$ = this.ngRedux.select().map(this.mapToProps(this.getOwnProps()));
-    this.subscription = state$.subscribe(state => {
-
-      const controlElement = state.uischema as ControlElement;
-      const labelRefInstancePath = removeSchemaKeywords(controlElement.options.labelRef);
-      const instancePath = toDataPath(`${controlElement.scope}/items`);
-      const resolvedSchema = resolveSchema(state.schema, `${controlElement.scope}/items`);
-      const detailUISchema = controlElement.options.detail ||
-        Generate.uiSchema(resolvedSchema, 'VerticalLayout');
-
-      this.masterItems = state.data.map((d, index) => {
-        return {
-          label: _.get(d, labelRefInstancePath),
-          data: d,
-          path: `${instancePath}.${index}`,
-          schema: resolvedSchema,
-          uischema: detailUISchema
-        };
-      });
-    });
-
-    this.masterDetailService.masterNav.setRoot(
-      MasterPage,
-      {
-        addToNavStack: true,
-        items: this.masterItems
-      }
-    );
-
-    this.detailNav.setRoot(
-      DetailPage,
-      {
-        addToNavStack: true,
-        // TODO: must have items
-        item: this.masterItems[0]
-      }
-    );
-
-    if (this.platform.width() < 768) {
-      this.masterDetailService.useParentNav = true;
-      this.parentNav.push(
-        MasterPage,
-        {
-          addToNavStack: true,
-          items: this.masterItems
-        }
-      );
-    } else {
-      this.masterDetailService.useParentNav = false;
+    constructor(
+        private parentNav: Nav,
+        private platform: Platform,
+        ngRedux: NgRedux<JsonFormsState>,
+        private masterDetailService: MasterDetailNavService
+    ) {
+        super(ngRedux);
     }
-  }
 
-  onSplitPaneChange(event) {
-    const isDetailVisible = event._visible;
-    this.masterDetailService.onDetailVisibilityChanged(isDetailVisible, this.parentNav);
-  }
+    ngOnInit() {
 
-  ngOnDestroy() {
-    this.subscription.unsubscribe();
-  }
+        this.masterDetailService.masterNav = this.masterNav;
+        this.masterDetailService.detailNav = this.detailNav;
+        this.masterDetailService.parentNav = this.parentNav;
+
+        this.subscription = this.ngRedux
+            .select()
+            .map((s: JsonFormsState) => this.mapToProps(s))
+            .subscribe(({ data, schema, uischema, }) => {
+                const controlElement = uischema as ControlElement;
+                const instancePath = toDataPath(`${controlElement.scope}/items`);
+                const resolvedSchema = resolveSchema(schema, `${controlElement.scope}/items`);
+                const detailUISchema = controlElement.options.detail ||
+                    Generate.uiSchema(resolvedSchema, 'VerticalLayout');
+                const masterItems = data.map((d, index) => {
+                    const labelRefInstancePath =
+                        removeSchemaKeywords(controlElement.options.labelRef);
+                    const masterItem: MasterItem = {
+                        label: _.get(d, labelRefInstancePath),
+                        data: d,
+                        path: `${instancePath}.${index}`,
+                        schema: resolvedSchema,
+                        uischema: detailUISchema
+                    };
+                    return masterItem;
+                });
+
+                if (this.masterItems === undefined ||
+                    this.masterItems.length !== masterItems.length) {
+                    this.masterItems = masterItems;
+                    this.masterDetailService.masterNav.setRoot(
+                        MasterPage,
+                        {
+                            addToNavStack: true,
+                            items: this.masterItems,
+                            path: composeWithUi(this.uischema as ControlElement, this.path),
+                            uischema: this.uischema,
+                            schema: this.schema
+                        }
+                    );
+                }
+
+                if (this.platform.width() < 768) {
+                    this.masterDetailService.useParentNav = true;
+                } else {
+                    this.masterDetailService.useParentNav = false;
+                }
+            });
+    }
+
+    onSplitPaneChange(event) {
+        const isDetailVisible = event._visible;
+        this.masterDetailService.onDetailVisibilityChanged(isDetailVisible, this.parentNav);
+    }
 }
 
 export const masterDetailTester: RankedTester = rankWith(
-  4,
-  uiTypeIs('FlatMasterDetail')
+    4,
+    uiTypeIs('FlatMasterDetail')
 );

--- a/packages/ionic/src/other/master-detail/pages/detail/detail.ts
+++ b/packages/ionic/src/other/master-detail/pages/detail/detail.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { JsonSchema, UISchemaElement } from '@jsonforms/core';
 import { IonicPage, NavParams } from 'ionic-angular';
 import { AbstractDetailPage } from '../AbstractDetailPage';
 
@@ -17,8 +18,8 @@ import { AbstractDetailPage } from '../AbstractDetailPage';
 })
 export class DetailPage extends AbstractDetailPage {
 
-  schema;
-  uischema;
+  schema: JsonSchema;
+  uischema: UISchemaElement;
   path: string;
 
   constructor(public navParams: NavParams) {

--- a/packages/ionic/test-config/karma.conf.js
+++ b/packages/ionic/test-config/karma.conf.js
@@ -44,7 +44,7 @@ module.exports = function(config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['ChromeHeadless', 'ChromeHeadlessNoSandbox'],
+    browsers: ['ChromeHeadlessNoSandbox'],
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: 'ChromeHeadless',

--- a/packages/ionic/test/boolean-control.spec.ts
+++ b/packages/ionic/test/boolean-control.spec.ts
@@ -67,7 +67,7 @@ describe('Boolean control', () => {
         component = fixture.componentInstance;
     });
 
-    it('should support setting the initial state', async(() => {
+    it('should support setting the initial state', () => {
         const mockSubStore = MockNgRedux.getSelectorStub();
         component.uischema = uischema;
 
@@ -81,10 +81,10 @@ describe('Boolean control', () => {
         });
         mockSubStore.complete();
         component.ngOnInit();
-        expect(component.value).toBe(true);
-    }));
+        expect(component.data).toBe(true);
+    });
 
-    it('should support updating the state', async(() => {
+    it('should support updating the state', () => {
         const mockSubStore = MockNgRedux.getSelectorStub();
         component.uischema = uischema;
 
@@ -109,11 +109,11 @@ describe('Boolean control', () => {
             }
         });
         mockSubStore2.complete();
-        component.subscribe();
-        expect(component.value).toBe(false);
-    }));
+        fixture.detectChanges();
+        expect(component.data).toBe(false);
+    });
 
-    it('should display errors', async(() => {
+    it('should display errors', () => {
         const mockSubStore = MockNgRedux.getSelectorStub();
         component.uischema = uischema;
 
@@ -133,6 +133,6 @@ describe('Boolean control', () => {
         component.ngOnInit();
         fixture.detectChanges();
         const booleanControl = fixture.nativeElement;
-        expect(booleanControl.getElementsByTagName("ion-label").length).toBe(2);
-    }));
+        expect(booleanControl.getElementsByTagName('ion-label').length).toBe(2);
+    });
 });

--- a/packages/ionic/test/horizontal-layout.spec.ts
+++ b/packages/ionic/test/horizontal-layout.spec.ts
@@ -1,0 +1,105 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2018 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import { TestBed } from '@angular/core/testing';
+import { JsonFormsOutlet } from '@jsonforms/angular';
+import { IonicModule, Platform } from 'ionic-angular';
+import { PlatformMock } from '../test-config/mocks-ionic';
+import { NgRedux } from '@angular-redux/store';
+import { MockNgRedux } from '@angular-redux/store/testing';
+import { HorizontalLayoutRenderer } from '../src';
+
+describe('Horizontal layout', () => {
+    let fixture;
+    let component;
+
+    const data = { foo: true };
+    const schema = {
+        type: 'object',
+        properties: {
+            foo: {
+                type: 'boolean'
+            }
+        }
+    };
+    const uischema = {
+        type: 'HorizontalLayout',
+        elements: [{
+            type: 'Control',
+            scope: '#/properties/foo'
+        }]
+    };
+
+    beforeEach((() => {
+        TestBed.configureTestingModule({
+            declarations: [
+                JsonFormsOutlet,
+                HorizontalLayoutRenderer
+            ],
+            imports: [
+                IonicModule.forRoot(HorizontalLayoutRenderer)
+            ],
+            providers: [
+                {provide: Platform, useClass: PlatformMock},
+                {provide: NgRedux, useFactory: MockNgRedux.getInstance}
+            ]
+        }).compileComponents();
+
+        MockNgRedux.reset();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(HorizontalLayoutRenderer);
+        component = fixture.componentInstance;
+    });
+
+    it('add elements', () => {
+        const mockSubStore = MockNgRedux.getSelectorStub();
+        component.uischema = uischema;
+
+        mockSubStore.next({
+            jsonforms: {
+                core: {
+                    data,
+                    schema,
+                }
+            }
+        });
+        mockSubStore.complete();
+        component.ngOnInit();
+        MockNgRedux.reset();
+        component.uischema = {
+            type: 'HorizontalLayout',
+            elements: [
+                ...uischema.elements,
+                {
+                    type: 'Control',
+                    scope: '#properties/bar'
+                }
+            ]
+        };
+        fixture.detectChanges();
+        expect(component.uischema.elements.length).toBe(2);
+    });
+});


### PR DESCRIPTION
This PR streamlines  the existing ionic renderer set regarding naming and usage of variables throughout the renderer hierarchy as well as subscription for additional properties in child renderers. It also adds featurs a test for the horizontal layout (testing the `Input` annotation effictively) as well as an Add button for the master page