### PR TITLE
Add alternative categorization renderer based on steppers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,4 @@
 {
-	"name": "jsonforms-edgar",
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
@@ -127,14 +126,12 @@
 		"@ava/babel-plugin-throws-helper": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-2.0.0.tgz",
-			"integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw=",
-			"dev": true
+			"integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw="
 		},
 		"@ava/babel-preset-stage-4": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-1.1.0.tgz",
 			"integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "^6.8.0",
 				"babel-plugin-syntax-trailing-function-commas": "^6.20.0",
@@ -154,7 +151,6 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
 					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-					"dev": true,
 					"requires": {
 						"md5-o-matic": "^0.1.1"
 					}
@@ -163,7 +159,6 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-1.2.0.tgz",
 					"integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
-					"dev": true,
 					"requires": {
 						"md5-hex": "^1.3.0"
 					}
@@ -174,7 +169,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-3.0.0.tgz",
 			"integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
-			"dev": true,
 			"requires": {
 				"@ava/babel-plugin-throws-helper": "^2.0.0",
 				"babel-plugin-espower": "^2.3.2"
@@ -184,7 +178,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@ava/write-file-atomic/-/write-file-atomic-2.2.0.tgz",
 			"integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
@@ -200,11 +193,11 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.2.tgz",
-			"integrity": "sha512-I4o675J/iS8k+P38dvJ3IBGqObLXyQLTxtrR4u9cSUJOURvafeEWb/pFMOTwtNrmq73mJzyF6ueTbO1BtN0Zeg==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.0.tgz",
+			"integrity": "sha512-dZTwMvTgWfhmibq4V9X+LMf6Bgl7zAodRn9PvcPdhlzFMbvUutx74dbEv7Atz3ToeEpevYEJtAwfxq/bDCzHWg==",
 			"requires": {
-				"@babel/types": "^7.2.2",
+				"@babel/types": "^7.3.0",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.10",
 				"source-map": "^0.5.0",
@@ -262,14 +255,14 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.3.tgz",
-			"integrity": "sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA=="
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.1.tgz",
+			"integrity": "sha512-ATz6yX/L8LEnC3dtLQnIx4ydcPxhLcoy9Vl6re00zb2w5lG6itY6Vhnr1KFRPq/FHNsgl/gh2mjNN20f9iJTTA=="
 		},
 		"@babel/runtime": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
-			"integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+			"integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
 			"requires": {
 				"regenerator-runtime": "^0.12.0"
 			},
@@ -323,9 +316,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.2.2.tgz",
-			"integrity": "sha512-fKCuD6UFUMkR541eDWL+2ih/xFZBXPOg/7EQFeTluMDebfqR4jrpaCjLhkWlQS4hT6nRa2PMEgXKbRB5/H2fpg==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.0.tgz",
+			"integrity": "sha512-QkFPw68QqWU1/RVPyBe8SO7lXbPfjtqAxRYQKpFpaB8yMq7X2qAqfwK5LKoQufEkSmO5NQ70O6Kc3Afk03RwXw==",
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.10",
@@ -343,7 +336,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz",
 			"integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
-			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1"
 			}
@@ -396,6 +388,11 @@
 				"xml2js": "^0.4.19"
 			},
 			"dependencies": {
+				"acorn": {
+					"version": "5.7.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+				},
 				"acorn-dynamic-import": {
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
@@ -530,7 +527,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/@ladjs/time-require/-/time-require-0.1.4.tgz",
 			"integrity": "sha512-weIbJqTMfQ4r1YX85u54DKfjLZs2jwn1XZ6tIOP/pFgMwhIN5BAtaCp/1wn9DzyLsDR9tW0R2NIePcVJ45ivQQ==",
-			"dev": true,
 			"requires": {
 				"chalk": "^0.4.0",
 				"date-time": "^0.1.1",
@@ -541,14 +537,12 @@
 				"ansi-styles": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-					"dev": true
+					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
 				},
 				"chalk": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "~1.0.0",
 						"has-color": "~0.1.0",
@@ -559,7 +553,6 @@
 					"version": "0.2.2",
 					"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
 					"integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
-					"dev": true,
 					"requires": {
 						"parse-ms": "^0.1.0"
 					}
@@ -567,15 +560,14 @@
 				"strip-ansi": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-					"dev": true
+					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
 				}
 			}
 		},
 		"@material-ui/core": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.8.3.tgz",
-			"integrity": "sha512-jgWx5uwpo+mCj+Y6JdygFRji8ZHDYZdbylqCXvpK42c2n6m/jsr4Y5Y7RnlgllkIqftKFGNnik/rd1gTLaF+Ig==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.0.tgz",
+			"integrity": "sha512-9fxu0B9zx/TfiU0OJmwRFk+I+2J7fcXzTfQl+ZPxqlVRrPDqTHnMZlqWRJjlHCe3AVXlgpJ6/a4QCvGEohEbIQ==",
 			"requires": {
 				"@babel/runtime": "^7.2.0",
 				"@material-ui/system": "^3.0.0-alpha.0",
@@ -746,14 +738,12 @@
 		"@types/events": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
-			"integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
-			"dev": true
+			"integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
 		},
 		"@types/fs-extra": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
 			"integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -762,7 +752,6 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
 			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
-			"dev": true,
 			"requires": {
 				"@types/events": "*",
 				"@types/minimatch": "*",
@@ -772,14 +761,12 @@
 		"@types/handlebars": {
 			"version": "4.0.40",
 			"resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.40.tgz",
-			"integrity": "sha512-sGWNtsjNrLOdKha2RV1UeF8+UbQnPSG7qbe5wwbni0mw4h2gHXyPFUMOC+xwGirIiiydM/HSqjDO4rk6NFB18w==",
-			"dev": true
+			"integrity": "sha512-sGWNtsjNrLOdKha2RV1UeF8+UbQnPSG7qbe5wwbni0mw4h2gHXyPFUMOC+xwGirIiiydM/HSqjDO4rk6NFB18w=="
 		},
 		"@types/highlight.js": {
 			"version": "9.12.3",
 			"resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
-			"integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
-			"dev": true
+			"integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ=="
 		},
 		"@types/invariant": {
 			"version": "2.2.29",
@@ -787,10 +774,9 @@
 			"integrity": "sha512-lRVw09gOvgviOfeUrKc/pmTiRZ7g7oDOU6OAutyuSHpm1/o2RaBQvRhgK8QEdu+FFuw/wnWb29A/iuxv9i8OpQ=="
 		},
 		"@types/jest": {
-			"version": "23.3.12",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.12.tgz",
-			"integrity": "sha512-/kQvbVzdEpOq4tEWT79yAHSM4nH4xMlhJv2GrLVQt4Qmo8yYsPdioBM1QpN/2GX1wkfMnyXvdoftvLUr0LBj7Q==",
-			"dev": true
+			"version": "23.3.13",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.13.tgz",
+			"integrity": "sha512-ePl4l+7dLLmCucIwgQHAgjiepY++qcI6nb8eAwGNkB6OxmTe3Z9rQU3rSpomqu42PCCnlThZbOoxsf+qylJsLA=="
 		},
 		"@types/jss": {
 			"version": "9.5.7",
@@ -802,21 +788,19 @@
 			}
 		},
 		"@types/lodash": {
-			"version": "4.14.119",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.119.tgz",
-			"integrity": "sha512-Z3TNyBL8Vd/M9D9Ms2S3LmFq2sSMzahodD6rCS9V2N44HUMINb75jNkSuwAx7eo2ufqTdfOdtGQpNbieUjPQmw=="
+			"version": "4.14.120",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.120.tgz",
+			"integrity": "sha512-jQ21kQ120mo+IrDs1nFNVm/AsdFxIx2+vZ347DbogHJPd/JzKNMOqU6HCYin1W6v8l5R9XSO2/e9cxmn7HAnVw=="
 		},
 		"@types/marked": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
-			"integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
-			"dev": true
+			"integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg=="
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-			"dev": true
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
 		},
 		"@types/node": {
 			"version": "10.12.18",
@@ -830,13 +814,13 @@
 		},
 		"@types/q": {
 			"version": "0.0.32",
-			"resolved": "http://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
+			"resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
 			"integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU="
 		},
 		"@types/react": {
-			"version": "16.7.18",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.7.18.tgz",
-			"integrity": "sha512-Tx4uu3ppK53/iHk6VpamMP3f3ahfDLEVt3ZQc8TFm30a1H3v9lMsCntBREswZIW/SKrvJjkb3Hq8UwO6GREBng==",
+			"version": "16.7.20",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.7.20.tgz",
+			"integrity": "sha512-Qd5RWkwl6SL7R2XzLk/cicjVQm1Mhc6HqXY5Ei4pWd1Vi8Fkbd5O0sA398x8fRSTPAuHdDYD9nrWmJMYTJI0vQ==",
 			"requires": {
 				"@types/prop-types": "*",
 				"csstype": "^2.2.0"
@@ -851,9 +835,9 @@
 			}
 		},
 		"@types/react-redux": {
-			"version": "6.0.12",
-			"resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-6.0.12.tgz",
-			"integrity": "sha512-fvcpm7cfW/JMflRdZgegCVbSGYt/hyEWQKriesaLZDRDjBGKQsAiui08VCQg5lBpocPmulVGKFhICtOAcMUPOQ==",
+			"version": "6.0.13",
+			"resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-6.0.13.tgz",
+			"integrity": "sha512-69lPYT69CSvzQ75Ut4MfT+oQU9TAjCycdL6BQOrPztqbzdhzSe1d4Qj8vrMkTOm454Xz151zh+YT6S4t2OBopw==",
 			"requires": {
 				"@types/react": "*",
 				"redux": "^4.0.0"
@@ -922,7 +906,6 @@
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.1.tgz",
 			"integrity": "sha512-1lQw+48BuVgp6c1+z8EMipp18IdnV2dLh6KQGwOm+kJy9nPjEkaqRKmwbDNEYf//EKBvKcwOC6V2cDrNxVoQeQ==",
-			"dev": true,
 			"requires": {
 				"@types/glob": "*",
 				"@types/node": "*"
@@ -932,7 +915,6 @@
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
 			"integrity": "sha512-ZEzy4vjvTzScC+SH8RBssQUawpaInUdMTYwYYLh54/s8TuT0gBLuyUnppKsVyZEi876VmmStKsUs28UxPgdvrA==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/helper-module-context": "1.7.11",
 				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
@@ -942,26 +924,22 @@
 		"@webassemblyjs/floating-point-hex-parser": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.11.tgz",
-			"integrity": "sha512-zY8dSNyYcgzNRNT666/zOoAyImshm3ycKdoLsyDw/Bwo6+/uktb7p4xyApuef1dwEBo/U/SYQzbGBvV+nru2Xg==",
-			"dev": true
+			"integrity": "sha512-zY8dSNyYcgzNRNT666/zOoAyImshm3ycKdoLsyDw/Bwo6+/uktb7p4xyApuef1dwEBo/U/SYQzbGBvV+nru2Xg=="
 		},
 		"@webassemblyjs/helper-api-error": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.11.tgz",
-			"integrity": "sha512-7r1qXLmiglC+wPNkGuXCvkmalyEstKVwcueZRP2GNC2PAvxbLYwLLPr14rcdJaE4UtHxQKfFkuDFuv91ipqvXg==",
-			"dev": true
+			"integrity": "sha512-7r1qXLmiglC+wPNkGuXCvkmalyEstKVwcueZRP2GNC2PAvxbLYwLLPr14rcdJaE4UtHxQKfFkuDFuv91ipqvXg=="
 		},
 		"@webassemblyjs/helper-buffer": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.11.tgz",
-			"integrity": "sha512-MynuervdylPPh3ix+mKZloTcL06P8tenNH3sx6s0qE8SLR6DdwnfgA7Hc9NSYeob2jrW5Vql6GVlsQzKQCa13w==",
-			"dev": true
+			"integrity": "sha512-MynuervdylPPh3ix+mKZloTcL06P8tenNH3sx6s0qE8SLR6DdwnfgA7Hc9NSYeob2jrW5Vql6GVlsQzKQCa13w=="
 		},
 		"@webassemblyjs/helper-code-frame": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.11.tgz",
 			"integrity": "sha512-T8ESC9KMXFTXA5urJcyor5cn6qWeZ4/zLPyWeEXZ03hj/x9weSokGNkVCdnhSabKGYWxElSdgJ+sFa9G/RdHNw==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/wast-printer": "1.7.11"
 			}
@@ -969,26 +947,22 @@
 		"@webassemblyjs/helper-fsm": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.11.tgz",
-			"integrity": "sha512-nsAQWNP1+8Z6tkzdYlXT0kxfa2Z1tRTARd8wYnc/e3Zv3VydVVnaeePgqUzFrpkGUyhUUxOl5ML7f1NuT+gC0A==",
-			"dev": true
+			"integrity": "sha512-nsAQWNP1+8Z6tkzdYlXT0kxfa2Z1tRTARd8wYnc/e3Zv3VydVVnaeePgqUzFrpkGUyhUUxOl5ML7f1NuT+gC0A=="
 		},
 		"@webassemblyjs/helper-module-context": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.11.tgz",
-			"integrity": "sha512-JxfD5DX8Ygq4PvXDucq0M+sbUFA7BJAv/GGl9ITovqE+idGX+J3QSzJYz+LwQmL7fC3Rs+utvWoJxDb6pmC0qg==",
-			"dev": true
+			"integrity": "sha512-JxfD5DX8Ygq4PvXDucq0M+sbUFA7BJAv/GGl9ITovqE+idGX+J3QSzJYz+LwQmL7fC3Rs+utvWoJxDb6pmC0qg=="
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.11.tgz",
-			"integrity": "sha512-cMXeVS9rhoXsI9LLL4tJxBgVD/KMOKXuFqYb5oCJ/opScWpkCMEz9EJtkonaNcnLv2R3K5jIeS4TRj/drde1JQ==",
-			"dev": true
+			"integrity": "sha512-cMXeVS9rhoXsI9LLL4tJxBgVD/KMOKXuFqYb5oCJ/opScWpkCMEz9EJtkonaNcnLv2R3K5jIeS4TRj/drde1JQ=="
 		},
 		"@webassemblyjs/helper-wasm-section": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.11.tgz",
 			"integrity": "sha512-8ZRY5iZbZdtNFE5UFunB8mmBEAbSI3guwbrsCl4fWdfRiAcvqQpeqd5KHhSWLL5wuxo53zcaGZDBU64qgn4I4Q==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-buffer": "1.7.11",
@@ -1000,7 +974,6 @@
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.11.tgz",
 			"integrity": "sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==",
-			"dev": true,
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
@@ -1009,7 +982,6 @@
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.11.tgz",
 			"integrity": "sha512-vuGmgZjjp3zjcerQg+JA+tGOncOnJLWVkt8Aze5eWQLwTQGNgVLcyOTqgSCxWTR4J42ijHbBxnuRaL1Rv7XMdw==",
-			"dev": true,
 			"requires": {
 				"@xtuc/long": "4.2.1"
 			}
@@ -1017,14 +989,12 @@
 		"@webassemblyjs/utf8": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.11.tgz",
-			"integrity": "sha512-C6GFkc7aErQIAH+BMrIdVSmW+6HSe20wg57HEC1uqJP8E/xpMjXqQUxkQw07MhNDSDcGpxI9G5JSNOQCqJk4sA==",
-			"dev": true
+			"integrity": "sha512-C6GFkc7aErQIAH+BMrIdVSmW+6HSe20wg57HEC1uqJP8E/xpMjXqQUxkQw07MhNDSDcGpxI9G5JSNOQCqJk4sA=="
 		},
 		"@webassemblyjs/wasm-edit": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.11.tgz",
 			"integrity": "sha512-FUd97guNGsCZQgeTPKdgxJhBXkUbMTY6hFPf2Y4OedXd48H97J+sOY2Ltaq6WGVpIH8o/TGOVNiVz/SbpEMJGg==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-buffer": "1.7.11",
@@ -1040,7 +1010,6 @@
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.11.tgz",
 			"integrity": "sha512-U/KDYp7fgAZX5KPfq4NOupK/BmhDc5Kjy2GIqstMhvvdJRcER/kUsMThpWeRP8BMn4LXaKhSTggIJPOeYHwISA==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
@@ -1053,7 +1022,6 @@
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.11.tgz",
 			"integrity": "sha512-XynkOwQyiRidh0GLua7SkeHvAPXQV/RxsUeERILmAInZegApOUAIJfRuPYe2F7RcjOC9tW3Cb9juPvAC/sCqvg==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-buffer": "1.7.11",
@@ -1065,7 +1033,6 @@
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.11.tgz",
 			"integrity": "sha512-6lmXRTrrZjYD8Ng8xRyvyXQJYUQKYSXhJqXOBLw24rdiXsHAOlvw5PhesjdcaMadU/pyPQOJ5dHreMjBxwnQKg==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-api-error": "1.7.11",
@@ -1079,7 +1046,6 @@
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.11.tgz",
 			"integrity": "sha512-lEyVCg2np15tS+dm7+JJTNhNWq9yTZvi3qEhAIIOaofcYlUp0UR5/tVqOwa/gXYr3gjwSZqw+/lS9dscyLelbQ==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/floating-point-hex-parser": "1.7.11",
@@ -1093,7 +1059,6 @@
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.11.tgz",
 			"integrity": "sha512-m5vkAsuJ32QpkdkDOUPGSltrg8Cuk3KBx4YrmAGQwCZPRdUHXxG4phIOuuycLemHFr74sWL9Wthqss4fzdzSwg==",
-			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/wast-parser": "1.7.11",
@@ -1108,20 +1073,17 @@
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-			"dev": true
+			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
 		},
 		"@xtuc/long": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz",
-			"integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==",
-			"dev": true
+			"integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g=="
 		},
 		"JSONStream": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
 			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-			"dev": true,
 			"requires": {
 				"jsonparse": "^1.2.0",
 				"through": ">=2.2.7 <3"
@@ -1147,18 +1109,14 @@
 			}
 		},
 		"acorn": {
-			"version": "5.7.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-			"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
+			"integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg=="
 		},
 		"acorn-dynamic-import": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
