### PR TITLE
Subclass JsonForms from ResolvedJsonForms.

### DIFF
--- a/packages/material-tree-renderer/src/tree/TreeWithDetailRenderer.tsx
+++ b/packages/material-tree-renderer/src/tree/TreeWithDetailRenderer.tsx
@@ -15,7 +15,7 @@ import {
     Runtime, StatePropsOfControl,
     UISchemaElement,
 } from '@jsonforms/core';
-import { Control, JsonForms } from '@jsonforms/react';
+import { Control, ResolvedJsonForms } from '@jsonforms/react';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { DragDropContext } from 'react-dnd';
 import { connect } from 'react-redux';
@@ -321,7 +321,7 @@ export class TreeWithDetailRenderer extends Control
                     <div className={classes.treeMasterDetailDetail}>
                         {
                             this.state.selected ?
-                                <JsonForms
+                                <ResolvedJsonForms
                                     schema={this.state.selected.schema}
                                     path={this.state.selected.path}
                                     uischema={detailUiSchema}

--- a/packages/material/src/complex/MaterialAllOfRenderer.tsx
+++ b/packages/material/src/complex/MaterialAllOfRenderer.tsx
@@ -12,7 +12,7 @@ import {
     UISchemaElement,
     VerticalLayout
 } from '@jsonforms/core';
-import { connectToJsonForms, JsonForms } from '@jsonforms/react';
+import { connectToJsonForms, ResolvedJsonForms } from '@jsonforms/react';
 
 const createControls =
     (allOf: JsonSchema[], schema: JsonSchema, scope: string): UISchemaElement => {
@@ -47,7 +47,7 @@ class MaterialAllOfRenderer extends React.Component<ControlProps, any> {
         );
 
         return (
-            <JsonForms
+            <ResolvedJsonForms
                 schema={schema}
                 uischema={elements}
             />

--- a/packages/material/src/complex/MaterialAnyOfRenderer.tsx
+++ b/packages/material/src/complex/MaterialAnyOfRenderer.tsx
@@ -15,7 +15,7 @@ import {
     toDataPath,
     UISchemaElement,
 } from '@jsonforms/core';
-import { connectToJsonForms, JsonForms } from '@jsonforms/react';
+import { connectToJsonForms, ResolvedJsonForms } from '@jsonforms/react';
 
 const createControls =
     (anyOf: JsonSchema[], schema: JsonSchema, scope: string): UISchemaElement => {
@@ -72,7 +72,7 @@ class MaterialAnyOfRenderer extends React.Component<ControlProps, any> {
         );
 
         return (
-            <JsonForms
+            <ResolvedJsonForms
                 schema={schema}
                 uischema={elements}
             />

--- a/packages/material/src/complex/MaterialObjectRenderer.tsx
+++ b/packages/material/src/complex/MaterialObjectRenderer.tsx
@@ -11,7 +11,7 @@ import {
     rankWith,
     UISchemaElement
 } from '@jsonforms/core';
-import { connectToJsonForms, JsonForms } from '@jsonforms/react';
+import { connectToJsonForms, ResolvedJsonForms } from '@jsonforms/react';
 import { Hidden } from '@material-ui/core';
 import * as _ from 'lodash';
 import * as React from 'react';
@@ -43,7 +43,7 @@ class MaterialObjectRenderer extends React.Component<MaterialObjectRendererProps
 
         return (
             <Hidden xsUp={!visible}>
-                <JsonForms
+                <ResolvedJsonForms
                     visible={visible}
                     schema={scopedSchema}
                     uischema={detailUiSchema}

--- a/packages/material/src/layouts/MaterialArrayLayout.tsx
+++ b/packages/material/src/layouts/MaterialArrayLayout.tsx
@@ -24,7 +24,7 @@
 */
 import * as React from 'react';
 import { ArrayControlProps, composePaths } from '@jsonforms/core';
-import { JsonForms } from '@jsonforms/react';
+import { ResolvedJsonForms } from '@jsonforms/react';
 import * as _ from 'lodash';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
@@ -132,7 +132,7 @@ export const MaterialArrayLayout =
                     </Grid>
                   </ExpansionPanelSummary>
                   <ExpansionPanelDetails>
-                    <JsonForms
+                    <ResolvedJsonForms
                       schema={scopedSchema}
                       uischema={foundUISchema || uischema}
                       path={childPath}

--- a/packages/material/src/util/layout.tsx
+++ b/packages/material/src/util/layout.tsx
@@ -29,7 +29,7 @@ import {
     OwnPropsOfRenderer,
     UISchemaElement,
 } from '@jsonforms/core';
-import { JsonForms } from '@jsonforms/react';
+import { ResolvedJsonForms } from '@jsonforms/react';
 import { Grid, Hidden } from '@material-ui/core';
 
 export const renderLayoutElements = (
@@ -40,7 +40,7 @@ export const renderLayoutElements = (
   elements.map((child, index) =>
       (
         <Grid item key={`${path}-${index}`} xs>
-          <JsonForms
+          <ResolvedJsonForms
             uischema={child}
             schema={schema}
             path={path}

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -145,7 +145,7 @@ export const ResolvedJsonForms = connect(
     null
 )(ResolvedJsonFormsDispatchRenderer);
 
-export class JsonFormsDispatchRenderer extends ResolvedJsonForms {
+export class JsonFormsDispatchRenderer extends ResolvedJsonFormsDispatchRenderer {
     constructor(props: JsonFormsProps) {
         super(props);
         const isResolved = !hasRefs(props.schema);

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -50,7 +50,7 @@ const hasRefs = (schema: JsonSchema) => {
     return false;
 };
 
-export class JsonFormsDispatchRenderer
+export class ResolvedJsonFormsDispatchRenderer
     extends React.Component<JsonFormsProps, JsonFormsRendererState> {
 
     static getDerivedStateFromProps(
@@ -75,12 +75,11 @@ export class JsonFormsDispatchRenderer
 
     constructor(props: JsonFormsProps) {
         super(props);
-        const isResolved = !hasRefs(props.schema);
         this.state = {
             id: isControl(props.uischema) ? createId(props.uischema.scope) : undefined,
             schema: props.schema,
-            resolvedSchema: isResolved ? props.schema : undefined,
-            resolving: !isResolved,
+            resolvedSchema: props.schema,
+            resolving: false,
         };
     }
 
@@ -138,6 +137,23 @@ export class JsonFormsDispatchRenderer
                 />
             );
         }
+    }
+}
+
+export const ResolvedJsonForms = connect(
+    mapStateToJsonFormsRendererProps,
+    null
+)(ResolvedJsonFormsDispatchRenderer);
+
+export class JsonFormsDispatchRenderer extends ResolvedJsonForms {
+    constructor(props: JsonFormsProps) {
+        super(props);
+        const isResolved = !hasRefs(props.schema);
+        this.state = {
+            ...this.state,
+            resolvedSchema: isResolved ? props.schema : undefined,
+            resolving: !isResolved,
+        };
     }
 }
 

--- a/packages/vanilla/src/complex/array/ArrayControl.tsx
+++ b/packages/vanilla/src/complex/array/ArrayControl.tsx
@@ -25,7 +25,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { ArrayControlProps, composePaths } from '@jsonforms/core';
-import { JsonForms } from '@jsonforms/react';
+import { ResolvedJsonForms } from '@jsonforms/react';
 import { VanillaRendererProps } from '../../index';
 
 export const ArrayControl  = (
@@ -62,7 +62,7 @@ export const ArrayControl  = (
                 const childPath = composePaths(path, `${index}`);
 
                 return (
-                  <JsonForms
+                  <ResolvedJsonForms
                     schema={scopedSchema}
                     uischema={foundUISchema || uischema}
                     path={childPath}

--- a/packages/vanilla/src/complex/categorization/SingleCategory.tsx
+++ b/packages/vanilla/src/complex/categorization/SingleCategory.tsx
@@ -24,7 +24,7 @@
 */
 import * as React from 'react';
 import { Category, JsonSchema } from '@jsonforms/core';
-import { JsonForms } from '@jsonforms/react';
+import { ResolvedJsonForms } from '@jsonforms/react';
 
 export interface CategoryProps {
   category: Category;
@@ -38,7 +38,7 @@ export const SingleCategory = ({ category, schema, path }: CategoryProps) => (
     {
       (category.elements || []).map((child, index) =>
         (
-          <JsonForms
+          <ResolvedJsonForms
             key={`${path}-${index}`}
             uischema={child}
             schema={schema}

--- a/packages/vanilla/src/layouts/util.tsx
+++ b/packages/vanilla/src/layouts/util.tsx
@@ -25,7 +25,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { JsonSchema, Layout } from '@jsonforms/core';
-import { JsonForms } from '@jsonforms/react';
+import { ResolvedJsonForms } from '@jsonforms/react';
 export interface RenderChildrenProps {
   layout: Layout;
   schema: JsonSchema;
@@ -46,7 +46,7 @@ export const renderChildren = (
   return layout.elements.map((child, index) => {
     return (
       <div className={className} key={`${path}-${index}`}>
-        <JsonForms
+        <ResolvedJsonForms
           uischema={child}
           schema={schema}
           path={path}

--- a/packages/webcomponent/src/JsonFormsElement.tsx
+++ b/packages/webcomponent/src/JsonFormsElement.tsx
@@ -37,7 +37,7 @@ import {
     JsonSchema,
     UISchemaElement
 } from '@jsonforms/core';
-import { JsonForms } from '@jsonforms/react';
+import { ResolvedJsonForms } from '@jsonforms/react';
 import { Store } from 'redux';
 
 /**
@@ -72,7 +72,7 @@ const CustomElement = (config: CustomElementConfig) => (cls: any) => {
 })
 export class JsonFormsElement extends HTMLElement {
 
-  private InnerComponent: any = JsonForms;
+  private InnerComponent: any = ResolvedJsonForms;
   private innerComponentParameters: any = {};
   private allowDynamicUpdate = false;
   private _store: JsonFormsStore;


### PR DESCRIPTION
When running with @jsonforms/react there is a significant performance issue when rendering a form with a lot of fields. I believe I have tracked this down to excessive calls to hasRefs. As I understand the code, that deferred call to resolve the refs on the schema, only needs to happen once on the root JsonForms component, as it will pass/provide the already resolve schema down to children, however, all of the children are also performing the hasRefs check, even though there will be no refs as the root JsonForms component has resolve them. hasRefs is an expensive call, especially when run on a large form. I was able to drop render time from 30s to 3 seconds by removing that call.

This is an alternate solution to #1209 (and #1208) which takes the route of subclassing the JsonForms to allow renderers that are not at the root to explicitly include a JsonForms that already has the schema fully resolved and avoid the expensive penalties of hasRefs checks.

Fixes: #1209
Fixes: #1208