### PR TITLE
Preselect with default schema values #1193

### DIFF
--- a/packages/core/src/util/validator.ts
+++ b/packages/core/src/util/validator.ts
@@ -1,12 +1,14 @@
 import * as AJV from 'ajv';
+import { Options } from 'ajv';
 import { Draft4 } from '../models/draft4';
 
-export const createAjv = () => {
+export const createAjv = (options?: Options) => {
   const ajv = new AJV({
     schemaId: 'auto',
     allErrors: true,
     jsonPointers: true,
-    errorDataPath: 'property'
+    errorDataPath: 'property',
+    ...options
   });
   ajv.addFormat('time', '^([0-1][0-9]|2[0-3]):[0-5][0-9]$');
   ajv.addMetaSchema(Draft4);

--- a/packages/core/test/util/renderer.test.ts
+++ b/packages/core/test/util/renderer.test.ts
@@ -629,14 +629,54 @@ test('should assign defaults to enum', t => {
   store.dispatch(
     init(data, schema, uischema, createAjv({ useDefaults: true }))
   );
-  const ownProps: OwnPropsOfControl = { schema };
-
-  mapDispatchToArrayControlProps(store.dispatch, ownProps);
 
   t.is(store.getState().jsonforms.core.data.color, 'green');
 });
 
-test('should assign defaults to array', t => {
+test('should assign defaults to empty item within nested object of an array', t => {
+  const schema: JsonSchema = {
+    type: 'array',
+    items: {
+      type: 'object',
+      properties: {
+        message: {
+          type: 'string',
+          default: 'foo'
+        }
+      }
+    }
+  };
+
+  const uischema: ControlElement = {
+    type: 'Control',
+    scope: '#'
+  };
+
+  const data = [{}];
+
+  const initState = {
+    jsonforms: {
+      core: {
+        uischema,
+        schema,
+        data,
+        errors: [] as ErrorObject[]
+      }
+    }
+  };
+  const store: Store<JsonFormsState> = createStore(
+    combineReducers({ jsonforms: jsonformsReducer() }),
+    initState
+  );
+  store.dispatch(
+    init(data, schema, uischema, createAjv({ useDefaults: true }))
+  );
+
+  t.is(store.getState().jsonforms.core.data.length, 1);
+  t.deepEqual(store.getState().jsonforms.core.data[0], { message: 'foo' });
+});
+
+test('should assign defaults to newly added item within nested object of an array', t => {
   const schema: JsonSchema = {
     type: 'array',
     items: {
@@ -683,6 +723,5 @@ test('should assign defaults to array', t => {
   props.addItem('')();
 
   t.is(store.getState().jsonforms.core.data.length, 2);
-  t.deepEqual(store.getState().jsonforms.core.data[0], { message: 'foo' });
   t.deepEqual(store.getState().jsonforms.core.data[1], { message: 'foo' });
 });


### PR DESCRIPTION
- Adds options to `createAjv` method . Clients that want to have preselected
default values should pass in the `useDefaults: true` option to the
`createAjv` method and use the Ajv object in the `Actions.init` call.