### PR TITLE
Generate UI schema for oneOf, allOf, anyOf & fix material renderer accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ In addition EclipseSource also offers [professional support](https://jsonforms.i
 * Update npm (version >= 5.8.0)
 * Clone this repository
 * Install dependencies: `npm ci`
-* Hook up dependencies between packages: `npx lerna bootstrap --hoist --npm-ci-mode`
+* Hook up dependencies between packages: `npm run init`
 
 ## Build & Testing
-* Build (all packages): `lerna run build`
-* Test (all packages): `lerna run test`
-* Clean (delete `dist` folder of all packages): `lerna run clean`
+* Build (all packages): `npx lerna run build`
+* Test (all packages): `npx lerna run test`
+* Clean (delete `dist` folder of all packages): `npx lerna run clean`
 * Run vanilla examples: `cd packages/vanilla && npm run dev`
 * Run material examples: `cd packages/material && npm run dev`
 * Check Formatting: `npm run check-format`

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
 		"lerna": "lerna",
 		"preparePublish": "git clean -dfx && npm ci && lerna bootstrap --hoist --npm-ci-mode && lerna run clean && lerna run build && lerna run doc && lerna run bundle && lerna run test",
 		"merge-report": "mkdir -p coverage && lcov-result-merger 'packages/**/coverage/lcov.info' 'coverage/lcov.info'",
-		"check-format": "prettier --list-different '**/*.ts' '!**/{lib,dist}/**/*.ts'"
+		"check-format": "prettier --list-different '**/*.ts' '!**/{lib,dist}/**/*.ts'",
+		"init": "lerna bootstrap --hoist --npm-ci-mode"
 	},
 	"devDependencies": {
 		"@types/jest": "^23.0.0",

--- a/packages/core/src/generators/uischema.ts
+++ b/packages/core/src/generators/uischema.ts
@@ -142,6 +142,20 @@ const addLabel = (layout: Layout, labelName: string) => {
   }
 };
 
+/**
+ * Returns whether the given {@code jsonSchema} is a combinator ({@code oneOf}, {@code anyOf}, {@code allOf}) at the root level
+ * @param jsonSchema
+ *      the schema to check
+ */
+const isCombinator = (jsonSchema: JsonSchema): boolean => {
+  return (
+    !_.isEmpty(jsonSchema) &&
+    (!_.isEmpty(jsonSchema.oneOf) ||
+      !_.isEmpty(jsonSchema.anyOf) ||
+      !_.isEmpty(jsonSchema.allOf))
+  );
+};
+
 const generateUISchema = (
   jsonSchema: JsonSchema,
   schemaElements: UISchemaElement[],
@@ -159,6 +173,16 @@ const generateUISchema = (
       layoutType,
       rootSchema
     );
+  }
+
+  if (isCombinator(jsonSchema)) {
+    const controlObject: ControlElement = createControlElement(
+      _.startCase(schemaName),
+      currentRef
+    );
+    schemaElements.push(controlObject);
+
+    return controlObject;
   }
 
   const type = deriveType(jsonSchema);

