### PR TITLE
Check registered uischemas in tree-master-detail

### DIFF
--- a/packages/angular-material/example/app/app.module.ts
+++ b/packages/angular-material/example/app/app.module.ts
@@ -25,7 +25,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { CUSTOM_ELEMENTS_SCHEMA, isDevMode, NgModule } from '@angular/core';
 import { DevToolsExtension, NgRedux } from '@angular-redux/store';
-import { Actions, JsonFormsState } from '@jsonforms/core';
+import { Actions, JsonFormsState, UISchemaTester } from '@jsonforms/core';
 import { AppComponent } from './app.component';
 import { JsonFormsAngularMaterialModule } from '../../src/module';
 
@@ -68,6 +68,30 @@ export class AppModule {
       example.data,
       example.schema,
       example.uischema
+    ));
+
+    const uiSchema = {
+      type: 'HorizontalLayout',
+      elements: [
+          {
+              type: 'Control',
+              scope: '#/properties/buyer/properties/email'
+          },
+          {
+              type: 'Control',
+              scope: '#/properties/status'
+          },
+      ]
+    };
+    const itemTester: UISchemaTester = (_schema, schemaPath, _path) => {
+      if (schemaPath === '#/properties/warehouseitems/items') {
+        return 10;
+      }
+      return -1;
+    };
+    ngRedux.dispatch(Actions.registerUISchema(
+      itemTester,
+      uiSchema
     ));
   }
 }

--- a/packages/angular-material/src/other/master-detail/master.ts
+++ b/packages/angular-material/src/other/master-detail/master.ts
@@ -5,7 +5,6 @@ import { NgRedux } from '@angular-redux/store';
 import {
   ControlElement,
   ControlProps,
-  Generate,
   JsonFormsState,
   mapDispatchToArrayControlProps,
   RankedTester,
@@ -120,7 +119,12 @@ export class MasterListComponent extends JsonFormsControl {
     this.propsPath = props.path;
     const resolvedSchema = resolveSchema(schema, `${controlElement.scope}/items`);
     const detailUISchema = controlElement.options.detail ||
-      Generate.uiSchema(resolvedSchema, 'VerticalLayout');
+                           props.findUISchema(
+                             resolvedSchema,
+                             `${controlElement.scope}/items`,
+                             props.path,
+                             'VerticalLayout');
+
     const masterItems = (data || []).map((d: any, index: number) => {
       const labelRefInstancePath =
         removeSchemaKeywords(controlElement.options.labelRef);

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -47,6 +47,7 @@ import * as config from './config';
 import * as text from './text';
 import * as numbers from './numbers';
 import * as listWithDetail from './list-with-detail';
+import * as listWithDetailRegistered from './list-with-detail-registered';
 import * as i18n from './i18n';
 import * as issue_1169 from './1169';
 export * from './register';
@@ -77,6 +78,7 @@ export {
   text,
   numbers,
   listWithDetail,
+  listWithDetailRegistered,
   i18n,
   issue_1169
 };

--- a/packages/examples/src/list-with-detail-registered.ts
+++ b/packages/examples/src/list-with-detail-registered.ts
@@ -1,0 +1,81 @@
+import { registerExamples } from './register';
+
+const data = {
+    warehouseitems: [
+        {
+            name: 'Fantasy Book',
+            buyer: {
+                email: 'buyerA@info.org',
+                age: 18
+            },
+            status: 'warehouse'
+        },
+        {
+            name: 'Boardgame',
+            buyer: {
+                email: 'buyerB@info.org',
+                age: 45
+            },
+            status: 'shipping'
+        },
+        {
+            name: 'Energy Drink',
+            buyer: {
+                email: 'buyerC@info.org',
+                age: 90
+            },
+            status: 'delivered'
+        }
+    ]
+};
+
+const schema = {
+    definitions: {
+        warehouseitem: {
+            type: 'object',
+            properties: {
+                name: { type: 'string' },
+                buyer: {
+                    type: 'object',
+                    properties: {
+                        email: { type: 'string', format: 'email' },
+                        age: { type: 'number' }
+                    }
+                },
+                status: {
+                    type: 'string',
+                    enum: ['warehouse', 'shipping', 'delivered']
+                }
+            },
+            required: ['name']
+        }
+    },
+    type: 'object',
+    properties: {
+        warehouseitems: {
+            type: 'array',
+            items: {
+                $ref: '#/definitions/warehouseitem'
+            }
+        }
+    }
+};
+
+const uischema = {
+    type: 'ListWithDetail',
+    scope: '#/properties/warehouseitems',
+    options: {
+        labelRef: '#/items/properties/name'
+        // detail uischema is registered in example itself
+    }
+};
+
+registerExamples([
+    {
+        name: 'list-with-detail-registered',
+        label: 'List With Detail (Registered)',
+        data,
+        schema,
+        uischema
+    }
+]);

--- a/packages/examples/src/list-with-detail.ts
+++ b/packages/examples/src/list-with-detail.ts
@@ -65,7 +65,8 @@ const schema = {
                     type: 'string',
                     enum: ['unordered', 'planned', 'ordered']
                 }
-            }
+            },
+            required: ['title']
         }
     },
     type: 'object',
@@ -76,8 +77,7 @@ const schema = {
                 $ref: '#/definitions/order'
             }
         }
-    },
-    required: ['title']
+    }
 };
 
 const uischema = {


### PR DESCRIPTION
Previously the uischema for a detail either had to be defined inline in the uischema or it was generated on the fly. Now the registered uischemas are also checked.

Motivation: #1086 