### PR TITLE
Inline UiSchema for Arrays

### DIFF
--- a/packages/core/src/reducers/index.ts
+++ b/packages/core/src/reducers/index.ts
@@ -42,7 +42,7 @@ import {
 } from './core';
 import { JsonFormsState } from '../store';
 import { findMatchingUISchema, uischemaRegistryReducer, UISchemaTester } from './uischemas';
-import { Generate, JsonSchema, UISchemaElement } from '..';
+import { ControlElement, Generate, JsonSchema, UISchemaElement } from '..';
 import { fetchLocale, findLocalizedSchema, i18nReducer, findLocalizedUISchema } from './i18n';
 
 export {
@@ -79,9 +79,26 @@ export const findUISchema = (state: JsonFormsState) =>
   (schema: JsonSchema,
    schemaPath: string,
    path: string,
-   fallbackLayoutType = 'VerticalLayout'
+   fallbackLayoutType = 'VerticalLayout',
+   control?: ControlElement
   ): UISchemaElement => {
-    const uiSchema = findMatchingUISchema(state.jsonforms.uischemas)(schema, schemaPath, path);
+    // handle options
+    if (control && control.options && control.options.detail) {
+      if (typeof control.options.detail === 'string') {
+        if (control.options.detail.toUpperCase() === 'GENERATE') {
+          // force generation of uischema
+          return Generate.uiSchema(schema, fallbackLayoutType);
+        }
+      } else if (typeof control.options.detail === 'object') {
+        // check if detail is a valid uischema
+        if (control.options.detail.type && typeof control.options.detail.type === 'string') {
+          return control.options.detail as UISchemaElement;
+        }
+      }
+    }
+    // default
+    const uiSchema = findMatchingUISchema(state.jsonforms.uischemas)
+    (schema, schemaPath, path);
     if (uiSchema === undefined) {
       return Generate.uiSchema(schema, fallbackLayoutType);
     }

--- a/packages/core/src/testers/index.ts
+++ b/packages/core/src/testers/index.ts
@@ -346,8 +346,9 @@ export const isObjectArrayWithNesting =
     const schemaPath = (uischema as ControlElement).scope;
     const resolvedSchema = resolveSchema(schema, schemaPath);
     const wantedNestingByType: { [key: string]: number; } = { 'object': 2, 'array': 1 };
-    return _.has(resolvedSchema, 'items') &&
-      traverse(resolvedSchema.items, val => {
+    if (_.has(resolvedSchema, 'items')) {
+      // check if nested arrays
+      if (traverse(resolvedSchema.items, val => {
         if (val === schema) { return false; }
         // we don't support multiple types
         if (typeof val.type !== 'string') { return true; }
@@ -358,7 +359,19 @@ export const isObjectArrayWithNesting =
           return true;
         }
         return false;
-      });
+      })) {
+        return true;
+      }
+      // check if uischema options detail is set
+      if (uischema.options && uischema.options.detail) {
+        if (typeof uischema.options.detail === 'string') {
+          return uischema.options.detail.toUpperCase() !== 'DEFAULT';
+        } else if (typeof uischema.options.detail === 'object' && uischema.options.detail.type) {
+          return true;
+        }
+      }
+    }
+    return false;
   };
 
 const traverse = (any: JsonSchema | JsonSchema[], pred: (obj: JsonSchema) => boolean): boolean => {

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -222,9 +222,11 @@ export interface StatePropsOfScopedRenderer extends OwnPropsOfControl, StateProp
      * @param schemaPath the according schema path
      * @param path the instance path
      * @param fallbackLayoutType the type of the layout to use
+     * @param control may be checked for embedded inline uischema options
      */
     findUISchema(schema: JsonSchema, schemaPath: string,
-                 path: string, fallbackLayoutType?: string): UISchemaElement;
+                 path: string, fallbackLayoutType?: string,
+                 control?: ControlElement): UISchemaElement;
 }
 
 /**

--- a/packages/core/test/testers.test.ts
+++ b/packages/core/test/testers.test.ts
@@ -648,6 +648,43 @@ test('tester isObjectArrayWithNesting', t => {
       }
     }
   };
+
+  const uischemaOptions: {
+    generate: ControlElement,
+    default: ControlElement,
+    inline: ControlElement,
+  } = {
+    default: {
+      type: 'Control',
+      scope: '#',
+      options: {
+        detail : 'DEFAULT'
+      }
+    },
+    generate: {
+      type: 'Control',
+      scope: '#',
+      options: {
+        detail : 'GENERATE'
+      }
+    },
+    inline: {
+      type: 'Control',
+      scope: '#',
+      options: {
+        detail : {
+          type: 'HorizontalLayout',
+          elements: [
+            {
+              type: 'Control',
+              scope: '#/properties/message'
+            }
+          ]
+        }
+      }
+    }
+  };
+
   t.false(isObjectArrayWithNesting(undefined, undefined));
   t.false(isObjectArrayWithNesting(null, undefined));
   t.false(isObjectArrayWithNesting({ type: 'Foo' }, undefined));
@@ -656,4 +693,8 @@ test('tester isObjectArrayWithNesting', t => {
   t.true(isObjectArrayWithNesting(uischema, nestedSchema));
   t.true(isObjectArrayWithNesting(uischema, nestedSchema2));
   t.true(isObjectArrayWithNesting(uischema, nestedSchema3));
+
+  t.false(isObjectArrayWithNesting(uischemaOptions.default, schema));
+  t.true(isObjectArrayWithNesting(uischemaOptions.generate, schema));
+  t.true(isObjectArrayWithNesting(uischemaOptions.inline, schema));
 });

--- a/packages/examples/src/arrays-with-detail.ts
+++ b/packages/examples/src/arrays-with-detail.ts
@@ -62,11 +62,11 @@ export const uischema = {
           elements: [
             {
               type: 'Control',
-              scope: '#/properties/date'
+              scope: '#/properties/message'
             },
             {
               type: 'Control',
-              scope: '#/properties/message'
+              scope: '#/properties/date'
             }
           ]
         }

--- a/packages/examples/src/arrays-with-detail.ts
+++ b/packages/examples/src/arrays-with-detail.ts
@@ -23,10 +23,13 @@
   THE SOFTWARE.
 */
 import { registerExamples } from './register';
