### PR TITLE
[feedback wanted] Extend core/i18n substates with actions to set schema and uischema

### DIFF
--- a/packages/core/src/actions/index.ts
+++ b/packages/core/src/actions/index.ts
@@ -40,8 +40,14 @@ export const REMOVE_FIELD: 'jsonforms/REMOVE_FIELD' = 'jsonforms/REMOVE_FIELD';
 export const SET_CONFIG : 'jsonforms/SET_CONFIG' = 'jsonforms/SET_CONFIG';
 export const ADD_UI_SCHEMA: 'jsonforms/ADD_UI_SCHEMA' = `jsonforms/ADD_UI_SCHEMA`;
 export const REMOVE_UI_SCHEMA: 'jsonforms/REMOVE_UI_SCHEMA' = `jsonforms/REMOVE_UI_SCHEMA`;
+export const SET_SCHEMA: 'jsonforms/SET_SCHEMA' = `jsonforms/SET_SCHEMA`;
+export const SET_UISCHEMA: 'jsonforms/SET_UISCHEMA' = `jsonforms/SET_UISCHEMA`;
 
 export const SET_LOCALE: 'jsonforms/SET_LOCALE' = `jsonforms/SET_LOCALE`;
+export const SET_LOCALIZED_SCHEMAS: 'jsonforms/SET_LOCALIZED_SCHEMAS' =
+  `jsonforms/SET_LOCALIZED_SCHEMAS`;
+export const SET_LOCALIZED_UISCHEMAS: 'jsonforms/SET_LOCALIZED_UISCHEMAS' =
+  `jsonforms/SET_LOCALIZED_UISCHEMAS`;
 
 export const ADD_DEFAULT_DATA: 'jsonforms/ADD_DEFAULT_DATA' = `jsonforms/ADD_DEFAULT_DATA`;
 export const REMOVE_DEFAULT_DATA: 'jsonforms/REMOVE_DEFAULT_DATA' = `jsonforms/REMOVE_DEFAULT_DATA`;
@@ -217,7 +223,7 @@ export const unregisterUISchema = (
 ): RemoveUISchemaAction => {
   return {
     type: REMOVE_UI_SCHEMA,
-    tester,
+    tester
   };
 };
 
@@ -230,4 +236,50 @@ export const setLocale = (locale: string): SetLocaleAction =>
   ({
     type: SET_LOCALE,
     locale,
+  });
+
+export interface SetLocalizedSchemasAction {
+  type: 'jsonforms/SET_LOCALIZED_SCHEMAS';
+  localizedSchemas: Map<string, JsonSchema>;
+}
+
+export const setLocalizedSchemas =
+  (localizedSchemas: Map<string, JsonSchema>): SetLocalizedSchemasAction =>
+    ({
+      type: SET_LOCALIZED_SCHEMAS,
+      localizedSchemas
+    });
+
+export interface SetSchemaAction {
+  type: 'jsonforms/SET_SCHEMA';
+  schema: JsonSchema;
+}
+
+export const setSchema = (schema: JsonSchema): SetSchemaAction =>
+  ({
+    type: SET_SCHEMA,
+    schema
+  });
+
+export interface SetLocalizedUISchemasAction {
+  type: 'jsonforms/SET_LOCALIZED_UISCHEMAS';
+  localizedUISchemas: Map<string, UISchemaElement>;
+}
+
+export const setLocalizedUISchemas =
+  (localizedUISchemas: Map<string, UISchemaElement>): SetLocalizedUISchemasAction =>
+    ({
+      type: SET_LOCALIZED_UISCHEMAS,
+      localizedUISchemas
+    });
+
+export interface SetUISchemaAction {
+  type: 'jsonforms/SET_UISCHEMA';
+  uischema: UISchemaElement;
+}
+
+export const setUISchema = (uischema: UISchemaElement): SetUISchemaAction =>
+  ({
+    type: SET_UISCHEMA,
+    uischema
   });

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -24,7 +24,18 @@
 */
 import * as _ from 'lodash';
 import { ErrorObject, ValidateFunction } from 'ajv';
-import { INIT, InitAction, SET_AJV, SetAjvAction, UPDATE_DATA, UpdateAction } from '../actions';
+import {
+  INIT,
+  InitAction,
+  SET_AJV,
+  SET_SCHEMA,
+  SET_UISCHEMA,
+  SetAjvAction,
+  SetSchemaAction,
+  SetUISchemaAction,
+  UPDATE_DATA,
+  UpdateAction
+} from '../actions';
 import { createAjv } from '../util/validator';
 import { JsonSchema, UISchemaElement } from '..';
 
@@ -63,7 +74,8 @@ const initState: JsonFormsCore = {
   validator: alwaysValid
 };
 
