### PR TITLE
Angular Material Labels and Errors have different fonts #1118

### DIFF
--- a/packages/angular-material/src/controls/boolean.renderer.ts
+++ b/packages/angular-material/src/controls/boolean.renderer.ts
@@ -38,7 +38,7 @@ import { isBooleanControl, JsonFormsState, RankedTester, rankWith } from '@jsonf
             [id]="id">
             {{ label }}
         </mat-checkbox>
-        <mat-error>{{ error }}</mat-error>
+        <mat-error class='mat-caption'>{{ error }}</mat-error>
     </div>
     `
 })

--- a/packages/angular-material/src/controls/range.renderer.ts
+++ b/packages/angular-material/src/controls/range.renderer.ts
@@ -43,7 +43,7 @@ import { isRangeControl, JsonFormsState, RankedTester, rankWith } from '@jsonfor
                 [tickInterval]="tickInterval"
                 [id]="id"
             ></mat-slider>
-            <mat-error>{{ error }}</mat-error>
+            <mat-error class='mat-caption'>{{ error }}</mat-error>
         </div>
     `
 })

--- a/packages/angular-material/src/controls/toggle.renderer.ts
+++ b/packages/angular-material/src/controls/toggle.renderer.ts
@@ -45,7 +45,7 @@ import {
             [id]="id">
             {{ label }}
         </mat-slide-toggle>
-        <mat-error>{{ error }}</mat-error>
+        <mat-error class='mat-caption'>{{ error }}</mat-error>
     </div>
     `
 })

--- a/packages/angular-material/src/layouts/horizontal-layout.renderer.ts
+++ b/packages/angular-material/src/layouts/horizontal-layout.renderer.ts
@@ -36,7 +36,7 @@ import { NgRedux } from '@angular-redux/store';
 @Component({
     selector: 'HorizontalLayoutRenderer',
     template: `
-        <div fxLayout='row' fxLayoutGap='16px' [fxHide]="hidden">
+        <div fxLayout='row' fxLayoutGap='16px' [fxHide]="hidden" fxLayoutAlign='center center'>
             <div *ngFor="let props of renderProps; trackBy: trackElement" fxFlex>
                 <jsonforms-outlet [renderProps]="props"></jsonforms-outlet>
             </div>


### PR DESCRIPTION
- fix style of validation errors by applying 'mat-caption' class
- center items in an horizontal layout

![selection_604](https://user-images.githubusercontent.com/6464495/50172201-c6143680-02f4-11e9-89ec-da0e3d8bd791.png)

For sliders, I could not find a good fix for fixing the alignment. The difference comes from the height of the slider control itself.
![selection_602](https://user-images.githubusercontent.com/6464495/50172230-dd532400-02f4-11e9-8288-20661fbc43e9.png)
