### PR TITLE
[material] Fix path of data change within confirm of one-of renderer

### DIFF
--- a/packages/material/src/complex/MaterialOneOfRenderer.tsx
+++ b/packages/material/src/complex/MaterialOneOfRenderer.tsx
@@ -94,10 +94,10 @@ class MaterialOneOfRenderer extends React.Component<ControlProps, MaterialOneOfS
 
     confirm = () => {
         // TODO: use setState based on function
-        const control = this.props.uischema as ControlElement;
-        this.props.handleChange(
-            toDataPath(control.scope),
-            createDefaultValue(this.props.scopedSchema.oneOf[this.state.selected])
+        const { path, scopedSchema, handleChange } = this.props;
+        handleChange(
+            path,
+            createDefaultValue(scopedSchema.oneOf[this.state.selected])
         );
         this.setState({
             open: false,


### PR DESCRIPTION
The `control.scope` is not correct, e.g. when the oneOf is nested within the array (indices). This PR does not include a test, which is the scope of a newly opened issue #1237.