-type ValidCoreActions = InitAction | UpdateAction | SetAjvAction;
+type ValidCoreActions =
+  InitAction | UpdateAction | SetAjvAction | SetSchemaAction | SetUISchemaAction;
 
 export const coreReducer = (
   state: JsonFormsCore = initState,
@@ -92,6 +104,18 @@ export const coreReducer = (
         ...state,
         validator,
         errors
+      };
+    }
+    case SET_SCHEMA: {
+      return {
+        ...state,
+        schema: action.schema
+      };
+    }
+    case SET_UISCHEMA: {
+      return {
+        ...state,
+        uischema: action.uischema
       };
     }
     case UPDATE_DATA: {

--- a/packages/core/src/reducers/i18n.ts
+++ b/packages/core/src/reducers/i18n.ts
@@ -22,20 +22,35 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import { SET_LOCALE } from '../actions';
+import { SET_LOCALE, SET_LOCALIZED_SCHEMAS } from '../actions';
+import { JsonSchema, SET_LOCALIZED_UISCHEMAS, UISchemaElement } from '..';
 
 export interface JsonFormsLocaleState {
   locale?: string;
+  localizedSchemas: Map<string, JsonSchema>;
+  localizedUISchemas: Map<string, UISchemaElement>;
 }
 
 const initState: JsonFormsLocaleState =  {
-  locale: undefined
+  locale: undefined,
+  localizedSchemas: new Map(),
+  localizedUISchemas: new Map()
 };
 
 export const i18nReducer = (
   state = initState,
   action: any) => {
   switch (action.type) {
+    case SET_LOCALIZED_SCHEMAS:
+      return {
+        ...state,
+        localizedSchemas: action.localizedSchemas
+      };
+    case SET_LOCALIZED_UISCHEMAS:
+      return {
+        ...state,
+        localizedUISchemas: action.localizedUISchemas
+      };
     case SET_LOCALE:
       return {
         ...state,
@@ -51,4 +66,22 @@ export const fetchLocale = (state?: JsonFormsLocaleState) => {
     return undefined;
   }
   return state.locale;
-}
+};
+
+export const findLocalizedSchema =
+  (locale: string) =>
+    (state?: JsonFormsLocaleState): JsonSchema => {
+      if (state === undefined) {
+        return undefined;
+      }
+      return state.localizedSchemas.get(locale);
+    };
+
+export const findLocalizedUISchema =
+  (locale: string) =>
+    (state?: JsonFormsLocaleState): UISchemaElement => {
+      if (state === undefined) {
+        return undefined;
+      }
+      return state.localizedUISchemas.get(locale);
+    };

--- a/packages/core/src/reducers/index.ts
+++ b/packages/core/src/reducers/index.ts
@@ -43,7 +43,7 @@ import {
 import { JsonFormsState } from '../store';
 import { findMatchingUISchema, uischemaRegistryReducer, UISchemaTester } from './uischemas';
 import { Generate, JsonSchema, UISchemaElement } from '..';
-import { fetchLocale, i18nReducer } from './i18n';
+import { fetchLocale, findLocalizedSchema, i18nReducer, findLocalizedUISchema } from './i18n';
 
 export {
   rendererReducer,
@@ -97,3 +97,9 @@ export const getSubErrorsAt = (instancePath: string) => (state: JsonFormsState) 
 export const getConfig = (state: JsonFormsState) => state.jsonforms.config;
 
 export const getLocale = (state: JsonFormsState) => fetchLocale(_.get(state, 'jsonforms.i18n'));
+
+export const getLocalizedSchema = (locale: string) => (state: JsonFormsState): JsonSchema =>
+  findLocalizedSchema(locale)(_.get(state, 'jsonforms.i18n'));
+
+export const getLocalizedUISchema = (locale: string) => (state: JsonFormsState): UISchemaElement =>
+  findLocalizedUISchema(locale)(_.get(state, 'jsonforms.i18n'));

--- a/packages/examples/src/i18n.ts
+++ b/packages/examples/src/i18n.ts
@@ -1,0 +1,57 @@
+import { registerExamples } from './register';
+import { personCoreSchema } from './person';
+
+export const uischema = {
+  type: 'VerticalLayout',
+  elements: [
+    {
+      type: 'HorizontalLayout',
+      elements: [
+        {
+          type: 'Control',
+          scope: '#/properties/name'
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/birthDate'
+        },
+      ]
+    },
+    {
+      type: 'Label',
+      text: 'Additional Information'
+    },
+    {
+      type: 'HorizontalLayout',
+      elements: [
+        {
+          type: 'Control',
+          scope: '#/properties/nationality'
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/vegetarian'
+        }
+      ]
+    }
+  ]
+};
+
+export const data = {
+  vegetarian: false,
+  birthDate: '1985-06-02',
+  personalData: {
+    age: 34
+  },
+  postalCode: '12345',
+};
+
+registerExamples([
+  {
+    name: 'i18n',
+    label: 'Person (i18n)',
+    data,
+    schema: personCoreSchema,
+    uischema
+  }
+]);

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -47,6 +47,7 @@ import * as config from './config';
 import * as text from './text';
 import * as numbers from './numbers';
 import * as listWithDetail from './list-with-detail';
+import * as i18n from './i18n';
 export * from './register';
 export * from './example';
 export {
@@ -74,5 +75,6 @@ export {
   config,
   text,
   numbers,
-  listWithDetail
+  listWithDetail,
+  i18n
 };


### PR DESCRIPTION
This PR introduces changes that are meant to be used in the following fashion:

During initialization one is ought to register the respective localized versions of the schema/UI schemas, e.g.:
```js
const localizedSchemas = new Map<string, JsonSchema>();
localizedSchemas.set('de-DE', deSchema);
localizedSchemas.set('en-US', usSchema);
store.dispatch(Actions.setLocalizedSchemas(localizedSchemas));
```
Likewise for UI schemas.

Then, within the locale switcher of the respective app (which needs to be custom anyway, I think), locales can be switched via the new actions (this could be probably be improved a bit since we need to pass the entire state ATM):

```js
changeLocale(locale: string) {
  store.dispatch(setLocale(locale));
  store.dispatch(setSchema(getLocalizedSchema(locale)(store.getState())));
  store.dispatch(setUISchema(getLocalizedUISchema(locale)(store.getState())));
}
```

This will cause the root schema/UI schema to be updated and hence the entire forms managed by JSON Forms will be re-rendered with the new schema/UI schema