-			"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
-			"dev": true,
-			"requires": {
-				"acorn": "^5.0.0"
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
+			"integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
 		},
 		"acorn-globals": {
 			"version": "4.3.0",
@@ -1167,13 +1125,6 @@
 			"requires": {
 				"acorn": "^6.0.1",
 				"acorn-walk": "^6.0.1"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
-					"integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg=="
-				}
 			}
 		},
 		"acorn-walk": {
@@ -1184,8 +1135,7 @@
 		"add-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
-			"dev": true
+			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo="
 		},
 		"adm-zip": {
 			"version": "0.4.13",
@@ -1361,8 +1311,7 @@
 		"arr-exclude": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/arr-exclude/-/arr-exclude-1.0.0.tgz",
-			"integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE=",
-			"dev": true
+			"integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE="
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
@@ -1377,8 +1326,7 @@
 		"array-differ": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-			"dev": true
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
 		},
 		"array-equal": {
 			"version": "1.0.0",
@@ -1398,8 +1346,7 @@
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
-			"dev": true
+			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
 		},
 		"array-slice": {
 			"version": "0.2.3",
@@ -1543,8 +1490,7 @@
 		"auto-bind": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-1.2.1.tgz",
-			"integrity": "sha512-/W9yj1yKmBLwpexwAujeD9YHwYmRuWFGV8HWE7smQab797VeHa4/cnE2NFeDhA+E+5e/OGBI8763EhLjfZ/MXA==",
-			"dev": true
+			"integrity": "sha512-/W9yj1yKmBLwpexwAujeD9YHwYmRuWFGV8HWE7smQab797VeHa4/cnE2NFeDhA+E+5e/OGBI8763EhLjfZ/MXA=="
 		},
 		"autobind-decorator": {
 			"version": "2.4.0",
@@ -1568,7 +1514,6 @@
 			"version": "0.25.0",
 			"resolved": "https://registry.npmjs.org/ava/-/ava-0.25.0.tgz",
 			"integrity": "sha512-4lGNJCf6xL8SvsKVEKxEE46se7JAUIAZoKHw9itTQuwcsydhpAMkBs5gOOiWiwt0JKNIuXWc2/r4r8ZdcNrBEw==",
-			"dev": true,
 			"requires": {
 				"@ava/babel-preset-stage-4": "^1.1.0",
 				"@ava/babel-preset-transform-test-files": "^3.0.0",
@@ -1659,7 +1604,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/ava-init/-/ava-init-0.2.1.tgz",
 			"integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
-			"dev": true,
 			"requires": {
 				"arr-exclude": "^1.0.0",
 				"execa": "^0.7.0",
@@ -2080,7 +2024,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2091,7 +2034,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2103,7 +2045,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-traverse": "^6.24.1",
@@ -2114,7 +2055,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2127,7 +2067,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2137,7 +2076,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2147,7 +2085,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"babel-types": "^6.26.0",
@@ -2158,7 +2095,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2189,7 +2125,6 @@
 			"version": "7.1.5",
 			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.5.tgz",
 			"integrity": "sha512-iCHfbieL5d1LfOQeeVJEUyD9rTwBcP/fcEbRCfempxTDuqrKpu0AZjLAQHEQa3Yqyj9ORKe2iHfoj4rHLf7xpw==",
-			"dev": true,
 			"requires": {
 				"find-cache-dir": "^1.0.0",
 				"loader-utils": "^1.0.2",
@@ -2208,7 +2143,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2217,7 +2151,6 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-2.4.0.tgz",
 			"integrity": "sha512-/+SRpy7pKgTI28oEHfn1wkuM5QFAdRq8WNsOOih1dVrdV6A/WbNbRZyl0eX5eyDgtb0lOE27PeDFuCX2j8OxVg==",
-			"dev": true,
 			"requires": {
 				"babel-generator": "^6.1.0",
 				"babylon": "^6.1.0",
@@ -2247,14 +2180,12 @@
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-			"dev": true
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-			"dev": true
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
@@ -2264,14 +2195,12 @@
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-			"dev": true
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
 		},
 		"babel-plugin-transform-async-to-generator": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "^6.24.1",
 				"babel-plugin-syntax-async-functions": "^6.8.0",
@@ -2282,7 +2211,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2291,7 +2219,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2302,7 +2229,6 @@
 			"version": "6.26.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
 			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "^6.24.1",
 				"babel-runtime": "^6.26.0",
@@ -2314,7 +2240,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "^6.24.1",
 				"babel-helper-get-function-arity": "^6.24.1",
@@ -2328,7 +2253,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2337,7 +2261,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-			"dev": true,
 			"requires": {
 				"babel-helper-regex": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2348,7 +2271,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-			"dev": true,
 			"requires": {
 				"babel-helper-regex": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2359,7 +2281,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
@@ -2370,7 +2291,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2616,7 +2536,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -2907,8 +2827,7 @@
 		"buf-compare": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
-			"integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=",
-			"dev": true
+			"integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o="
 		},
 		"buffer": {
 			"version": "4.9.1",
@@ -2967,8 +2886,7 @@
 		"byline": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
-			"dev": true
+			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
 		},
 		"bytes": {
 			"version": "3.0.0",
@@ -2979,7 +2897,6 @@
 			"version": "11.3.2",
 			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
 			"integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
-			"dev": true,
 			"requires": {
 				"bluebird": "^3.5.3",
 				"chownr": "^1.1.1",
@@ -3001,7 +2918,6 @@
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
 					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-					"dev": true,
 					"requires": {
 						"yallist": "^3.0.2"
 					}
@@ -3009,14 +2925,12 @@
 				"y18n": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-					"dev": true
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-					"dev": true
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 				}
 			}
 		},
@@ -3047,7 +2961,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
 			"integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
-			"dev": true,
 			"requires": {
 				"md5-hex": "^1.2.0",
 				"mkdirp": "^0.5.1",
@@ -3058,7 +2971,6 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
 					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-					"dev": true,
 					"requires": {
 						"md5-o-matic": "^0.1.1"
 					}
@@ -3067,7 +2979,6 @@
 					"version": "1.3.4",
 					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
 					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
 						"imurmurhash": "^0.1.4",
@@ -3080,7 +2991,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.1.0.tgz",
 			"integrity": "sha512-IoQLeNwwf9KTNbtSA7aEBb1yfDbdnzwjCetjkC8io5oGeOmK2CBNdg0xr+tadRYKO0p7uQyZzvon0kXlZbvGrw==",
-			"dev": true,
 			"requires": {
 				"core-js": "^2.0.0",
 				"deep-equal": "^1.0.0",
@@ -3091,8 +3001,7 @@
 		"call-signature": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
-			"integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
-			"dev": true
+			"integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY="
 		},
 		"callsite": {
 			"version": "1.0.0",
@@ -3128,9 +3037,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000928",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000928.tgz",
-			"integrity": "sha512-aSpMWRXL6ZXNnzm8hgE4QDLibG5pVJ2Ujzsuj3icazlIkxXkPXtL+BWnMx6FBkWmkZgBHGUxPZQvrbRw2ZTxhg=="
+			"version": "1.0.30000929",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000929.tgz",
+			"integrity": "sha512-n2w1gPQSsYyorSVYqPMqbSaz1w7o9ZC8VhOEGI9T5MfGDzp7sbopQxG6GaQmYsaq13Xfx/mkxJUWC1Dz3oZfzw=="
 		},
 		"capture-exit": {
 			"version": "1.2.0",
@@ -3177,8 +3086,7 @@
 		"chardet": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-			"dev": true
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
 		},
 		"cheerio": {
 			"version": "1.0.0-rc.2",
@@ -3218,7 +3126,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
 			"integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
-			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -3291,14 +3198,12 @@
 		"clean-stack": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
-			"integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE=",
-			"dev": true
+			"integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
 		},
 		"clean-yaml-object": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
-			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
-			"dev": true
+			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g="
 		},
 		"cli-boxes": {
 			"version": "1.0.0",
@@ -3309,7 +3214,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-			"dev": true,
 			"requires": {
 				"restore-cursor": "^2.0.0"
 			}
@@ -3317,14 +3221,12 @@
 		"cli-spinners": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
-			"integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
-			"dev": true
+			"integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg=="
 		},
 		"cli-truncate": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
 			"integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
-			"dev": true,
 			"requires": {
 				"slice-ansi": "^1.0.0",
 				"string-width": "^2.0.0"
@@ -3333,8 +3235,7 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-			"dev": true
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
 		},
 		"cliui": {
 			"version": "3.2.0",
@@ -3382,20 +3283,17 @@
 		"clone-buffer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-			"dev": true
+			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
 		},
 		"clone-stats": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-			"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-			"dev": true
+			"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
 		},
 		"cloneable-readable": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
 			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"process-nextick-args": "^2.0.0",
@@ -3406,7 +3304,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
 			"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"mkdirp": "~0.5.0"
@@ -3421,7 +3318,6 @@
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co-with-promise/-/co-with-promise-4.6.0.tgz",
 			"integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
-			"dev": true,
 			"requires": {
 				"pinkie-promise": "^1.0.0"
 			}
@@ -3430,7 +3326,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.1.tgz",
 			"integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
-			"dev": true,
 			"requires": {
 				"convert-to-spaces": "^1.0.1"
 			}
@@ -3471,7 +3366,6 @@
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
 			"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
-			"dev": true,
 			"requires": {
 				"strip-ansi": "^3.0.0",
 				"wcwidth": "^1.0.0"
@@ -3481,7 +3375,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -3507,8 +3400,7 @@
 		"command-join": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz",
-			"integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8=",
-			"dev": true
+			"integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8="
 		},
 		"commander": {
 			"version": "2.17.1",
@@ -3518,8 +3410,7 @@
 		"common-path-prefix": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
-			"integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA=",
-			"dev": true
+			"integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA="
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -3530,7 +3421,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
 			"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
-			"dev": true,
 			"requires": {
 				"array-ify": "^1.0.0",
 				"dot-prop": "^3.0.0"
@@ -3540,7 +3430,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
 					"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-					"dev": true,
 					"requires": {
 						"is-obj": "^1.0.0"
 					}
@@ -3624,7 +3513,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/concordance/-/concordance-3.0.0.tgz",
 			"integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
-			"dev": true,
 			"requires": {
 				"date-time": "^2.1.0",
 				"esutils": "^2.0.2",
@@ -3643,7 +3531,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
 					"integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
-					"dev": true,
 					"requires": {
 						"time-zone": "^1.0.0"
 					}
@@ -3750,7 +3637,6 @@
 			"version": "1.1.24",
 			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.24.tgz",
 			"integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
-			"dev": true,
 			"requires": {
 				"conventional-changelog-angular": "^1.6.6",
 				"conventional-changelog-atom": "^0.2.8",
@@ -3769,7 +3655,6 @@
 			"version": "1.6.6",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
 			"integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
-			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"q": "^1.5.1"
@@ -3779,7 +3664,6 @@
 			"version": "0.2.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.8.tgz",
 			"integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -3788,7 +3672,6 @@
 			"version": "1.3.22",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.22.tgz",
 			"integrity": "sha512-pnjdIJbxjkZ5VdAX/H1wndr1G10CY8MuZgnXuJhIHglOXfIrXygb7KZC836GW9uo1u8PjEIvIw/bKX0lOmOzZg==",
-			"dev": true,
 			"requires": {
 				"add-stream": "^1.0.0",
 				"conventional-changelog": "^1.1.24",
@@ -3800,14 +3683,12 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"camelcase-keys": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0",
 						"map-obj": "^2.0.0",
@@ -3818,7 +3699,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -3829,14 +3709,12 @@
 				"map-obj": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-					"dev": true
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
 				},
 				"meow": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -3852,14 +3730,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -3869,7 +3745,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -3877,14 +3752,12 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -3895,7 +3768,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -3905,7 +3777,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-					"dev": true,
 					"requires": {
 						"indent-string": "^3.0.0",
 						"strip-indent": "^2.0.0"
@@ -3914,14 +3785,12 @@
 				"strip-indent": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-					"dev": true
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
 				},
 				"trim-newlines": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-					"dev": true
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
 				}
 			}
 		},
@@ -3929,7 +3798,6 @@
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.8.tgz",
 			"integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -3938,7 +3806,6 @@
 			"version": "2.0.11",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.11.tgz",
 			"integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
-			"dev": true,
 			"requires": {
 				"conventional-changelog-writer": "^3.0.9",
 				"conventional-commits-parser": "^2.1.7",
@@ -3959,7 +3826,6 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
 					"requires": {
 						"path-exists": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
@@ -3969,7 +3835,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -3982,7 +3847,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
@@ -3991,7 +3855,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"pify": "^2.0.0",
@@ -4001,14 +3864,12 @@
 				"pinkie": {
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-					"dev": true
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-					"dev": true,
 					"requires": {
 						"pinkie": "^2.0.0"
 					}
@@ -4017,7 +3878,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^1.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -4028,7 +3888,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"dev": true,
 					"requires": {
 						"find-up": "^1.0.0",
 						"read-pkg": "^1.0.0"
@@ -4038,7 +3897,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -4049,7 +3907,6 @@
 			"version": "0.3.12",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.12.tgz",
 			"integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -4058,7 +3915,6 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.9.tgz",
 			"integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -4067,7 +3923,6 @@
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz",
 			"integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -4076,7 +3931,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
 			"integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
-			"dev": true,
 			"requires": {
 				"q": "^1.4.1"
 			}
@@ -4085,7 +3939,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
 			"integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
-			"dev": true,
 			"requires": {
 				"q": "^1.4.1"
 			}
@@ -4094,7 +3947,6 @@
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.8.tgz",
 			"integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
-			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"q": "^1.5.1"
@@ -4103,14 +3955,12 @@
 		"conventional-changelog-preset-loader": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz",
-			"integrity": "sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw==",
-			"dev": true
+			"integrity": "sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw=="
 		},
 		"conventional-changelog-writer": {
 			"version": "3.0.9",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz",
 			"integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
-			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"conventional-commits-filter": "^1.1.6",
@@ -4127,14 +3977,12 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"camelcase-keys": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0",
 						"map-obj": "^2.0.0",
@@ -4145,7 +3993,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -4156,14 +4003,12 @@
 				"map-obj": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-					"dev": true
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
 				},
 				"meow": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -4179,14 +4024,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -4196,7 +4039,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -4204,14 +4046,12 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -4222,7 +4062,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -4232,7 +4071,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-					"dev": true,
 					"requires": {
 						"indent-string": "^3.0.0",
 						"strip-indent": "^2.0.0"
@@ -4241,14 +4079,12 @@
 				"strip-indent": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-					"dev": true
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
 				},
 				"trim-newlines": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-					"dev": true
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
 				}
 			}
 		},
@@ -4256,7 +4092,6 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
 			"integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
-			"dev": true,
 			"requires": {
 				"is-subset": "^0.1.1",
 				"modify-values": "^1.0.0"
@@ -4266,7 +4101,6 @@
 			"version": "2.1.7",
 			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
 			"integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
-			"dev": true,
 			"requires": {
 				"JSONStream": "^1.0.4",
 				"is-text-path": "^1.0.0",
@@ -4280,14 +4114,12 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"camelcase-keys": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0",
 						"map-obj": "^2.0.0",
@@ -4298,7 +4130,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -4309,14 +4140,12 @@
 				"map-obj": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-					"dev": true
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
 				},
 				"meow": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -4332,14 +4161,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -4349,7 +4176,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -4357,14 +4183,12 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -4375,7 +4199,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -4385,7 +4208,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-					"dev": true,
 					"requires": {
 						"indent-string": "^3.0.0",
 						"strip-indent": "^2.0.0"
@@ -4394,14 +4216,12 @@
 				"strip-indent": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-					"dev": true
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
 				},
 				"trim-newlines": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-					"dev": true
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
 				}
 			}
 		},
@@ -4409,7 +4229,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.2.1.tgz",
 			"integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
-			"dev": true,
 			"requires": {
 				"concat-stream": "^1.4.10",
 				"conventional-commits-filter": "^1.1.1",
@@ -4431,8 +4250,7 @@
 		"convert-to-spaces": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
-			"integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU=",
-			"dev": true
+			"integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU="
 		},
 		"cookie": {
 			"version": "0.3.1",
@@ -4578,7 +4396,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
 			"integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
-			"dev": true,
 			"requires": {
 				"buf-compare": "^1.0.0",
 				"is-error": "^2.2.0"
@@ -4598,7 +4415,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
 			"integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
-			"dev": true,
 			"requires": {
 				"growl": "~> 1.10.0",
 				"js-yaml": "^3.11.0",
@@ -4611,8 +4427,7 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
 		},
@@ -4662,7 +4477,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
 			"integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
-			"dev": true,
 			"requires": {
 				"cross-spawn": "^6.0.5",
 				"is-windows": "^1.0.0"
@@ -4672,7 +4486,6 @@
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -4728,7 +4541,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.1.tgz",
 			"integrity": "sha512-+ZHAZm/yqvJ2kDtPne3uX0C+Vr3Zn5jFn2N4HywtS5ujwvsVkyg0VArEXpl3BgczDA8anieki1FIzhchX4yrDw==",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"css-selector-tokenizer": "^0.7.0",
@@ -4764,7 +4576,6 @@
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
 			"integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
-			"dev": true,
 			"requires": {
 				"cssesc": "^0.1.0",
 				"fastparse": "^1.1.1",
@@ -4775,7 +4586,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
 					"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-					"dev": true,
 					"requires": {
 						"regenerate": "^1.2.1",
 						"regjsgen": "^0.2.0",
@@ -4800,8 +4610,7 @@
 		"cssesc": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
-			"dev": true
+			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
 		},
 		"cssom": {
 			"version": "0.3.4",
@@ -4817,9 +4626,9 @@
 			}
 		},
 		"csstype": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.0.tgz",
-			"integrity": "sha512-by8hi8BlLbowQq0qtkx54d9aN73R9oUW20HISpka5kmgsR9F7nnxgfsemuR2sdCKZh+CDNf5egW9UZMm4mgJRg=="
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.1.tgz",
+			"integrity": "sha512-wv7IRqCGsL7WGKB8gPvrl+++HlFM9kxAM6jL1EXNPNTshEJYilMkbfS2SnuHha77uosp/YVK0wAp2jmlBzn1tg=="
 		},
 		"cuint": {
 			"version": "0.2.2",
@@ -4856,7 +4665,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
 			"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -4904,14 +4712,12 @@
 		"date-time": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
-			"integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
-			"dev": true
+			"integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc="
 		},
 		"dateformat": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-			"dev": true
+			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
 		},
 		"debounce": {
 			"version": "1.2.0",
@@ -4935,7 +4741,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
-			"dev": true,
 			"requires": {
 				"decamelize": "^1.1.0",
 				"map-obj": "^1.0.0"
@@ -4949,8 +4754,7 @@
 		"dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
-			"dev": true
+			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
 		},
 		"deep-equal": {
 			"version": "1.0.1",
@@ -4968,9 +4772,9 @@
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
 		"deepmerge": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.0.0.tgz",
-			"integrity": "sha512-a8z8bkgHsAML+uHLqmMS83HHlpy3PvZOOuiTQqaa3wu8ZVg3h0hqHk6aCsGdOnZV2XMM/FRimNGjUh0KCcmHBw=="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.1.0.tgz",
+			"integrity": "sha512-/TnecbwXEdycfbsM2++O3eGiatEFHjjNciHEwJclM+T5Kd94qD1AP+2elP/Mq0L5b9VZJao5znR01Mz6eX8Seg=="
 		},
 		"default-gateway": {
 			"version": "2.7.2",
@@ -5031,7 +4835,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-			"dev": true,
 			"requires": {
 				"clone": "^1.0.2"
 			},
@@ -5039,8 +4842,7 @@
 				"clone": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-					"dev": true
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
 				}
 			}
 		},
@@ -5214,9 +5016,9 @@
 			}
 		},
 		"dir-glob": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.1.tgz",
-			"integrity": "sha512-UN6X6XwRjllabfRhBdkVSo63uurJ8nSvMGrwl94EYVz6g+exhTV+yVSYk5VC/xl3MBFBTtC0J20uFKce4Brrng==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+			"integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
 			"requires": {
 				"path-type": "^3.0.0"
 			},
@@ -5409,8 +5211,7 @@
 		"duplexer": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-			"dev": true
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
 		},
 		"duplexer3": {
 			"version": "0.1.4",
@@ -5443,9 +5244,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.102",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.102.tgz",
-			"integrity": "sha512-2nzZuXw/KBPnI3QX3UOCSRvJiVy7o9+VHRDQ3D/EHCvVc89X6aj/GlNmEgiR2GBIhmSWXIi4W1M5okA5ScSlNg=="
+			"version": "1.3.103",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.103.tgz",
+			"integrity": "sha512-tObPqGmY9X8MUM8i3MEimYmbnLLf05/QV5gPlkR8MQ3Uj8G8B2govE1U4cQcBYtv3ymck9Y8cIOu4waoiykMZQ=="
 		},
 		"elliptic": {
 			"version": "6.4.1",
@@ -5470,7 +5271,6 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
 			"integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
-			"dev": true,
 			"requires": {
 				"call-signature": "0.0.2",
 				"core-js": "^2.0.0"
@@ -5631,12 +5431,13 @@
 			}
 		},
 		"enzyme-adapter-utils": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.9.1.tgz",
-			"integrity": "sha512-LWc88BbKztLXlpRf5Ba/pSMJRaNezAwZBvis3N/IuB65ltZEh2E2obWU9B36pAbw7rORYeBUuqc79OL17ZzN1A==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.10.0.tgz",
+			"integrity": "sha512-VnIXJDYVTzKGbdW+lgK8MQmYHJquTQZiGzu/AseCZ7eHtOMAj4Rtvk8ZRopodkfPves0EXaHkXBDkVhPa3t0jA==",
 			"requires": {
 				"function.prototype.name": "^1.1.0",
 				"object.assign": "^4.1.0",
+				"object.fromentries": "^2.0.0",
 				"prop-types": "^15.6.2",
 				"semver": "^5.6.0"
 			}
@@ -5644,8 +5445,7 @@
 		"equal-length": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/equal-length/-/equal-length-1.0.1.tgz",
-			"integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w=",
-			"dev": true
+			"integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w="
 		},
 		"errno": {
 			"version": "0.1.7",
@@ -5696,9 +5496,9 @@
 			}
 		},
 		"es5-ext": {
-			"version": "0.10.46",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
-			"integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
+			"version": "0.10.47",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.47.tgz",
+			"integrity": "sha512-/1TItLfj+TTfWoeRcDn/0FbGV6SNo4R+On2GGVucPU/j3BWnXE2Co8h8CTo4Tu34gFJtnmwS9xiScKs4EjZhdw==",
 			"requires": {
 				"es6-iterator": "~2.0.3",
 				"es6-symbol": "~3.1.1",
@@ -5708,8 +5508,7 @@
 		"es6-error": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-			"dev": true
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
 		},
 		"es6-iterator": {
 			"version": "2.0.3",
@@ -5843,7 +5642,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
 			"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
-			"dev": true,
 			"requires": {
 				"esrecurse": "^4.1.0",
 				"estraverse": "^4.1.1"
@@ -5853,7 +5651,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
 			"integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
-			"dev": true,
 			"requires": {
 				"is-url": "^1.2.1",
 				"path-is-absolute": "^1.0.0",
@@ -5870,7 +5667,6 @@
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.1.tgz",
 			"integrity": "sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==",
-			"dev": true,
 			"requires": {
 				"core-js": "^2.0.0"
 			}
@@ -5918,9 +5714,9 @@
 			"integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
 		},
 		"events": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+			"integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
 		},
 		"eventsource": {
 			"version": "1.0.7",
@@ -6122,7 +5918,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-			"dev": true,
 			"requires": {
 				"chardet": "^0.4.0",
 				"iconv-lite": "^0.4.17",
@@ -6150,8 +5945,7 @@
 		"fast-diff": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
-			"dev": true
+			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
@@ -6208,14 +6002,12 @@
 		"figgy-pudding": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
-			"dev": true
+			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
 		},
 		"figures": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			}
@@ -6588,8 +6380,7 @@
 		"first-chunk-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-			"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-			"dev": true
+			"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
 		},
 		"flatted": {
 			"version": "2.0.0",
@@ -6608,8 +6399,7 @@
 		"fn-name": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-			"integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
-			"dev": true
+			"integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc="
 		},
 		"follow-redirects": {
 			"version": "1.6.1",
@@ -6729,9 +6519,9 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+			"integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
 			"optional": true,
 			"requires": {
 				"nan": "^2.9.2",
@@ -6753,7 +6543,7 @@
 					"optional": true
 				},
 				"are-we-there-yet": {
-					"version": "1.1.4",
+					"version": "1.1.5",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -6774,7 +6564,7 @@
 					}
 				},
 				"chownr": {
-					"version": "1.0.1",
+					"version": "1.1.1",
 					"bundled": true,
 					"optional": true
 				},
@@ -6804,7 +6594,7 @@
 					}
 				},
 				"deep-extend": {
-					"version": "0.5.1",
+					"version": "0.6.0",
 					"bundled": true,
 					"optional": true
 				},
@@ -6847,7 +6637,7 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.2",
+					"version": "7.1.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -6865,11 +6655,11 @@
 					"optional": true
 				},
 				"iconv-lite": {
-					"version": "0.4.21",
+					"version": "0.4.24",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": ">= 2.1.2 < 3"
 					}
 				},
 				"ignore-walk": {
@@ -6922,15 +6712,15 @@
 					"bundled": true
 				},
 				"minipass": {
-					"version": "2.2.4",
+					"version": "2.3.5",
 					"bundled": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
 					}
 				},
 				"minizlib": {
-					"version": "1.1.0",
+					"version": "1.2.1",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -6950,7 +6740,7 @@
 					"optional": true
 				},
 				"needle": {
-					"version": "2.2.0",
+					"version": "2.2.4",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -6960,17 +6750,17 @@
 					}
 				},
 				"node-pre-gyp": {
-					"version": "0.10.0",
+					"version": "0.10.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
 						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
+						"needle": "^2.2.1",
 						"nopt": "^4.0.1",
 						"npm-packlist": "^1.1.6",
 						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
+						"rc": "^1.2.7",
 						"rimraf": "^2.6.1",
 						"semver": "^5.3.0",
 						"tar": "^4"
@@ -6986,12 +6776,12 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.3",
+					"version": "1.0.5",
 					"bundled": true,
 					"optional": true
 				},
 				"npm-packlist": {
-					"version": "1.1.10",
+					"version": "1.2.0",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -7056,11 +6846,11 @@
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.7",
+					"version": "1.2.8",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
+						"deep-extend": "^0.6.0",
 						"ini": "~1.3.0",
 						"minimist": "^1.2.0",
 						"strip-json-comments": "~2.0.1"
@@ -7088,15 +6878,15 @@
 					}
 				},
 				"rimraf": {
-					"version": "2.6.2",
+					"version": "2.6.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "^7.1.3"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.1.1",
+					"version": "5.1.2",
 					"bundled": true
 				},
 				"safer-buffer": {
@@ -7110,7 +6900,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "5.5.0",
+					"version": "5.6.0",
 					"bundled": true,
 					"optional": true
 				},
@@ -7154,16 +6944,16 @@
 					"optional": true
 				},
 				"tar": {
-					"version": "4.4.1",
+					"version": "4.4.8",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
+						"chownr": "^1.1.1",
 						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
+						"minipass": "^2.3.4",
+						"minizlib": "^1.1.1",
 						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.2"
 					}
 				},
@@ -7173,11 +6963,11 @@
 					"optional": true
 				},
 				"wide-align": {
-					"version": "1.1.2",
+					"version": "1.1.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "^1.0.2 || 2"
 					}
 				},
 				"wrappy": {
@@ -7185,7 +6975,7 @@
 					"bundled": true
 				},
 				"yallist": {
-					"version": "3.0.2",
+					"version": "3.0.3",
 					"bundled": true
 				}
 			}
@@ -7209,8 +6999,7 @@
 		"function-name-support": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/function-name-support/-/function-name-support-0.2.0.tgz",
-			"integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE=",
-			"dev": true
+			"integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE="
 		},
 		"function.prototype.name": {
 			"version": "1.1.0",
@@ -7298,7 +7087,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
 			"integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
-			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
 				"meow": "^3.3.0",
@@ -7310,8 +7098,7 @@
 		"get-port": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
-			"dev": true
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
 		},
 		"get-stdin": {
 			"version": "4.0.1",
@@ -7340,7 +7127,6 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
 			"integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
-			"dev": true,
 			"requires": {
 				"dargs": "^4.0.1",
 				"lodash.template": "^4.0.2",
@@ -7352,14 +7138,12 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"camelcase-keys": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0",
 						"map-obj": "^2.0.0",
@@ -7370,7 +7154,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -7381,14 +7164,12 @@
 				"map-obj": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-					"dev": true
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
 				},
 				"meow": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -7404,14 +7185,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -7421,7 +7200,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -7429,14 +7207,12 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -7447,7 +7223,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -7457,7 +7232,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-					"dev": true,
 					"requires": {
 						"indent-string": "^3.0.0",
 						"strip-indent": "^2.0.0"
@@ -7466,14 +7240,12 @@
 				"strip-indent": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-					"dev": true
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
 				},
 				"trim-newlines": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-					"dev": true
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
 				}
 			}
 		},
@@ -7481,7 +7253,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
 			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
-			"dev": true,
 			"requires": {
 				"gitconfiglocal": "^1.0.0",
 				"pify": "^2.3.0"
@@ -7491,7 +7262,6 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz",
 			"integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
-			"dev": true,
 			"requires": {
 				"meow": "^4.0.0",
 				"semver": "^5.5.0"
@@ -7500,14 +7270,12 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"camelcase-keys": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0",
 						"map-obj": "^2.0.0",
@@ -7518,7 +7286,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -7529,14 +7296,12 @@
 				"map-obj": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-					"dev": true
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
 				},
 				"meow": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -7552,14 +7317,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -7569,7 +7332,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -7577,14 +7339,12 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -7595,7 +7355,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -7605,7 +7364,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-					"dev": true,
 					"requires": {
 						"indent-string": "^3.0.0",
 						"strip-indent": "^2.0.0"
@@ -7614,14 +7372,12 @@
 				"strip-indent": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-					"dev": true
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
 				},
 				"trim-newlines": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-					"dev": true
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
 				}
 			}
 		},
@@ -7629,7 +7385,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
 			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
-			"dev": true,
 			"requires": {
 				"ini": "^1.3.2"
 			}
@@ -7668,7 +7423,6 @@
 			"version": "5.3.5",
 			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
 			"integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
