### PR TITLE
Fix hasRef performance issues.

### DIFF
--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -474,10 +474,12 @@ export const mapStateToLayoutProps =
 
 export interface JsonFormsProps extends StatePropsOfRenderer {
     renderers?: { tester: RankedTester, renderer: any }[];
+    isSubForm?: Boolean;
 }
 
 export interface StatePropsOfJsonFormsRenderer extends OwnPropsOfRenderer {
     renderers: JsonFormsRendererRegistryEntry[];
+    isSubForm: Boolean;
 }
 
 export const mapStateToJsonFormsRendererProps =
@@ -494,6 +496,7 @@ export const mapStateToJsonFormsRendererProps =
         return {
             renderers: _.get(state.jsonforms, 'renderers') || [],
             schema: ownProps.schema || getSchema(state),
-            uischema
+            uischema,
+            isSubForm: !!ownProps.schema,
         };
     };

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -75,7 +75,7 @@ export class JsonFormsDispatchRenderer
 
     constructor(props: JsonFormsProps) {
         super(props);
-        const isResolved = !hasRefs(props.schema);
+        const isResolved = props.isSubForm || !hasRefs(props.schema);
         this.state = {
             id: isControl(props.uischema) ? createId(props.uischema.scope) : undefined,
             schema: props.schema,


### PR DESCRIPTION
When running with `@jsonforms/react` there is a significant performance issue when rendering a form with a lot of fields. I believe I have tracked this down to [excessive calls to `hasRefs`](https://github.com/eclipsesource/jsonforms/blob/master/packages/react/src/JsonForms.tsx#L78). As I understand the code, that deferred call to resolve the refs on the schema, only needs to happen once on the root `JsonForms` component, as it will pass/provide the already resolve schema down to children, however, all of the children are also performing the `hasRefs` check, even though there will be no refs as the root `JsonForms` component has resolve them. `hasRefs` is an expensive call, especially when run on a large form. I was able to drop render time from 30s to 3 seconds by removing that call.

Fixes #1208