--- a/packages/core/src/util/resolvers.ts
+++ b/packages/core/src/util/resolvers.ts
@@ -127,7 +127,7 @@ export const resolveSchema = (
     pathSegment === '#' || pathSegment === undefined || pathSegment === '';
   const resultSchema = validPathSegments.reduce((curSchema, pathSegment) => {
     curSchema =
-      curSchema.$ref === undefined
+      curSchema === undefined || curSchema.$ref === undefined
         ? curSchema
         : resolveSchema(schema, curSchema.$ref);
     return invalidSegment(pathSegment)

--- a/packages/core/test/generators/uischema.test.ts
+++ b/packages/core/test/generators/uischema.test.ts
@@ -478,3 +478,156 @@ test('generate for undefined schema', t => {
   const uischema: Layout = null;
   t.deepEqual(generateDefaultUISchema(schema), uischema);
 });
+
+test('generate control for oneOf', t => {
+  const schema: JsonSchema = {
+    oneOf: [
+      {
+        properties: {
+          name: {
+            type: 'string'
+          }
+        }
+      },
+      {
+        type: 'number'
+      }
+    ]
+  };
+  const control = {
+    label: '',
+    type: 'Control',
+    scope: '#'
+  };
+  const uischema: Layout = {
+    type: 'VerticalLayout',
+    elements: [control]
+  };
+  t.deepEqual(generateDefaultUISchema(schema), uischema);
+});
+
+test('generate control for anyOf', t => {
+  const schema: JsonSchema = {
+    anyOf: [
+      {
+        properties: {
+          name: {
+            type: 'string'
+          }
+        }
+      },
+      {
+        type: 'number'
+      }
+    ]
+  };
+  const control = {
+    label: '',
+    type: 'Control',
+    scope: '#'
+  };
+  const uischema: Layout = {
+    type: 'VerticalLayout',
+    elements: [control]
+  };
+  t.deepEqual(generateDefaultUISchema(schema), uischema);
+});
+
+test('generate control for allOf', t => {
+  const schema: JsonSchema = {
+    allOf: [
+      {
+        properties: {
+          name: {
+            type: 'string'
+          }
+        }
+      },
+      {
+        type: 'number'
+      }
+    ]
+  };
+  const control = {
+    label: '',
+    type: 'Control',
+    scope: '#'
+  };
+  const uischema: Layout = {
+    type: 'VerticalLayout',
+    elements: [control]
+  };
+  t.deepEqual(generateDefaultUISchema(schema), uischema);
+});
+
+test('no separate control for oneOf in array', t => {
+  const schema: JsonSchema = {
+    properties: {
+      myarray: {
+        items: {
+          oneOf: [
+            {
+              properties: {
+                name: {
+                  type: 'string'
+                }
+              }
+            },
+            {
+              type: 'number'
+            }
+          ]
+        }
+      }
+    }
+  };
+  const control = {
+    label: 'Myarray',
+    type: 'Control',
+    scope: '#/properties/myarray'
+  };
+  const uischema: Layout = {
+    type: 'VerticalLayout',
+    elements: [control]
+  };
+  t.deepEqual(generateDefaultUISchema(schema), uischema);
+});
+
+test('generate control for nested oneOf', t => {
+  const schema: JsonSchema = {
+    properties: {
+      myarray: {
+        properties: {
+          nameOrAge: {
+            oneOf: [
+              {
+                properties: {
+                  name: {
+                    type: 'string'
+                  }
+                }
+              },
+              {
+                type: 'number'
+              }
+            ]
+          }
+        }
+      }
+    }
+  };
+  const control = {
+    label: 'Name Or Age',
+    type: 'Control',
+    scope: '#/properties/myarray/properties/nameOrAge'
+  };
+  const nestedUiSchema: Layout = {
+    type: 'VerticalLayout',
+    elements: [control]
+  };
+  const uischema: Layout = {
+    type: 'VerticalLayout',
+    elements: [nestedUiSchema]
+  };
+  t.deepEqual(generateDefaultUISchema(schema), uischema);
+});

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -25,6 +25,7 @@
 import * as allOf from './allOf';
 import * as anyOf from './anyOf';
 import * as oneOf from './oneOf';
+import * as oneOfArray from './oneOfArray';
 import * as array from './arrays';
 import * as nestedArray from './nestedArrays';
 import * as arrayWithDetail from './arrays-with-detail';
@@ -59,6 +60,7 @@ export {
   allOf,
   anyOf,
   oneOf,
+  oneOfArray,
   stringArray,
   array,
   nestedArray,

--- a/packages/examples/src/oneOfArray.ts
+++ b/packages/examples/src/oneOfArray.ts
@@ -1,0 +1,75 @@
+import { registerExamples } from './register';
+
+export const schema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+
+  definitions: {
+    address: {
+      type: 'object',
+      properties: {
+        street_address: { type: 'string' },
+        city: { type: 'string' },
+        state: { type: 'string' }
+      },
+      required: ['street_address', 'city', 'state']
+    },
+    user: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        mail: { type: 'string' }
+      },
+      required: ['name', 'mail']
+    }
+  },
+
+  type: 'object',
+
+  properties: {
+    name: { type: 'string' },
+    addressOrUsers: {
+      type: 'array',
+      items: {
+        oneOf: [
+          { $ref: '#/definitions/address' },
+          { $ref: '#/definitions/user' }
+        ]
+      }
+    }
+  }
+};
+
+export const uischema = {
+  type: 'VerticalLayout',
+  elements: [
+    {
+      type: 'Control',
+      scope: '#/properties/addressOrUsers'
+    }
+  ]
+};
+
+const data = {
+  name: 'test',
+  addressOrUsers: [
+    {
+      street_address: '1600 Pennsylvania Avenue NW',
+      city: 'Washington',
+      state: 'DC'
+    },
+    {
+      name: 'User',
+      mail: 'user@user.user'
+    }
+  ]
+};
+
+registerExamples([
+  {
+    name: 'oneOfArray',
+    label: 'oneOf (in array)',
+    data,
+    schema,
+    uischema
+  }
+]);

--- a/packages/material/src/complex/MaterialAllOfRenderer.tsx
+++ b/packages/material/src/complex/MaterialAllOfRenderer.tsx
@@ -39,6 +39,7 @@ class MaterialAllOfRenderer extends React.Component<ControlProps, any> {
             schema,
             uischema,
             scopedSchema,
+            path
         } = this.props;
 
         const elements = createControls(
@@ -51,6 +52,7 @@ class MaterialAllOfRenderer extends React.Component<ControlProps, any> {
             <ResolvedJsonForms
                 schema={schema}
                 uischema={elements}
+                path={path}
             />
         );
 

--- a/packages/material/src/complex/MaterialAnyOfRenderer.tsx
+++ b/packages/material/src/complex/MaterialAnyOfRenderer.tsx
@@ -64,6 +64,7 @@ class MaterialAnyOfRenderer extends React.Component<ControlProps, any> {
             schema,
             uischema,
             scopedSchema,
+            path
         } = this.props;
 
         const elements = createControls(
@@ -76,6 +77,7 @@ class MaterialAnyOfRenderer extends React.Component<ControlProps, any> {
             <ResolvedJsonForms
                 schema={schema}
                 uischema={elements}
+                path={path}
             />
         );
 

--- a/packages/material/src/complex/MaterialOneOfRenderer.tsx
+++ b/packages/material/src/complex/MaterialOneOfRenderer.tsx
@@ -83,14 +83,14 @@ class MaterialOneOfRenderer extends React.Component<ControlProps, MaterialOneOfS
 
     handleClose = () => {
         this.setState({ open: false });
-    }
+    };
 
     cancel = () => {
         this.setState({
             open: false,
             proceed: false,
         });
-    }
+    };
 
     confirm = () => {
         // TODO: use setState based on function
@@ -104,7 +104,7 @@ class MaterialOneOfRenderer extends React.Component<ControlProps, MaterialOneOfS
             proceed: true,
             selected: this.state.newSelection
         });