-			"dev": true,
 			"requires": {
 				"extend": "^3.0.0",
 				"glob": "^5.0.3",
@@ -7684,7 +7438,6 @@
 					"version": "5.0.15",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"dev": true,
 					"requires": {
 						"inflight": "^1.0.4",
 						"inherits": "2",
@@ -7697,7 +7450,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"dev": true,
 					"requires": {
 						"is-glob": "^3.1.0",
 						"path-dirname": "^1.0.0"
@@ -7706,14 +7458,12 @@
 				"is-extglob": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 				},
 				"is-glob": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.0"
 					}
@@ -7721,14 +7471,12 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -7739,14 +7487,12 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"through2": {
 					"version": "0.6.5",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
 					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"dev": true,
 					"requires": {
 						"readable-stream": ">=1.0.33-1 <1.1.0-0",
 						"xtend": ">=4.0.0 <4.1.0-0"
@@ -7865,8 +7611,7 @@
 		"growl": {
 			"version": "1.10.5",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-			"dev": true
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
 		},
 		"growly": {
 			"version": "1.3.0",
@@ -7877,7 +7622,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
 			"integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
-			"dev": true,
 			"requires": {
 				"convert-source-map": "^1.1.1",
 				"graceful-fs": "^4.1.2",
@@ -7889,26 +7633,22 @@
 				"clone": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-					"dev": true
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
 				},
 				"clone-stats": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-					"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-					"dev": true
+					"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
 				},
 				"replace-ext": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-					"dev": true
+					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -7917,7 +7657,6 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
 					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-					"dev": true,
 					"requires": {
 						"clone": "^1.0.0",
 						"clone-stats": "^0.0.1",
@@ -8010,8 +7749,7 @@
 		"has-color": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-			"dev": true
+			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
 		},
 		"has-cors": {
 			"version": "1.1.0",
@@ -8090,8 +7828,7 @@
 		"has-yarn": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
-			"integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
-			"dev": true
+			"integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac="
 		},
 		"hash-base": {
 			"version": "3.0.4",
@@ -8130,8 +7867,7 @@
 		"highlight.js": {
 			"version": "9.13.1",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
-			"integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
-			"dev": true
+			"integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A=="
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -8599,7 +8335,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.1.1.tgz",
 			"integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
-			"dev": true,
 			"requires": {
 				"dot-prop": "^4.1.0",
 				"es6-error": "^4.0.2",
@@ -8633,14 +8368,12 @@
 		"icss-replace-symbols": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
-			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
-			"dev": true
+			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
 		},
 		"icss-utils": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
 			"integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
-			"dev": true,
 			"requires": {
 				"postcss": "^6.0.1"
 			}
@@ -8663,8 +8396,7 @@
 		"ignore-by-default": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
-			"dev": true
+			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk="
 		},
 		"image-size": {
 			"version": "0.5.5",
@@ -8686,7 +8418,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
 			"integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
-			"dev": true,
 			"requires": {
 				"pkg-dir": "^2.0.0",
 				"resolve-cwd": "^2.0.0"
@@ -8713,8 +8444,7 @@
 		"indent-string": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-			"dev": true
+			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
 		},
 		"indexof": {
 			"version": "0.0.1",
@@ -8749,7 +8479,6 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.0",
@@ -8827,8 +8556,7 @@
 		"irregular-plurals": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
-			"integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
-			"dev": true
+			"integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
@@ -8928,8 +8656,7 @@
 		"is-error": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz",
-			"integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw=",
-			"dev": true
+			"integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw="
 		},
 		"is-extendable": {
 			"version": "0.1.1",
@@ -9030,7 +8757,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
 			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-			"dev": true,
 			"requires": {
 				"symbol-observable": "^1.1.0"
 			}
@@ -9059,8 +8785,7 @@
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-			"dev": true
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -9090,8 +8815,7 @@
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-			"dev": true
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
 		},
 		"is-property": {
 			"version": "1.0.2",
@@ -9143,7 +8867,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
 			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
-			"dev": true,
 			"requires": {
 				"text-extensions": "^1.0.0"
 			}
@@ -9156,8 +8879,7 @@
 		"is-url": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-			"dev": true
+			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
 		},
 		"is-utf8": {
 			"version": "0.2.1",
@@ -9167,8 +8889,7 @@
 		"is-valid-glob": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
-			"dev": true
+			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
 		},
 		"is-windows": {
 			"version": "1.0.2",
@@ -9468,7 +9189,7 @@
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"requires": {
 						"cliui": "^4.0.0",
@@ -9734,7 +9455,7 @@
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"requires": {
 						"cliui": "^4.0.0",
@@ -9835,15 +9556,14 @@
 			}
 		},
 		"js-base64": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.0.tgz",
-			"integrity": "sha512-wlEBIZ5LP8usDylWbDNhKPEFVFdI5hCHpnVoT/Ysvoi/PRhJENm/Rlh9TvjYB38HFfKZN7OzEbRjmjvLkFw11g=="
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
+			"integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
 		},
 		"js-string-escape": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
-			"dev": true
+			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
 		},
 		"js-tokens": {
 			"version": "3.0.2",
@@ -9897,6 +9617,11 @@
 				"xml-name-validator": "^3.0.0"
 			},
 			"dependencies": {
+				"acorn": {
+					"version": "5.7.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+				},
 				"parse5": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
@@ -9920,8 +9645,7 @@
 		"jsesc": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-			"dev": true
+			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 		},
 		"json-loader": {
 			"version": "0.5.7",
@@ -9976,8 +9700,7 @@
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-			"dev": true
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
@@ -10005,8 +9728,7 @@
 		"jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-			"dev": true
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
 		},
 		"jsonpointer": {
 			"version": "4.0.1",
@@ -10112,7 +9834,7 @@
 				},
 				"es6-promise": {
 					"version": "3.0.2",
-					"resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+					"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
 					"integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
 				},
 				"process-nextick-args": {
@@ -10122,7 +9844,7 @@
 				},
 				"readable-stream": {
 					"version": "2.0.6",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
 					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -10702,7 +10424,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/last-line-stream/-/last-line-stream-1.0.0.tgz",
 			"integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
-			"dev": true,
 			"requires": {
 				"through2": "^2.0.0"
 			}
@@ -10724,7 +10445,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
 			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "^2.0.5"
 			}
@@ -10740,14 +10460,12 @@
 		"lcov-parse": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
-			"dev": true
+			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
 		},
 		"lcov-result-merger": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/lcov-result-merger/-/lcov-result-merger-2.0.0.tgz",
 			"integrity": "sha512-CMjYOcPtl0G3SLrPWYDtZ4zyhsy/2heUf6RKwvyDcJRfyUBQbqLhAlS2PBhTKVCxGp7Ri8AYJ5SGNVEtbEo0fA==",
-			"dev": true,
 			"requires": {
 				"through2": "^2.0.1",
 				"vinyl": "^2.0.0",
@@ -10763,7 +10481,6 @@
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/lerna/-/lerna-2.11.0.tgz",
 			"integrity": "sha512-kgM6zwe2P2tR30MYvgiLLW+9buFCm6E7o8HnRlhTgm70WVBvXVhydqv+q/MF2HrVZkCawfVtCfetyQmtd4oHhQ==",
-			"dev": true,
 			"requires": {
 				"async": "^1.5.0",
 				"chalk": "^2.1.0",
@@ -10810,7 +10527,6 @@
 					"version": "0.8.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
 					"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -10825,7 +10541,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"dev": true,
 					"requires": {
 						"is-glob": "^3.1.0",
 						"path-dirname": "^1.0.0"
@@ -10834,14 +10549,12 @@
 				"is-extglob": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 				},
 				"is-glob": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.0"
 					}
@@ -10850,7 +10563,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -10862,7 +10574,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -10872,7 +10583,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -10880,14 +10590,12 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -10964,9 +10672,9 @@
 			}
 		},
 		"loader-runner": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.1.tgz",
-			"integrity": "sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw=="
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
+			"integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
 		},
 		"loader-utils": {
 			"version": "1.2.3",
@@ -11015,8 +10723,7 @@
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-			"dev": true
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
 		},
 		"lodash.assign": {
 			"version": "4.2.0",
@@ -11031,8 +10738,7 @@
 		"lodash.clonedeepwith": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
-			"integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ=",
-			"dev": true
+			"integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ="
 		},
 		"lodash.debounce": {
 			"version": "4.0.8",
@@ -11042,8 +10748,7 @@
 		"lodash.difference": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-			"dev": true
+			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
 		},
 		"lodash.escape": {
 			"version": "4.0.1",
@@ -11053,8 +10758,7 @@
 		"lodash.flatten": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-			"dev": true
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
 		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
@@ -11074,8 +10778,7 @@
 		"lodash.merge": {
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
-			"dev": true
+			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
 		},
 		"lodash.mergewith": {
 			"version": "4.6.1",
@@ -11091,7 +10794,6 @@
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
 			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "~3.0.0",
 				"lodash.templatesettings": "^4.0.0"
@@ -11101,7 +10803,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
 			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "~3.0.0"
 			}
@@ -11109,8 +10810,7 @@
 		"log-driver": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
-			"dev": true
+			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
 		},
 		"log-symbols": {
 			"version": "2.2.0",
@@ -11257,14 +10957,12 @@
 		"marked": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
-			"integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
-			"dev": true
+			"integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
 		},
 		"matcher": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.1.tgz",
 			"integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
-			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.4"
 			}
@@ -11283,15 +10981,14 @@
 			}
 		},
 		"math-random": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.2.tgz",
-			"integrity": "sha512-Bp2Bx2wFaUymE7pWi0bbldiheIXMvyzC3hRkT5YAv2qiqqJO5VB8KafgYgZmGCxkTmloLuAx3Jv2OmJ66990mg=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
 		},
 		"md5-hex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
 			"integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
-			"dev": true,
 			"requires": {
 				"md5-o-matic": "^0.1.1"
 			}
@@ -11299,8 +10996,7 @@
 		"md5-o-matic": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
-			"dev": true
+			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -11539,7 +11235,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
 			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
-			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
 				"is-plain-obj": "^1.1.0"
@@ -11549,7 +11244,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
 			"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
