### PR TITLE
Remove template value bindings

### DIFF
--- a/packages/angular-material/src/controls/autocomplete.renderer.ts
+++ b/packages/angular-material/src/controls/autocomplete.renderer.ts
@@ -69,7 +69,6 @@ import { startWith } from 'rxjs/operators/startWith';
                 matInput
                 type="text"
                 (change)="onChange($event)"
-                [value]="getValue()"
                 placeholder="{{ description }}"
                 [id]="id"
                 [formControl]="form"
@@ -92,7 +91,6 @@ export class AutocompleteControlRenderer extends JsonFormsControl {
     constructor(ngRedux: NgRedux<JsonFormsState>) {
         super(ngRedux);
     }
-    getValue = () => this.data || '';
     getEventValue = (event: any) => event.target.value;
 
     ngOnInit() {

--- a/packages/angular-material/src/controls/date.renderer.ts
+++ b/packages/angular-material/src/controls/date.renderer.ts
@@ -11,7 +11,6 @@ import { JsonFormsControl } from '@jsonforms/angular';
     <input
         matInput
         (dateChange)="onChange($event)"
-        [value]="data"
         placeholder="{{ description }}"
         [id]="id"
         [formControl]="form"

--- a/packages/angular-material/src/controls/number.renderer.ts
+++ b/packages/angular-material/src/controls/number.renderer.ts
@@ -43,7 +43,6 @@ import {
                 matInput
                 type="number"
                 (change)="onChange($event)"
-                [value]="data"
                 placeholder="{{ description }}"
                 [id]="id"
                 [formControl]="form"

--- a/packages/angular-material/src/controls/text.renderer.ts
+++ b/packages/angular-material/src/controls/text.renderer.ts
@@ -36,7 +36,6 @@ import { isControl, JsonFormsState, RankedTester, rankWith } from '@jsonforms/co
                 matInput
                 [type]="getType()"
                 (change)="onChange($event)"
-                [value]="getValue()"
                 placeholder="{{ description }}"
                 [id]="id"
                 [formControl]="form"
@@ -49,7 +48,6 @@ export class TextControlRenderer extends JsonFormsControl {
     constructor(ngRedux: NgRedux<JsonFormsState>) {
         super(ngRedux);
     }
-    getValue = () => this.data || '';
     getEventValue = (event: any) => event.target.value;
     getType = (): string => {
         if (this.uischema.options && this.uischema.options.format) {

--- a/packages/angular-material/src/controls/textarea.renderer.ts
+++ b/packages/angular-material/src/controls/textarea.renderer.ts
@@ -35,7 +35,6 @@ import { isMultiLineControl, JsonFormsState, RankedTester, rankWith } from '@jso
             <textarea
                 matInput
                 (change)="onChange($event)"
-                [value]="getValue()"
                 placeholder="{{ description }}"
                 [id]="id"
                 [formControl]="form"
@@ -48,7 +47,6 @@ export class TextAreaRenderer extends JsonFormsControl {
     constructor(ngRedux: NgRedux<JsonFormsState>) {
         super(ngRedux);
     }
-    getValue = () => this.data || '';
     getEventValue = (event: any) => event.target.value;
 }
 export const TextAreaRendererTester: RankedTester = rankWith(2, isMultiLineControl);

--- a/packages/angular-material/test-config/karma.conf.js
+++ b/packages/angular-material/test-config/karma.conf.js
@@ -44,7 +44,7 @@ module.exports = function(config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['ChromeHeadless', 'ChromeHeadlessNoSandbox'],
+    browsers: ['ChromeHeadlessNoSandbox'],
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: 'ChromeHeadless',

--- a/packages/angular-material/test/autocomplete-control.spec.ts
+++ b/packages/angular-material/test/autocomplete-control.spec.ts
@@ -23,11 +23,11 @@
   THE SOFTWARE.
 */
 import {
-    MatAutocompleteModule,
-    MatAutocompleteSelectedEvent,
-    MatError,
-    MatFormFieldModule,
-    MatInputModule
+  MatAutocompleteModule,
+  MatAutocompleteSelectedEvent,
+  MatError,
+  MatFormFieldModule,
+  MatInputModule
 } from '@angular/material';
 import { NgRedux } from '@angular-redux/store';
 import { OverlayContainer } from '@angular/cdk/overlay';
@@ -44,387 +44,391 @@ import { AutocompleteControlRenderer } from '../src';
 
 const data = { foo: 'A' };
 const schema: JsonSchema = {
-    type: 'object',
-    properties: {
-        foo: {
-            type: 'string',
-            enum: [
-                'A',
-                'B',
-                'C'
-            ]
-        }
+  type: 'object',
+  properties: {
+    foo: {
+      type: 'string',
+      enum: [
+        'A',
+        'B',
+        'C'
+      ]
     }
+  }
 };
 const uischema: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/foo'
+  type: 'Control',
+  scope: '#/properties/foo'
 };
 
 const imports = [
-    MatAutocompleteModule,
-    MatInputModule,
-    MatFormFieldModule,
-    NoopAnimationsModule,
-    ReactiveFormsModule
+  MatAutocompleteModule,
+  MatInputModule,
+  MatFormFieldModule,
+  NoopAnimationsModule,
+  ReactiveFormsModule
 ];
 const providers = [
-    { provide: NgRedux, useFactory: MockNgRedux.getInstance }
+  { provide: NgRedux, useFactory: MockNgRedux.getInstance }
 ];
 const componentUT: any = AutocompleteControlRenderer;
 const errorTest: ErrorTestExpectation = {
-    errorInstance: MatError,
-    numberOfElements: 1,
-    indexOfElement: 0
+  errorInstance: MatError,
+  numberOfElements: 1,
+  indexOfElement: 0
 };
 
 describe('Autocomplete control Base Tests', () => {
-    let fixture: ComponentFixture<AutocompleteControlRenderer>;
-    let component: AutocompleteControlRenderer;
-    let inputElement: HTMLInputElement;
-    beforeEach(() => {
-        TestBed.configureTestingModule({
-            declarations: [componentUT],
-            imports: imports,
-            providers: providers
-        }).compileComponents();
+  let fixture: ComponentFixture<AutocompleteControlRenderer>;
+  let component: AutocompleteControlRenderer;
+  let inputElement: HTMLInputElement;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [componentUT],
+      imports: imports,
+      providers: providers
+    }).compileComponents();
 
-        MockNgRedux.reset();
+    MockNgRedux.reset();
+  });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(componentUT);
+    component = fixture.componentInstance;
+
+    inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+  });
+
+  it('should render', fakeAsync(() => {
+    const mockSubStore = MockNgRedux.getSelectorStub();
+    component.uischema = uischema;
+    component.schema = schema;
+    mockSubStore.next({
+      jsonforms: {
+        core: {
+          data: data,
+          schema: schema,
+        }
+      }
     });
-    beforeEach(() => {
-        fixture = TestBed.createComponent(componentUT);
-        component = fixture.componentInstance;
+    mockSubStore.complete();
+    fixture.detectChanges();
+    component.ngOnInit();
+    tick();
+    expect(component.data).toBe('A');
+    expect(inputElement.value).toBe('A');
+    expect(inputElement.disabled).toBe(false);
+  }));
 
-        inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+  it('should support updating the state', fakeAsync(() => {
+    const mockSubStore = MockNgRedux.getSelectorStub();
+    component.uischema = uischema;
+    component.schema = schema;
+
+    mockSubStore.next({
+      jsonforms: {
+        core: {
+          data: data,
+          schema: schema,
+        }
+      }
     });
-
-    it('should render', () => {
-        const mockSubStore = MockNgRedux.getSelectorStub();
-        component.uischema = uischema;
-        component.schema = schema;
-        mockSubStore.next({
-            jsonforms: {
-                core: {
-                    data: data,
-                    schema: schema,
-                }
-            }
-        });
-        mockSubStore.complete();
-        fixture.detectChanges();
-        component.ngOnInit();
-        expect(component.data).toBe('A');
-        expect(inputElement.value).toBe('A');
-        expect(inputElement.disabled).toBe(false);
+    fixture.detectChanges();
+    component.ngOnInit();
+    tick();
+    mockSubStore.next({
+      jsonforms: {
+        core: {
+          data: { foo: 'B' },
+          schema: schema,
+        }
+      }
     });
+    mockSubStore.complete();
+    tick();
+    fixture.detectChanges();
+    expect(component.data).toBe('B');
+    expect(inputElement.value).toBe('B');
+  }));
 
-    it('should support updating the state', () => {
-        const mockSubStore = MockNgRedux.getSelectorStub();
-        component.uischema = uischema;
-        component.schema = schema;
+  it('should update with undefined value', () => {
+    const mockSubStore = MockNgRedux.getSelectorStub();
+    component.uischema = uischema;
+    component.schema = schema;
 
-        mockSubStore.next({
-            jsonforms: {
-                core: {
-                    data: data,
-                    schema: schema,
-                }
-            }
-        });
-        fixture.detectChanges();
-        component.ngOnInit();
-
-        mockSubStore.next({
-            jsonforms: {
-                core: {
-                    data: { foo: 'B' },
-                    schema: schema,
-                }
-            }
-        });
-        mockSubStore.complete();
-        fixture.detectChanges();
-        expect(component.data).toBe('B');
-        expect(inputElement.value).toBe('B');
+    mockSubStore.next({
+      jsonforms: {
+        core: {
+          data: data,
+          schema: schema,
+        }
+      }
     });
-    it('should update with undefined value', () => {
-        const mockSubStore = MockNgRedux.getSelectorStub();
-        component.uischema = uischema;
-        component.schema = schema;
+    fixture.detectChanges();
+    component.ngOnInit();
 
-        mockSubStore.next({
-            jsonforms: {
-                core: {
-                    data: data,
-                    schema: schema,
-                }
-            }
-        });
-        fixture.detectChanges();
-        component.ngOnInit();
-
-        mockSubStore.next({
-            jsonforms: {
-                core: {
-                    data: { foo: undefined },
-                    schema: schema,
-                }
-            }
-        });
-        mockSubStore.complete();
-        fixture.detectChanges();
-        expect(component.data).toBe(undefined);
-        expect(inputElement.value).toBe('');
+    mockSubStore.next({
+      jsonforms: {
+        core: {
+          data: { foo: undefined },
+          schema: schema,
+        }
+      }
     });
-    it('should update with null value', () => {
-        const mockSubStore = MockNgRedux.getSelectorStub();
-        component.uischema = uischema;
-        component.schema = schema;
+    mockSubStore.complete();
+    fixture.detectChanges();
+    expect(component.data).toBe(undefined);
+    expect(inputElement.value).toBe('');
+  });
+  it('should update with null value', () => {
+    const mockSubStore = MockNgRedux.getSelectorStub();
+    component.uischema = uischema;
+    component.schema = schema;
 
-        mockSubStore.next({
-            jsonforms: {
-                core: {
-                    data: data,
-                    schema: schema,
-                }
-            }
-        });
-        fixture.detectChanges();
-        component.ngOnInit();
-
-        mockSubStore.next({
-            jsonforms: {
-                core: {
-                    data: { foo: null },
-                    schema: schema,
-                }
-            }
-        });
-        mockSubStore.complete();
-        fixture.detectChanges();
-        expect(component.data).toBe(null);
-        expect(inputElement.value).toBe('');
+    mockSubStore.next({
+      jsonforms: {
+        core: {
+          data: data,
+          schema: schema,
+        }
+      }
     });
-    it('should not update with wrong ref', () => {
-        const mockSubStore = MockNgRedux.getSelectorStub();
-        component.uischema = uischema;
-        component.schema = schema;
+    fixture.detectChanges();
+    component.ngOnInit();
 
-        mockSubStore.next({
-            jsonforms: {
-                core: {
-                    data: data,
-                    schema: schema,
-                }
-            }
-        });
-        fixture.detectChanges();
-        component.ngOnInit();
-
-        mockSubStore.next({
-            jsonforms: {
-                core: {
-                    data: { foo: 'A', bar: 'B' },
-                    schema: schema,
-                }
-            }
-        });
-        mockSubStore.complete();
-        fixture.detectChanges();
-        expect(component.data).toBe('A');
-        expect(inputElement.value).toBe('A');
+    mockSubStore.next({
+      jsonforms: {
+        core: {
+          data: { foo: null },
+          schema: schema,
+        }
+      }
     });
-    // store needed as we evaluate the calculated enabled value to disable/enable the control
-    it('can be disabled', () => {
-        const mockSubStore = MockNgRedux.getSelectorStub();
-        component.uischema = uischema;
-        component.schema = schema;
-        component.disabled = true;
+    mockSubStore.complete();
+    fixture.detectChanges();
+    expect(component.data).toBe(null);
+    expect(inputElement.value).toBe('');
+  });
+  it('should not update with wrong ref', fakeAsync(() => {
+    const mockSubStore = MockNgRedux.getSelectorStub();
+    component.uischema = uischema;
+    component.schema = schema;
 
-        mockSubStore.next({
-            jsonforms: {
-                core: {
-                    data: data,
-                    schema: schema,
-                }
-            }
-        });
-        mockSubStore.complete();
-        fixture.detectChanges();
-        component.ngOnInit();
-        expect(inputElement.disabled).toBe(true);
-
+    mockSubStore.next({
+      jsonforms: {
+        core: {
+          data: data,
+          schema: schema,
+        }
+      }
     });
-    it('id should be present in output', () => {
-        const mockSubStore = MockNgRedux.getSelectorStub();
-        component.uischema = uischema;
-        component.schema = schema;
-        component.id = 'myId';
-
-        mockSubStore.next({
-            jsonforms: {
-                core: {
-                    data: data,
-                    schema: schema,
-                }
-            }
-        });
-        mockSubStore.complete();
-
-        fixture.detectChanges();
-        component.ngOnInit();
-        expect(inputElement.id).toBe('myId');
-
+    fixture.detectChanges();
+    component.ngOnInit();
+    tick();
+    mockSubStore.next({
+      jsonforms: {
+        core: {
+          data: { foo: 'A', bar: 'B' },
+          schema: schema,
+        }
+      }
     });
+    mockSubStore.complete();
+    fixture.detectChanges();
+    tick();
+    expect(component.data).toBe('A');
+    expect(inputElement.value).toBe('A');
+  }));
+  // store needed as we evaluate the calculated enabled value to disable/enable the control
+  it('can be disabled', () => {
+    const mockSubStore = MockNgRedux.getSelectorStub();
+    component.uischema = uischema;
+    component.schema = schema;
+    component.disabled = true;
+
+    mockSubStore.next({
+      jsonforms: {
+        core: {
+          data: data,
+          schema: schema,
+        }
+      }
+    });
+    mockSubStore.complete();
+    fixture.detectChanges();
+    component.ngOnInit();
+    expect(inputElement.disabled).toBe(true);
+
+  });
+  it('id should be present in output', () => {
+    const mockSubStore = MockNgRedux.getSelectorStub();
+    component.uischema = uischema;
+    component.schema = schema;
+    component.id = 'myId';
+
+    mockSubStore.next({
+      jsonforms: {
+        core: {
+          data: data,
+          schema: schema,
+        }
+      }
+    });
+    mockSubStore.complete();
+
+    fixture.detectChanges();
+    component.ngOnInit();
+    expect(inputElement.id).toBe('myId');
+
+  });
 });
 describe('AutoComplete control Input Event Tests', () => {
-    let fixture: ComponentFixture<AutocompleteControlRenderer>;
-    let component: AutocompleteControlRenderer;
-    let inputElement: HTMLInputElement;
-    let overlayContainer: OverlayContainer;
-    let overlayContainerElement: HTMLElement;
-    let zone: MockNgZone;
-    beforeEach(() => {
-        TestBed.configureTestingModule({
-            declarations: [componentUT],
-            imports: imports,
-            providers: [
-                ...providers,
-                {provide: NgZone, useFactory: () => zone = new MockNgZone()}
-            ]
-        }).compileComponents();
+  let fixture: ComponentFixture<AutocompleteControlRenderer>;
+  let component: AutocompleteControlRenderer;
+  let inputElement: HTMLInputElement;
+  let overlayContainer: OverlayContainer;
+  let overlayContainerElement: HTMLElement;
+  let zone: MockNgZone;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [componentUT],
+      imports: imports,
+      providers: [
+        ...providers,
+        {provide: NgZone, useFactory: () => zone = new MockNgZone()}
+      ]
+    }).compileComponents();
 
-        inject([OverlayContainer], (oc: OverlayContainer) => {
-            overlayContainer = oc;
-            overlayContainerElement = oc.getContainerElement();
-        })();
-        MockNgRedux.reset();
+    inject([OverlayContainer], (oc: OverlayContainer) => {
+      overlayContainer = oc;
+      overlayContainerElement = oc.getContainerElement();
+    })();
+    MockNgRedux.reset();
+  });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(componentUT);
+    component = fixture.componentInstance;
+
+    inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+  });
+
+  afterEach(inject([OverlayContainer], (currentOverlayContainer: OverlayContainer) => {
+    // Since we're resetting the testing module in some of the tests,
+    // we can potentially have multiple overlay containers.
+    currentOverlayContainer.ngOnDestroy();
+    overlayContainer.ngOnDestroy();
+  }));
+  it('should update via input event', fakeAsync(() => {
+
+    const mockSubStore = MockNgRedux.getSelectorStub();
+    component.uischema = uischema;
+    component.schema = schema;
+
+    mockSubStore.next({
+      jsonforms: {
+        core: {
+          data: data,
+          schema: schema,
+        }
+      }
     });
-    beforeEach(() => {
-        fixture = TestBed.createComponent(componentUT);
-        component = fixture.componentInstance;
+    mockSubStore.complete();
+    fixture.detectChanges();
+    component.ngOnInit();
 
-        inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+    const spy = spyOn(component, 'onSelect');
+
+    inputElement.focus();
+    zone.simulateZoneExit();
+    fixture.detectChanges();
+
+    const options =
+      overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+    options[1].click();
+    tick();
+    fixture.detectChanges();
+
+    expect(spy).toHaveBeenCalled();
+    const event = spy.calls.mostRecent().args[0] as MatAutocompleteSelectedEvent;
+
+    expect(event.option.value).toBe('B');
+  }));
+  it('options should prefer own props', fakeAsync(() => {
+
+    const mockSubStore = MockNgRedux.getSelectorStub();
+    component.uischema = uischema;
+    component.schema = schema;
+    component.options = ['X', 'Y', 'Z'];
+
+    mockSubStore.next({
+      jsonforms: {
+        core: {
+          data: data,
+          schema: schema,
+        }
+      }
     });
+    mockSubStore.complete();
+    fixture.detectChanges();
+    component.ngOnInit();
 
-    afterEach(inject([OverlayContainer], (currentOverlayContainer: OverlayContainer) => {
-        // Since we're resetting the testing module in some of the tests,
-        // we can potentially have multiple overlay containers.
-        currentOverlayContainer.ngOnDestroy();
-        overlayContainer.ngOnDestroy();
-    }));
-    it('should update via input event', fakeAsync(() => {
+    const spy = spyOn(component, 'onSelect');
 
-        const mockSubStore = MockNgRedux.getSelectorStub();
-        component.uischema = uischema;
-        component.schema = schema;
+    inputElement.focus();
+    zone.simulateZoneExit();
+    fixture.detectChanges();
 
-        mockSubStore.next({
-            jsonforms: {
-                core: {
-                    data: data,
-                    schema: schema,
-                }
-            }
-        });
-        mockSubStore.complete();
-        fixture.detectChanges();
-        component.ngOnInit();
+    const options =
+      overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
+    options[0].click();
+    tick();
+    fixture.detectChanges();
 
-        const spy = spyOn(component, 'onSelect');
+    expect(spy).toHaveBeenCalled();
+    const event = spy.calls.mostRecent().args[0] as MatAutocompleteSelectedEvent;
 
-        inputElement.focus();
-        zone.simulateZoneExit();
-        fixture.detectChanges();
-
-        const options =
-            overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
-        options[1].click();
-        tick();
-        fixture.detectChanges();
-
-        expect(spy).toHaveBeenCalled();
-        const event = spy.calls.mostRecent().args[0] as MatAutocompleteSelectedEvent;
-
-        expect(event.option.value).toBe('B');
-    }));
-    it('options should prefer own props', fakeAsync(() => {
-
-        const mockSubStore = MockNgRedux.getSelectorStub();
-        component.uischema = uischema;
-        component.schema = schema;
-        component.options = ['X', 'Y', 'Z'];
-
-        mockSubStore.next({
-            jsonforms: {
-                core: {
-                    data: data,
-                    schema: schema,
-                }
-            }
-        });
-        mockSubStore.complete();
-        fixture.detectChanges();
-        component.ngOnInit();
-
-        const spy = spyOn(component, 'onSelect');
-
-        inputElement.focus();
-        zone.simulateZoneExit();
-        fixture.detectChanges();
-
-        const options =
-            overlayContainerElement.querySelectorAll('mat-option') as NodeListOf<HTMLElement>;
-        options[0].click();
-        tick();
-        fixture.detectChanges();
-
-        expect(spy).toHaveBeenCalled();
-        const event = spy.calls.mostRecent().args[0] as MatAutocompleteSelectedEvent;
-
-        expect(event.option.value).toBe('X');
-    }));
+    expect(event.option.value).toBe('X');
+  }));
 });
 describe('AutoComplete control Error Tests', () => {
-    let fixture: ComponentFixture<AutocompleteControlRenderer>;
-    let component: AutocompleteControlRenderer;
-    beforeEach(() => {
-        TestBed.configureTestingModule({
-            declarations: [componentUT],
-            imports: imports,
-            providers: providers
-        }).compileComponents();
+  let fixture: ComponentFixture<AutocompleteControlRenderer>;
+  let component: AutocompleteControlRenderer;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [componentUT],
+      imports: imports,
+      providers: providers
+    }).compileComponents();
 
-        MockNgRedux.reset();
-    });
-    beforeEach(() => {
-        fixture = TestBed.createComponent(componentUT);
-        component = fixture.componentInstance;
-    });
-    it('should display errors', () => {
-        const mockSubStore = MockNgRedux.getSelectorStub();
-        component.uischema = uischema;
-        component.schema = schema;
+    MockNgRedux.reset();
+  });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(componentUT);
+    component = fixture.componentInstance;
+  });
+  it('should display errors', () => {
+    const mockSubStore = MockNgRedux.getSelectorStub();
+    component.uischema = uischema;
+    component.schema = schema;
 
-        mockSubStore.next({
-            jsonforms: {
-                core: {
-                    data: data,
-                    schema: schema,
-                    errors: [{
-                        dataPath: 'foo',
-                        message: 'Hi, this is me, test error!'
-                    }]
-                }
-            },
-        });
-        mockSubStore.complete();
-        fixture.detectChanges();
-        component.ngOnInit();
-        const debugErrors: DebugElement[] =
-            fixture.debugElement.queryAll(By.directive(errorTest.errorInstance));
-        expect(debugErrors.length).toBe(errorTest.numberOfElements);
-        expect(debugErrors[errorTest.indexOfElement].nativeElement.textContent)
-            .toBe('Hi, this is me, test error!');
+    mockSubStore.next({
+      jsonforms: {
+        core: {
+          data: data,
+          schema: schema,
+          errors: [{
+            dataPath: 'foo',
+            message: 'Hi, this is me, test error!'
+          }]
+        }
+      },
     });
+    mockSubStore.complete();
+    fixture.detectChanges();
+    component.ngOnInit();
+    const debugErrors: DebugElement[] =
+      fixture.debugElement.queryAll(By.directive(errorTest.errorInstance));
+    expect(debugErrors.length).toBe(errorTest.numberOfElements);
+    expect(debugErrors[errorTest.indexOfElement].nativeElement.textContent)
+      .toBe('Hi, this is me, test error!');
+  });
 });

--- a/packages/angular-material/test/group-layout.spec.ts
+++ b/packages/angular-material/test/group-layout.spec.ts
@@ -38,7 +38,6 @@ describe('Group layout tester', () => {
 });
 describe('Group layout', () => {
     let fixture: ComponentFixture<any>;
-    let component: any;
 
     beforeEach(() => {
         fixture = beforeEachLayoutTest(
@@ -48,7 +47,6 @@ describe('Group layout', () => {
               imports: [FlexLayoutModule]
             }
         );
-        component = fixture.componentInstance;
     });
 
     it('render with undefined elements', () => {

--- a/packages/angular-material/test/horizontal-layout.spec.ts
+++ b/packages/angular-material/test/horizontal-layout.spec.ts
@@ -40,7 +40,6 @@ describe('Horizontal layout tester', () => {
 });
 describe('Horizontal layout', () => {
   let fixture: ComponentFixture<any>;
-  let component: any;
 
   beforeEach(() => {
       fixture = beforeEachLayoutTest(
@@ -49,7 +48,6 @@ describe('Horizontal layout', () => {
             imports: [FlexLayoutModule]
           }
       );
-      component = fixture.componentInstance;
   });
 
   it('render with undefined elements', () => {

--- a/packages/angular/src/control.ts
+++ b/packages/angular/src/control.ts
@@ -37,7 +37,10 @@ export class JsonFormsControl extends JsonFormsBaseRenderer implements OnInit, O
     constructor(protected ngRedux: NgRedux<JsonFormsState>) {
         super();
         this.form = new FormControl(
-            {value: '', disabled: true},
+            {
+              value: '',
+              disabled: true
+            },
             {
                 updateOn: 'change',
                 validators: this.validator.bind(this),
@@ -69,6 +72,7 @@ export class JsonFormsControl extends JsonFormsBaseRenderer implements OnInit, O
                 this.hidden = !visible;
                 this.scopedSchema = Resolve.schema(schema, (uischema as ControlElement).scope);
                 this.id = props.id;
+                this.form.setValue(data);
                 this.mapAdditionalProps(props);
             });
         this.triggerValidation();


### PR DESCRIPTION
Form value is set via `form` attribute. This does not apply to the ionic renderer set, e.g. because of https://forum.ionicframework.com/t/disable-enable-of-ion-input-using-angular-reactive-forms/116901 (for the `disabled` property). Also, removing the `value` property on string/multiline tests causes them to fail, hence I left it there for the time being.