-    }
+    };
 
     render() {
 
@@ -112,6 +112,7 @@ class MaterialOneOfRenderer extends React.Component<ControlProps, MaterialOneOfS
             schema,
             uischema,
             scopedSchema,
+            path,
         } = this.props;
 
         const elements = createControls(
@@ -136,6 +137,7 @@ class MaterialOneOfRenderer extends React.Component<ControlProps, MaterialOneOfS
                     selected={this.state.selected}
                     schema={schema}
                     uischema={elements}
+                    path={path}
                 />
                 <Dialog
                     open={this.state.open}

--- a/packages/material/src/layouts/MaterialArrayLayout.tsx
+++ b/packages/material/src/layouts/MaterialArrayLayout.tsx
@@ -53,12 +53,12 @@ export const MaterialArrayLayout =
      removeItems
    }: ArrayControlProps) => {
 
-    const firstPrimitiveProp = _.find(Object.keys(scopedSchema.properties), propName => {
+    const firstPrimitiveProp = scopedSchema.properties ? _.find(Object.keys(scopedSchema.properties), propName => {
       const prop = scopedSchema.properties[propName];
       return prop.type === 'string' ||
         prop.type === 'number' ||
         prop.type === 'integer';
-    });
+    }) : undefined;
 
     return (
       <Paper style={{ padding: 10 }}>
@@ -99,7 +99,7 @@ export const MaterialArrayLayout =
               const foundUISchema =
                 findUISchema(scopedSchema, uischema.scope, path, undefined, uischema);
               const childPath = composePaths(path, `${index}`);
-              const childLabel = childData[firstPrimitiveProp];
+              const childLabel = firstPrimitiveProp ? childData[firstPrimitiveProp] : '';
 
               return (
                 <ExpansionPanel key={index}>
@@ -134,7 +134,7 @@ export const MaterialArrayLayout =
                   <ExpansionPanelDetails>
                     <ResolvedJsonForms
                       schema={scopedSchema}
-                      uischema={foundUISchema || uischema}
+                      uischema={foundUISchema}
                       path={childPath}
                       key={childPath}
                     />

--- a/webpack/webpack.build.base.js
+++ b/webpack/webpack.build.base.js
@@ -2,6 +2,7 @@ const merge = require('webpack-merge');
 const baseConfig = require('./webpack.base.js');
 
 module.exports = merge(baseConfig, {
+    mode: 'production',
     entry: './src/index.ts',
     output: {
       libraryTarget: 'umd',

--- a/webpack/webpack.dev.base.js
+++ b/webpack/webpack.dev.base.js
@@ -3,6 +3,7 @@ const merge = require('webpack-merge');
 const baseConfig = require('./webpack.base.js');
 
 module.exports = merge(baseConfig, {
+    mode: 'development',
     entry: [
         'webpack-dev-server/client?http://localhost:8080',
         'webpack/hot/dev-server',


### PR DESCRIPTION
## `oneOf`, `anyOf`, `allOf` changes
 * Generate ui schemas for 'oneOf', 'anyOf' and 'allOf'
 * Adjust MaterialOne/Any/AllOfRenderers to use paths
 * Fix undefined errors in resolvers
 * Add oneOfArray example
 * Add UiSchema generator tests

## Minor tweaks
* Add webpack modes to dev and build configuration files
 * Add 'init' script as shorthand for lerna bootstrap
 * Adapt readme accordingly

Fixes #1213 