-			"dev": true,
 			"requires": {
 				"concat-stream": "^1.5.0",
 				"duplexify": "^3.4.2",
@@ -11593,13 +11287,12 @@
 		"modify-values": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
-			"dev": true
+			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw=="
 		},
 		"moment": {
-			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
-			"integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA=="
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+			"integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
 		},
 		"moo": {
 			"version": "0.4.3",
@@ -11642,7 +11335,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-			"dev": true,
 			"requires": {
 				"array-differ": "^1.0.0",
 				"array-union": "^1.0.1",
@@ -11653,8 +11345,7 @@
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-			"dev": true
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"nan": {
 			"version": "2.12.1",
@@ -11958,9 +11649,9 @@
 			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
 		},
 		"node-libs-browser": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
-			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
+			"integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
 			"requires": {
 				"assert": "^1.1.1",
 				"browserify-zlib": "^0.2.0",
@@ -11969,7 +11660,7 @@
 				"constants-browserify": "^1.0.0",
 				"crypto-browserify": "^3.11.0",
 				"domain-browser": "^1.1.1",
-				"events": "^1.0.0",
+				"events": "^3.0.0",
 				"https-browserify": "^1.0.0",
 				"os-browserify": "^0.3.0",
 				"path-browserify": "0.0.0",
@@ -11983,7 +11674,7 @@
 				"timers-browserify": "^2.0.4",
 				"tty-browserify": "0.0.0",
 				"url": "^0.11.0",
-				"util": "^0.10.3",
+				"util": "^0.11.0",
 				"vm-browserify": "0.0.4"
 			},
 			"dependencies": {
@@ -12287,7 +11978,6 @@
 			"version": "11.9.0",
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
 			"integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
-			"dev": true,
 			"requires": {
 				"archy": "^1.0.0",
 				"arrify": "^1.0.1",
@@ -12321,7 +12011,6 @@
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2",
 						"longest": "^1.0.1",
@@ -12330,76 +12019,62 @@
 				},
 				"amdefine": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"append-transform": {
 					"version": "0.4.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"default-require-extensions": "^1.0.0"
 					}
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"arr-diff": {
 					"version": "4.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"arr-flatten": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"arr-union": {
 					"version": "3.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"array-unique": {
 					"version": "0.3.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"arrify": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"assign-symbols": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"async": {
 					"version": "1.5.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"atob": {
 					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"babel-code-frame": {
 					"version": "6.26.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"chalk": "^1.1.3",
 						"esutils": "^2.0.2",
@@ -12409,7 +12084,6 @@
 				"babel-generator": {
 					"version": "6.26.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"babel-messages": "^6.23.0",
 						"babel-runtime": "^6.26.0",
@@ -12424,7 +12098,6 @@
 				"babel-messages": {
 					"version": "6.23.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"babel-runtime": "^6.22.0"
 					}
@@ -12432,7 +12105,6 @@
 				"babel-runtime": {
 					"version": "6.26.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"core-js": "^2.4.0",
 						"regenerator-runtime": "^0.11.0"
@@ -12441,7 +12113,6 @@
 				"babel-template": {
 					"version": "6.26.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"babel-runtime": "^6.26.0",
 						"babel-traverse": "^6.26.0",
@@ -12453,7 +12124,6 @@
 				"babel-traverse": {
 					"version": "6.26.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"babel-code-frame": "^6.26.0",
 						"babel-messages": "^6.23.0",
@@ -12469,7 +12139,6 @@
 				"babel-types": {
 					"version": "6.26.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"babel-runtime": "^6.26.0",
 						"esutils": "^2.0.2",
@@ -12479,18 +12148,15 @@
 				},
 				"babylon": {
 					"version": "6.18.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"base": {
 					"version": "0.11.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"cache-base": "^1.0.1",
 						"class-utils": "^0.3.5",
@@ -12504,7 +12170,6 @@
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -12512,7 +12177,6 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -12520,7 +12184,6 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -12528,7 +12191,6 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -12537,20 +12199,17 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -12559,7 +12218,6 @@
 				"braces": {
 					"version": "2.3.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
 						"array-unique": "^0.3.2",
@@ -12576,7 +12234,6 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -12585,13 +12242,11 @@
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"cache-base": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"collection-visit": "^1.0.0",
 						"component-emitter": "^1.2.1",
@@ -12606,15 +12261,13 @@
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"caching-transform": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"md5-hex": "^1.2.0",
 						"mkdirp": "^0.5.1",
@@ -12624,13 +12277,11 @@
 				"camelcase": {
 					"version": "1.2.1",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"center-align": {
 					"version": "0.1.3",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "^0.1.3",
@@ -12640,7 +12291,6 @@
 				"chalk": {
 					"version": "1.1.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -12652,7 +12302,6 @@
 				"class-utils": {
 					"version": "0.3.6",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"arr-union": "^3.1.0",
 						"define-property": "^0.2.5",
@@ -12663,22 +12312,19 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"cliui": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"center-align": "^0.1.1",
@@ -12689,20 +12335,17 @@
 						"wordwrap": {
 							"version": "0.0.2",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"collection-visit": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"map-visit": "^1.0.0",
 						"object-visit": "^1.0.0"
@@ -12710,38 +12353,31 @@
 				},
 				"commondir": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"component-emitter": {
 					"version": "1.2.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"convert-source-map": {
 					"version": "1.5.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"copy-descriptor": {
 					"version": "0.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"core-js": {
 					"version": "2.5.6",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
 						"which": "^1.2.9"
@@ -12750,30 +12386,25 @@
 				"debug": {
 					"version": "2.6.9",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
 				"debug-log": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"decode-uri-component": {
 					"version": "0.2.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"default-require-extensions": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"strip-bom": "^2.0.0"
 					}
@@ -12781,7 +12412,6 @@
 				"define-property": {
 					"version": "2.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.2",
 						"isobject": "^3.0.1"
@@ -12790,7 +12420,6 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -12798,7 +12427,6 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -12806,7 +12434,6 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -12815,20 +12442,17 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"detect-indent": {
 					"version": "4.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"repeating": "^2.0.0"
 					}
@@ -12836,25 +12460,21 @@
 				"error-ex": {
 					"version": "1.3.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-arrayish": "^0.2.1"
 					}
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"esutils": {
 					"version": "2.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"execa": {
 					"version": "0.7.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -12868,7 +12488,6 @@
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"lru-cache": "^4.0.1",
 								"shebang-command": "^1.2.0",
@@ -12880,7 +12499,6 @@
 				"expand-brackets": {
 					"version": "2.1.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"debug": "^2.3.3",
 						"define-property": "^0.2.5",
@@ -12894,7 +12512,6 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -12902,7 +12519,6 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -12912,7 +12528,6 @@
 				"extend-shallow": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"assign-symbols": "^1.0.0",
 						"is-extendable": "^1.0.1"
@@ -12921,7 +12536,6 @@
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-plain-object": "^2.0.4"
 							}
@@ -12931,7 +12545,6 @@
 				"extglob": {
 					"version": "2.0.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"array-unique": "^0.3.2",
 						"define-property": "^1.0.0",
@@ -12946,7 +12559,6 @@
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -12954,7 +12566,6 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -12962,7 +12573,6 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -12970,7 +12580,6 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -12978,7 +12587,6 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -12987,15 +12595,13 @@
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"fill-range": {
 					"version": "4.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-number": "^3.0.0",
@@ -13006,7 +12612,6 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -13016,7 +12621,6 @@
 				"find-cache-dir": {
 					"version": "0.1.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"commondir": "^1.0.1",
 						"mkdirp": "^0.5.1",
@@ -13026,20 +12630,17 @@
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
 				},
 				"for-in": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"foreground-child": {
 					"version": "1.5.6",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"cross-spawn": "^4",
 						"signal-exit": "^3.0.0"
@@ -13048,35 +12649,29 @@
 				"fragment-cache": {
 					"version": "0.2.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"map-cache": "^0.2.2"
 					}
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"get-value": {
 					"version": "2.0.6",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -13088,18 +12683,15 @@
 				},
 				"globals": {
 					"version": "9.18.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"handlebars": {
 					"version": "4.0.11",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"async": "^1.4.0",
 						"optimist": "^0.6.1",
@@ -13110,7 +12702,6 @@
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"amdefine": ">=0.0.4"
 							}
@@ -13120,20 +12711,17 @@
 				"has-ansi": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"has-value": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"get-value": "^2.0.6",
 						"has-values": "^1.0.0",
@@ -13142,15 +12730,13 @@
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"has-values": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-number": "^3.0.0",
 						"kind-of": "^4.0.0"
@@ -13159,7 +12745,6 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
@@ -13167,7 +12752,6 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -13177,7 +12761,6 @@
 						"kind-of": {
 							"version": "4.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -13186,18 +12769,15 @@
 				},
 				"hosted-git-info": {
 					"version": "2.6.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"once": "^1.3.0",
 						"wrappy": "1"
@@ -13205,44 +12785,37 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"invariant": {
 					"version": "2.2.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"loose-envify": "^1.0.0"
 					}
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-accessor-descriptor": {
 					"version": "0.1.6",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-buffer": {
 					"version": "1.1.6",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"builtin-modules": "^1.0.0"
 					}
@@ -13250,7 +12823,6 @@
 				"is-data-descriptor": {
 					"version": "0.1.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -13258,7 +12830,6 @@
 				"is-descriptor": {
 					"version": "0.1.6",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^0.1.6",
 						"is-data-descriptor": "^0.1.4",
@@ -13267,33 +12838,28 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "5.1.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"is-extendable": {
 					"version": "0.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-finite": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-number": {
 					"version": "3.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -13301,72 +12867,60 @@
 				"is-odd": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-number": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
 							"version": "4.0.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"is-plain-object": {
 					"version": "2.0.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-utf8": {
 					"version": "0.2.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"is-windows": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"istanbul-lib-coverage": {
 					"version": "1.2.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"istanbul-lib-hook": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"append-transform": "^0.4.0"
 					}
@@ -13374,7 +12928,6 @@
 				"istanbul-lib-instrument": {
 					"version": "1.10.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"babel-generator": "^6.18.0",
 						"babel-template": "^6.16.0",
@@ -13388,7 +12941,6 @@
 				"istanbul-lib-report": {
 					"version": "1.1.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"istanbul-lib-coverage": "^1.1.2",
 						"mkdirp": "^0.5.1",
@@ -13399,7 +12951,6 @@
 						"supports-color": {
 							"version": "3.2.3",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"has-flag": "^1.0.0"
 							}
@@ -13409,7 +12960,6 @@
 				"istanbul-lib-source-maps": {
 					"version": "1.2.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"debug": "^3.1.0",
 						"istanbul-lib-coverage": "^1.1.2",
@@ -13421,7 +12971,6 @@
 						"debug": {
 							"version": "3.1.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"ms": "2.0.0"
 							}
@@ -13431,25 +12980,21 @@
 				"istanbul-reports": {
 					"version": "1.4.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"handlebars": "^4.0.3"
 					}
 				},
 				"js-tokens": {
 					"version": "3.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"jsesc": {
 					"version": "1.3.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -13457,13 +13002,11 @@
 				"lazy-cache": {
 					"version": "1.0.4",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"lcid": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"invert-kv": "^1.0.0"
 					}
@@ -13471,7 +13014,6 @@
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -13483,7 +13025,6 @@
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
@@ -13491,25 +13032,21 @@
 					"dependencies": {
 						"path-exists": {
 							"version": "3.0.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"lodash": {
 					"version": "4.17.10",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"longest": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"loose-envify": {
 					"version": "1.3.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"js-tokens": "^3.0.0"
 					}
@@ -13517,7 +13054,6 @@
 				"lru-cache": {
 					"version": "4.1.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"pseudomap": "^1.0.2",
 						"yallist": "^2.1.2"
@@ -13525,13 +13061,11 @@
 				},
 				"map-cache": {
 					"version": "0.2.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"map-visit": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"object-visit": "^1.0.0"
 					}
@@ -13539,20 +13073,17 @@
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"md5-o-matic": {
 					"version": "0.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"mem": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
 					}
@@ -13560,22 +13091,19 @@
 				"merge-source-map": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
 							"version": "0.6.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"micromatch": {
 					"version": "3.1.10",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -13594,33 +13122,28 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"mimic-fn": {
 					"version": "1.2.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"mixin-deep": {
 					"version": "1.3.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"for-in": "^1.0.2",
 						"is-extendable": "^1.0.1"
@@ -13629,7 +13152,6 @@
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-plain-object": "^2.0.4"
 							}
@@ -13639,20 +13161,17 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"nanomatch": {
 					"version": "1.2.9",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -13670,25 +13189,21 @@
 					"dependencies": {
 						"arr-diff": {
 							"version": "4.0.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"array-unique": {
 							"version": "0.3.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.1.4",
 						"is-builtin-module": "^1.0.0",
@@ -13699,25 +13214,21 @@
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"object-copy": {
 					"version": "0.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"copy-descriptor": "^0.1.0",
 						"define-property": "^0.2.5",
@@ -13727,7 +13238,6 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -13737,37 +13247,32 @@
 				"object-visit": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"object.pick": {
 					"version": "1.3.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -13775,7 +13280,6 @@
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"minimist": "~0.0.1",
 						"wordwrap": "~0.0.2"
@@ -13783,13 +13287,11 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
 						"lcid": "^1.0.0",
@@ -13798,13 +13300,11 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"p-limit": {
 					"version": "1.2.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"p-try": "^1.0.0"
 					}
@@ -13812,56 +13312,47 @@
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"parse-json": {
 					"version": "2.2.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
 				},
 				"pascalcase": {
 					"version": "0.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"path-exists": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"path-parse": {
 					"version": "1.0.5",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"pify": "^2.0.0",
@@ -13870,18 +13361,15 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"pinkie": {
 					"version": "2.0.4",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"pinkie": "^2.0.0"
 					}
@@ -13889,7 +13377,6 @@
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"find-up": "^1.0.0"
 					},
@@ -13897,7 +13384,6 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"path-exists": "^2.0.0",
 								"pinkie-promise": "^2.0.0"
@@ -13907,18 +13393,15 @@
 				},
 				"posix-character-classes": {
 					"version": "0.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"load-json-file": "^1.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -13928,7 +13411,6 @@
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"find-up": "^1.0.0",
 						"read-pkg": "^1.0.0"
@@ -13937,7 +13419,6 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"path-exists": "^2.0.0",
 								"pinkie-promise": "^2.0.0"
@@ -13947,13 +13428,11 @@
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"regex-not": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"extend-shallow": "^3.0.2",
 						"safe-regex": "^1.1.0"
@@ -13961,51 +13440,42 @@
 				},
 				"repeat-element": {
 					"version": "1.1.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"repeat-string": {
 					"version": "1.6.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"repeating": {
 					"version": "2.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-finite": "^1.0.0"
 					}
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"resolve-from": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"resolve-url": {
 					"version": "0.2.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"ret": {
 					"version": "0.1.15",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"right-align": {
 					"version": "0.1.3",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "^0.1.1"
@@ -14014,7 +13484,6 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"glob": "^7.0.5"
 					}
@@ -14022,25 +13491,21 @@
 				"safe-regex": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ret": "~0.1.10"
 					}
 				},
 				"semver": {
 					"version": "5.5.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"set-value": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-extendable": "^0.1.1",
@@ -14051,7 +13516,6 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -14061,30 +13525,25 @@
 				"shebang-command": {
 					"version": "1.2.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"snapdragon": {
 					"version": "0.8.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"base": "^0.11.1",
 						"debug": "^2.2.0",
@@ -14099,7 +13558,6 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -14107,7 +13565,6 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -14117,7 +13574,6 @@
 				"snapdragon-node": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"define-property": "^1.0.0",
 						"isobject": "^3.0.0",
@@ -14127,7 +13583,6 @@
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -14135,7 +13590,6 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -14143,7 +13597,6 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -14151,7 +13604,6 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -14160,33 +13612,28 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"snapdragon-util": {
 					"version": "3.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.2.0"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"source-map-resolve": {
 					"version": "0.5.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"atob": "^2.0.0",
 						"decode-uri-component": "^0.2.0",
@@ -14197,13 +13644,11 @@
 				},
 				"source-map-url": {
 					"version": "0.4.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"spawn-wrap": {
 					"version": "1.4.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"foreground-child": "^1.5.6",
 						"mkdirp": "^0.5.0",
@@ -14216,7 +13661,6 @@
 				"spdx-correct": {
 					"version": "3.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"spdx-expression-parse": "^3.0.0",
 						"spdx-license-ids": "^3.0.0"
@@ -14224,13 +13668,11 @@
 				},
 				"spdx-exceptions": {
 					"version": "2.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"spdx-expression-parse": {
 					"version": "3.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"spdx-exceptions": "^2.1.0",
 						"spdx-license-ids": "^3.0.0"
@@ -14238,13 +13680,11 @@
 				},
 				"spdx-license-ids": {
 					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"split-string": {
 					"version": "3.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"extend-shallow": "^3.0.0"
 					}
@@ -14252,7 +13692,6 @@
 				"static-extend": {
 					"version": "0.1.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"define-property": "^0.2.5",
 						"object-copy": "^0.1.0"
@@ -14261,7 +13700,6 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -14271,7 +13709,6 @@
 				"string-width": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -14279,13 +13716,11 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
@@ -14295,7 +13730,6 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -14303,25 +13737,21 @@
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"supports-color": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"test-exclude": {
 					"version": "4.2.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"arrify": "^1.0.1",
 						"micromatch": "^3.1.8",
@@ -14332,18 +13762,15 @@
 					"dependencies": {
 						"arr-diff": {
 							"version": "4.0.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"array-unique": {
 							"version": "0.3.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"braces": {
 							"version": "2.3.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"arr-flatten": "^1.1.0",
 								"array-unique": "^0.3.2",
@@ -14360,7 +13787,6 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -14370,7 +13796,6 @@
 						"expand-brackets": {
 							"version": "2.1.4",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"debug": "^2.3.3",
 								"define-property": "^0.2.5",
@@ -14384,7 +13809,6 @@
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-descriptor": "^0.1.0"
 									}
@@ -14392,7 +13816,6 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -14400,7 +13823,6 @@
 								"is-accessor-descriptor": {
 									"version": "0.1.6",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"kind-of": "^3.0.2"
 									},
@@ -14408,7 +13830,6 @@
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
-											"dev": true,
 											"requires": {
 												"is-buffer": "^1.1.5"
 											}
@@ -14418,7 +13839,6 @@
 								"is-data-descriptor": {
 									"version": "0.1.4",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"kind-of": "^3.0.2"
 									},
@@ -14426,7 +13846,6 @@
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
-											"dev": true,
 											"requires": {
 												"is-buffer": "^1.1.5"
 											}
@@ -14436,7 +13855,6 @@
 								"is-descriptor": {
 									"version": "0.1.6",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-accessor-descriptor": "^0.1.6",
 										"is-data-descriptor": "^0.1.4",
@@ -14445,15 +13863,13 @@
 								},
 								"kind-of": {
 									"version": "5.1.0",
-									"bundled": true,
-									"dev": true
+									"bundled": true
 								}
 							}
 						},
 						"extglob": {
 							"version": "2.0.4",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"array-unique": "^0.3.2",
 								"define-property": "^1.0.0",
@@ -14468,7 +13884,6 @@
 								"define-property": {
 									"version": "1.0.0",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-descriptor": "^1.0.0"
 									}
@@ -14476,7 +13891,6 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -14486,7 +13900,6 @@
 						"fill-range": {
 							"version": "4.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"extend-shallow": "^2.0.1",
 								"is-number": "^3.0.0",
@@ -14497,7 +13910,6 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -14507,7 +13919,6 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -14515,7 +13926,6 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -14523,7 +13933,6 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -14533,7 +13942,6 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
@@ -14541,7 +13949,6 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -14550,18 +13957,15 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"micromatch": {
 							"version": "3.1.10",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"arr-diff": "^4.0.0",
 								"array-unique": "^0.3.2",
@@ -14582,13 +13986,11 @@
 				},
 				"to-fast-properties": {
 					"version": "1.0.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"to-object-path": {
 					"version": "0.3.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -14596,7 +13998,6 @@
 				"to-regex": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"define-property": "^2.0.2",
 						"extend-shallow": "^3.0.2",
@@ -14607,7 +14008,6 @@
 				"to-regex-range": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"is-number": "^3.0.0",
 						"repeat-string": "^1.6.1"
@@ -14616,7 +14016,6 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							}
@@ -14625,13 +14024,11 @@
 				},
 				"trim-right": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"uglify-js": {
 					"version": "2.8.29",
 					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"source-map": "~0.5.1",
@@ -14642,7 +14039,6 @@
 						"yargs": {
 							"version": "3.10.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"camelcase": "^1.0.2",
@@ -14656,13 +14052,11 @@
 				"uglify-to-browserify": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"union-value": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"arr-union": "^3.1.0",
 						"get-value": "^2.0.6",
@@ -14673,7 +14067,6 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -14681,7 +14074,6 @@
 						"set-value": {
 							"version": "0.4.3",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"extend-shallow": "^2.0.1",
 								"is-extendable": "^0.1.1",
@@ -14694,7 +14086,6 @@
 				"unset-value": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"has-value": "^0.3.1",
 						"isobject": "^3.0.0"
@@ -14703,7 +14094,6 @@
 						"has-value": {
 							"version": "0.3.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"get-value": "^2.0.3",
 								"has-values": "^0.1.4",
@@ -14713,7 +14103,6 @@
 								"isobject": {
 									"version": "2.1.0",
 									"bundled": true,
-									"dev": true,
 									"requires": {
 										"isarray": "1.0.0"
 									}
@@ -14722,40 +14111,34 @@
 						},
 						"has-values": {
 							"version": "0.1.4",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"urix": {
 					"version": "0.1.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"use": {
 					"version": "3.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"spdx-correct": "^3.0.0",
 						"spdx-expression-parse": "^3.0.0"
@@ -14764,31 +14147,26 @@
 				"which": {
 					"version": "1.3.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"window-size": {
 					"version": "0.1.0",
 					"bundled": true,
-					"dev": true,
 					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1"
@@ -14797,7 +14175,6 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -14805,7 +14182,6 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -14816,13 +14192,11 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"write-file-atomic": {
 					"version": "1.3.4",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
 						"imurmurhash": "^0.1.4",
@@ -14831,18 +14205,15 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"bundled": true,
-					"dev": true
+					"bundled": true
 				},
 				"yargs": {
 					"version": "11.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.1.1",
@@ -14860,18 +14231,15 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"cliui": {
 							"version": "4.1.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"string-width": "^2.1.1",
 								"strip-ansi": "^4.0.0",
@@ -14881,7 +14249,6 @@
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
@@ -14889,7 +14256,6 @@
 						"yargs-parser": {
 							"version": "9.0.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"camelcase": "^4.1.0"
 							}
@@ -14899,15 +14265,13 @@
 				"yargs-parser": {
 					"version": "8.1.0",
 					"bundled": true,
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				}
@@ -15000,6 +14364,17 @@
 				"has": "^1.0.3"
 			}
 		},
+		"object.fromentries": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
+			"integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.11.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.1"
+			}
+		},
 		"object.getownpropertydescriptors": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
@@ -15048,7 +14423,6 @@
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-0.5.0.tgz",
 			"integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
-			"dev": true,
 			"requires": {
 				"is-observable": "^0.2.0",
 				"symbol-observable": "^1.0.4"
@@ -15058,7 +14432,6 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
 					"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
-					"dev": true,
 					"requires": {
 						"symbol-observable": "^0.2.2"
 					},
@@ -15066,8 +14439,7 @@
 						"symbol-observable": {
 							"version": "0.2.4",
 							"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
-							"integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
-							"dev": true
+							"integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A="
 						}
 					}
 				}
@@ -15103,7 +14475,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
@@ -15128,8 +14499,7 @@
 		"option-chain": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/option-chain/-/option-chain-1.0.0.tgz",
-			"integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI=",
-			"dev": true
+			"integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI="
 		},
 		"optionator": {
 			"version": "0.8.2",
@@ -15155,7 +14525,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 			"integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
-			"dev": true,
 			"requires": {
 				"is-stream": "^1.0.1",
 				"readable-stream": "^2.0.1"
@@ -15257,7 +14626,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
 			"integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"lodash.flattendeep": "^4.4.0",
@@ -15277,9 +14645,9 @@
 			}
 		},
 		"pako": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.7.tgz",
-			"integrity": "sha512-3HNK5tW4x8o5mO8RuHZp3Ydw9icZXx0RANAOMzlMzx7LVXhMJ4mo3MOBpzyd7r/+RUu8BmndP47LXT+vzjtWcQ=="
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.8.tgz",
+			"integrity": "sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA=="
 		},
 		"parallel-transform": {
 			"version": "1.1.0",
@@ -15300,22 +14668,22 @@
 			}
 		},
 		"parse-asn1": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
-			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.3.tgz",
+			"integrity": "sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==",
 			"requires": {
 				"asn1.js": "^4.0.0",
 				"browserify-aes": "^1.0.0",
 				"create-hash": "^1.1.0",
 				"evp_bytestokey": "^1.0.0",
-				"pbkdf2": "^3.0.3"
+				"pbkdf2": "^3.0.3",
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"parse-github-repo-url": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
-			"dev": true
+			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A="
 		},
 		"parse-glob": {
 			"version": "3.0.4",
@@ -15339,8 +14707,7 @@
 		"parse-ms": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
-			"integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
-			"dev": true
+			"integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4="
 		},
 		"parse-passwd": {
 			"version": "1.0.0",
@@ -15463,14 +14830,12 @@
 		"pinkie": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-			"integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
-			"dev": true
+			"integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q="
 		},
 		"pinkie-promise": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
 			"integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
-			"dev": true,
 			"requires": {
 				"pinkie": "^1.0.0"
 			}
@@ -15479,7 +14844,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
 			"integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
-			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
 				"load-json-file": "^4.0.0"
@@ -15489,7 +14853,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -15501,7 +14864,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -15510,8 +14872,7 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
@@ -15527,7 +14888,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
 			"integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
-			"dev": true,
 			"requires": {
 				"irregular-plurals": "^1.0.0"
 			}
@@ -15602,7 +14962,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
 			"integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
-			"dev": true,
 			"requires": {
 				"postcss": "^6.0.1"
 			}
@@ -15611,7 +14970,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
 			"integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
-			"dev": true,
 			"requires": {
 				"css-selector-tokenizer": "^0.7.0",
 				"postcss": "^6.0.1"
@@ -15621,7 +14979,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
 			"integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
-			"dev": true,
 			"requires": {
 				"css-selector-tokenizer": "^0.7.0",
 				"postcss": "^6.0.1"
@@ -15631,7 +14988,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
 			"integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
-			"dev": true,
 			"requires": {
 				"icss-replace-symbols": "^1.1.0",
 				"postcss": "^6.0.1"
@@ -15670,10 +15026,9 @@
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
 		},
 		"prettier": {
-			"version": "1.15.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
-			"integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
-			"dev": true
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.0.tgz",
+			"integrity": "sha512-MCBCYeAuZfejUPdEpkleLWvpRBwLii/Sp5jQs0eb8Ul/drGIDjkL6tAU24tk6yCGf0KPV5rhPPPlczfBmN2pWQ=="
 		},
 		"pretty-format": {
 			"version": "23.6.0",
@@ -15695,7 +15050,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.2.0.tgz",
 			"integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
-			"dev": true,
 			"requires": {
 				"parse-ms": "^1.0.0"
 			},
@@ -15703,8 +15057,7 @@
 				"parse-ms": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-					"integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
-					"dev": true
+					"integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0="
 				}
 			}
 		},
@@ -15726,8 +15079,7 @@
 		"progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-			"dev": true
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
 		},
 		"promise": {
 			"version": "7.3.1",
@@ -15789,7 +15141,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "^2.2.1",
@@ -15816,7 +15168,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"q": {
@@ -15945,8 +15297,7 @@
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-			"dev": true
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
 		},
 		"qjobs": {
 			"version": "1.2.0",
@@ -15976,8 +15327,7 @@
 		"quick-lru": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
-			"dev": true
+			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
 		},
 		"raf": {
 			"version": "3.4.1",
@@ -16146,6 +15496,21 @@
 				"@babel/runtime": "7.2.0",
 				"prop-types": "^15.6.0",
 				"warning": "^4.0.1"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
+					"integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
+					"requires": {
+						"regenerator-runtime": "^0.12.0"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.12.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+				}
 			}
 		},
 		"react-is": {
@@ -16206,7 +15571,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
 			"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2"
 			}
@@ -16547,7 +15911,6 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-			"dev": true,
 			"requires": {
 				"resolve": "^1.1.6"
 			}
@@ -16611,15 +15974,14 @@
 			}
 		},
 		"reflect-metadata": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.12.tgz",
-			"integrity": "sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A=="
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
 		},
 		"regenerate": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
-			"dev": true
+			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
 		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
@@ -16647,7 +16009,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-			"dev": true,
 			"requires": {
 				"regenerate": "^1.2.1",
 				"regjsgen": "^0.2.0",
@@ -16674,14 +16035,12 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-			"dev": true
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
 			}
@@ -16695,7 +16054,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
 			"integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
-			"dev": true,
 			"requires": {
 				"es6-error": "^4.0.1"
 			}
@@ -16726,8 +16084,7 @@
 		"replace-ext": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-			"dev": true
+			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
 		},
 		"request": {
 			"version": "2.88.0",
@@ -16787,8 +16144,7 @@
 		"require-precompiled": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
-			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo=",
-			"dev": true
+			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo="
 		},
 		"requires-port": {
 			"version": "1.0.0",
@@ -16796,9 +16152,9 @@
 			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
 		"resolve": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
-			"integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -16834,7 +16190,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-			"dev": true,
 			"requires": {
 				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
@@ -16890,6 +16245,13 @@
 				"magic-string": "^0.22.4",
 				"resolve": "^1.4.0",
 				"rollup-pluginutils": "^2.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.7.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+				}
 			}
 		},
 		"rollup-plugin-node-resolve": {
@@ -16939,7 +16301,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-			"dev": true,
 			"requires": {
 				"is-promise": "^2.1.0"
 			}
@@ -16955,14 +16316,12 @@
 		"rx-lite": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-			"dev": true
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
 		},
 		"rx-lite-aggregates": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"dev": true,
 			"requires": {
 				"rx-lite": "*"
 			}
@@ -17488,7 +16847,6 @@
 			"version": "0.4.7",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
 			"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-			"dev": true,
 			"requires": {
 				"ajv": "^6.1.0",
 				"ajv-keywords": "^3.1.0"
@@ -17598,8 +16956,7 @@
 		"serialize-error": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-			"integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
-			"dev": true
+			"integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
 		},
 		"serialize-javascript": {
 			"version": "1.6.1",
@@ -17718,7 +17075,6 @@
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
 			"integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
@@ -17749,7 +17105,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0"
 			}
@@ -17757,8 +17112,7 @@
 		"slide": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-			"dev": true
+			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -18013,7 +17367,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-			"dev": true,
 			"requires": {
 				"is-plain-obj": "^1.0.0"
 			}
@@ -18032,7 +17385,6 @@
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
 			"integrity": "sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==",
-			"dev": true,
 			"requires": {
 				"async": "^2.5.0",
 				"loader-utils": "^1.1.0"
@@ -18042,7 +17394,6 @@
 					"version": "2.6.1",
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
 					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-					"dev": true,
 					"requires": {
 						"lodash": "^4.17.10"
 					}
@@ -18174,7 +17525,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
 			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
 			"requires": {
 				"through": "2"
 			}
@@ -18191,7 +17541,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
 			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
-			"dev": true,
 			"requires": {
 				"through2": "^2.0.2"
 			}
@@ -18221,7 +17570,6 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
 			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
-			"dev": true,
 			"requires": {
 				"figgy-pudding": "^3.5.1"
 			}
@@ -18384,7 +17732,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
 			"integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
-			"dev": true,
 			"requires": {
 				"is-utf8": "^0.2.1"
 			}
@@ -18393,7 +17740,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 			"integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-			"dev": true,
 			"requires": {
 				"first-chunk-stream": "^1.0.0",
 				"strip-bom": "^2.0.0"
@@ -18403,7 +17749,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -18432,7 +17777,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz",
 			"integrity": "sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=",
-			"dev": true,
 			"requires": {
 				"byline": "^5.0.0",
 				"duplexer": "^0.1.1",
@@ -18444,8 +17788,7 @@
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
-					"dev": true
+					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
 				}
 			}
 		},
@@ -18453,7 +17796,6 @@
 			"version": "0.21.0",
 			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.21.0.tgz",
 			"integrity": "sha512-T+UNsAcl3Yg+BsPKs1vd22Fr8sVT+CJMtzqc6LEw9bbJZb43lm9GoeIfUcDEefBSWC0BhYbcdupV1GtI4DGzxg==",
-			"dev": true,
 			"requires": {
 				"loader-utils": "^1.1.0",
 				"schema-utils": "^0.4.5"
@@ -18521,7 +17863,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supertap/-/supertap-1.0.0.tgz",
 			"integrity": "sha512-HZJ3geIMPgVwKk2VsmO5YHqnnJYl6bV5A9JW2uzqV43WmpgliNEYbuvukfor7URpaqpxuw3CfZ3ONdVbZjCgIA==",
-			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
 				"indent-string": "^3.2.0",
@@ -18597,14 +17938,12 @@
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
-			"dev": true
+			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
 		},
 		"temp-write": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/temp-write/-/temp-write-3.4.0.tgz",
 			"integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"is-stream": "^1.1.0",
@@ -18617,8 +17956,7 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
@@ -18626,7 +17964,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
 			"integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "^1.0.0",
 				"uuid": "^2.0.1"
@@ -18635,8 +17972,7 @@
 				"uuid": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-					"dev": true
+					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
 				}
 			}
 		},
@@ -18652,7 +17988,6 @@
 			"version": "3.14.1",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-3.14.1.tgz",
 			"integrity": "sha512-NSo3E99QDbYSMeJaEk9YW2lTg3qS9V0aKGlb+PlOrei1X02r1wSBHCNX/O+yeTRFSWPKPIGj6MqvvdqV4rnVGw==",
-			"dev": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1",
@@ -18662,8 +17997,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -18671,7 +18005,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.1.tgz",
 			"integrity": "sha512-GGSt+gbT0oKcMDmPx4SRSfJPE1XaN3kQRWG4ghxKQw9cn5G9x6aCKSsgYdvyM0na9NJ4Drv0RG6jbBByZ5CMjw==",
-			"dev": true,
 			"requires": {
 				"cacache": "^11.0.2",
 				"find-cache-dir": "^2.0.0",
@@ -18687,7 +18020,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
 					"integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
-					"dev": true,
 					"requires": {
 						"commondir": "^1.0.1",
 						"make-dir": "^1.0.0",
@@ -18698,7 +18030,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
 					"requires": {
 						"locate-path": "^3.0.0"
 					}
@@ -18707,7 +18038,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
 					"requires": {
 						"p-locate": "^3.0.0",
 						"path-exists": "^3.0.0"
@@ -18717,7 +18047,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
 					"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
-					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
 					}
@@ -18726,7 +18055,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
 					"requires": {
 						"p-limit": "^2.0.0"
 					}
@@ -18734,14 +18062,12 @@
 				"p-try": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
-					"dev": true
+					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
 				},
 				"pkg-dir": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
 					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-					"dev": true,
 					"requires": {
 						"find-up": "^3.0.0"
 					}
@@ -18750,7 +18076,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
 					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-					"dev": true,
 					"requires": {
 						"ajv": "^6.1.0",
 						"ajv-errors": "^1.0.0",
@@ -18760,8 +18085,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -18861,14 +18185,12 @@
 		"text-extensions": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
-			"integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
-			"dev": true
+			"integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ=="
 		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-			"dev": true
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
 		},
 		"throat": {
 			"version": "4.1.0",
@@ -18893,7 +18215,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
 			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
-			"dev": true,
 			"requires": {
 				"through2": "~2.0.0",
 				"xtend": "~4.0.0"
@@ -18907,8 +18228,7 @@
 		"time-zone": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
-			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
-			"dev": true
+			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0="
 		},
 		"timed-out": {
 			"version": "4.0.1",
@@ -18953,7 +18273,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
 			"integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1"
 			},
@@ -18962,7 +18281,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -19054,8 +18372,7 @@
 		"trim-off-newlines": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
-			"dev": true
+			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
 		},
 		"trim-right": {
 			"version": "1.0.1",
@@ -19118,7 +18435,6 @@
 			"version": "5.3.3",
 			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-5.3.3.tgz",
 			"integrity": "sha512-KwF1SplmOJepnoZ4eRIloH/zXL195F51skt7reEsS6jvDqzgc/YSbz9b8E07GxIUwLXdcD4ssrJu6v8CwaTafA==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.3.0",
 				"enhanced-resolve": "^4.0.0",
@@ -19130,20 +18446,17 @@
 				"arr-diff": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 				},
 				"array-unique": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 				},
 				"braces": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
 						"array-unique": "^0.3.2",
@@ -19161,7 +18474,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -19172,7 +18484,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -19181,7 +18492,6 @@
 					"version": "2.1.4",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
 					"requires": {
 						"debug": "^2.3.3",
 						"define-property": "^0.2.5",
@@ -19196,7 +18506,6 @@
 							"version": "0.2.5",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -19205,7 +18514,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -19214,7 +18522,6 @@
 							"version": "0.1.6",
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
@@ -19223,7 +18530,6 @@
 									"version": "3.2.2",
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -19234,7 +18540,6 @@
 							"version": "0.1.4",
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
@@ -19243,7 +18548,6 @@
 									"version": "3.2.2",
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -19254,7 +18558,6 @@
 							"version": "0.1.6",
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^0.1.6",
 								"is-data-descriptor": "^0.1.4",
@@ -19264,8 +18567,7 @@
 						"kind-of": {
 							"version": "5.1.0",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 						}
 					}
 				},
@@ -19273,7 +18575,6 @@
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"dev": true,
 					"requires": {
 						"array-unique": "^0.3.2",
 						"define-property": "^1.0.0",
@@ -19289,7 +18590,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -19298,7 +18598,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -19309,7 +18608,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-number": "^3.0.0",
@@ -19321,7 +18619,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -19332,7 +18629,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -19341,7 +18637,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -19350,7 +18645,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -19361,7 +18655,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -19370,7 +18663,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -19380,20 +18672,17 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				},
 				"micromatch": {
 					"version": "3.1.10",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -19413,8 +18702,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -19435,7 +18723,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -19508,7 +18796,6 @@
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/tslint-loader/-/tslint-loader-3.5.4.tgz",
 			"integrity": "sha512-jBHNNppXut6SgZ7CsTBh+6oMwVum9n8azbmcYSeMlsABhWWoHwjq631vIFXef3VSd75cCdX3rc6kstsB7rSVVw==",
-			"dev": true,
 			"requires": {
 				"loader-utils": "^1.0.2",
 				"mkdirp": "^0.5.1",
@@ -19521,7 +18808,6 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/tslint-react/-/tslint-react-3.6.0.tgz",
 			"integrity": "sha512-AIv1QcsSnj7e9pFir6cJ6vIncTqxfqeFF3Lzh8SuuBljueYzEAtByuB6zMaD27BL0xhMEqsZ9s5eHuCONydjBw==",
-			"dev": true,
 			"requires": {
 				"tsutils": "^2.13.1"
 			}
@@ -19578,7 +18864,6 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.12.0.tgz",
 			"integrity": "sha512-dsdlaYZ7Je8JC+jQ3j2Iroe4uyD0GhqzADNUVyBRgLuytQDP/g0dPkAw5PdM/4drnmmJjRzSWW97FkKo+ITqQg==",
-			"dev": true,
 			"requires": {
 				"@types/fs-extra": "^5.0.3",
 				"@types/handlebars": "^4.0.38",
@@ -19603,7 +18888,6 @@
 					"version": "7.0.1",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
 					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"jsonfile": "^4.0.0",
@@ -19613,22 +18897,19 @@
 				"typescript": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
-					"integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
-					"dev": true
+					"integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg=="
 				}
 			}
 		},
 		"typedoc-default-themes": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
-			"integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
-			"dev": true
+			"integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic="
 		},
 		"typescript": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-			"integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
-			"dev": true
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
 		},
 		"ua-parser-js": {
 			"version": "0.7.19",
@@ -19713,8 +18994,7 @@
 		"uid2": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
-			"dev": true
+			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
 		},
 		"ultron": {
 			"version": "1.1.1",
@@ -19773,7 +19053,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
 			"integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
-			"dev": true,
 			"requires": {
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"through2-filter": "^3.0.0"
@@ -19783,7 +19062,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
 					"integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
-					"dev": true,
 					"requires": {
 						"through2": "~2.0.0",
 						"xtend": "~4.0.0"
@@ -19803,7 +19081,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
 			"integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
-			"dev": true,
 			"requires": {
 				"mkdirp": "^0.5.1",
 				"os-tmpdir": "^1.0.1",
@@ -19959,9 +19236,9 @@
 			}
 		},
 		"util": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+			"integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
 			"requires": {
 				"inherits": "2.0.3"
 			}
@@ -19998,8 +19275,7 @@
 		"vali-date": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
-			"dev": true
+			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
@@ -20029,7 +19305,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
 			"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-			"dev": true,
 			"requires": {
 				"clone": "^2.1.1",
 				"clone-buffer": "^1.0.0",
@@ -20043,7 +19318,6 @@
 			"version": "2.4.4",
 			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
 			"integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
-			"dev": true,
 			"requires": {
 				"duplexify": "^3.2.0",
 				"glob-stream": "^5.3.2",
@@ -20067,26 +19341,22 @@
 				"clone": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-					"dev": true
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
 				},
 				"clone-stats": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-					"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-					"dev": true
+					"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
 				},
 				"replace-ext": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-					"dev": true
+					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -20095,7 +19365,6 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
 					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-					"dev": true,
 					"requires": {
 						"clone": "^1.0.0",
 						"clone-stats": "^0.0.1",
@@ -20508,7 +19777,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
 			}
@@ -20528,17 +19796,16 @@
 			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"webpack": {
-			"version": "4.28.4",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.28.4.tgz",
-			"integrity": "sha512-NxjD61WsK/a3JIdwWjtIpimmvE6UrRi3yG54/74Hk9rwNj5FPkA4DJCf1z4ByDWLkvZhTZE+P3C/eh6UD5lDcw==",
-			"dev": true,
+			"version": "4.29.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.29.0.tgz",
+			"integrity": "sha512-pxdGG0keDBtamE1mNvT5zyBdx+7wkh6mh7uzMOo/uRQ/fhsdj5FXkh/j5mapzs060forql1oXqXN9HJGju+y7w==",
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-module-context": "1.7.11",
 				"@webassemblyjs/wasm-edit": "1.7.11",
 				"@webassemblyjs/wasm-parser": "1.7.11",
-				"acorn": "^5.6.2",
-				"acorn-dynamic-import": "^3.0.0",
+				"acorn": "^6.0.5",
+				"acorn-dynamic-import": "^4.0.0",
 				"ajv": "^6.1.0",
 				"ajv-keywords": "^3.1.0",
 				"chrome-trace-event": "^1.0.0",
@@ -20562,20 +19829,17 @@
 				"arr-diff": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 				},
 				"array-unique": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 				},
 				"braces": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
 						"array-unique": "^0.3.2",
@@ -20593,7 +19857,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -20604,7 +19867,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -20613,7 +19875,6 @@
 					"version": "2.1.4",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
 					"requires": {
 						"debug": "^2.3.3",
 						"define-property": "^0.2.5",
@@ -20628,7 +19889,6 @@
 							"version": "0.2.5",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -20637,7 +19897,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -20646,7 +19905,6 @@
 							"version": "0.1.6",
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
@@ -20655,7 +19913,6 @@
 									"version": "3.2.2",
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -20666,7 +19923,6 @@
 							"version": "0.1.4",
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
@@ -20675,7 +19931,6 @@
 									"version": "3.2.2",
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -20686,7 +19941,6 @@
 							"version": "0.1.6",
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^0.1.6",
 								"is-data-descriptor": "^0.1.4",
@@ -20696,8 +19950,7 @@
 						"kind-of": {
 							"version": "5.1.0",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 						}
 					}
 				},
@@ -20705,7 +19958,6 @@
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"dev": true,
 					"requires": {
 						"array-unique": "^0.3.2",
 						"define-property": "^1.0.0",
@@ -20721,7 +19973,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -20730,7 +19981,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -20741,7 +19991,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-number": "^3.0.0",
@@ -20753,7 +20002,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -20764,7 +20012,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -20773,7 +20020,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -20782,7 +20028,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -20793,7 +20038,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -20802,7 +20046,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -20812,20 +20055,17 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				},
 				"micromatch": {
 					"version": "3.1.10",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -20845,8 +20085,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -21682,7 +20921,6 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.1.tgz",
 			"integrity": "sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.17.5"
 			}
@@ -21720,8 +20958,7 @@
 		"well-known-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-1.0.0.tgz",
-			"integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg=",
-			"dev": true
+			"integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg="
 		},
 		"whatwg-encoding": {
 			"version": "1.0.5",
@@ -21802,7 +21039,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
 			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
-			"dev": true,
 			"requires": {
 				"errno": "~0.1.7"
 			}
@@ -21863,7 +21099,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
 			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
-			"dev": true,
 			"requires": {
 				"detect-indent": "^5.0.0",
 				"graceful-fs": "^4.1.2",
@@ -21876,14 +21111,12 @@
 				"detect-indent": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-					"dev": true
+					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
 				},
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
@@ -21891,7 +21124,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.2.0.tgz",
 			"integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
-			"dev": true,
 			"requires": {
 				"sort-keys": "^2.0.0",
 				"write-json-file": "^2.2.0"
@@ -22017,9 +21249,9 @@
 			"integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
 		},
 		"zone.js": {
-			"version": "0.8.27",
-			"resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.27.tgz",
-			"integrity": "sha512-Gbv0wmh0paF4Q60zzcF28+qBWIxtMVuRKBCBm0hvLupZsN/SX7TYYcgYWoVH8MkP+yl0jHlyGHy4dIYUgZvBqA=="
+			"version": "0.8.28",
+			"resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.28.tgz",
+			"integrity": "sha512-MjwlvV0wr65IQiT0WSHedo/zUhAqtypMdTUjqroV81RohGj1XANwHuC37dwYxphTRbZBYidk0gNS0dQrU2Q3Pw=="
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4 +1,5 @@
 {
+	"name": "jsonforms-edgar",
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
@@ -126,12 +127,14 @@
 		"@ava/babel-plugin-throws-helper": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-2.0.0.tgz",
-			"integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw="
+			"integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw=",
+			"dev": true
 		},
 		"@ava/babel-preset-stage-4": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-1.1.0.tgz",
 			"integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
+			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "^6.8.0",
 				"babel-plugin-syntax-trailing-function-commas": "^6.20.0",
@@ -151,6 +154,7 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
 					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+					"dev": true,
 					"requires": {
 						"md5-o-matic": "^0.1.1"
 					}
@@ -159,6 +163,7 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-1.2.0.tgz",
 					"integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
+					"dev": true,
 					"requires": {
 						"md5-hex": "^1.3.0"
 					}
@@ -169,6 +174,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-3.0.0.tgz",
 			"integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
+			"dev": true,
 			"requires": {
 				"@ava/babel-plugin-throws-helper": "^2.0.0",
 				"babel-plugin-espower": "^2.3.2"
@@ -178,6 +184,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@ava/write-file-atomic/-/write-file-atomic-2.2.0.tgz",
 			"integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
@@ -336,6 +343,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz",
 			"integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
+			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1"
 			}
@@ -522,6 +530,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/@ladjs/time-require/-/time-require-0.1.4.tgz",
 			"integrity": "sha512-weIbJqTMfQ4r1YX85u54DKfjLZs2jwn1XZ6tIOP/pFgMwhIN5BAtaCp/1wn9DzyLsDR9tW0R2NIePcVJ45ivQQ==",
+			"dev": true,
 			"requires": {
 				"chalk": "^0.4.0",
 				"date-time": "^0.1.1",
@@ -532,12 +541,14 @@
 				"ansi-styles": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
+					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "~1.0.0",
 						"has-color": "~0.1.0",
@@ -548,6 +559,7 @@
 					"version": "0.2.2",
 					"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
 					"integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
+					"dev": true,
 					"requires": {
 						"parse-ms": "^0.1.0"
 					}
@@ -555,7 +567,8 @@
 				"strip-ansi": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
+					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+					"dev": true
 				}
 			}
 		},
@@ -733,12 +746,14 @@
 		"@types/events": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
-			"integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
+			"integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
+			"dev": true
 		},
 		"@types/fs-extra": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
 			"integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
+			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -747,6 +762,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
 			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"dev": true,
 			"requires": {
 				"@types/events": "*",
 				"@types/minimatch": "*",
@@ -756,12 +772,14 @@
 		"@types/handlebars": {
 			"version": "4.0.40",
 			"resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.40.tgz",
-			"integrity": "sha512-sGWNtsjNrLOdKha2RV1UeF8+UbQnPSG7qbe5wwbni0mw4h2gHXyPFUMOC+xwGirIiiydM/HSqjDO4rk6NFB18w=="
+			"integrity": "sha512-sGWNtsjNrLOdKha2RV1UeF8+UbQnPSG7qbe5wwbni0mw4h2gHXyPFUMOC+xwGirIiiydM/HSqjDO4rk6NFB18w==",
+			"dev": true
 		},
 		"@types/highlight.js": {
 			"version": "9.12.3",
 			"resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
-			"integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ=="
+			"integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
+			"dev": true
 		},
 		"@types/invariant": {
 			"version": "2.2.29",
@@ -771,7 +789,8 @@
 		"@types/jest": {
 			"version": "23.3.12",
 			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.12.tgz",
-			"integrity": "sha512-/kQvbVzdEpOq4tEWT79yAHSM4nH4xMlhJv2GrLVQt4Qmo8yYsPdioBM1QpN/2GX1wkfMnyXvdoftvLUr0LBj7Q=="
+			"integrity": "sha512-/kQvbVzdEpOq4tEWT79yAHSM4nH4xMlhJv2GrLVQt4Qmo8yYsPdioBM1QpN/2GX1wkfMnyXvdoftvLUr0LBj7Q==",
+			"dev": true
 		},
 		"@types/jss": {
 			"version": "9.5.7",
@@ -790,12 +809,14 @@
 		"@types/marked": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
-			"integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg=="
+			"integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
+			"dev": true
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+			"dev": true
 		},
 		"@types/node": {
 			"version": "10.12.18",
@@ -809,7 +830,7 @@
 		},
 		"@types/q": {
 			"version": "0.0.32",
-			"resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
+			"resolved": "http://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
 			"integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU="
 		},
 		"@types/react": {
@@ -901,6 +922,7 @@
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.1.tgz",
 			"integrity": "sha512-1lQw+48BuVgp6c1+z8EMipp18IdnV2dLh6KQGwOm+kJy9nPjEkaqRKmwbDNEYf//EKBvKcwOC6V2cDrNxVoQeQ==",
+			"dev": true,
 			"requires": {
 				"@types/glob": "*",
 				"@types/node": "*"
@@ -910,6 +932,7 @@
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
 			"integrity": "sha512-ZEzy4vjvTzScC+SH8RBssQUawpaInUdMTYwYYLh54/s8TuT0gBLuyUnppKsVyZEi876VmmStKsUs28UxPgdvrA==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/helper-module-context": "1.7.11",
 				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
@@ -919,22 +942,26 @@
 		"@webassemblyjs/floating-point-hex-parser": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.11.tgz",
-			"integrity": "sha512-zY8dSNyYcgzNRNT666/zOoAyImshm3ycKdoLsyDw/Bwo6+/uktb7p4xyApuef1dwEBo/U/SYQzbGBvV+nru2Xg=="
+			"integrity": "sha512-zY8dSNyYcgzNRNT666/zOoAyImshm3ycKdoLsyDw/Bwo6+/uktb7p4xyApuef1dwEBo/U/SYQzbGBvV+nru2Xg==",
+			"dev": true
 		},
 		"@webassemblyjs/helper-api-error": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.11.tgz",
-			"integrity": "sha512-7r1qXLmiglC+wPNkGuXCvkmalyEstKVwcueZRP2GNC2PAvxbLYwLLPr14rcdJaE4UtHxQKfFkuDFuv91ipqvXg=="
+			"integrity": "sha512-7r1qXLmiglC+wPNkGuXCvkmalyEstKVwcueZRP2GNC2PAvxbLYwLLPr14rcdJaE4UtHxQKfFkuDFuv91ipqvXg==",
+			"dev": true
 		},
 		"@webassemblyjs/helper-buffer": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.11.tgz",
-			"integrity": "sha512-MynuervdylPPh3ix+mKZloTcL06P8tenNH3sx6s0qE8SLR6DdwnfgA7Hc9NSYeob2jrW5Vql6GVlsQzKQCa13w=="
+			"integrity": "sha512-MynuervdylPPh3ix+mKZloTcL06P8tenNH3sx6s0qE8SLR6DdwnfgA7Hc9NSYeob2jrW5Vql6GVlsQzKQCa13w==",
+			"dev": true
 		},
 		"@webassemblyjs/helper-code-frame": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.11.tgz",
 			"integrity": "sha512-T8ESC9KMXFTXA5urJcyor5cn6qWeZ4/zLPyWeEXZ03hj/x9weSokGNkVCdnhSabKGYWxElSdgJ+sFa9G/RdHNw==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/wast-printer": "1.7.11"
 			}
@@ -942,22 +969,26 @@
 		"@webassemblyjs/helper-fsm": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.11.tgz",
-			"integrity": "sha512-nsAQWNP1+8Z6tkzdYlXT0kxfa2Z1tRTARd8wYnc/e3Zv3VydVVnaeePgqUzFrpkGUyhUUxOl5ML7f1NuT+gC0A=="
+			"integrity": "sha512-nsAQWNP1+8Z6tkzdYlXT0kxfa2Z1tRTARd8wYnc/e3Zv3VydVVnaeePgqUzFrpkGUyhUUxOl5ML7f1NuT+gC0A==",
+			"dev": true
 		},
 		"@webassemblyjs/helper-module-context": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.11.tgz",
-			"integrity": "sha512-JxfD5DX8Ygq4PvXDucq0M+sbUFA7BJAv/GGl9ITovqE+idGX+J3QSzJYz+LwQmL7fC3Rs+utvWoJxDb6pmC0qg=="
+			"integrity": "sha512-JxfD5DX8Ygq4PvXDucq0M+sbUFA7BJAv/GGl9ITovqE+idGX+J3QSzJYz+LwQmL7fC3Rs+utvWoJxDb6pmC0qg==",
+			"dev": true
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.11.tgz",
-			"integrity": "sha512-cMXeVS9rhoXsI9LLL4tJxBgVD/KMOKXuFqYb5oCJ/opScWpkCMEz9EJtkonaNcnLv2R3K5jIeS4TRj/drde1JQ=="
+			"integrity": "sha512-cMXeVS9rhoXsI9LLL4tJxBgVD/KMOKXuFqYb5oCJ/opScWpkCMEz9EJtkonaNcnLv2R3K5jIeS4TRj/drde1JQ==",
+			"dev": true
 		},
 		"@webassemblyjs/helper-wasm-section": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.11.tgz",
 			"integrity": "sha512-8ZRY5iZbZdtNFE5UFunB8mmBEAbSI3guwbrsCl4fWdfRiAcvqQpeqd5KHhSWLL5wuxo53zcaGZDBU64qgn4I4Q==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-buffer": "1.7.11",
@@ -969,6 +1000,7 @@
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.11.tgz",
 			"integrity": "sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==",
+			"dev": true,
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
@@ -977,6 +1009,7 @@
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.11.tgz",
 			"integrity": "sha512-vuGmgZjjp3zjcerQg+JA+tGOncOnJLWVkt8Aze5eWQLwTQGNgVLcyOTqgSCxWTR4J42ijHbBxnuRaL1Rv7XMdw==",
+			"dev": true,
 			"requires": {
 				"@xtuc/long": "4.2.1"
 			}
@@ -984,12 +1017,14 @@
 		"@webassemblyjs/utf8": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.11.tgz",
-			"integrity": "sha512-C6GFkc7aErQIAH+BMrIdVSmW+6HSe20wg57HEC1uqJP8E/xpMjXqQUxkQw07MhNDSDcGpxI9G5JSNOQCqJk4sA=="
+			"integrity": "sha512-C6GFkc7aErQIAH+BMrIdVSmW+6HSe20wg57HEC1uqJP8E/xpMjXqQUxkQw07MhNDSDcGpxI9G5JSNOQCqJk4sA==",
+			"dev": true
 		},
 		"@webassemblyjs/wasm-edit": {
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.11.tgz",
 			"integrity": "sha512-FUd97guNGsCZQgeTPKdgxJhBXkUbMTY6hFPf2Y4OedXd48H97J+sOY2Ltaq6WGVpIH8o/TGOVNiVz/SbpEMJGg==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-buffer": "1.7.11",
@@ -1005,6 +1040,7 @@
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.11.tgz",
 			"integrity": "sha512-U/KDYp7fgAZX5KPfq4NOupK/BmhDc5Kjy2GIqstMhvvdJRcER/kUsMThpWeRP8BMn4LXaKhSTggIJPOeYHwISA==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
@@ -1017,6 +1053,7 @@
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.11.tgz",
 			"integrity": "sha512-XynkOwQyiRidh0GLua7SkeHvAPXQV/RxsUeERILmAInZegApOUAIJfRuPYe2F7RcjOC9tW3Cb9juPvAC/sCqvg==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-buffer": "1.7.11",
@@ -1028,6 +1065,7 @@
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.11.tgz",
 			"integrity": "sha512-6lmXRTrrZjYD8Ng8xRyvyXQJYUQKYSXhJqXOBLw24rdiXsHAOlvw5PhesjdcaMadU/pyPQOJ5dHreMjBxwnQKg==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-api-error": "1.7.11",
@@ -1041,6 +1079,7 @@
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.11.tgz",
 			"integrity": "sha512-lEyVCg2np15tS+dm7+JJTNhNWq9yTZvi3qEhAIIOaofcYlUp0UR5/tVqOwa/gXYr3gjwSZqw+/lS9dscyLelbQ==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/floating-point-hex-parser": "1.7.11",
@@ -1054,6 +1093,7 @@
 			"version": "1.7.11",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.11.tgz",
 			"integrity": "sha512-m5vkAsuJ32QpkdkDOUPGSltrg8Cuk3KBx4YrmAGQwCZPRdUHXxG4phIOuuycLemHFr74sWL9Wthqss4fzdzSwg==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/wast-parser": "1.7.11",
@@ -1068,17 +1108,20 @@
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+			"dev": true
 		},
 		"@xtuc/long": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz",
-			"integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g=="
+			"integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==",
+			"dev": true
 		},
 		"JSONStream": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
 			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+			"dev": true,
 			"requires": {
 				"jsonparse": "^1.2.0",
 				"through": ">=2.2.7 <3"
@@ -1112,6 +1155,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
 			"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+			"dev": true,
 			"requires": {
 				"acorn": "^5.0.0"
 			}
@@ -1140,7 +1184,8 @@
 		"add-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo="
+			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
+			"dev": true
 		},
 		"adm-zip": {
 			"version": "0.4.13",
@@ -1316,7 +1361,8 @@
 		"arr-exclude": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/arr-exclude/-/arr-exclude-1.0.0.tgz",
-			"integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE="
+			"integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE=",
+			"dev": true
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
@@ -1331,7 +1377,8 @@
 		"array-differ": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+			"dev": true
 		},
 		"array-equal": {
 			"version": "1.0.0",
@@ -1351,7 +1398,8 @@
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
+			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+			"dev": true
 		},
 		"array-slice": {
 			"version": "0.2.3",
@@ -1495,7 +1543,8 @@
 		"auto-bind": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-1.2.1.tgz",
-			"integrity": "sha512-/W9yj1yKmBLwpexwAujeD9YHwYmRuWFGV8HWE7smQab797VeHa4/cnE2NFeDhA+E+5e/OGBI8763EhLjfZ/MXA=="
+			"integrity": "sha512-/W9yj1yKmBLwpexwAujeD9YHwYmRuWFGV8HWE7smQab797VeHa4/cnE2NFeDhA+E+5e/OGBI8763EhLjfZ/MXA==",
+			"dev": true
 		},
 		"autobind-decorator": {
 			"version": "2.4.0",
@@ -1519,6 +1568,7 @@
 			"version": "0.25.0",
 			"resolved": "https://registry.npmjs.org/ava/-/ava-0.25.0.tgz",
 			"integrity": "sha512-4lGNJCf6xL8SvsKVEKxEE46se7JAUIAZoKHw9itTQuwcsydhpAMkBs5gOOiWiwt0JKNIuXWc2/r4r8ZdcNrBEw==",
+			"dev": true,
 			"requires": {
 				"@ava/babel-preset-stage-4": "^1.1.0",
 				"@ava/babel-preset-transform-test-files": "^3.0.0",
@@ -1609,6 +1659,7 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/ava-init/-/ava-init-0.2.1.tgz",
 			"integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
+			"dev": true,
 			"requires": {
 				"arr-exclude": "^1.0.0",
 				"execa": "^0.7.0",
@@ -2029,6 +2080,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2039,6 +2091,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2050,6 +2103,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-traverse": "^6.24.1",
@@ -2060,6 +2114,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2072,6 +2127,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2081,6 +2137,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2090,6 +2147,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"babel-types": "^6.26.0",
@@ -2100,6 +2158,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2130,6 +2189,7 @@
 			"version": "7.1.5",
 			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.5.tgz",
 			"integrity": "sha512-iCHfbieL5d1LfOQeeVJEUyD9rTwBcP/fcEbRCfempxTDuqrKpu0AZjLAQHEQa3Yqyj9ORKe2iHfoj4rHLf7xpw==",
+			"dev": true,
 			"requires": {
 				"find-cache-dir": "^1.0.0",
 				"loader-utils": "^1.0.2",
@@ -2148,6 +2208,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2156,6 +2217,7 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-2.4.0.tgz",
 			"integrity": "sha512-/+SRpy7pKgTI28oEHfn1wkuM5QFAdRq8WNsOOih1dVrdV6A/WbNbRZyl0eX5eyDgtb0lOE27PeDFuCX2j8OxVg==",
+			"dev": true,
 			"requires": {
 				"babel-generator": "^6.1.0",
 				"babylon": "^6.1.0",
@@ -2185,12 +2247,14 @@
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+			"dev": true
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
@@ -2200,12 +2264,14 @@
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+			"dev": true
 		},
 		"babel-plugin-transform-async-to-generator": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "^6.24.1",
 				"babel-plugin-syntax-async-functions": "^6.8.0",
@@ -2216,6 +2282,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2224,6 +2291,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2234,6 +2302,7 @@
 			"version": "6.26.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
 			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "^6.24.1",
 				"babel-runtime": "^6.26.0",
@@ -2245,6 +2314,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "^6.24.1",
 				"babel-helper-get-function-arity": "^6.24.1",
@@ -2258,6 +2328,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -2266,6 +2337,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2276,6 +2348,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -2286,6 +2359,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
@@ -2296,6 +2370,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -2541,7 +2616,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -2832,7 +2907,8 @@
 		"buf-compare": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
-			"integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o="
+			"integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=",
+			"dev": true
 		},
 		"buffer": {
 			"version": "4.9.1",
@@ -2891,7 +2967,8 @@
 		"byline": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
+			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
+			"dev": true
 		},
 		"bytes": {
 			"version": "3.0.0",
@@ -2902,6 +2979,7 @@
 			"version": "11.3.2",
 			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
 			"integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+			"dev": true,
 			"requires": {
 				"bluebird": "^3.5.3",
 				"chownr": "^1.1.1",
@@ -2923,6 +3001,7 @@
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
 					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"dev": true,
 					"requires": {
 						"yallist": "^3.0.2"
 					}
@@ -2930,12 +3009,14 @@
 				"y18n": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+					"dev": true
 				}
 			}
 		},
@@ -2966,6 +3047,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
 			"integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+			"dev": true,
 			"requires": {
 				"md5-hex": "^1.2.0",
 				"mkdirp": "^0.5.1",
@@ -2976,6 +3058,7 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
 					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+					"dev": true,
 					"requires": {
 						"md5-o-matic": "^0.1.1"
 					}
@@ -2984,6 +3067,7 @@
 					"version": "1.3.4",
 					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
 					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
 						"imurmurhash": "^0.1.4",
@@ -2996,6 +3080,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.1.0.tgz",
 			"integrity": "sha512-IoQLeNwwf9KTNbtSA7aEBb1yfDbdnzwjCetjkC8io5oGeOmK2CBNdg0xr+tadRYKO0p7uQyZzvon0kXlZbvGrw==",
+			"dev": true,
 			"requires": {
 				"core-js": "^2.0.0",
 				"deep-equal": "^1.0.0",
@@ -3006,7 +3091,8 @@
 		"call-signature": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
-			"integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY="
+			"integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
+			"dev": true
 		},
 		"callsite": {
 			"version": "1.0.0",
@@ -3091,7 +3177,8 @@
 		"chardet": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+			"dev": true
 		},
 		"cheerio": {
 			"version": "1.0.0-rc.2",
@@ -3131,6 +3218,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
 			"integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
+			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -3203,12 +3291,14 @@
 		"clean-stack": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
-			"integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
+			"integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE=",
+			"dev": true
 		},
 		"clean-yaml-object": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
-			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g="
+			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
+			"dev": true
 		},
 		"cli-boxes": {
 			"version": "1.0.0",
@@ -3219,6 +3309,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "^2.0.0"
 			}
@@ -3226,12 +3317,14 @@
 		"cli-spinners": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
-			"integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg=="
+			"integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
+			"dev": true
 		},
 		"cli-truncate": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
 			"integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
+			"dev": true,
 			"requires": {
 				"slice-ansi": "^1.0.0",
 				"string-width": "^2.0.0"
@@ -3240,7 +3333,8 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
 		},
 		"cliui": {
 			"version": "3.2.0",
@@ -3288,17 +3382,20 @@
 		"clone-buffer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
+			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+			"dev": true
 		},
 		"clone-stats": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-			"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+			"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+			"dev": true
 		},
 		"cloneable-readable": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
 			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"process-nextick-args": "^2.0.0",
@@ -3309,6 +3406,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
 			"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"mkdirp": "~0.5.0"
@@ -3323,6 +3421,7 @@
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co-with-promise/-/co-with-promise-4.6.0.tgz",
 			"integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
+			"dev": true,
 			"requires": {
 				"pinkie-promise": "^1.0.0"
 			}
@@ -3331,6 +3430,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.1.tgz",
 			"integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
+			"dev": true,
 			"requires": {
 				"convert-to-spaces": "^1.0.1"
 			}
@@ -3371,6 +3471,7 @@
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
 			"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+			"dev": true,
 			"requires": {
 				"strip-ansi": "^3.0.0",
 				"wcwidth": "^1.0.0"
@@ -3380,6 +3481,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -3405,7 +3507,8 @@
 		"command-join": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz",
-			"integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8="
+			"integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8=",
+			"dev": true
 		},
 		"commander": {
 			"version": "2.17.1",
@@ -3415,7 +3518,8 @@
 		"common-path-prefix": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
-			"integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA="
+			"integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA=",
+			"dev": true
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -3426,6 +3530,7 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
 			"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
+			"dev": true,
 			"requires": {
 				"array-ify": "^1.0.0",
 				"dot-prop": "^3.0.0"
@@ -3435,6 +3540,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
 					"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+					"dev": true,
 					"requires": {
 						"is-obj": "^1.0.0"
 					}
@@ -3518,6 +3624,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/concordance/-/concordance-3.0.0.tgz",
 			"integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
+			"dev": true,
 			"requires": {
 				"date-time": "^2.1.0",
 				"esutils": "^2.0.2",
@@ -3536,6 +3643,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
 					"integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
+					"dev": true,
 					"requires": {
 						"time-zone": "^1.0.0"
 					}
@@ -3642,6 +3750,7 @@
 			"version": "1.1.24",
 			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.24.tgz",
 			"integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
+			"dev": true,
 			"requires": {
 				"conventional-changelog-angular": "^1.6.6",
 				"conventional-changelog-atom": "^0.2.8",
@@ -3660,6 +3769,7 @@
 			"version": "1.6.6",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
 			"integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
+			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"q": "^1.5.1"
@@ -3669,6 +3779,7 @@
 			"version": "0.2.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.8.tgz",
 			"integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
+			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -3677,6 +3788,7 @@
 			"version": "1.3.22",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.22.tgz",
 			"integrity": "sha512-pnjdIJbxjkZ5VdAX/H1wndr1G10CY8MuZgnXuJhIHglOXfIrXygb7KZC836GW9uo1u8PjEIvIw/bKX0lOmOzZg==",
+			"dev": true,
 			"requires": {
 				"add-stream": "^1.0.0",
 				"conventional-changelog": "^1.1.24",
@@ -3688,12 +3800,14 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
 				},
 				"camelcase-keys": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0",
 						"map-obj": "^2.0.0",
@@ -3704,6 +3818,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -3714,12 +3829,14 @@
 				"map-obj": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+					"dev": true
 				},
 				"meow": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -3735,12 +3852,14 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -3750,6 +3869,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -3757,12 +3877,14 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -3773,6 +3895,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -3782,6 +3905,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+					"dev": true,
 					"requires": {
 						"indent-string": "^3.0.0",
 						"strip-indent": "^2.0.0"
@@ -3790,12 +3914,14 @@
 				"strip-indent": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+					"dev": true
 				},
 				"trim-newlines": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+					"dev": true
 				}
 			}
 		},
@@ -3803,6 +3929,7 @@
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.8.tgz",
 			"integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
+			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -3811,6 +3938,7 @@
 			"version": "2.0.11",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.11.tgz",
 			"integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
+			"dev": true,
 			"requires": {
 				"conventional-changelog-writer": "^3.0.9",
 				"conventional-commits-parser": "^2.1.7",
@@ -3831,6 +3959,7 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
 					"requires": {
 						"path-exists": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
@@ -3840,6 +3969,7 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -3852,6 +3982,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
@@ -3860,6 +3991,7 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"pify": "^2.0.0",
@@ -3869,12 +4001,14 @@
 				"pinkie": {
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+					"dev": true
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+					"dev": true,
 					"requires": {
 						"pinkie": "^2.0.0"
 					}
@@ -3883,6 +4017,7 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"dev": true,
 					"requires": {
 						"load-json-file": "^1.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -3893,6 +4028,7 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"dev": true,
 					"requires": {
 						"find-up": "^1.0.0",
 						"read-pkg": "^1.0.0"
@@ -3902,6 +4038,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -3912,6 +4049,7 @@
 			"version": "0.3.12",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.12.tgz",
 			"integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
+			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -3920,6 +4058,7 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.9.tgz",
 			"integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
+			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -3928,6 +4067,7 @@
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz",
 			"integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
+			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -3936,6 +4076,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
 			"integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
+			"dev": true,
 			"requires": {
 				"q": "^1.4.1"
 			}
@@ -3944,6 +4085,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
 			"integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
+			"dev": true,
 			"requires": {
 				"q": "^1.4.1"
 			}
@@ -3952,6 +4094,7 @@
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.8.tgz",
 			"integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
+			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"q": "^1.5.1"
@@ -3960,12 +4103,14 @@
 		"conventional-changelog-preset-loader": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz",
-			"integrity": "sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw=="
+			"integrity": "sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw==",
+			"dev": true
 		},
 		"conventional-changelog-writer": {
 			"version": "3.0.9",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz",
 			"integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
+			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"conventional-commits-filter": "^1.1.6",
@@ -3982,12 +4127,14 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
 				},
 				"camelcase-keys": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0",
 						"map-obj": "^2.0.0",
@@ -3998,6 +4145,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -4008,12 +4156,14 @@
 				"map-obj": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+					"dev": true
 				},
 				"meow": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -4029,12 +4179,14 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -4044,6 +4196,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -4051,12 +4204,14 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -4067,6 +4222,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -4076,6 +4232,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+					"dev": true,
 					"requires": {
 						"indent-string": "^3.0.0",
 						"strip-indent": "^2.0.0"
@@ -4084,12 +4241,14 @@
 				"strip-indent": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+					"dev": true
 				},
 				"trim-newlines": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+					"dev": true
 				}
 			}
 		},
@@ -4097,6 +4256,7 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
 			"integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
+			"dev": true,
 			"requires": {
 				"is-subset": "^0.1.1",
 				"modify-values": "^1.0.0"
@@ -4106,6 +4266,7 @@
 			"version": "2.1.7",
 			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
 			"integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
+			"dev": true,
 			"requires": {
 				"JSONStream": "^1.0.4",
 				"is-text-path": "^1.0.0",
@@ -4119,12 +4280,14 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
 				},
 				"camelcase-keys": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0",
 						"map-obj": "^2.0.0",
@@ -4135,6 +4298,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -4145,12 +4309,14 @@
 				"map-obj": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+					"dev": true
 				},
 				"meow": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -4166,12 +4332,14 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -4181,6 +4349,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -4188,12 +4357,14 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -4204,6 +4375,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -4213,6 +4385,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+					"dev": true,
 					"requires": {
 						"indent-string": "^3.0.0",
 						"strip-indent": "^2.0.0"
@@ -4221,12 +4394,14 @@
 				"strip-indent": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+					"dev": true
 				},
 				"trim-newlines": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+					"dev": true
 				}
 			}
 		},
@@ -4234,6 +4409,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.2.1.tgz",
 			"integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
+			"dev": true,
 			"requires": {
 				"concat-stream": "^1.4.10",
 				"conventional-commits-filter": "^1.1.1",
@@ -4255,7 +4431,8 @@
 		"convert-to-spaces": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
-			"integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU="
+			"integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU=",
+			"dev": true
 		},
 		"cookie": {
 			"version": "0.3.1",
@@ -4401,6 +4578,7 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
 			"integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
+			"dev": true,
 			"requires": {
 				"buf-compare": "^1.0.0",
 				"is-error": "^2.2.0"
@@ -4420,6 +4598,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
 			"integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
+			"dev": true,
 			"requires": {
 				"growl": "~> 1.10.0",
 				"js-yaml": "^3.11.0",
@@ -4432,7 +4611,8 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				}
 			}
 		},
@@ -4482,6 +4662,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
 			"integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+			"dev": true,
 			"requires": {
 				"cross-spawn": "^6.0.5",
 				"is-windows": "^1.0.0"
@@ -4491,6 +4672,7 @@
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -4546,6 +4728,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.1.tgz",
 			"integrity": "sha512-+ZHAZm/yqvJ2kDtPne3uX0C+Vr3Zn5jFn2N4HywtS5ujwvsVkyg0VArEXpl3BgczDA8anieki1FIzhchX4yrDw==",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"css-selector-tokenizer": "^0.7.0",
@@ -4581,6 +4764,7 @@
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
 			"integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
+			"dev": true,
 			"requires": {
 				"cssesc": "^0.1.0",
 				"fastparse": "^1.1.1",
@@ -4591,6 +4775,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
 					"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+					"dev": true,
 					"requires": {
 						"regenerate": "^1.2.1",
 						"regjsgen": "^0.2.0",
@@ -4615,7 +4800,8 @@
 		"cssesc": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
+			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+			"dev": true
 		},
 		"cssom": {
 			"version": "0.3.4",
@@ -4670,6 +4856,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
 			"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -4717,12 +4904,14 @@
 		"date-time": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
-			"integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc="
+			"integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
+			"dev": true
 		},
 		"dateformat": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
+			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+			"dev": true
 		},
 		"debounce": {
 			"version": "1.2.0",
@@ -4746,6 +4935,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+			"dev": true,
 			"requires": {
 				"decamelize": "^1.1.0",
 				"map-obj": "^1.0.0"
@@ -4759,7 +4949,8 @@
 		"dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
+			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+			"dev": true
 		},
 		"deep-equal": {
 			"version": "1.0.1",
@@ -4840,6 +5031,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+			"dev": true,
 			"requires": {
 				"clone": "^1.0.2"
 			},
@@ -4847,7 +5039,8 @@
 				"clone": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+					"dev": true
 				}
 			}
 		},
@@ -5216,7 +5409,8 @@
 		"duplexer": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
 		},
 		"duplexer3": {
 			"version": "0.1.4",
@@ -5276,6 +5470,7 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
 			"integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
+			"dev": true,
 			"requires": {
 				"call-signature": "0.0.2",
 				"core-js": "^2.0.0"
@@ -5449,7 +5644,8 @@
 		"equal-length": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/equal-length/-/equal-length-1.0.1.tgz",
-			"integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w="
+			"integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w=",
+			"dev": true
 		},
 		"errno": {
 			"version": "0.1.7",
@@ -5512,7 +5708,8 @@
 		"es6-error": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+			"dev": true
 		},
 		"es6-iterator": {
 			"version": "2.0.3",
@@ -5646,6 +5843,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
 			"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+			"dev": true,
 			"requires": {
 				"esrecurse": "^4.1.0",
 				"estraverse": "^4.1.1"
@@ -5655,6 +5853,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
 			"integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
+			"dev": true,
 			"requires": {
 				"is-url": "^1.2.1",
 				"path-is-absolute": "^1.0.0",
@@ -5671,6 +5870,7 @@
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.1.tgz",
 			"integrity": "sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==",
+			"dev": true,
 			"requires": {
 				"core-js": "^2.0.0"
 			}
@@ -5922,6 +6122,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+			"dev": true,
 			"requires": {
 				"chardet": "^0.4.0",
 				"iconv-lite": "^0.4.17",
@@ -5949,7 +6150,8 @@
 		"fast-diff": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
+			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
@@ -6006,12 +6208,14 @@
 		"figgy-pudding": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
+			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+			"dev": true
 		},
 		"figures": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			}
@@ -6384,7 +6588,8 @@
 		"first-chunk-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-			"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
+			"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+			"dev": true
 		},
 		"flatted": {
 			"version": "2.0.0",
@@ -6403,7 +6608,8 @@
 		"fn-name": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-			"integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc="
+			"integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
+			"dev": true
 		},
 		"follow-redirects": {
 			"version": "1.6.1",
@@ -7003,7 +7209,8 @@
 		"function-name-support": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/function-name-support/-/function-name-support-0.2.0.tgz",
-			"integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE="
+			"integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE=",
+			"dev": true
 		},
 		"function.prototype.name": {
 			"version": "1.1.0",
@@ -7091,6 +7298,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
 			"integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
+			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
 				"meow": "^3.3.0",
@@ -7102,7 +7310,8 @@
 		"get-port": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
+			"dev": true
 		},
 		"get-stdin": {
 			"version": "4.0.1",
@@ -7131,6 +7340,7 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
 			"integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
+			"dev": true,
 			"requires": {
 				"dargs": "^4.0.1",
 				"lodash.template": "^4.0.2",
@@ -7142,12 +7352,14 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
 				},
 				"camelcase-keys": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0",
 						"map-obj": "^2.0.0",
@@ -7158,6 +7370,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -7168,12 +7381,14 @@
 				"map-obj": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+					"dev": true
 				},
 				"meow": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -7189,12 +7404,14 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -7204,6 +7421,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -7211,12 +7429,14 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -7227,6 +7447,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -7236,6 +7457,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+					"dev": true,
 					"requires": {
 						"indent-string": "^3.0.0",
 						"strip-indent": "^2.0.0"
@@ -7244,12 +7466,14 @@
 				"strip-indent": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+					"dev": true
 				},
 				"trim-newlines": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+					"dev": true
 				}
 			}
 		},
@@ -7257,6 +7481,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
 			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+			"dev": true,
 			"requires": {
 				"gitconfiglocal": "^1.0.0",
 				"pify": "^2.3.0"
@@ -7266,6 +7491,7 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz",
 			"integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
+			"dev": true,
 			"requires": {
 				"meow": "^4.0.0",
 				"semver": "^5.5.0"
@@ -7274,12 +7500,14 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
 				},
 				"camelcase-keys": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0",
 						"map-obj": "^2.0.0",
@@ -7290,6 +7518,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -7300,12 +7529,14 @@
 				"map-obj": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+					"dev": true
 				},
 				"meow": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -7321,12 +7552,14 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -7336,6 +7569,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -7343,12 +7577,14 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -7359,6 +7595,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -7368,6 +7605,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+					"dev": true,
 					"requires": {
 						"indent-string": "^3.0.0",
 						"strip-indent": "^2.0.0"
@@ -7376,12 +7614,14 @@
 				"strip-indent": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+					"dev": true
 				},
 				"trim-newlines": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+					"dev": true
 				}
 			}
 		},
@@ -7389,6 +7629,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
 			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+			"dev": true,
 			"requires": {
 				"ini": "^1.3.2"
 			}
@@ -7427,6 +7668,7 @@
 			"version": "5.3.5",
 			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
 			"integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+			"dev": true,
 			"requires": {
 				"extend": "^3.0.0",
 				"glob": "^5.0.3",
@@ -7442,6 +7684,7 @@
 					"version": "5.0.15",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"dev": true,
 					"requires": {
 						"inflight": "^1.0.4",
 						"inherits": "2",
@@ -7454,6 +7697,7 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+					"dev": true,
 					"requires": {
 						"is-glob": "^3.1.0",
 						"path-dirname": "^1.0.0"
@@ -7462,12 +7706,14 @@
 				"is-extglob": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.0"
 					}
@@ -7475,12 +7721,14 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
 				},
 				"readable-stream": {
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -7491,12 +7739,14 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
 				},
 				"through2": {
 					"version": "0.6.5",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
 					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+					"dev": true,
 					"requires": {
 						"readable-stream": ">=1.0.33-1 <1.1.0-0",
 						"xtend": ">=4.0.0 <4.1.0-0"
@@ -7615,7 +7865,8 @@
 		"growl": {
 			"version": "1.10.5",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true
 		},
 		"growly": {
 			"version": "1.3.0",
@@ -7626,6 +7877,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
 			"integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+			"dev": true,
 			"requires": {
 				"convert-source-map": "^1.1.1",
 				"graceful-fs": "^4.1.2",
@@ -7637,22 +7889,26 @@
 				"clone": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+					"dev": true
 				},
 				"clone-stats": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-					"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+					"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+					"dev": true
 				},
 				"replace-ext": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+					"dev": true
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -7661,6 +7917,7 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
 					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"dev": true,
 					"requires": {
 						"clone": "^1.0.0",
 						"clone-stats": "^0.0.1",
@@ -7753,7 +8010,8 @@
 		"has-color": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+			"dev": true
 		},
 		"has-cors": {
 			"version": "1.1.0",
@@ -7832,7 +8090,8 @@
 		"has-yarn": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
-			"integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac="
+			"integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
+			"dev": true
 		},
 		"hash-base": {
 			"version": "3.0.4",
@@ -7871,7 +8130,8 @@
 		"highlight.js": {
 			"version": "9.13.1",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
-			"integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A=="
+			"integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
+			"dev": true
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -8339,6 +8599,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.1.1.tgz",
 			"integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
+			"dev": true,
 			"requires": {
 				"dot-prop": "^4.1.0",
 				"es6-error": "^4.0.2",
@@ -8372,12 +8633,14 @@
 		"icss-replace-symbols": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
-			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
+			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+			"dev": true
 		},
 		"icss-utils": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
 			"integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+			"dev": true,
 			"requires": {
 				"postcss": "^6.0.1"
 			}
@@ -8400,7 +8663,8 @@
 		"ignore-by-default": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk="
+			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
+			"dev": true
 		},
 		"image-size": {
 			"version": "0.5.5",
@@ -8422,6 +8686,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
 			"integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
+			"dev": true,
 			"requires": {
 				"pkg-dir": "^2.0.0",
 				"resolve-cwd": "^2.0.0"
@@ -8448,7 +8713,8 @@
 		"indent-string": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+			"dev": true
 		},
 		"indexof": {
 			"version": "0.0.1",
@@ -8483,6 +8749,7 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.0",
@@ -8560,7 +8827,8 @@
 		"irregular-plurals": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
-			"integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
+			"integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
+			"dev": true
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
@@ -8660,7 +8928,8 @@
 		"is-error": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz",
-			"integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw="
+			"integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw=",
+			"dev": true
 		},
 		"is-extendable": {
 			"version": "0.1.1",
@@ -8761,6 +9030,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
 			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+			"dev": true,
 			"requires": {
 				"symbol-observable": "^1.1.0"
 			}
@@ -8789,7 +9059,8 @@
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+			"dev": true
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -8819,7 +9090,8 @@
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
 		},
 		"is-property": {
 			"version": "1.0.2",
@@ -8871,6 +9143,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
 			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+			"dev": true,
 			"requires": {
 				"text-extensions": "^1.0.0"
 			}
@@ -8883,7 +9156,8 @@
 		"is-url": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+			"dev": true
 		},
 		"is-utf8": {
 			"version": "0.2.1",
@@ -8893,7 +9167,8 @@
 		"is-valid-glob": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
+			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+			"dev": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
@@ -9193,7 +9468,7 @@
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"requires": {
 						"cliui": "^4.0.0",
@@ -9459,7 +9734,7 @@
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"requires": {
 						"cliui": "^4.0.0",
@@ -9567,7 +9842,8 @@
 		"js-string-escape": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
+			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
+			"dev": true
 		},
 		"js-tokens": {
 			"version": "3.0.2",
@@ -9644,7 +9920,8 @@
 		"jsesc": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+			"dev": true
 		},
 		"json-loader": {
 			"version": "0.5.7",
@@ -9699,7 +9976,8 @@
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
@@ -9727,7 +10005,8 @@
 		"jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+			"dev": true
 		},
 		"jsonpointer": {
 			"version": "4.0.1",
@@ -9833,7 +10112,7 @@
 				},
 				"es6-promise": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+					"resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
 					"integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
 				},
 				"process-nextick-args": {
@@ -9843,7 +10122,7 @@
 				},
 				"readable-stream": {
 					"version": "2.0.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
 					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -10423,6 +10702,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/last-line-stream/-/last-line-stream-1.0.0.tgz",
 			"integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
+			"dev": true,
 			"requires": {
 				"through2": "^2.0.0"
 			}
@@ -10444,6 +10724,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
 			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+			"dev": true,
 			"requires": {
 				"readable-stream": "^2.0.5"
 			}
@@ -10459,12 +10740,14 @@
 		"lcov-parse": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
+			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+			"dev": true
 		},
 		"lcov-result-merger": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/lcov-result-merger/-/lcov-result-merger-2.0.0.tgz",
 			"integrity": "sha512-CMjYOcPtl0G3SLrPWYDtZ4zyhsy/2heUf6RKwvyDcJRfyUBQbqLhAlS2PBhTKVCxGp7Ri8AYJ5SGNVEtbEo0fA==",
+			"dev": true,
 			"requires": {
 				"through2": "^2.0.1",
 				"vinyl": "^2.0.0",
@@ -10480,6 +10763,7 @@
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/lerna/-/lerna-2.11.0.tgz",
 			"integrity": "sha512-kgM6zwe2P2tR30MYvgiLLW+9buFCm6E7o8HnRlhTgm70WVBvXVhydqv+q/MF2HrVZkCawfVtCfetyQmtd4oHhQ==",
+			"dev": true,
 			"requires": {
 				"async": "^1.5.0",
 				"chalk": "^2.1.0",
@@ -10526,6 +10810,7 @@
 					"version": "0.8.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
 					"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -10540,6 +10825,7 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+					"dev": true,
 					"requires": {
 						"is-glob": "^3.1.0",
 						"path-dirname": "^1.0.0"
@@ -10548,12 +10834,14 @@
 				"is-extglob": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.0"
 					}
@@ -10562,6 +10850,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -10573,6 +10862,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -10582,6 +10872,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -10589,12 +10880,14 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				},
 				"read-pkg": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -10722,7 +11015,8 @@
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+			"dev": true
 		},
 		"lodash.assign": {
 			"version": "4.2.0",
@@ -10737,7 +11031,8 @@
 		"lodash.clonedeepwith": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
-			"integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ="
+			"integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ=",
+			"dev": true
 		},
 		"lodash.debounce": {
 			"version": "4.0.8",
@@ -10747,7 +11042,8 @@
 		"lodash.difference": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+			"dev": true
 		},
 		"lodash.escape": {
 			"version": "4.0.1",
@@ -10757,7 +11053,8 @@
 		"lodash.flatten": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+			"dev": true
 		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
@@ -10777,7 +11074,8 @@
 		"lodash.merge": {
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+			"dev": true
 		},
 		"lodash.mergewith": {
 			"version": "4.6.1",
@@ -10793,6 +11091,7 @@
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
 			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "~3.0.0",
 				"lodash.templatesettings": "^4.0.0"
@@ -10802,6 +11101,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
 			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "~3.0.0"
 			}
@@ -10809,7 +11109,8 @@
 		"log-driver": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
+			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+			"dev": true
 		},
 		"log-symbols": {
 			"version": "2.2.0",
@@ -10956,12 +11257,14 @@
 		"marked": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
-			"integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
+			"integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
+			"dev": true
 		},
 		"matcher": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.1.tgz",
 			"integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.4"
 			}
@@ -10988,6 +11291,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
 			"integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
+			"dev": true,
 			"requires": {
 				"md5-o-matic": "^0.1.1"
 			}
@@ -10995,7 +11299,8 @@
 		"md5-o-matic": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
+			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+			"dev": true
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -11234,6 +11539,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
 			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
 				"is-plain-obj": "^1.1.0"
@@ -11243,6 +11549,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
 			"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+			"dev": true,
 			"requires": {
 				"concat-stream": "^1.5.0",
 				"duplexify": "^3.4.2",
@@ -11286,7 +11593,8 @@
 		"modify-values": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw=="
+			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+			"dev": true
 		},
 		"moment": {
 			"version": "2.23.0",
@@ -11334,6 +11642,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+			"dev": true,
 			"requires": {
 				"array-differ": "^1.0.0",
 				"array-union": "^1.0.1",
@@ -11344,7 +11653,8 @@
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
 		},
 		"nan": {
 			"version": "2.12.1",
@@ -11977,6 +12287,7 @@
 			"version": "11.9.0",
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
 			"integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
+			"dev": true,
 			"requires": {
 				"archy": "^1.0.0",
 				"arrify": "^1.0.1",
@@ -12010,6 +12321,7 @@
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2",
 						"longest": "^1.0.1",
@@ -12018,62 +12330,76 @@
 				},
 				"amdefine": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"append-transform": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"default-require-extensions": "^1.0.0"
 					}
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arr-diff": {
 					"version": "4.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arr-flatten": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arr-union": {
 					"version": "3.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"array-unique": {
 					"version": "0.3.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arrify": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"assign-symbols": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"async": {
 					"version": "1.5.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"atob": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"babel-code-frame": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"chalk": "^1.1.3",
 						"esutils": "^2.0.2",
@@ -12083,6 +12409,7 @@
 				"babel-generator": {
 					"version": "6.26.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-messages": "^6.23.0",
 						"babel-runtime": "^6.26.0",
@@ -12097,6 +12424,7 @@
 				"babel-messages": {
 					"version": "6.23.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "^6.22.0"
 					}
@@ -12104,6 +12432,7 @@
 				"babel-runtime": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"core-js": "^2.4.0",
 						"regenerator-runtime": "^0.11.0"
@@ -12112,6 +12441,7 @@
 				"babel-template": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "^6.26.0",
 						"babel-traverse": "^6.26.0",
@@ -12123,6 +12453,7 @@
 				"babel-traverse": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-code-frame": "^6.26.0",
 						"babel-messages": "^6.23.0",
@@ -12138,6 +12469,7 @@
 				"babel-types": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "^6.26.0",
 						"esutils": "^2.0.2",
@@ -12147,15 +12479,18 @@
 				},
 				"babylon": {
 					"version": "6.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"base": {
 					"version": "0.11.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cache-base": "^1.0.1",
 						"class-utils": "^0.3.5",
@@ -12169,6 +12504,7 @@
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -12176,6 +12512,7 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -12183,6 +12520,7 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -12190,6 +12528,7 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -12198,17 +12537,20 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -12217,6 +12559,7 @@
 				"braces": {
 					"version": "2.3.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
 						"array-unique": "^0.3.2",
@@ -12233,6 +12576,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -12241,11 +12585,13 @@
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cache-base": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"collection-visit": "^1.0.0",
 						"component-emitter": "^1.2.1",
@@ -12260,13 +12606,15 @@
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"caching-transform": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-hex": "^1.2.0",
 						"mkdirp": "^0.5.1",
@@ -12276,11 +12624,13 @@
 				"camelcase": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"center-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "^0.1.3",
@@ -12290,6 +12640,7 @@
 				"chalk": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -12301,6 +12652,7 @@
 				"class-utils": {
 					"version": "0.3.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-union": "^3.1.0",
 						"define-property": "^0.2.5",
@@ -12311,19 +12663,22 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"cliui": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"center-align": "^0.1.1",
@@ -12334,17 +12689,20 @@
 						"wordwrap": {
 							"version": "0.0.2",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"collection-visit": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"map-visit": "^1.0.0",
 						"object-visit": "^1.0.0"
@@ -12352,31 +12710,38 @@
 				},
 				"commondir": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"component-emitter": {
 					"version": "1.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"convert-source-map": {
 					"version": "1.5.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"copy-descriptor": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-js": {
 					"version": "2.5.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
 						"which": "^1.2.9"
@@ -12385,25 +12750,30 @@
 				"debug": {
 					"version": "2.6.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
 				"debug-log": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"decode-uri-component": {
 					"version": "0.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"default-require-extensions": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"strip-bom": "^2.0.0"
 					}
@@ -12411,6 +12781,7 @@
 				"define-property": {
 					"version": "2.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.2",
 						"isobject": "^3.0.1"
@@ -12419,6 +12790,7 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -12426,6 +12798,7 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -12433,6 +12806,7 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -12441,17 +12815,20 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"detect-indent": {
 					"version": "4.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"repeating": "^2.0.0"
 					}
@@ -12459,21 +12836,25 @@
 				"error-ex": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-arrayish": "^0.2.1"
 					}
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"esutils": {
 					"version": "2.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -12487,6 +12868,7 @@
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"lru-cache": "^4.0.1",
 								"shebang-command": "^1.2.0",
@@ -12498,6 +12880,7 @@
 				"expand-brackets": {
 					"version": "2.1.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"debug": "^2.3.3",
 						"define-property": "^0.2.5",
@@ -12511,6 +12894,7 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -12518,6 +12902,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -12527,6 +12912,7 @@
 				"extend-shallow": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"assign-symbols": "^1.0.0",
 						"is-extendable": "^1.0.1"
@@ -12535,6 +12921,7 @@
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-plain-object": "^2.0.4"
 							}
@@ -12544,6 +12931,7 @@
 				"extglob": {
 					"version": "2.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"array-unique": "^0.3.2",
 						"define-property": "^1.0.0",
@@ -12558,6 +12946,7 @@
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -12565,6 +12954,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -12572,6 +12962,7 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -12579,6 +12970,7 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -12586,6 +12978,7 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -12594,13 +12987,15 @@
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"fill-range": {
 					"version": "4.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-number": "^3.0.0",
@@ -12611,6 +13006,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -12620,6 +13016,7 @@
 				"find-cache-dir": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"commondir": "^1.0.1",
 						"mkdirp": "^0.5.1",
@@ -12629,17 +13026,20 @@
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
 				},
 				"for-in": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"foreground-child": {
 					"version": "1.5.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "^4",
 						"signal-exit": "^3.0.0"
@@ -12648,29 +13048,35 @@
 				"fragment-cache": {
 					"version": "0.2.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"map-cache": "^0.2.2"
 					}
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-value": {
 					"version": "2.0.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -12682,15 +13088,18 @@
 				},
 				"globals": {
 					"version": "9.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"handlebars": {
 					"version": "4.0.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"async": "^1.4.0",
 						"optimist": "^0.6.1",
@@ -12701,6 +13110,7 @@
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"amdefine": ">=0.0.4"
 							}
@@ -12710,17 +13120,20 @@
 				"has-ansi": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"has-value": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"get-value": "^2.0.6",
 						"has-values": "^1.0.0",
@@ -12729,13 +13142,15 @@
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"has-values": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "^3.0.0",
 						"kind-of": "^4.0.0"
@@ -12744,6 +13159,7 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
@@ -12751,6 +13167,7 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -12760,6 +13177,7 @@
 						"kind-of": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -12768,15 +13186,18 @@
 				},
 				"hosted-git-info": {
 					"version": "2.6.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "^1.3.0",
 						"wrappy": "1"
@@ -12784,37 +13205,44 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"invariant": {
 					"version": "2.2.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"loose-envify": "^1.0.0"
 					}
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-accessor-descriptor": {
 					"version": "0.1.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-buffer": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"builtin-modules": "^1.0.0"
 					}
@@ -12822,6 +13250,7 @@
 				"is-data-descriptor": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -12829,6 +13258,7 @@
 				"is-descriptor": {
 					"version": "0.1.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^0.1.6",
 						"is-data-descriptor": "^0.1.4",
@@ -12837,28 +13267,33 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "5.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"is-extendable": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-finite": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-number": {
 					"version": "3.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -12866,60 +13301,72 @@
 				"is-odd": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
 							"version": "4.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"is-plain-object": {
 					"version": "2.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-utf8": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-windows": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"istanbul-lib-coverage": {
 					"version": "1.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"istanbul-lib-hook": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"append-transform": "^0.4.0"
 					}
@@ -12927,6 +13374,7 @@
 				"istanbul-lib-instrument": {
 					"version": "1.10.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-generator": "^6.18.0",
 						"babel-template": "^6.16.0",
@@ -12940,6 +13388,7 @@
 				"istanbul-lib-report": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"istanbul-lib-coverage": "^1.1.2",
 						"mkdirp": "^0.5.1",
@@ -12950,6 +13399,7 @@
 						"supports-color": {
 							"version": "3.2.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"has-flag": "^1.0.0"
 							}
@@ -12959,6 +13409,7 @@
 				"istanbul-lib-source-maps": {
 					"version": "1.2.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"debug": "^3.1.0",
 						"istanbul-lib-coverage": "^1.1.2",
@@ -12970,6 +13421,7 @@
 						"debug": {
 							"version": "3.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ms": "2.0.0"
 							}
@@ -12979,21 +13431,25 @@
 				"istanbul-reports": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"handlebars": "^4.0.3"
 					}
 				},
 				"js-tokens": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"jsesc": {
 					"version": "1.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -13001,11 +13457,13 @@
 				"lazy-cache": {
 					"version": "1.0.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"lcid": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"invert-kv": "^1.0.0"
 					}
@@ -13013,6 +13471,7 @@
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -13024,6 +13483,7 @@
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
@@ -13031,21 +13491,25 @@
 					"dependencies": {
 						"path-exists": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"lodash": {
 					"version": "4.17.10",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"longest": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"loose-envify": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"js-tokens": "^3.0.0"
 					}
@@ -13053,6 +13517,7 @@
 				"lru-cache": {
 					"version": "4.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pseudomap": "^1.0.2",
 						"yallist": "^2.1.2"
@@ -13060,11 +13525,13 @@
 				},
 				"map-cache": {
 					"version": "0.2.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"map-visit": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"object-visit": "^1.0.0"
 					}
@@ -13072,17 +13539,20 @@
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"md5-o-matic": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mem": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
 					}
@@ -13090,19 +13560,22 @@
 				"merge-source-map": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
 							"version": "0.6.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"micromatch": {
 					"version": "3.1.10",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -13121,28 +13594,33 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"mimic-fn": {
 					"version": "1.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mixin-deep": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"for-in": "^1.0.2",
 						"is-extendable": "^1.0.1"
@@ -13151,6 +13629,7 @@
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-plain-object": "^2.0.4"
 							}
@@ -13160,17 +13639,20 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"nanomatch": {
 					"version": "1.2.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -13188,21 +13670,25 @@
 					"dependencies": {
 						"arr-diff": {
 							"version": "4.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"array-unique": {
 							"version": "0.3.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.1.4",
 						"is-builtin-module": "^1.0.0",
@@ -13213,21 +13699,25 @@
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object-copy": {
 					"version": "0.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"copy-descriptor": "^0.1.0",
 						"define-property": "^0.2.5",
@@ -13237,6 +13727,7 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -13246,32 +13737,37 @@
 				"object-visit": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"object.pick": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -13279,6 +13775,7 @@
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "~0.0.1",
 						"wordwrap": "~0.0.2"
@@ -13286,11 +13783,13 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
 						"lcid": "^1.0.0",
@@ -13299,11 +13798,13 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"p-limit": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-try": "^1.0.0"
 					}
@@ -13311,47 +13812,56 @@
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"parse-json": {
 					"version": "2.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
 				},
 				"pascalcase": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-exists": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-parse": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"pify": "^2.0.0",
@@ -13360,15 +13870,18 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie": {
 					"version": "2.0.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie": "^2.0.0"
 					}
@@ -13376,6 +13889,7 @@
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "^1.0.0"
 					},
@@ -13383,6 +13897,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "^2.0.0",
 								"pinkie-promise": "^2.0.0"
@@ -13392,15 +13907,18 @@
 				},
 				"posix-character-classes": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"load-json-file": "^1.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -13410,6 +13928,7 @@
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "^1.0.0",
 						"read-pkg": "^1.0.0"
@@ -13418,6 +13937,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "^2.0.0",
 								"pinkie-promise": "^2.0.0"
@@ -13427,11 +13947,13 @@
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"regex-not": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"extend-shallow": "^3.0.2",
 						"safe-regex": "^1.1.0"
@@ -13439,42 +13961,51 @@
 				},
 				"repeat-element": {
 					"version": "1.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeat-string": {
 					"version": "1.6.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeating": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-finite": "^1.0.0"
 					}
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"resolve-from": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"resolve-url": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ret": {
 					"version": "0.1.15",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"right-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "^0.1.1"
@@ -13483,6 +14014,7 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "^7.0.5"
 					}
@@ -13490,21 +14022,25 @@
 				"safe-regex": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ret": "~0.1.10"
 					}
 				},
 				"semver": {
 					"version": "5.5.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"set-value": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-extendable": "^0.1.1",
@@ -13515,6 +14051,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -13524,25 +14061,30 @@
 				"shebang-command": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"snapdragon": {
 					"version": "0.8.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"base": "^0.11.1",
 						"debug": "^2.2.0",
@@ -13557,6 +14099,7 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -13564,6 +14107,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -13573,6 +14117,7 @@
 				"snapdragon-node": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"define-property": "^1.0.0",
 						"isobject": "^3.0.0",
@@ -13582,6 +14127,7 @@
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -13589,6 +14135,7 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -13596,6 +14143,7 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -13603,6 +14151,7 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -13611,28 +14160,33 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"snapdragon-util": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.2.0"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"source-map-resolve": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"atob": "^2.0.0",
 						"decode-uri-component": "^0.2.0",
@@ -13643,11 +14197,13 @@
 				},
 				"source-map-url": {
 					"version": "0.4.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spawn-wrap": {
 					"version": "1.4.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"foreground-child": "^1.5.6",
 						"mkdirp": "^0.5.0",
@@ -13660,6 +14216,7 @@
 				"spdx-correct": {
 					"version": "3.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-expression-parse": "^3.0.0",
 						"spdx-license-ids": "^3.0.0"
@@ -13667,11 +14224,13 @@
 				},
 				"spdx-exceptions": {
 					"version": "2.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spdx-expression-parse": {
 					"version": "3.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-exceptions": "^2.1.0",
 						"spdx-license-ids": "^3.0.0"
@@ -13679,11 +14238,13 @@
 				},
 				"spdx-license-ids": {
 					"version": "3.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"split-string": {
 					"version": "3.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"extend-shallow": "^3.0.0"
 					}
@@ -13691,6 +14252,7 @@
 				"static-extend": {
 					"version": "0.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"define-property": "^0.2.5",
 						"object-copy": "^0.1.0"
@@ -13699,6 +14261,7 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -13708,6 +14271,7 @@
 				"string-width": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -13715,11 +14279,13 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
@@ -13729,6 +14295,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -13736,21 +14303,25 @@
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"supports-color": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"test-exclude": {
 					"version": "4.2.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arrify": "^1.0.1",
 						"micromatch": "^3.1.8",
@@ -13761,15 +14332,18 @@
 					"dependencies": {
 						"arr-diff": {
 							"version": "4.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"array-unique": {
 							"version": "0.3.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"braces": {
 							"version": "2.3.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"arr-flatten": "^1.1.0",
 								"array-unique": "^0.3.2",
@@ -13786,6 +14360,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -13795,6 +14370,7 @@
 						"expand-brackets": {
 							"version": "2.1.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"debug": "^2.3.3",
 								"define-property": "^0.2.5",
@@ -13808,6 +14384,7 @@
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-descriptor": "^0.1.0"
 									}
@@ -13815,6 +14392,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -13822,6 +14400,7 @@
 								"is-accessor-descriptor": {
 									"version": "0.1.6",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^3.0.2"
 									},
@@ -13829,6 +14408,7 @@
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"is-buffer": "^1.1.5"
 											}
@@ -13838,6 +14418,7 @@
 								"is-data-descriptor": {
 									"version": "0.1.4",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^3.0.2"
 									},
@@ -13845,6 +14426,7 @@
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"is-buffer": "^1.1.5"
 											}
@@ -13854,6 +14436,7 @@
 								"is-descriptor": {
 									"version": "0.1.6",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-accessor-descriptor": "^0.1.6",
 										"is-data-descriptor": "^0.1.4",
@@ -13862,13 +14445,15 @@
 								},
 								"kind-of": {
 									"version": "5.1.0",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"extglob": {
 							"version": "2.0.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"array-unique": "^0.3.2",
 								"define-property": "^1.0.0",
@@ -13883,6 +14468,7 @@
 								"define-property": {
 									"version": "1.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-descriptor": "^1.0.0"
 									}
@@ -13890,6 +14476,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -13899,6 +14486,7 @@
 						"fill-range": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"extend-shallow": "^2.0.1",
 								"is-number": "^3.0.0",
@@ -13909,6 +14497,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -13918,6 +14507,7 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -13925,6 +14515,7 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -13932,6 +14523,7 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -13941,6 +14533,7 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
@@ -13948,6 +14541,7 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -13956,15 +14550,18 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"micromatch": {
 							"version": "3.1.10",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"arr-diff": "^4.0.0",
 								"array-unique": "^0.3.2",
@@ -13985,11 +14582,13 @@
 				},
 				"to-fast-properties": {
 					"version": "1.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"to-object-path": {
 					"version": "0.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -13997,6 +14596,7 @@
 				"to-regex": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"define-property": "^2.0.2",
 						"extend-shallow": "^3.0.2",
@@ -14007,6 +14607,7 @@
 				"to-regex-range": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "^3.0.0",
 						"repeat-string": "^1.6.1"
@@ -14015,6 +14616,7 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							}
@@ -14023,11 +14625,13 @@
 				},
 				"trim-right": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uglify-js": {
 					"version": "2.8.29",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"source-map": "~0.5.1",
@@ -14038,6 +14642,7 @@
 						"yargs": {
 							"version": "3.10.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"camelcase": "^1.0.2",
@@ -14051,11 +14656,13 @@
 				"uglify-to-browserify": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"union-value": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-union": "^3.1.0",
 						"get-value": "^2.0.6",
@@ -14066,6 +14673,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -14073,6 +14681,7 @@
 						"set-value": {
 							"version": "0.4.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"extend-shallow": "^2.0.1",
 								"is-extendable": "^0.1.1",
@@ -14085,6 +14694,7 @@
 				"unset-value": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"has-value": "^0.3.1",
 						"isobject": "^3.0.0"
@@ -14093,6 +14703,7 @@
 						"has-value": {
 							"version": "0.3.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"get-value": "^2.0.3",
 								"has-values": "^0.1.4",
@@ -14102,6 +14713,7 @@
 								"isobject": {
 									"version": "2.1.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"isarray": "1.0.0"
 									}
@@ -14110,34 +14722,40 @@
 						},
 						"has-values": {
 							"version": "0.1.4",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"urix": {
 					"version": "0.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"use": {
 					"version": "3.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-correct": "^3.0.0",
 						"spdx-expression-parse": "^3.0.0"
@@ -14146,26 +14764,31 @@
 				"which": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"window-size": {
 					"version": "0.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1"
@@ -14174,6 +14797,7 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -14181,6 +14805,7 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -14191,11 +14816,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
 						"imurmurhash": "^0.1.4",
@@ -14204,15 +14831,18 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yargs": {
 					"version": "11.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.1.1",
@@ -14230,15 +14860,18 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"cliui": {
 							"version": "4.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"string-width": "^2.1.1",
 								"strip-ansi": "^4.0.0",
@@ -14248,6 +14881,7 @@
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
@@ -14255,6 +14889,7 @@
 						"yargs-parser": {
 							"version": "9.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"camelcase": "^4.1.0"
 							}
@@ -14264,13 +14899,15 @@
 				"yargs-parser": {
 					"version": "8.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				}
@@ -14411,6 +15048,7 @@
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-0.5.0.tgz",
 			"integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
+			"dev": true,
 			"requires": {
 				"is-observable": "^0.2.0",
 				"symbol-observable": "^1.0.4"
@@ -14420,6 +15058,7 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
 					"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+					"dev": true,
 					"requires": {
 						"symbol-observable": "^0.2.2"
 					},
@@ -14427,7 +15066,8 @@
 						"symbol-observable": {
 							"version": "0.2.4",
 							"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
-							"integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A="
+							"integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+							"dev": true
 						}
 					}
 				}
@@ -14463,6 +15103,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
@@ -14487,7 +15128,8 @@
 		"option-chain": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/option-chain/-/option-chain-1.0.0.tgz",
-			"integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI="
+			"integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI=",
+			"dev": true
 		},
 		"optionator": {
 			"version": "0.8.2",
@@ -14513,6 +15155,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 			"integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+			"dev": true,
 			"requires": {
 				"is-stream": "^1.0.1",
 				"readable-stream": "^2.0.1"
@@ -14614,6 +15257,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
 			"integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"lodash.flattendeep": "^4.4.0",
@@ -14670,7 +15314,8 @@
 		"parse-github-repo-url": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A="
+			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
+			"dev": true
 		},
 		"parse-glob": {
 			"version": "3.0.4",
@@ -14694,7 +15339,8 @@
 		"parse-ms": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
-			"integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4="
+			"integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
+			"dev": true
 		},
 		"parse-passwd": {
 			"version": "1.0.0",
@@ -14817,12 +15463,14 @@
 		"pinkie": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-			"integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q="
+			"integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
 			"integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+			"dev": true,
 			"requires": {
 				"pinkie": "^1.0.0"
 			}
@@ -14831,6 +15479,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
 			"integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
 				"load-json-file": "^4.0.0"
@@ -14840,6 +15489,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -14851,6 +15501,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -14859,7 +15510,8 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				}
 			}
 		},
@@ -14875,6 +15527,7 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
 			"integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+			"dev": true,
 			"requires": {
 				"irregular-plurals": "^1.0.0"
 			}
@@ -14949,6 +15602,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
 			"integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
+			"dev": true,
 			"requires": {
 				"postcss": "^6.0.1"
 			}
@@ -14957,6 +15611,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
 			"integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+			"dev": true,
 			"requires": {
 				"css-selector-tokenizer": "^0.7.0",
 				"postcss": "^6.0.1"
@@ -14966,6 +15621,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
 			"integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+			"dev": true,
 			"requires": {
 				"css-selector-tokenizer": "^0.7.0",
 				"postcss": "^6.0.1"
@@ -14975,6 +15631,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
 			"integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+			"dev": true,
 			"requires": {
 				"icss-replace-symbols": "^1.1.0",
 				"postcss": "^6.0.1"
@@ -15015,7 +15672,8 @@
 		"prettier": {
 			"version": "1.15.3",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
-			"integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg=="
+			"integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
+			"dev": true
 		},
 		"pretty-format": {
 			"version": "23.6.0",
@@ -15037,6 +15695,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.2.0.tgz",
 			"integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
+			"dev": true,
 			"requires": {
 				"parse-ms": "^1.0.0"
 			},
@@ -15044,7 +15703,8 @@
 				"parse-ms": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-					"integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0="
+					"integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
+					"dev": true
 				}
 			}
 		},
@@ -15066,7 +15726,8 @@
 		"progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"dev": true
 		},
 		"promise": {
 			"version": "7.3.1",
@@ -15128,7 +15789,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "^2.2.1",
@@ -15155,7 +15816,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"q": {
@@ -15284,7 +15945,8 @@
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+			"dev": true
 		},
 		"qjobs": {
 			"version": "1.2.0",
@@ -15314,7 +15976,8 @@
 		"quick-lru": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
+			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+			"dev": true
 		},
 		"raf": {
 			"version": "3.4.1",
@@ -15543,6 +16206,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
 			"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2"
 			}
@@ -15883,6 +16547,7 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dev": true,
 			"requires": {
 				"resolve": "^1.1.6"
 			}
@@ -15953,7 +16618,8 @@
 		"regenerate": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
+			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+			"dev": true
 		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
@@ -15981,6 +16647,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"dev": true,
 			"requires": {
 				"regenerate": "^1.2.1",
 				"regjsgen": "^0.2.0",
@@ -16007,12 +16674,14 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"dev": true
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
 			}
@@ -16026,6 +16695,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
 			"integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+			"dev": true,
 			"requires": {
 				"es6-error": "^4.0.1"
 			}
@@ -16056,7 +16726,8 @@
 		"replace-ext": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+			"dev": true
 		},
 		"request": {
 			"version": "2.88.0",
@@ -16116,7 +16787,8 @@
 		"require-precompiled": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
-			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo="
+			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo=",
+			"dev": true
 		},
 		"requires-port": {
 			"version": "1.0.0",
@@ -16162,6 +16834,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
 			"requires": {
 				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
@@ -16266,6 +16939,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
 			"requires": {
 				"is-promise": "^2.1.0"
 			}
@@ -16281,12 +16955,14 @@
 		"rx-lite": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+			"dev": true
 		},
 		"rx-lite-aggregates": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"dev": true,
 			"requires": {
 				"rx-lite": "*"
 			}
@@ -16812,6 +17488,7 @@
 			"version": "0.4.7",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
 			"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+			"dev": true,
 			"requires": {
 				"ajv": "^6.1.0",
 				"ajv-keywords": "^3.1.0"
@@ -16921,7 +17598,8 @@
 		"serialize-error": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-			"integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
+			"integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
+			"dev": true
 		},
 		"serialize-javascript": {
 			"version": "1.6.1",
@@ -17040,6 +17718,7 @@
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
 			"integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.0.0",
 				"interpret": "^1.0.0",
@@ -17070,6 +17749,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0"
 			}
@@ -17077,7 +17757,8 @@
 		"slide": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+			"dev": true
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -17332,6 +18013,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+			"dev": true,
 			"requires": {
 				"is-plain-obj": "^1.0.0"
 			}
@@ -17350,6 +18032,7 @@
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
 			"integrity": "sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==",
+			"dev": true,
 			"requires": {
 				"async": "^2.5.0",
 				"loader-utils": "^1.1.0"
@@ -17359,6 +18042,7 @@
 					"version": "2.6.1",
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
 					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"dev": true,
 					"requires": {
 						"lodash": "^4.17.10"
 					}
@@ -17490,6 +18174,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
 			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"dev": true,
 			"requires": {
 				"through": "2"
 			}
@@ -17506,6 +18191,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
 			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+			"dev": true,
 			"requires": {
 				"through2": "^2.0.2"
 			}
@@ -17535,6 +18221,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
 			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+			"dev": true,
 			"requires": {
 				"figgy-pudding": "^3.5.1"
 			}
@@ -17697,6 +18384,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
 			"integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+			"dev": true,
 			"requires": {
 				"is-utf8": "^0.2.1"
 			}
@@ -17705,6 +18393,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 			"integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+			"dev": true,
 			"requires": {
 				"first-chunk-stream": "^1.0.0",
 				"strip-bom": "^2.0.0"
@@ -17714,6 +18403,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -17742,6 +18432,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz",
 			"integrity": "sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=",
+			"dev": true,
 			"requires": {
 				"byline": "^5.0.0",
 				"duplexer": "^0.1.1",
@@ -17753,7 +18444,8 @@
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
+					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
+					"dev": true
 				}
 			}
 		},
@@ -17761,6 +18453,7 @@
 			"version": "0.21.0",
 			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.21.0.tgz",
 			"integrity": "sha512-T+UNsAcl3Yg+BsPKs1vd22Fr8sVT+CJMtzqc6LEw9bbJZb43lm9GoeIfUcDEefBSWC0BhYbcdupV1GtI4DGzxg==",
+			"dev": true,
 			"requires": {
 				"loader-utils": "^1.1.0",
 				"schema-utils": "^0.4.5"
@@ -17828,6 +18521,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supertap/-/supertap-1.0.0.tgz",
 			"integrity": "sha512-HZJ3geIMPgVwKk2VsmO5YHqnnJYl6bV5A9JW2uzqV43WmpgliNEYbuvukfor7URpaqpxuw3CfZ3ONdVbZjCgIA==",
+			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
 				"indent-string": "^3.2.0",
@@ -17903,12 +18597,14 @@
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
+			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+			"dev": true
 		},
 		"temp-write": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/temp-write/-/temp-write-3.4.0.tgz",
 			"integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"is-stream": "^1.1.0",
@@ -17921,7 +18617,8 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				}
 			}
 		},
@@ -17929,6 +18626,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
 			"integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
+			"dev": true,
 			"requires": {
 				"os-tmpdir": "^1.0.0",
 				"uuid": "^2.0.1"
@@ -17937,7 +18635,8 @@
 				"uuid": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+					"dev": true
 				}
 			}
 		},
@@ -17953,6 +18652,7 @@
 			"version": "3.14.1",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-3.14.1.tgz",
 			"integrity": "sha512-NSo3E99QDbYSMeJaEk9YW2lTg3qS9V0aKGlb+PlOrei1X02r1wSBHCNX/O+yeTRFSWPKPIGj6MqvvdqV4rnVGw==",
+			"dev": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1",
@@ -17962,7 +18662,8 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -17970,6 +18671,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.1.tgz",
 			"integrity": "sha512-GGSt+gbT0oKcMDmPx4SRSfJPE1XaN3kQRWG4ghxKQw9cn5G9x6aCKSsgYdvyM0na9NJ4Drv0RG6jbBByZ5CMjw==",
+			"dev": true,
 			"requires": {
 				"cacache": "^11.0.2",
 				"find-cache-dir": "^2.0.0",
@@ -17985,6 +18687,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
 					"integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
+					"dev": true,
 					"requires": {
 						"commondir": "^1.0.1",
 						"make-dir": "^1.0.0",
@@ -17995,6 +18698,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
 					"requires": {
 						"locate-path": "^3.0.0"
 					}
@@ -18003,6 +18707,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
 					"requires": {
 						"p-locate": "^3.0.0",
 						"path-exists": "^3.0.0"
@@ -18012,6 +18717,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
 					"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
 					}
@@ -18020,6 +18726,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
 					"requires": {
 						"p-limit": "^2.0.0"
 					}
@@ -18027,12 +18734,14 @@
 				"p-try": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+					"dev": true
 				},
 				"pkg-dir": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
 					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+					"dev": true,
 					"requires": {
 						"find-up": "^3.0.0"
 					}
@@ -18041,6 +18750,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
 					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"dev": true,
 					"requires": {
 						"ajv": "^6.1.0",
 						"ajv-errors": "^1.0.0",
@@ -18050,7 +18760,8 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -18150,12 +18861,14 @@
 		"text-extensions": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
-			"integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ=="
+			"integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+			"dev": true
 		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
 		},
 		"throat": {
 			"version": "4.1.0",
@@ -18180,6 +18893,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
 			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+			"dev": true,
 			"requires": {
 				"through2": "~2.0.0",
 				"xtend": "~4.0.0"
@@ -18193,7 +18907,8 @@
 		"time-zone": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
-			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0="
+			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
+			"dev": true
 		},
 		"timed-out": {
 			"version": "4.0.1",
@@ -18238,6 +18953,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
 			"integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1"
 			},
@@ -18246,6 +18962,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -18337,7 +19054,8 @@
 		"trim-off-newlines": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
+			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+			"dev": true
 		},
 		"trim-right": {
 			"version": "1.0.1",
@@ -18400,6 +19118,7 @@
 			"version": "5.3.3",
 			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-5.3.3.tgz",
 			"integrity": "sha512-KwF1SplmOJepnoZ4eRIloH/zXL195F51skt7reEsS6jvDqzgc/YSbz9b8E07GxIUwLXdcD4ssrJu6v8CwaTafA==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.3.0",
 				"enhanced-resolve": "^4.0.0",
@@ -18411,17 +19130,20 @@
 				"arr-diff": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
 				},
 				"array-unique": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
 				},
 				"braces": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
 						"array-unique": "^0.3.2",
@@ -18439,6 +19161,7 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -18449,6 +19172,7 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -18457,6 +19181,7 @@
 					"version": "2.1.4",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"dev": true,
 					"requires": {
 						"debug": "^2.3.3",
 						"define-property": "^0.2.5",
@@ -18471,6 +19196,7 @@
 							"version": "0.2.5",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -18479,6 +19205,7 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -18487,6 +19214,7 @@
 							"version": "0.1.6",
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
@@ -18495,6 +19223,7 @@
 									"version": "3.2.2",
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -18505,6 +19234,7 @@
 							"version": "0.1.4",
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
@@ -18513,6 +19243,7 @@
 									"version": "3.2.2",
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -18523,6 +19254,7 @@
 							"version": "0.1.6",
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^0.1.6",
 								"is-data-descriptor": "^0.1.4",
@@ -18532,7 +19264,8 @@
 						"kind-of": {
 							"version": "5.1.0",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
 						}
 					}
 				},
@@ -18540,6 +19273,7 @@
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"dev": true,
 					"requires": {
 						"array-unique": "^0.3.2",
 						"define-property": "^1.0.0",
@@ -18555,6 +19289,7 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -18563,6 +19298,7 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -18573,6 +19309,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-number": "^3.0.0",
@@ -18584,6 +19321,7 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -18594,6 +19332,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -18602,6 +19341,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -18610,6 +19350,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -18620,6 +19361,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -18628,6 +19370,7 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -18637,17 +19380,20 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
 				},
 				"micromatch": {
 					"version": "3.1.10",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -18667,7 +19413,8 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
 				}
 			}
 		},
@@ -18688,7 +19435,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -18761,6 +19508,7 @@
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/tslint-loader/-/tslint-loader-3.5.4.tgz",
 			"integrity": "sha512-jBHNNppXut6SgZ7CsTBh+6oMwVum9n8azbmcYSeMlsABhWWoHwjq631vIFXef3VSd75cCdX3rc6kstsB7rSVVw==",
+			"dev": true,
 			"requires": {
 				"loader-utils": "^1.0.2",
 				"mkdirp": "^0.5.1",
@@ -18773,6 +19521,7 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/tslint-react/-/tslint-react-3.6.0.tgz",
 			"integrity": "sha512-AIv1QcsSnj7e9pFir6cJ6vIncTqxfqeFF3Lzh8SuuBljueYzEAtByuB6zMaD27BL0xhMEqsZ9s5eHuCONydjBw==",
+			"dev": true,
 			"requires": {
 				"tsutils": "^2.13.1"
 			}
@@ -18829,6 +19578,7 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.12.0.tgz",
 			"integrity": "sha512-dsdlaYZ7Je8JC+jQ3j2Iroe4uyD0GhqzADNUVyBRgLuytQDP/g0dPkAw5PdM/4drnmmJjRzSWW97FkKo+ITqQg==",
+			"dev": true,
 			"requires": {
 				"@types/fs-extra": "^5.0.3",
 				"@types/handlebars": "^4.0.38",
@@ -18853,6 +19603,7 @@
 					"version": "7.0.1",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
 					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"jsonfile": "^4.0.0",
@@ -18862,19 +19613,22 @@
 				"typescript": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
-					"integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg=="
+					"integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+					"dev": true
 				}
 			}
 		},
 		"typedoc-default-themes": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
-			"integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic="
+			"integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
+			"dev": true
 		},
 		"typescript": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-			"integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg=="
+			"integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
+			"dev": true
 		},
 		"ua-parser-js": {
 			"version": "0.7.19",
@@ -18959,7 +19713,8 @@
 		"uid2": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
+			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
+			"dev": true
 		},
 		"ultron": {
 			"version": "1.1.1",
@@ -19018,6 +19773,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
 			"integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+			"dev": true,
 			"requires": {
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"through2-filter": "^3.0.0"
@@ -19027,6 +19783,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
 					"integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
+					"dev": true,
 					"requires": {
 						"through2": "~2.0.0",
 						"xtend": "~4.0.0"
@@ -19046,6 +19803,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
 			"integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
+			"dev": true,
 			"requires": {
 				"mkdirp": "^0.5.1",
 				"os-tmpdir": "^1.0.1",
@@ -19240,7 +19998,8 @@
 		"vali-date": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
+			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+			"dev": true
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
@@ -19270,6 +20029,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
 			"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+			"dev": true,
 			"requires": {
 				"clone": "^2.1.1",
 				"clone-buffer": "^1.0.0",
@@ -19283,6 +20043,7 @@
 			"version": "2.4.4",
 			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
 			"integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+			"dev": true,
 			"requires": {
 				"duplexify": "^3.2.0",
 				"glob-stream": "^5.3.2",
@@ -19306,22 +20067,26 @@
 				"clone": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+					"dev": true
 				},
 				"clone-stats": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-					"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+					"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+					"dev": true
 				},
 				"replace-ext": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+					"dev": true
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -19330,6 +20095,7 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
 					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"dev": true,
 					"requires": {
 						"clone": "^1.0.0",
 						"clone-stats": "^0.0.1",
@@ -19742,6 +20508,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
 			}
@@ -19764,6 +20531,7 @@
 			"version": "4.28.4",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.28.4.tgz",
 			"integrity": "sha512-NxjD61WsK/a3JIdwWjtIpimmvE6UrRi3yG54/74Hk9rwNj5FPkA4DJCf1z4ByDWLkvZhTZE+P3C/eh6UD5lDcw==",
+			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.7.11",
 				"@webassemblyjs/helper-module-context": "1.7.11",
@@ -19794,17 +20562,20 @@
 				"arr-diff": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
 				},
 				"array-unique": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
 				},
 				"braces": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
 						"array-unique": "^0.3.2",
@@ -19822,6 +20593,7 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -19832,6 +20604,7 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -19840,6 +20613,7 @@
 					"version": "2.1.4",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"dev": true,
 					"requires": {
 						"debug": "^2.3.3",
 						"define-property": "^0.2.5",
@@ -19854,6 +20628,7 @@
 							"version": "0.2.5",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -19862,6 +20637,7 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -19870,6 +20646,7 @@
 							"version": "0.1.6",
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
@@ -19878,6 +20655,7 @@
 									"version": "3.2.2",
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -19888,6 +20666,7 @@
 							"version": "0.1.4",
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
@@ -19896,6 +20675,7 @@
 									"version": "3.2.2",
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -19906,6 +20686,7 @@
 							"version": "0.1.6",
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^0.1.6",
 								"is-data-descriptor": "^0.1.4",
@@ -19915,7 +20696,8 @@
 						"kind-of": {
 							"version": "5.1.0",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
 						}
 					}
 				},
@@ -19923,6 +20705,7 @@
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"dev": true,
 					"requires": {
 						"array-unique": "^0.3.2",
 						"define-property": "^1.0.0",
@@ -19938,6 +20721,7 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -19946,6 +20730,7 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -19956,6 +20741,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-number": "^3.0.0",
@@ -19967,6 +20753,7 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -19977,6 +20764,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -19985,6 +20773,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -19993,6 +20782,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -20003,6 +20793,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -20011,6 +20802,7 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -20020,17 +20812,20 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
 				},
 				"micromatch": {
 					"version": "3.1.10",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -20050,7 +20845,8 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
 				}
 			}
 		},
@@ -20886,6 +21682,7 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.1.tgz",
 			"integrity": "sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==",
+			"dev": true,
 			"requires": {
 				"lodash": "^4.17.5"
 			}
@@ -20923,7 +21720,8 @@
 		"well-known-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-1.0.0.tgz",
-			"integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg="
+			"integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg=",
+			"dev": true
 		},
 		"whatwg-encoding": {
 			"version": "1.0.5",
@@ -21004,6 +21802,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
 			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+			"dev": true,
 			"requires": {
 				"errno": "~0.1.7"
 			}
@@ -21064,6 +21863,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
 			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
+			"dev": true,
 			"requires": {
 				"detect-indent": "^5.0.0",
 				"graceful-fs": "^4.1.2",
@@ -21076,12 +21876,14 @@
 				"detect-indent": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
+					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+					"dev": true
 				},
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				}
 			}
 		},
@@ -21089,6 +21891,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.2.0.tgz",
 			"integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
+			"dev": true,
 			"requires": {
 				"sort-keys": "^2.0.0",
 				"write-json-file": "^2.2.0"

--- a/packages/core/src/testers/index.ts
+++ b/packages/core/src/testers/index.ts
@@ -497,7 +497,7 @@ export const isCategorization = (
 export const isCategory = (uischema: UISchemaElement): boolean =>
   uischema.type === 'Category';
 
-const hasCategory = (categorization: Categorization): boolean => {
+export const hasCategory = (categorization: Categorization): boolean => {
   if (_.isEmpty(categorization.elements)) {
     return false;
   }

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -30,6 +30,7 @@ import * as nestedArray from './nestedArrays';
 import * as arrayWithDetail from './arrays-with-detail';
 import * as stringArray from './stringArray';
 import * as categorization from './categorization';
+import * as stepper from './stepper';
 import * as day1 from './day1';
 import * as day2 from './day2';
 import * as day3 from './day3';
@@ -64,6 +65,7 @@ export {
   nestedArray,
   arrayWithDetail,
   categorization,
+  stepper,
   day1,
   day2,
   day3,

--- a/packages/examples/src/stepper.ts
+++ b/packages/examples/src/stepper.ts
@@ -1,0 +1,51 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2018 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import { registerExamples } from './register';
+import {
+  data as categorizationData,
+  schema as categorizationSchema,
+  uischema as categorizationUiSchema
+} from './categorization';
+
+export const schema = categorizationSchema;
+
+export const uischema = {
+  ...categorizationUiSchema,
+  options: {
+    variant: 'stepper'
+  }
+};
+
+export const data = categorizationData;
+
+registerExamples([
+  {
+    name: 'categorizationstepper',
+    label: 'Categorization (Stepper)',
+    data,
+    schema,
+    uischema
+  }
+]);

--- a/packages/material/package.json
+++ b/packages/material/package.json
@@ -69,6 +69,8 @@
     "@jsonforms/test": "^2.1.1-alpha.0",
     "ava": "^0.25.0",
     "copy-webpack-plugin": "^4.5.1",
+    "enzyme": "^3.6.0",
+    "enzyme-adapter-react-16": "^1.7.1",
     "jest": "^23.0.0",
     "react-dom": "^16.3.2",
     "react-redux": "^5.0.6",

--- a/packages/material/src/index.ts
+++ b/packages/material/src/index.ts
@@ -84,6 +84,7 @@ import {
   materialTimeFieldTester
 } from './fields';
 import { ComponentType } from 'react';
+import MaterialCategorizationStepperLayout, { materialCategorizationStepperTester } from './layouts/MaterialCategorizationStepperLayout';
 
 export * from './complex';
 export * from './controls';
@@ -117,6 +118,10 @@ export const materialRenderers: { tester: RankedTester; renderer: any }[] = [
   {
     tester: materialCategorizationTester,
     renderer: MaterialCategorizationLayout
+  },
+  {
+    tester: materialCategorizationStepperTester,
+    renderer: MaterialCategorizationStepperLayout
   },
   { tester: materialArrayLayoutTester, renderer: MaterialArrayLayout },
   // additional

--- a/packages/material/src/index.ts
+++ b/packages/material/src/index.ts
@@ -84,7 +84,9 @@ import {
   materialTimeFieldTester
 } from './fields';
 import { ComponentType } from 'react';
-import MaterialCategorizationStepperLayout, { materialCategorizationStepperTester } from './layouts/MaterialCategorizationStepperLayout';
+import MaterialCategorizationStepperLayout, {
+  materialCategorizationStepperTester
+} from './layouts/MaterialCategorizationStepperLayout';
 
 export * from './complex';
 export * from './controls';

--- a/packages/material/src/layouts/MaterialCategorizationLayout.tsx
+++ b/packages/material/src/layouts/MaterialCategorizationLayout.tsx
@@ -40,7 +40,7 @@ import {
 import { RendererComponent } from '@jsonforms/react';
 import { MaterialLayoutRenderer, MaterialLayoutRendererProps } from '../util/layout';
 
-const isSingleLevelCategorization: Tester = and(
+export const isSingleLevelCategorization: Tester = and(
     uiTypeIs('Categorization'),
     (uischema: UISchemaElement): boolean => {
       const categorization = uischema as Categorization;

--- a/packages/material/src/layouts/MaterialCategorizationStepperLayout.tsx
+++ b/packages/material/src/layouts/MaterialCategorizationStepperLayout.tsx
@@ -1,0 +1,106 @@
+/*
+  The MIT License
+
+  Copyright (c) 2018 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Step, StepButton, Stepper, Hidden } from '@material-ui/core';
+import {
+  and,
+  Categorization,
+  categorizationHasCategory,
+  mapStateToLayoutProps,
+  optionIs,
+  RankedTester,
+  rankWith,
+  RendererProps,
+  uiTypeIs
+} from '@jsonforms/core';
+import { RendererComponent } from '@jsonforms/react';
+import { MaterialLayoutRenderer, MaterialLayoutRendererProps } from '../util/layout';
+import { isSingleLevelCategorization } from './MaterialCategorizationLayout';
+
+export const materialCategorizationStepperTester: RankedTester = rankWith(
+  2,
+  and(
+    uiTypeIs('Categorization'),
+    categorizationHasCategory,
+    isSingleLevelCategorization,
+    optionIs('variant', 'stepper')
+  )
+);
+
+export interface CategorizationStepperState {
+  activeCategory: number;
+}
+
+export class MaterialCategorizationStepperLayoutRenderer
+  extends RendererComponent<RendererProps, CategorizationStepperState> {
+
+  state = {
+    activeCategory: 0
+  };
+
+  handleStep = (step: number) => () => {
+    this.setState({
+      activeCategory: step,
+    });
+  };
+
+  render() {
+    const { uischema, schema, path, visible } = this.props;
+    const categorization = uischema as Categorization;
+    const { activeCategory } = this.state;
+
+    const childProps: MaterialLayoutRendererProps = {
+      elements: categorization.elements[activeCategory].elements,
+      schema,
+      path,
+      direction: 'column',
+      visible
+    };
+
+    return (
+      <Hidden xsUp={!visible}>
+        <Stepper activeStep={activeCategory} nonLinear>
+          {categorization.elements.map((e, idx) =>
+            (
+              <Step key={e.label}>
+                <StepButton onClick={this.handleStep(idx)}>
+                  {e.label}
+                </StepButton>
+              </Step>
+            ))
+          }
+        </Stepper>
+        <div>
+          <MaterialLayoutRenderer {...childProps} />
+        </div>
+      </Hidden>
+    );
+  }
+}
+
+export default connect(
+  mapStateToLayoutProps
+)(MaterialCategorizationStepperLayoutRenderer);

--- a/packages/material/src/layouts/MaterialCategorizationStepperLayout.tsx
+++ b/packages/material/src/layouts/MaterialCategorizationStepperLayout.tsx
@@ -38,14 +38,12 @@ import {
 } from '@jsonforms/core';
 import { RendererComponent } from '@jsonforms/react';
 import { MaterialLayoutRenderer, MaterialLayoutRendererProps } from '../util/layout';
-import { isSingleLevelCategorization } from './MaterialCategorizationLayout';
 
 export const materialCategorizationStepperTester: RankedTester = rankWith(
   2,
   and(
     uiTypeIs('Categorization'),
     categorizationHasCategory,
-    isSingleLevelCategorization,
     optionIs('variant', 'stepper')
   )
 );

--- a/packages/material/test/renderers/MaterialCategorizationStepperLayout.test.tsx
+++ b/packages/material/test/renderers/MaterialCategorizationStepperLayout.test.tsx
@@ -1,0 +1,352 @@
+/*
+  The MIT License
+
+  Copyright (c) 2018 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+import * as React from 'react';
+import { Provider } from 'react-redux';
+import {
+  Actions,
+  Categorization,
+  ControlElement,
+  jsonformsReducer,
+  JsonFormsState,
+  Layout
+} from '@jsonforms/core';
+import { mount } from 'enzyme';
+import { configure } from 'enzyme';
+
+import { combineReducers, createStore, Store } from 'redux';
+import MaterialCategorizationStepperLayoutRenderer, {
+  MaterialCategorizationStepperLayoutRenderer as CategorizationStepperRenderer,
+  materialCategorizationStepperTester
+} from '../../src/layouts/MaterialCategorizationStepperLayout';
+import { materialFields, materialRenderers } from '../../src';
+import { Step, StepButton, Stepper } from '@material-ui/core';
+
+import * as Adapter from 'enzyme-adapter-react-16';
+configure({ adapter: new Adapter() });
+
+export const initJsonFormsStore = (initState: any): Store<JsonFormsState> => {
+
+  const store: Store<JsonFormsState> = createStore(
+    combineReducers({ jsonforms: jsonformsReducer() }),
+    {
+      jsonforms: {
+        renderers: materialRenderers,
+        fields: materialFields,
+      }
+    }
+  );
+
+  const { data, schema, uischema } = initState;
+  store.dispatch(Actions.init(data, schema, uischema));
+
+  return store;
+};
+
+const fixture = {
+  data: {},
+  schema: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string'
+      }
+    }
+  },
+  uischema: {
+    type: 'Categorization',
+    elements: [
+      {
+        type: 'Category',
+        label: 'B'
+      },
+    ]
+  }
+};
+
+describe('Material categorization stepper layout tester', () => {
+  it('should not fail when given undefined data', () => {
+    expect(materialCategorizationStepperTester(undefined, undefined)).toBe(-1);
+    expect(materialCategorizationStepperTester(null, undefined)).toBe(-1);
+    expect(materialCategorizationStepperTester({type: 'Foo'}, undefined)).toBe(-1);
+    expect(materialCategorizationStepperTester({type: 'Categorization'}, undefined)).toBe(-1);
+  });
+
+  it('should not fail with null elements and no schema', () => {
+    const uischema: Layout = {
+      type: 'Categorization',
+      elements: null
+    };
+    expect(materialCategorizationStepperTester(uischema, undefined)).toBe(-1);
+  });
+
+  it('should not fail with empty elements and no schema', () => {
+    const uischema: Layout = {
+      type: 'Categorization',
+      elements: []
+    };
+    expect(materialCategorizationStepperTester(uischema, undefined)).toBe(-1);
+  });
+
+  it('should not fail tester with single unknown element and no schema', () => {
+    const uischema: Layout = {
+      type: 'Categorization',
+      elements: [
+        {
+          type: 'Foo'
+        },
+      ]
+    };
+    expect(materialCategorizationStepperTester(uischema, undefined)).toBe(-1);
+  });
+
+  it('should not apply to a single category and no schema', () => {
+    const categorization =  {
+      type: 'Categorization',
+      elements: [
+        {
+          type: 'Category'
+        }
+      ]
+    };
+    expect(materialCategorizationStepperTester(categorization, undefined)).toBe(-1);
+  });
+
+  it('should not apply to a nested categorization with single category and no schema', () => {
+    const nestedCategorization: Layout = {
+      type: 'Categorization',
+      elements: [
+        {
+          type: 'Category'
+        }
+      ]
+    };
+    const categorization: Layout = {
+      type: 'Categorization',
+      elements: [nestedCategorization]
+    };
+    expect(materialCategorizationStepperTester(categorization, undefined)).toBe(-1);
+  });
+
+  it('should not apply to nested categorizations without categories and no schema', () => {
+    const categorization: any = {
+      type: 'Categorization',
+      elements: [
+        {
+          type: 'Categorization'
+        }
+      ]
+    };
+    expect(materialCategorizationStepperTester(categorization, undefined)).toBe(-1);
+  });
+
+  it('should not apply to a nested categorization with null elements and no schema', () => {
+    const categorization: any = {
+      type: 'Categorization',
+      elements: [
+        {
+          type: 'Categorization',
+          label: 'Test',
+          elements: null
+        }
+      ]
+    };
+
+    expect(materialCategorizationStepperTester(categorization, undefined)).toBe(-1);
+  });
+
+  it('should not apply to a nested categorizations with empty elements and no schema', () => {
+    const categorization: any = {
+      type: 'Categorization',
+      elements: [
+        {
+          type: 'Categorization',
+          elements: []
+        }
+      ]
+    };
+    expect(materialCategorizationStepperTester(categorization, undefined)).toBe(-1);
+  });
+});
+
+describe('Material categorization stepper layout', () => {
+
+  it('should render', () => {
+    const nameControl = {
+      type: 'Control',
+      scope: '#/properties/name'
+    };
+    const uischema: Categorization = {
+      type: 'Categorization',
+      label: 'Root',
+      elements: [
+        {
+          type: 'Categorization',
+          label: 'Bar',
+          elements: [
+            {
+              type: 'Category',
+              label: 'A',
+              elements: [nameControl]
+            }
+          ]
+        },
+        {
+          type: 'Category',
+          label: 'B',
+          elements: [nameControl]
+        }
+      ]
+    };
+
+    const store = initJsonFormsStore(fixture);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MaterialCategorizationStepperLayoutRenderer
+          schema={fixture.schema}
+          uischema={uischema}
+        />
+      </Provider>
+    );
+    const steps = wrapper.find(Step);
+    expect(steps.length).toBe(2);
+    wrapper.unmount();
+  });
+
+  it('should render on click', () => {
+    const data = {'name': 'Foo'};
+    const nameControl: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/name'
+    };
+    const innerCategorization: Categorization = {
+      type: 'Categorization',
+      label: 'Bar',
+      elements: [
+        {
+          type: 'Category',
+          label: 'A',
+          elements: [nameControl]
+        },
+      ]
+    };
+    const uischema: Categorization = {
+      type: 'Categorization',
+      label: 'Root',
+      elements: [
+        innerCategorization,
+        {
+          type: 'Category',
+          label: 'B',
+          elements: [nameControl, nameControl]
+        },
+        {
+          type: 'Category',
+          label: 'C',
+          elements: undefined
+        },
+        {
+          type: 'Category',
+          label: 'D',
+          elements: null
+        },
+      ]
+    };
+    const store = initJsonFormsStore({
+      ...fixture,
+      data
+    });
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MaterialCategorizationStepperLayoutRenderer
+          schema={fixture.schema}
+          uischema={uischema}
+        />
+      </Provider>
+    );
+    const beforeClick = wrapper.find(CategorizationStepperRenderer).state().activeCategory;
+    wrapper.find(StepButton).at(1).simulate('click');
+    const afterClick = wrapper.find(CategorizationStepperRenderer).state().activeCategory;
+
+    expect(beforeClick).toBe(0);
+    expect(afterClick).toBe(1);
+    wrapper.unmount();
+  });
+
+  it('can be hidden', () => {
+    const uischema: Categorization = {
+      type: 'Categorization',
+      label: '',
+      elements: [
+        {
+          type: 'Category',
+          label: 'B',
+          elements: []
+        }
+      ]
+    };
+    const store = initJsonFormsStore(fixture);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MaterialCategorizationStepperLayoutRenderer
+          schema={fixture.schema}
+          uischema={uischema}
+          visible={false}
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find(Stepper).exists()).toBeFalsy();
+    wrapper.unmount();
+  });
+
+  it('is shown by default', () => {
+    const uischema: Categorization = {
+      type: 'Categorization',
+      label: '',
+      elements: [
+        {
+          type: 'Category',
+          label: 'B',
+          elements: []
+        }
+      ]
+    };
+    const store = initJsonFormsStore(fixture);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MaterialCategorizationStepperLayoutRenderer
+          schema={fixture.schema}
+          uischema={uischema}
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find(Stepper).exists()).toBeTruthy();
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
This is an alternative categorization renderer based on [Steppers](https://material-ui.com/demos/steppers/). It can be used by specifying an option `variant` in the UI schema with a value of `"stepper"`.

Fixes #1232 