+import { personCoreSchema } from './person';
 
 export const schema = {
   type: 'object',
   properties: {
+    ...personCoreSchema.properties,
+    occupation: { type: 'string' },
     comments: {
       type: 'array',
       items: {
@@ -43,7 +46,8 @@ export const schema = {
         }
       }
     }
-  }
+  },
+  required: ['occupation', 'nationality']
 };
 
 export const uischema = {
@@ -51,7 +55,22 @@ export const uischema = {
   elements: [
     {
       type: 'Control',
-      scope: '#/properties/comments'
+      scope: '#/properties/comments',
+      options: {
+        detail: {
+          type: 'VerticalLayout',
+          elements: [
+            {
+              type: 'Control',
+              scope: '#/properties/date'
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/message'
+            }
+          ]
+        }
+      }
     }
   ]
 };
@@ -71,8 +90,8 @@ export const data = {
 
 registerExamples([
   {
-    name: 'array',
-    label: 'Array',
+    name: 'array-with-detail',
+    label: 'Array with detail',
     data,
     schema,
     uischema

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -27,6 +27,7 @@ import * as anyOf from './anyOf';
 import * as oneOf from './oneOf';
 import * as array from './arrays';
 import * as nestedArray from './nestedArrays';
+import * as arrayWithDetail from './arrays-with-detail';
 import * as stringArray from './stringArray';
 import * as categorization from './categorization';
 import * as day1 from './day1';
@@ -58,6 +59,7 @@ export {
   stringArray,
   array,
   nestedArray,
+  arrayWithDetail,
   categorization,
   day1,
   day2,

--- a/packages/material/src/layouts/MaterialArrayLayout.tsx
+++ b/packages/material/src/layouts/MaterialArrayLayout.tsx
@@ -96,7 +96,8 @@ export const MaterialArrayLayout =
           {
             data ? _.map(data, (childData, index) => {
 
-              const foundUISchema = findUISchema(scopedSchema, uischema.scope, path);
+              const foundUISchema =
+                findUISchema(scopedSchema, uischema.scope, path, undefined, uischema);
               const childPath = composePaths(path, `${index}`);
               const childLabel = childData[firstPrimitiveProp];
 

--- a/packages/material/test/renderers/MaterialArrayLayout.test.tsx
+++ b/packages/material/test/renderers/MaterialArrayLayout.test.tsx
@@ -111,12 +111,53 @@ const nestedSchema2 = {
   }
 };
 
+const uischemaOptions: {
+  generate: ControlElement,
+  default: ControlElement,
+  inline: ControlElement,
+} = {
+  default: {
+    type: 'Control',
+    scope: '#',
+    options: {
+      detail : 'DEFAULT'
+    }
+  },
+  generate: {
+    type: 'Control',
+    scope: '#',
+    options: {
+      detail : 'GENERATE'
+    }
+  },
+  inline: {
+    type: 'Control',
+    scope: '#',
+    options: {
+      detail : {
+        type: 'HorizontalLayout',
+        elements: [
+          {
+            type: 'Control',
+            scope: '#/properties/message'
+          }
+        ]
+      }
+    }
+  }
+};
+
 describe('Material array layout', () => {
-  it('should only be applicable for intermediate array', () => {
+  it('should only be applicable for intermediate array or when containing proper options', () => {
     expect(materialArrayLayoutTester(uischema, schema)).toBe(-1);
     expect(materialArrayLayoutTester(uischema, nestedSchema)).toBe(4);
     expect(materialArrayLayoutTester(uischema, nestedSchema2)).toBe(4);
+
+    expect(materialArrayLayoutTester(uischemaOptions.default, schema)).toBe(-1);
+    expect(materialArrayLayoutTester(uischemaOptions.generate, schema)).toBe(4);
+    expect(materialArrayLayoutTester(uischemaOptions.inline, schema)).toBe(4);
   });
+
   it('should render two by two children', () => {
     const store = initJsonFormsStore();
     const tree = TestUtils.renderIntoDocument(
@@ -128,5 +169,31 @@ describe('Material array layout', () => {
     const controls = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
     // 2 data entries with each having 2 controls
     expect(controls.length).toBe(4);
+  });
+
+  it('should generate uischema when options.detail=GENERATE', () => {
+    const store = initJsonFormsStore();
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialArrayLayout schema={schema} uischema={uischemaOptions.generate}/>
+      </Provider>
+    );
+
+    const controls = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
+    // 2 data entries with each having 2 controls
+    expect(controls.length).toBe(4);
+  });
+
+  it('should use inline options.detail uischema', () => {
+    const store = initJsonFormsStore();
+    const tree = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <MaterialArrayLayout schema={schema} uischema={uischemaOptions.inline}/>
+      </Provider>
+    );
+
+    const controls = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
+    // 2 data entries with each having 1 control
+    expect(controls.length).toBe(2);
   });
 });


### PR DESCRIPTION
UiSchemas for controls referring to arrays can now have an optional `options` attribute specifying how the array shall be rendered. Motivation: #1157 

## Default
```
options: {
    detail : 'DEFAULT'
}
```
The array will be rendered as before. The string is case insensitive.

## Inline UiSchema
```
options: {
    detail : {
        type: 'HorizontalLayout',
        ...
    }
}
```
The array will be rendered using the nested array renderer. The nested renderer will use the specified uischema to render the array elements.

## Generated UiSchema
```
options: {
    detail : 'GENERATED'
}
```
The array will be rendered using the nested array renderer. The nested renderer will use a generated uischema to render the array elements. The string is case insensitive.

## Registered / Generated UiSchema
```
options: {
    detail : 'REGISTERED'
}
```
The array will be rendered using the nested array renderer. The nested renderer will check if a uischema was registered for the type to be rendered or generate one itself. This case will be triggered if detail is any string besides `GENERATED` (case insensitiv) or `DEFAULT` (case insensitive).