### PR TITLE
Handle recursive combinators based schemas

### DIFF
--- a/packages/angular-material/src/other/object.renderer.ts
+++ b/packages/angular-material/src/other/object.renderer.ts
@@ -54,7 +54,7 @@ export class ObjectControlRenderer extends JsonFormsControl {
   }
   mapAdditionalProps(props: ControlProps) {
     this.detailUiSchema = props.findUISchema(
-      props.scopedSchema,
+      props.schema,
       undefined,
       props.path
     );

--- a/packages/angular-material/test/master-detail.spec.ts
+++ b/packages/angular-material/test/master-detail.spec.ts
@@ -469,7 +469,7 @@ describe('Master detail', () => {
               title: 'Carrots'
             },
             path: 'orders.0',
-            schema: undefined,
+            schema: schema.definitions.order,
             uischema: {
               type: 'VerticalLayout',
               elements: [

--- a/packages/angular/src/control.ts
+++ b/packages/angular/src/control.ts
@@ -9,8 +9,7 @@ import {
   JsonSchema,
   mapDispatchToControlProps,
   mapStateToControlProps,
-  OwnPropsOfControl,
-  Resolve
+  OwnPropsOfControl
 } from '@jsonforms/core';
 import { Input, OnDestroy, OnInit } from '@angular/core';
 import { NgRedux } from '@angular-redux/store';
@@ -37,6 +36,7 @@ export class JsonFormsControl extends JsonFormsBaseRenderer<ControlElement>
   description: string;
   error: string | null;
   scopedSchema: JsonSchema;
+  rootSchema: JsonSchema;
   enabled: boolean;
   hidden: boolean;
 
@@ -74,7 +74,7 @@ export class JsonFormsControl extends JsonFormsBaseRenderer<ControlElement>
           label,
           required,
           schema,
-          uischema,
+          rootSchema,
           visible
         } = props;
         this.label = computeLabel(
@@ -86,7 +86,8 @@ export class JsonFormsControl extends JsonFormsBaseRenderer<ControlElement>
         this.enabled = enabled;
         this.enabled ? this.form.enable() : this.form.disable();
         this.hidden = !visible;
-        this.scopedSchema = Resolve.schema(schema, uischema.scope);
+        this.scopedSchema = schema;
+        this.rootSchema = rootSchema;
         this.description =
           this.scopedSchema !== undefined ? this.scopedSchema.description : '';
         this.id = props.id;

--- a/packages/core/src/util/index.ts
+++ b/packages/core/src/util/index.ts
@@ -61,7 +61,11 @@ export const formatErrorMessage = (errors: string[]) => {
  * Convenience wrapper around resolveData and resolveSchema.
  */
 const Resolve: {
-  schema(schema: JsonSchema, schemaPath: string): JsonSchema;
+  schema(
+    schema: JsonSchema,
+    schemaPath: string,
+    rootSchema?: JsonSchema
+  ): JsonSchema;
   data(data: any, path: string): any;
 } = {
   schema: resolveSchema,

--- a/packages/core/test/util/field.test.ts
+++ b/packages/core/test/util/field.test.ts
@@ -196,24 +196,17 @@ test('mapStateToFieldProps - enabled via state ', t => {
 
 test('mapStateToFieldProps - path', t => {
   const ownProps = {
-    uischema: coreUISchema
+    uischema: coreUISchema,
+    path: 'firstName'
   };
   const props = mapStateToFieldProps(createState(coreUISchema), ownProps);
   t.is(props.path, 'firstName');
 });
 
-test('mapStateToFieldProps - compose path with ownProps.path', t => {
-  const ownProps = {
-    uischema: coreUISchema,
-    path: 'yo'
-  };
-  const props = mapStateToFieldProps(createState(coreUISchema), ownProps);
-  t.is(props.path, 'yo.firstName');
-});
-
 test('mapStateToFieldProps - data', t => {
   const ownProps = {
-    uischema: coreUISchema
+    uischema: coreUISchema,
+    path: 'firstName'
   };
   const props = mapStateToFieldProps(createState(coreUISchema), ownProps);
   t.is(props.data, 'Homer');
@@ -230,58 +223,24 @@ test('mapStateToFieldProps - id', t => {
 });
 
 test('mapStateToEnumFieldProps - set default options for dropdown list', t => {
-  const uiSchema: ControlElement = {
+  const uischema: ControlElement = {
     type: 'Control',
     scope: '#/properties/nationality'
   };
   const ownProps = {
     schema: {
-      type: 'object',
-      properties: {
-        firstName: { type: 'string' },
-        lastName: { type: 'string' },
-        nationality: {
-          type: 'string',
-          enum: ['DE', 'IT', 'JP', 'US', 'RU', 'Other']
-        }
-      }
+      enum: ['DE', 'IT', 'JP', 'US', 'RU', 'Other']
     },
-    uischema: uiSchema
+    uischema,
+    path: 'nationality'
   };
 
   const props = defaultMapStateToEnumFieldProps(
-    createState(uiSchema),
+    createState(uischema),
     ownProps
   );
   t.deepEqual(props.options, ['DE', 'IT', 'JP', 'US', 'RU', 'Other']);
   t.is(props.data, undefined);
-});
-
-test('mapStateToFieldProps - set data of enum field', t => {
-  const uiSchema: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/nationality'
-  };
-  const ownProps = {
-    data: {
-      nationality: 'JP'
-    },
-    schema: {
-      type: 'object',
-      properties: {
-        firstName: { type: 'string' },
-        lastName: { type: 'string' },
-        nationality: {
-          type: 'string',
-          enum: ['DE', 'IT', 'JP', 'US', 'RU', 'Other']
-        }
-      }
-    },
-    uischema: uiSchema
-  };
-
-  const props = mapStateToFieldProps(createState(uiSchema), ownProps);
-  t.is(props.data, 'JP');
 });
 
 test('defaultMapDispatchToControlProps, initialized with custom handleChange', t => {

--- a/packages/core/test/util/renderer.test.ts
+++ b/packages/core/test/util/renderer.test.ts
@@ -33,8 +33,7 @@ import {
   mapDispatchToControlProps,
   mapStateToControlProps,
   mapStateToJsonFormsRendererProps,
-  mapStateToLayoutProps,
-  OwnPropsOfControl
+  mapStateToLayoutProps
 } from '../../src/util';
 import configureStore from 'redux-mock-store';
 import * as _ from 'lodash';
@@ -480,12 +479,8 @@ test('mapDispatchToArrayControlProps should adding items to array', t => {
     initState
   );
   store.dispatch(init(data, schema, uischema));
-  const ownProps: OwnPropsOfControl = {
-    schema,
-    uischema
-  };
-  const props = mapDispatchToArrayControlProps(store.dispatch, ownProps);
-  props.addItem('')();
+  const props = mapDispatchToArrayControlProps(store.dispatch);
+  props.addItem('', createDefaultValue(schema))();
   t.is(store.getState().jsonforms.core.data.length, 2);
 });
 
@@ -516,11 +511,7 @@ test('mapDispatchToArrayControlProps should remove items from array', t => {
     initState
   );
   store.dispatch(init(data, schema, uischema));
-  const ownProps: OwnPropsOfControl = {
-    schema,
-    uischema
-  };
-  const props = mapDispatchToArrayControlProps(store.dispatch, ownProps);
+  const props = mapDispatchToArrayControlProps(store.dispatch);
   props.removeItems('', ['foo', 'bar'])();
   t.is(store.getState().jsonforms.core.data.length, 1);
   t.is(store.getState().jsonforms.core.data[0], 'quux');
@@ -714,14 +705,10 @@ test('should assign defaults to newly added item within nested object of an arra
   store.dispatch(
     init(data, schema, uischema, createAjv({ useDefaults: true }))
   );
-  const ownProps: OwnPropsOfControl = {
-    schema,
-    uischema
-  };
-  const props = mapDispatchToArrayControlProps(store.dispatch, ownProps);
+  const props = mapDispatchToArrayControlProps(store.dispatch);
 
-  props.addItem('')();
+  props.addItem('', createDefaultValue(schema))();
 
   t.is(store.getState().jsonforms.core.data.length, 2);
-  t.deepEqual(store.getState().jsonforms.core.data[1], { message: 'foo' });
+  t.deepEqual(store.getState().jsonforms.core.data[0], { message: 'foo' });
 });

--- a/packages/ionic/src/controls/number/number-control.ts
+++ b/packages/ionic/src/controls/number/number-control.ts
@@ -75,11 +75,12 @@ export class NumberControlRenderer extends JsonFormsControl {
   };
 
   mapAdditionalProps(props: ControlProps) {
-    if (!isEmpty(props.scopedSchema)) {
+    if (!isEmpty(props.schema)) {
+      // TODO
       const defaultStep = isNumberControl(this.uischema, this.schema) ? 0.1 : 1;
-      this.min = props.scopedSchema.minimum;
-      this.max = props.scopedSchema.maximum;
-      this.step = props.scopedSchema.multipleOf || defaultStep;
+      this.min = props.schema.minimum;
+      this.max = props.schema.maximum;
+      this.step = props.schema.multipleOf || defaultStep;
       // this doesn't seem to work reliably; an entered value will be formatted
       // the 1st time when blurring out, but it doesn't work the 2nd time
       // although the internal state seems correct

--- a/packages/ionic/src/controls/object/object.control.ts
+++ b/packages/ionic/src/controls/object/object.control.ts
@@ -60,7 +60,7 @@ export class ObjectControlRenderer extends JsonFormsControl {
   mapAdditionalProps(props: ControlProps) {
     this.propsPath = props.path;
     this.detailUiSchema = props.findUISchema(
-      props.scopedSchema,
+      props.schema,
       undefined,
       props.path
     );

--- a/packages/ionic/src/other/list-with-detail/list-with-detail-control.ts
+++ b/packages/ionic/src/other/list-with-detail/list-with-detail-control.ts
@@ -2,11 +2,14 @@ import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 import { Component, ViewChild } from '@angular/core';
 import {
+  ArrayControlProps,
   composeWithUi,
   ControlElement,
   Generate,
   JsonFormsState,
   JsonSchema,
+  mapDispatchToArrayControlProps,
+  mapStateToArrayControlProps,
   RankedTester,
   rankWith,
   resolveSchema,
@@ -71,7 +74,9 @@ export class ListWithDetailControl extends JsonFormsControl {
     this.subscription = this.ngRedux
       .select()
       .subscribe((state: JsonFormsState) => {
-        const { data, schema, uischema } = this.mapToProps(state);
+        const { data, createDefaultValue, schema, uischema } = this.mapToProps(
+          state
+        );
         const controlElement = uischema as ControlElement;
         const instancePath = toDataPath(`${controlElement.scope}/items`);
         const resolvedSchema = resolveSchema(
@@ -107,7 +112,8 @@ export class ListWithDetailControl extends JsonFormsControl {
             path: composeWithUi(this.uischema as ControlElement, this.path),
             uischema: this.uischema,
             schema: this.schema,
-            pushDetail: this.updateDetail
+            pushDetail: this.updateDetail,
+            createDefaultValue
           };
           this.updateMaster();
         } else if (this.masterItems !== undefined) {
@@ -200,6 +206,12 @@ export class ListWithDetailControl extends JsonFormsControl {
       this.detailNav.pop();
     }
   };
+
+  protected mapToProps(state: JsonFormsState): ArrayControlProps {
+    const props = mapStateToArrayControlProps(state, this.getOwnProps());
+    const dispatch = mapDispatchToArrayControlProps(this.ngRedux.dispatch);
+    return { ...props, ...dispatch };
+  }
 }
 
 export const listWithDetailTester: RankedTester = rankWith(

--- a/packages/ionic/src/other/list-with-detail/pages/master/master.ts
+++ b/packages/ionic/src/other/list-with-detail/pages/master/master.ts
@@ -37,8 +37,9 @@ export class MasterPage extends AbstractMasterPage implements OnInit {
   uischema: ControlElement;
   schema: JsonSchema;
   path: string;
-  addItem: (path: string) => () => void;
+  addItem: (path: string, value: any) => () => void;
   pushDetail: (params: any) => void;
+  createDefaultValue: () => void;
 
   constructor(
     public navParams: NavParams,
@@ -50,13 +51,11 @@ export class MasterPage extends AbstractMasterPage implements OnInit {
     this.uischema = this.navParams.get('uischema');
     this.path = this.navParams.get('path');
     this.pushDetail = this.navParams.get('pushDetail');
+    this.createDefaultValue = this.navParams.get('createDefaultValue');
   }
 
   ngOnInit() {
-    const { addItem } = mapDispatchToArrayControlProps(this.ngRedux.dispatch, {
-      uischema: this.uischema,
-      schema: this.schema
-    });
+    const { addItem } = mapDispatchToArrayControlProps(this.ngRedux.dispatch);
     this.addItem = addItem;
   }
 
@@ -65,6 +64,6 @@ export class MasterPage extends AbstractMasterPage implements OnInit {
   }
 
   onClick() {
-    this.addItem(this.path)();
+    this.addItem(this.path, this.createDefaultValue())();
   }
 }

--- a/packages/material-tree-renderer/src/tree/TreeWithDetailRenderer.tsx
+++ b/packages/material-tree-renderer/src/tree/TreeWithDetailRenderer.tsx
@@ -4,17 +4,17 @@ import has from 'lodash/has';
 import get from 'lodash/get';
 import React from 'react';
 import {
-    Actions,
-    ControlState,
-    findUISchema,
-    getData,
-    JsonFormsState,
-    JsonSchema,
-    OwnPropsOfControl,
-    Paths,
-    Resolve,
-    Runtime, StatePropsOfControl,
-    UISchemaElement,
+  Actions,
+  ControlState,
+  findUISchema,
+  getData, getSchema,
+  JsonFormsState,
+  JsonSchema,
+  OwnPropsOfControl,
+  Paths,
+  Resolve,
+  Runtime, StatePropsOfControl,
+  UISchemaElement
 } from '@jsonforms/core';
 import { Control, ResolvedJsonForms } from '@jsonforms/react';
 /* tslint:disable:next-line */
@@ -30,395 +30,400 @@ import { InstanceLabelProvider, SchemaLabelProvider } from '../helpers/LabelProv
 import { AnyAction, Dispatch } from 'redux';
 
 export interface MasterProps {
-    schema: JsonSchema;
-    path: string;
-    rootData: any;
-    selection: any;
-    // TODO: unify types
-    handlers: {
-        onAdd: any;
-        onRemove?: any;
-        onSelect: any;
-        resetSelection: any;
-    };
-    uischema: UISchemaElement;
-    filterPredicate: any;
-    labelProviders: {
-        forSchema: SchemaLabelProvider;
-        forData: InstanceLabelProvider;
-    };
-    imageProvider: any;
+  schema: JsonSchema;
+  path: string;
+  rootData: any;
+  selection: any;
+  // TODO: unify types
+  handlers: {
+    onAdd: any;
+    onRemove?: any;
+    onSelect: any;
+    resetSelection: any;
+  };
+  uischema: UISchemaElement;
+  filterPredicate: any;
+  labelProviders: {
+    forSchema: SchemaLabelProvider;
+    forData: InstanceLabelProvider;
+  };
+  imageProvider: any;
 }
 
 const Master = (
-    {
-        schema,
-        path,
-        selection,
-        handlers,
-        uischema,
-        rootData,
-        filterPredicate,
-        labelProviders,
-        imageProvider
-    }: MasterProps) => {
-    if (schema.items !== undefined) {
-        return (
-            <ul>
-                <ExpandRootArray
-                    rootData={rootData}
-                    schema={schema.items}
-                    path={path}
-                    selection={selection}
-                    handlers={handlers}
-                    filterPredicate={filterPredicate}
-                    labelProvider={labelProviders.forData}
-                    imageProvider={imageProvider}
-                />
-            </ul>
-        );
-    }
-
+  {
+    schema,
+    path,
+    selection,
+    handlers,
+    uischema,
+    rootData,
+    filterPredicate,
+    labelProviders,
+    imageProvider
+  }: MasterProps) => {
+  if (schema.items !== undefined) {
     return (
-        <ul>
-            <ObjectListItem
-                path={path}
-                schema={schema}
-                uischema={uischema}
-                selection={selection}
-                handlers={handlers}
-                isRoot={true}
-                filterPredicate={filterPredicate}
-                labelProvider={labelProviders.forData}
-                imageProvider={imageProvider}
-            />
-        </ul>
+      <ul>
+        <ExpandRootArray
+          rootData={rootData}
+          schema={schema.items}
+          path={path}
+          selection={selection}
+          handlers={handlers}
+          filterPredicate={filterPredicate}
+          labelProvider={labelProviders.forData}
+          imageProvider={imageProvider}
+        />
+      </ul>
     );
+  }
+
+  return (
+    <ul>
+      <ObjectListItem
+        path={path}
+        schema={schema}
+        uischema={uischema}
+        selection={selection}
+        handlers={handlers}
+        isRoot={true}
+        filterPredicate={filterPredicate}
+        labelProvider={labelProviders.forData}
+        imageProvider={imageProvider}
+      />
+    </ul>
+  );
 };
 
 const isNotTuple = (schema: JsonSchema) => !Array.isArray(schema.items);
 
 const styles: StyleRulesCallback<'treeMasterDetailContent' |
-    'treeMasterDetail' |
-    'treeMasterDetailMaster' |
-    'treeMasterDetailDetail'> = () => ({
-    treeMasterDetailContent: {
-      paddingTop: '1em',
-      paddingBottom: '1em'
-    },
-    // tslint:disable-next-line: object-literal-key-quotes
-    treeMasterDetail: {
-        display: 'flex',
-        flexDirection: 'column',
-        // tslint:disable-next-line:object-literal-key-quotes
-        '& $treeMasterDetailContent': {
-            display: 'flex',
-            flexDirection: 'row'
-        }
-    },
-    // tslint:disable-next-line: object-literal-key-quotes
-    treeMasterDetailMaster: {
-        flex: 1,
-        padding: '0.5em',
-        height: 'auto',
-        borderRight: '0.2em solid lightgrey',
-        borderWidth: 'thin',
-        // tslint:disable-next-line:object-literal-key-quotes
-        '& ul': {
-            listStyleType: 'none',
-            margin: 0,
-            padding: 0,
-            position: 'relative',
-            overflow: 'hidden',
-            // tslint:disable-next-line:object-literal-key-quotes
-            '&:after': {
-                content: '""',
-                position: 'absolute',
-                left: '0.2em',
-                height: '0.6em',
-                bottom: '0'
-            }, // tslint:disable-next-line:object-literal-key-quotes
-            '&:last-child::after': {
-                display: 'none'
-            }
-        }
-    },
-    // tslint:disable-next-line: object-literal-key-quotes
-    treeMasterDetailDetail: {
-        flex: 3,
-        padding: '0.5em',
-        paddingLeft: '1em',
-      // tslint:disable-next-line:object-literal-key-quotes
-        '&:first-child': {
-            marginRight: '0.25em'
-        }
+  'treeMasterDetail' |
+  'treeMasterDetailMaster' |
+  'treeMasterDetailDetail'> = () => ({
+  treeMasterDetailContent: {
+    paddingTop: '1em',
+    paddingBottom: '1em'
+  },
+  // tslint:disable-next-line: object-literal-key-quotes
+  treeMasterDetail: {
+    display: 'flex',
+    flexDirection: 'column',
+    // tslint:disable-next-line:object-literal-key-quotes
+    '& $treeMasterDetailContent': {
+      display: 'flex',
+      flexDirection: 'row'
     }
+  },
+  // tslint:disable-next-line: object-literal-key-quotes
+  treeMasterDetailMaster: {
+    flex: 1,
+    padding: '0.5em',
+    height: 'auto',
+    borderRight: '0.2em solid lightgrey',
+    borderWidth: 'thin',
+    // tslint:disable-next-line:object-literal-key-quotes
+    '& ul': {
+      listStyleType: 'none',
+      margin: 0,
+      padding: 0,
+      position: 'relative',
+      overflow: 'hidden',
+      // tslint:disable-next-line:object-literal-key-quotes
+      '&:after': {
+        content: '""',
+        position: 'absolute',
+        left: '0.2em',
+        height: '0.6em',
+        bottom: '0'
+      }, // tslint:disable-next-line:object-literal-key-quotes
+      '&:last-child::after': {
+        display: 'none'
+      }
+    }
+  },
+  // tslint:disable-next-line: object-literal-key-quotes
+  treeMasterDetailDetail: {
+    flex: 3,
+    padding: '0.5em',
+    paddingLeft: '1em',
+    // tslint:disable-next-line:object-literal-key-quotes
+    '&:first-child': {
+      marginRight: '0.25em'
+    }
+  }
 });
 
 export interface TreeWithDetailState extends ControlState {
-    selected: {
-        schema: JsonSchema,
-        data: any,
-        path: string
-    };
-    dialog: {
-        open: boolean,
-        schema: JsonSchema,
-        path: string
-    };
+  selected: {
+    schema: JsonSchema,
+    data: any,
+    path: string
+  };
+  dialog: {
+    open: boolean,
+    schema: JsonSchema,
+    path: string
+  };
 }
 
 export interface StatePropsOfTreeWithDetail extends StatePropsOfControl {
-    classes?: any;
-    rootData: any;
-    resolvedRootData: any;
-    filterPredicate: any;
-    labelProviders: {
-        forSchema: SchemaLabelProvider;
-        forData: InstanceLabelProvider;
-    };
-    imageProvider: any;
+  classes?: any;
+  rootData: any;
+  resolvedRootData: any;
+  filterPredicate: any;
+  labelProviders: {
+    forSchema: SchemaLabelProvider;
+    forData: InstanceLabelProvider;
+  };
+  imageProvider: any;
 }
 
 export interface DispatchPropsOfTreeWithDetail {
-    addToRoot: any;
+  addToRoot: any;
 }
 
 export interface TreeWithDetailProps
-    extends StatePropsOfTreeWithDetail, DispatchPropsOfTreeWithDetail {
+  extends StatePropsOfTreeWithDetail, DispatchPropsOfTreeWithDetail {
 
 }
 
 export class TreeWithDetailRenderer extends Control
-    <TreeWithDetailProps &
-        WithStyles<'treeMasterDetailContent' |
-            'treeMasterDetail'|
-            'treeMasterDetailMaster' |
-            'treeMasterDetailDetail'>,
-        TreeWithDetailState> {
+  <TreeWithDetailProps &
+    WithStyles<'treeMasterDetailContent' |
+      'treeMasterDetail'|
+      'treeMasterDetailMaster' |
+      'treeMasterDetailDetail'>,
+    TreeWithDetailState> {
 
-    componentWillMount() {
-        const { uischema, resolvedRootData, scopedSchema } = this.props;
-        const controlElement = uischema;
-        this.setState({
-            dialog: {
-                open: false,
-                schema: undefined,
-                path: undefined
-            }
-        });
+  componentWillMount() {
+    const { uischema, resolvedRootData, schema } = this.props;
+    const controlElement = uischema;
+    this.setState({
+      dialog: {
+        open: false,
+        schema: undefined,
+        path: undefined
+      }
+    });
 
-        const path = Paths.fromScopable(controlElement);
-        if (Array.isArray(resolvedRootData)) {
-            this.setState({
-                selected: {
-                    schema: scopedSchema.items as JsonSchema,
-                    data: resolvedRootData[0],
-                    path: Paths.compose(path, '0')
-                }
-            });
-        } else {
-            this.setState({
-                selected: {
-                    schema: scopedSchema,
-                    data: resolvedRootData,
-                    path: path
-                }
-            });
+    const path = Paths.fromScopable(controlElement);
+    if (Array.isArray(resolvedRootData)) {
+      this.setState({
+        selected: {
+          schema: schema.items as JsonSchema,
+          data: resolvedRootData[0],
+          path: Paths.compose(path, '0')
         }
-    }
-
-    setSelection = (schema: JsonSchema, data: any, path: string) => () => {
-        this.setState({
-            selected: {
-                schema,
-                data,
-                path
-            }
-        });
-    };
-
-    openDialog = (schema: JsonSchema, path: string) => () => {
-        this.setState({
-            dialog: {
-                open: true,
-                schema,
-                path
-            }
-        });
-    };
-
-    closeDialog = () => {
-        this.setState({
-            dialog: {
-                open: false,
-                schema: undefined,
-                path: undefined
-            }
-        });
-    };
-
-    render() {
-        const {
-            uischema,
-            schema,
-            scopedSchema,
-            visible,
-            path,
-            resolvedRootData,
-            rootData,
-            addToRoot,
-            filterPredicate,
-            labelProviders,
-            imageProvider,
-            classes
-        } = this.props;
-        const controlElement = uischema;
-        const dialogProps = {
-            open: this.state.dialog.open
-        };
-
-        let resetSelection;
-        if (scopedSchema.items !== undefined) {
-            resetSelection = this.setSelection(scopedSchema.items as JsonSchema, resolvedRootData[0], Paths.compose(path, '0'));
-        } else {
-            resetSelection = this.setSelection(scopedSchema, resolvedRootData, path);
+      });
+    } else {
+      this.setState({
+        selected: {
+          schema: schema,
+          data: resolvedRootData,
+          path: path
         }
-        const handlers = {
-            onSelect: this.setSelection,
-            onAdd: this.openDialog,
-            resetSelection: resetSelection
-        };
-
-        const detailUiSchema = this.props.findUISchema(this.state.selected.schema, undefined, path);
-
-        return (
-            <div hidden={!visible} className={classes.treeMasterDetail}>
-                <div>
-                    <label>
-                        {typeof controlElement.label === 'string' ? controlElement.label : ''}
-                    </label>
-                    {
-                        Array.isArray(resolvedRootData) &&
-                        <button onClick={addToRoot(schema, path)}>
-                            Add to root
-                        </button>
-                    }
-                </div>
-                <div className={classes.treeMasterDetailContent}>
-                    <div className={classes.treeMasterDetailMaster}>
-                        <Master
-                            uischema={uischema}
-                            schema={scopedSchema}
-                            path={path}
-                            handlers={handlers}
-                            selection={this.state.selected.data}
-                            rootData={rootData}
-                            filterPredicate={filterPredicate}
-                            labelProviders={labelProviders}
-                            imageProvider={imageProvider}
-                        />
-                    </div>
-                    <div className={classes.treeMasterDetailDetail}>
-                        {
-                            this.state.selected ?
-                                <ResolvedJsonForms
-                                    schema={this.state.selected.schema}
-                                    path={this.state.selected.path}
-                                    uischema={detailUiSchema}
-                                /> : 'Select an item'
-                        }
-                    </div>
-                </div>
-                <div>
-                    {
-                        this.state.dialog.open &&
-                        <AddItemDialog
-                            path={this.state.dialog.path}
-                            schema={this.state.dialog.schema}
-                            closeDialog={this.closeDialog}
-                            dialogProps={dialogProps}
-                            setSelection={this.setSelection}
-                            labelProvider={labelProviders.forSchema}
-                            imageProvider={imageProvider}
-                        />
-                    }
-                </div>
-            </div>
-        );
+      });
     }
+  }
+
+  setSelection = (schema: JsonSchema, data: any, path: string) => () => {
+    this.setState({
+      selected: {
+        schema,
+        data,
+        path
+      }
+    });
+  };
+
+  openDialog = (schema: JsonSchema, path: string) => () => {
+    this.setState({
+      dialog: {
+        open: true,
+        schema,
+        path
+      }
+    });
+  };
+
+  closeDialog = () => {
+    this.setState({
+      dialog: {
+        open: false,
+        schema: undefined,
+        path: undefined
+      }
+    });
+  };
+
+  render() {
+    const {
+      uischema,
+      schema,
+      visible,
+      path,
+      resolvedRootData,
+      rootData,
+      addToRoot,
+      filterPredicate,
+      labelProviders,
+      imageProvider,
+      classes
+    } = this.props;
+    const controlElement = uischema;
+    const dialogProps = {
+      open: this.state.dialog.open
+    };
+
+    let resetSelection;
+    if (schema.items !== undefined) {
+      resetSelection = this.setSelection(schema.items as JsonSchema, resolvedRootData[0], Paths.compose(path, '0'));
+    } else {
+      resetSelection = this.setSelection(schema, resolvedRootData, path);
+    }
+    const handlers = {
+      onSelect: this.setSelection,
+      onAdd: this.openDialog,
+      resetSelection: resetSelection
+    };
+
+    const detailUiSchema = this.props.findUISchema(this.state.selected.schema, undefined, path);
+
+    return (
+      <div hidden={!visible} className={classes.treeMasterDetail}>
+        <div>
+          <label>
+            {typeof controlElement.label === 'string' ? controlElement.label : ''}
+          </label>
+          {
+            Array.isArray(resolvedRootData) &&
+            <button onClick={addToRoot(schema, path)}>
+              Add to root
+            </button>
+          }
+        </div>
+        <div className={classes.treeMasterDetailContent}>
+          <div className={classes.treeMasterDetailMaster}>
+            <Master
+              uischema={uischema}
+              schema={schema}
+              path={path}
+              handlers={handlers}
+              selection={this.state.selected.data}
+              rootData={rootData}
+              filterPredicate={filterPredicate}
+              labelProviders={labelProviders}
+              imageProvider={imageProvider}
+            />
+          </div>
+          <div className={classes.treeMasterDetailDetail}>
+            {
+              this.state.selected ?
+                <ResolvedJsonForms
+                  schema={this.state.selected.schema}
+                  path={this.state.selected.path}
+                  uischema={detailUiSchema}
+                /> : 'Select an item'
+            }
+          </div>
+        </div>
+        <div>
+          {
+            this.state.dialog.open &&
+            <AddItemDialog
+              path={this.state.dialog.path}
+              schema={this.state.dialog.schema}
+              closeDialog={this.closeDialog}
+              dialogProps={dialogProps}
+              setSelection={this.setSelection}
+              labelProvider={labelProviders.forSchema}
+              imageProvider={imageProvider}
+            />
+          }
+        </div>
+      </div>
+    );
+  }
 }
 
 export interface WithLabelProviders {
-    // TODO typings
-    labelProviders: {
-        forSchema: SchemaLabelProvider;
-        forData: InstanceLabelProvider;
-    };
+  // TODO typings
+  labelProviders: {
+    forSchema: SchemaLabelProvider;
+    forData: InstanceLabelProvider;
+  };
 }
 
 export interface WithLabelProvider {
-    labelProvider: any;
+  labelProvider: any;
 }
 
 export interface WithImageProvider {
-    imageProvider: any;
+  imageProvider: any;
 }
 
 export interface OwnPropsOfTreeControl extends OwnPropsOfControl {
-    filterPredicate: any;
+  filterPredicate: any;
 }
 
 const mapStateToProps = (state: JsonFormsState, ownProps: OwnPropsOfTreeControl & WithImageProvider & WithLabelProviders): StatePropsOfTreeWithDetail => {
-    const path = Paths.compose(ownProps.path, Paths.fromScopable(ownProps.uischema));
-    const visible = has(ownProps, 'visible') ? ownProps.visible :  Runtime.isVisible(ownProps, state);
-    const enabled = has(ownProps, 'enabled') ? ownProps.enabled :  Runtime.isEnabled(ownProps, state);
-    const rootData = getData(state);
+  const path = Paths.compose(ownProps.path, Paths.fromScopable(ownProps.uischema));
+  const visible = has(ownProps, 'visible') ? ownProps.visible :  Runtime.isVisible(ownProps, state);
+  const enabled = has(ownProps, 'enabled') ? ownProps.enabled :  Runtime.isEnabled(ownProps, state);
+  const rootData = getData(state);
+  const rootSchema = getSchema(state);
+  const resolvedSchema = Resolve.schema(
+    ownProps.schema,
+    ownProps.uischema.scope,
+    rootSchema
+  );
 
-    return {
-        rootData: getData(state),
-        label: get(ownProps.uischema, 'label') as string,
-        resolvedRootData: Resolve.data(rootData, path),
-        uischema: ownProps.uischema,
-        schema: ownProps.schema,
-        scopedSchema: Resolve.schema(ownProps.schema, ownProps.uischema.scope),
-        findUISchema: findUISchema(state),
-        path,
-        visible,
-        enabled,
-        filterPredicate: ownProps.filterPredicate,
-        imageProvider: ownProps.imageProvider,
-        labelProviders: ownProps.labelProviders
-    };
+  return {
+    rootData: getData(state),
+    label: get(ownProps.uischema, 'label') as string,
+    resolvedRootData: Resolve.data(rootData, path),
+    uischema: ownProps.uischema,
+    schema:  resolvedSchema || rootSchema,
+    findUISchema: findUISchema(state),
+    path,
+    visible,
+    enabled,
+    filterPredicate: ownProps.filterPredicate,
+    imageProvider: ownProps.imageProvider,
+    labelProviders: ownProps.labelProviders,
+    rootSchema: getSchema(state)
+  };
 };
 
 const mapDispatchToProps = (dispatch: Dispatch<AnyAction>): DispatchPropsOfTreeWithDetail => ({
-    addToRoot(schema: JsonSchema, path: string) {
-        return () => {
-            if (isNotTuple(schema)) {
-                dispatch(
-                    Actions.update(
-                        path,
-                        data => {
-                            const clonedData = data.slice();
-                            clonedData.push({});
+  addToRoot(schema: JsonSchema, path: string) {
+    return () => {
+      if (isNotTuple(schema)) {
+        dispatch(
+          Actions.update(
+            path,
+            data => {
+              const clonedData = data.slice();
+              clonedData.push({});
 
-                            return clonedData;
-                        }
-                    )
-                );
+              return clonedData;
             }
-        };
-    }
+          )
+        );
+      }
+    };
+  }
 });
 
 const DnDTreeMasterDetail = compose<TreeWithDetailProps, TreeWithDetailProps>(
-    withStyles(styles, { name: 'TreeMasterDetail' }),
-    DragDropContext(HTML5Backend)
+  withStyles(styles, { name: 'TreeMasterDetail' }),
+  DragDropContext(HTML5Backend)
 )(TreeWithDetailRenderer);
 
 const ConnectedTreeWithDetailRenderer = connect(
-    mapStateToProps,
-    mapDispatchToProps
+  mapStateToProps,
+  mapDispatchToProps
 )(DnDTreeMasterDetail);
 export default ConnectedTreeWithDetailRenderer;

--- a/packages/material/src/complex/CombinatorProperties.tsx
+++ b/packages/material/src/complex/CombinatorProperties.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import _ from 'lodash';
+import { Generate, JsonSchema, Layout, UISchemaElement } from '@jsonforms/core';
+import { ResolvedJsonForms } from '@jsonforms/react';
+
+interface CombinatorPropertiesProps {
+  schema: JsonSchema;
+  combinatorKeyword: 'oneOf' | 'anyOf';
+  path: string;
+}
+
+export const isLayout = (uischema: UISchemaElement): uischema is Layout =>
+  uischema.hasOwnProperty('elements');
+
+export class CombinatorProperties extends React.Component<CombinatorPropertiesProps, {}> {
+
+  render() {
+
+    const { schema, combinatorKeyword, path } = this.props;
+
+    const otherProps: JsonSchema = _.omit(schema, combinatorKeyword) as JsonSchema;
+    const foundUISchema: UISchemaElement = Generate.uiSchema(otherProps, 'VerticalLayout');
+    let isLayoutWithElements = false;
+    if (foundUISchema !== null && isLayout(foundUISchema)) {
+      isLayoutWithElements = foundUISchema.elements.length > 0;
+    }
+
+    if (isLayoutWithElements) {
+      return (
+        <ResolvedJsonForms
+          schema={otherProps}
+          path={path}
+          uischema={foundUISchema}
+        />
+      );
+    }
+
+    return null;
+  }
+}
+
+export default CombinatorProperties;

--- a/packages/material/src/complex/MaterialAllOfRenderer.tsx
+++ b/packages/material/src/complex/MaterialAllOfRenderer.tsx
@@ -2,65 +2,48 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import {
-    ControlElement,
-    ControlProps,
-    generateDefaultUISchema,
-    isAllOfControl,
-    JsonSchema,
-    mapStateToControlProps,
-    RankedTester,
-    rankWith,
-    UISchemaElement,
-    VerticalLayout
+  ControlProps,
+  isAllOfControl,
+  JsonSchema,
+  mapStateToControlProps,
+  RankedTester,
+  rankWith
 } from '@jsonforms/core';
 import { ResolvedJsonForms } from '@jsonforms/react';
-
-const createControls =
-    (allOf: JsonSchema[], schema: JsonSchema, scope: string): UISchemaElement => {
-        const verticalLayout: VerticalLayout = { type: 'VerticalLayout', elements: [] };
-        return allOf.map((subSchema, index) =>
-            generateDefaultUISchema(subSchema, 'VerticalLayout', `${scope}/allOf/${index}`, schema)
-        ).reduce(
-            (layout, element) => {
-                return {
-                    ...layout,
-                    elements: (layout as VerticalLayout).elements.slice().concat([element])
-                };
-            },
-            verticalLayout
-        );
-    };
+import { createCombinatorRenderInfos, resolveSubSchemas } from './combinators';
 
 class MaterialAllOfRenderer extends React.Component<ControlProps, any> {
 
-    render() {
+  render() {
 
-        const {
-            schema,
-            uischema,
-            scopedSchema,
-            path
-        } = this.props;
+    const {
+      schema,
+      rootSchema,
+      path
+    } = this.props;
 
-        const elements = createControls(
-            (scopedSchema as JsonSchema).allOf,
-            schema,
-            (uischema as ControlElement).scope
-        );
+    const _schema = resolveSubSchemas(schema, rootSchema, 'allOf');
+    const allOfRenderInfos = createCombinatorRenderInfos((_schema as JsonSchema).allOf, rootSchema, 'allOf');
 
-        return (
+    return (
+      <React.Fragment>
+        {
+          allOfRenderInfos.map((allOfRenderInfo, allOfIndex) => (
             <ResolvedJsonForms
-                schema={schema}
-                uischema={elements}
-                path={path}
+              key={allOfIndex}
+              schema={allOfRenderInfo.schema}
+              uischema={allOfRenderInfo.uischema}
+              path={path}
             />
-        );
-
-    }
+          ))
+        }
+      </React.Fragment>
+    );
+  }
 }
 
 const ConnectedMaterialAllOfRenderer = connect(
-    mapStateToControlProps
+  mapStateToControlProps
 )(MaterialAllOfRenderer);
 
 export const materialAllOfControlTester: RankedTester = rankWith(2, isAllOfControl);

--- a/packages/material/src/complex/MaterialAnyOfRenderer.tsx
+++ b/packages/material/src/complex/MaterialAnyOfRenderer.tsx
@@ -2,90 +2,65 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import {
-    Categorization,
-    Category,
-    ControlElement,
-    ControlProps,
-    createCleanLabel,
-    generateDefaultUISchema,
-    isAnyOfControl,
-    JsonSchema,
-    mapStateToControlProps,
-    RankedTester,
-    rankWith,
-    toDataPath,
-    UISchemaElement,
+  ControlProps,
+  isAnyOfControl,
+  JsonSchema,
+  mapStateToControlProps,
+  RankedTester,
+  rankWith
 } from '@jsonforms/core';
 import { ResolvedJsonForms } from '@jsonforms/react';
+import CombinatorProperties from './CombinatorProperties';
+import { createCombinatorRenderInfos, resolveSubSchemas } from './combinators';
+import { Tab, Tabs } from '@material-ui/core';
 
-const createControls =
-    (anyOf: JsonSchema[], schema: JsonSchema, scope: string): UISchemaElement => {
-        const categorization: Categorization = {
-            label: scope,
-            type: 'Categorization',
-            elements: []
-        };
-        return anyOf.map((subSchema, index) => {
-                let label = toDataPath(scope);
-                if (subSchema.type === 'object') {
-                    label = createCleanLabel(Object.keys(subSchema.properties)[0]) + '...';
-                }
-                return {
-                    uischema: generateDefaultUISchema(
-                        subSchema,
-                        'VerticalLayout',
-                        `${scope}/anyOf/${index}`,
-                        schema
-                    ),
-                    label
-                };
-            }
-        ).reduce(
-            (layout, element) => {
-                const category: Category = {
-                    type: 'Category',
-                    label: element.label,
-                    elements: [element.uischema]
-                };
-                return {
-                    ...layout,
-                    elements: (layout as Categorization).elements.slice().concat([category])
-                };
-            },
-            categorization
-        );
-    };
+interface MaterialAnyOfState {
+  selectedAnyOf: number;
+}
 
-class MaterialAnyOfRenderer extends React.Component<ControlProps, any> {
+class MaterialAnyOfRenderer extends React.Component<ControlProps, MaterialAnyOfState> {
 
-    render() {
+  state: MaterialAnyOfState = {
+    selectedAnyOf: 0
+  };
 
-        const {
-            schema,
-            uischema,
-            scopedSchema,
-            path
-        } = this.props;
+  handleChange = (_event: any, value: number) => {
+    this.setState({ selectedAnyOf: value });
+  };
 
-        const elements = createControls(
-            (scopedSchema as JsonSchema).anyOf,
-            schema,
-            (uischema as ControlElement).scope
-        );
+  render() {
 
-        return (
-            <ResolvedJsonForms
-                schema={schema}
-                uischema={elements}
-                path={path}
+    const anyOf = 'anyOf';
+    const { path, schema, rootSchema } = this.props;
+    const _schema = resolveSubSchemas(schema, rootSchema, anyOf);
+    const anyOfRenderInfos = createCombinatorRenderInfos((_schema as JsonSchema).anyOf, rootSchema, anyOf);
+
+    return (
+      <React.Fragment>
+        <CombinatorProperties
+          schema={_schema}
+          combinatorKeyword={'anyOf'}
+          path={path}
+        />
+        <Tabs value={this.state.selectedAnyOf} onChange={this.handleChange}>
+          {anyOfRenderInfos.map(anyOfRenderInfo => <Tab key={anyOfRenderInfo.label} label={anyOfRenderInfo.label}/>)}
+        </Tabs>
+        {
+          anyOfRenderInfos.map((anyOfRenderInfo, anyOfIndex) => (
+            this.state.selectedAnyOf === anyOfIndex && <ResolvedJsonForms
+              schema={anyOfRenderInfo.schema}
+              uischema={anyOfRenderInfo.uischema}
+              path={path}
             />
-        );
-
-    }
+          ))
+        }
+      </React.Fragment>
+    );
+  }
 }
 
 const ConnectedMaterialAnyOfRenderer = connect(
-    mapStateToControlProps
+  mapStateToControlProps
 )(MaterialAnyOfRenderer);
 ConnectedMaterialAnyOfRenderer.displayName = 'MaterialAnyOfRenderer';
 export const materialAnyOfControlTester: RankedTester = rankWith(2, isAnyOfControl);

--- a/packages/material/src/complex/MaterialObjectRenderer.tsx
+++ b/packages/material/src/complex/MaterialObjectRenderer.tsx
@@ -1,17 +1,17 @@
 import isEmpty from 'lodash/isEmpty';
 import startCase from 'lodash/startCase';
 import {
-    ControlProps,
-    findUISchema,
-    GroupLayout,
-    isObjectControl,
-    JsonFormsState,
-    JsonSchema,
-    mapStateToControlProps,
-    OwnPropsOfControl,
-    RankedTester,
-    rankWith,
-    UISchemaElement
+  ControlProps,
+  findUISchema,
+  GroupLayout,
+  isObjectControl,
+  JsonFormsState,
+  JsonSchema,
+  mapStateToControlProps,
+  OwnPropsOfControl,
+  RankedTester,
+  rankWith,
+  UISchemaElement
 } from '@jsonforms/core';
 import { ResolvedJsonForms } from '@jsonforms/react';
 import { Hidden } from '@material-ui/core';
@@ -31,23 +31,22 @@ class MaterialObjectRenderer extends React.Component<MaterialObjectRendererProps
     render() {
         const {
             findUiSchema,
-            scopedSchema,
+            schema,
             path,
             visible,
         } = this.props;
 
-        const detailUiSchema = findUiSchema(scopedSchema, undefined, path, 'Group');
+        const detailUiSchema = findUiSchema(schema, undefined, path, 'Group');
         if (isEmpty(path)) {
             detailUiSchema.type = 'VerticalLayout';
         } else {
             (detailUiSchema as GroupLayout).label = startCase(path);
         }
-
         return (
             <Hidden xsUp={!visible}>
                 <ResolvedJsonForms
                     visible={visible}
-                    schema={scopedSchema}
+                    schema={schema}
                     uischema={detailUiSchema}
                     path={path}
                 />

--- a/packages/material/src/complex/MaterialOneOfRenderer.tsx
+++ b/packages/material/src/complex/MaterialOneOfRenderer.tsx
@@ -1,170 +1,136 @@
 import React from 'react';
 
 import {
-  Categorization,
-  Category,
-  ControlElement,
   ControlProps,
-  createCleanLabel,
   createDefaultValue,
-  generateDefaultUISchema,
   isOneOfControl,
   JsonSchema,
   mapDispatchToControlProps,
   mapStateToControlProps,
   RankedTester,
-  rankWith,
-  toDataPath,
-  UISchemaElement,
+  rankWith
 } from '@jsonforms/core';
-import MaterialCategorizationLayout from '../layouts/MaterialCategorizationLayout';
 import {
   Button,
   Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
-  DialogTitle
+  DialogTitle,
+  Tab,
+  Tabs
 } from '@material-ui/core';
 import { connect } from 'react-redux';
-
-const createControls =
-    (oneOf: JsonSchema[], schema: JsonSchema, scope: string): UISchemaElement => {
-        const categorization: Categorization = {
-            label: scope,
-            type: 'Categorization',
-            elements: []
-        };
-        return oneOf.map((subSchema, index) => {
-                let label = toDataPath(scope);
-                if (subSchema.type === 'object') {
-                    label = createCleanLabel(Object.keys(subSchema.properties)[0]) + '...';
-                }
-                return {
-                    uischema: generateDefaultUISchema(
-                        subSchema,
-                        'VerticalLayout',
-                        `${scope}/oneOf/${index}`,
-                        schema
-                    ),
-                    label
-                };
-            }
-        ).reduce(
-            (layout, element) => {
-                const category: Category = {
-                    type: 'Category',
-                    label: element.label,
-                    elements: [element.uischema]
-                };
-                return {
-                    ...layout,
-                    elements: (layout as Categorization).elements.slice().concat([category])
-                };
-            },
-            categorization
-        );
-    };
+import { ResolvedJsonForms } from '@jsonforms/react';
+import { createCombinatorRenderInfos, resolveSubSchemas } from './combinators';
+import CombinatorProperties from './CombinatorProperties';
 
 interface MaterialOneOfState {
-    open: boolean;
-    proceed: boolean;
-    selected: number;
-    newSelection?: any;
+  open: boolean;
+  proceed: boolean;
+  selectedOneOf: number;
+  newOneOfIndex?: any;
 }
 
-class MaterialOneOfRenderer extends React.Component<ControlProps, MaterialOneOfState> {
+interface OneOfProps {
+  rootSchema: JsonSchema;
+}
 
-    state: MaterialOneOfState = {
-        open: false,
-        proceed: false,
-        selected: 0,
-    };
+class MaterialOneOfRenderer extends React.Component<ControlProps & OneOfProps, MaterialOneOfState> {
 
-    handleClose = () => {
-        this.setState({ open: false });
-    };
+  state: MaterialOneOfState = {
+    open: false,
+    proceed: false,
+    selectedOneOf: 0,
+    newOneOfIndex: 0
+  };
 
-    cancel = () => {
-        this.setState({
-            open: false,
-            proceed: false,
-        });
-    };
+  handleClose = () => {
+    this.setState({ open: false });
+  };
 
-    confirm = () => {
-        // TODO: use setState based on function
-        const { path, scopedSchema, handleChange } = this.props;
-        handleChange(
-            path,
-            createDefaultValue(scopedSchema.oneOf[this.state.selected])
-        );
-        this.setState({
-            open: false,
-            proceed: true,
-            selected: this.state.newSelection
-        });
-    };
+  cancel = () => {
+    this.setState({
+      open: false,
+      proceed: false
+    });
+  };
 
-    render() {
+  confirm = () => {
+    const { path, schema, handleChange } = this.props;
+    handleChange(
+      path,
+      createDefaultValue(schema.oneOf[this.state.selectedOneOf])
+    );
+    this.setState({
+      open: false,
+      proceed: true,
+      selectedOneOf: this.state.newOneOfIndex
+    });
+  };
 
-        const {
-            schema,
-            uischema,
-            scopedSchema,
-            path,
-        } = this.props;
+  handleChange = (_event: any, newOneOfIndex: number) => {
+    this.setState({
+      open: true,
+      newOneOfIndex
+    });
+  };
 
-        const elements = createControls(
-            (scopedSchema as JsonSchema).oneOf,
-            schema,
-            (uischema as ControlElement).scope
-        );
+  render() {
 
-        return (
-            <React.Fragment>
-                <MaterialCategorizationLayout
-                    ownState={false}
-                    onChange={(newSelection: any) => {
-                        if (newSelection !== this.state.selected) {
-                            this.setState({
-                                proceed: false,
-                                open: true,
-                                newSelection,
-                            });
-                        }
-                    }}
-                    selected={this.state.selected}
-                    schema={schema}
-                    uischema={elements}
-                    path={path}
-                />
-                <Dialog
-                    open={this.state.open}
-                    onClose={this.handleClose}
-                    aria-labelledby='alert-dialog-title'
-                    aria-describedby='alert-dialog-description'
-                >
-                    <DialogTitle id='alert-dialog-title'>{'Clear form?'}</DialogTitle>
-                    <DialogContent>
-                        <DialogContentText id='alert-dialog-description'>
-                           Your data will be cleared if you navigate away from this tab.
-                            Do you want to proceed?
-                        </DialogContentText>
-                    </DialogContent>
-                    <DialogActions>
-                        <Button onClick={this.cancel} color='primary'>
-                            No
-                        </Button>
-                        <Button onClick={this.confirm} color='primary' autoFocus>
-                            Yes
-                        </Button>
-                    </DialogActions>
-                </Dialog>
-            </React.Fragment>
-        );
+    const oneOf = 'oneOf';
+    const { schema, path, rootSchema } = this.props;
+    const _schema = resolveSubSchemas(schema, rootSchema, oneOf);
+    const oneOfRenderInfos = createCombinatorRenderInfos((_schema as JsonSchema).oneOf, rootSchema, oneOf);
 
-    }
+    return (
+      <React.Fragment>
+        <CombinatorProperties
+          schema={_schema}
+          combinatorKeyword={'oneOf'}
+          path={path}
+        />
+        <Tabs value={this.state.selectedOneOf} onChange={this.handleChange}>
+          {oneOfRenderInfos.map(oneOfRenderInfo => <Tab key={oneOfRenderInfo.label} label={oneOfRenderInfo.label}/>)}
+        </Tabs>
+        {
+          oneOfRenderInfos.map((oneOfRenderInfo, oneOfIndex) => (
+            this.state.selectedOneOf === oneOfIndex && (
+              <ResolvedJsonForms
+                key={oneOfIndex}
+                schema={oneOfRenderInfo.schema}
+                uischema={oneOfRenderInfo.uischema}
+                path={path}
+              />
+            )
+          ))
+        }
+        <Dialog
+          open={this.state.open}
+          onClose={this.handleClose}
+          aria-labelledby='alert-dialog-title'
+          aria-describedby='alert-dialog-description'
+        >
+          <DialogTitle id='alert-dialog-title'>{'Clear form?'}</DialogTitle>
+          <DialogContent>
+            <DialogContentText id='alert-dialog-description'>
+              Your data will be cleared if you navigate away from this tab.
+              Do you want to proceed?
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={this.cancel} color='primary'>
+              No
+            </Button>
+            <Button onClick={this.confirm} color='primary' autoFocus>
+              Yes
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </React.Fragment>
+    );
+
+  }
 }
 
 const ConnectedMaterialOneOfRenderer = connect(
@@ -172,5 +138,5 @@ const ConnectedMaterialOneOfRenderer = connect(
   mapDispatchToControlProps
 )(MaterialOneOfRenderer);
 ConnectedMaterialOneOfRenderer.displayName = 'MaterialOneOfRenderer';
-export const materialOneOfControlTester: RankedTester = rankWith(2, isOneOfControl);
+export const materialOneOfControlTester: RankedTester = rankWith(3, isOneOfControl);
 export default ConnectedMaterialOneOfRenderer;

--- a/packages/material/src/complex/MaterialTableControl.tsx
+++ b/packages/material/src/complex/MaterialTableControl.tsx
@@ -172,13 +172,13 @@ const NonEmptyRow = (
 
 const TableRows = (
   {
-    data, path, scopedSchema, childErrors, openDeleteDialog
+    data, path, schema, childErrors, openDeleteDialog
   }: ArrayControlProps & WithDeleteDialogSupport) => {
 
   const isEmptyTable = !data || !Array.isArray(data) || data.length === 0;
 
   if (isEmptyTable) {
-    return (<EmptyTable numColumns={getValidColumnProps(scopedSchema).length + 1} />);
+    return (<EmptyTable numColumns={getValidColumnProps(schema).length + 1} />);
   }
 
   return data.map((_child: any, index: number) => {
@@ -189,7 +189,7 @@ const TableRows = (
         key={childPath}
         childPath={childPath}
         rowData={_child}
-        scopedSchema={scopedSchema}
+        scopedSchema={schema}
         childErrors={childErrors}
         openDeleteDialog={openDeleteDialog}
       />
@@ -204,19 +204,21 @@ export class MaterialTableControl
     const {
       label,
       path,
-      scopedSchema,
+      schema,
+      rootSchema,
       uischema,
       childErrors,
       errors,
+      createDefaultValue,
       addItem,
       openDeleteDialog
     } = this.props;
     const controlElement = uischema as ControlElement;
     const labelObject = Helpers.createLabelDescriptionFrom(controlElement);
     const allErrors = [].concat(errors).concat(childErrors.map((e: ErrorObject) => e.message));
-    const isObjectSchema = scopedSchema.type === 'object';
+    const isObjectSchema = schema.type === 'object';
     const headerCells: any = isObjectSchema ?
-      generateCells(TableHeaderCell, scopedSchema, path) : undefined;
+      generateCells(TableHeaderCell, schema, path) : undefined;
 
     return (
       <React.Fragment>
@@ -229,6 +231,10 @@ export class MaterialTableControl
               addItem={addItem}
               numColumns={isObjectSchema ? headerCells.length : 1}
               path={path}
+              uischema={controlElement}
+              schema={schema}
+              rootSchema={rootSchema}
+              createDefaultValue={createDefaultValue}
             />
             {
               isObjectSchema &&

--- a/packages/material/src/complex/TableToolbar.tsx
+++ b/packages/material/src/complex/TableToolbar.tsx
@@ -23,12 +23,11 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { LabelDescription, Labels } from '@jsonforms/core';
+import { ControlElement, JsonSchema, LabelDescription, Labels } from '@jsonforms/core';
 import IconButton from '@material-ui/core/IconButton';
-import { Grid, Hidden } from '@material-ui/core';
+import { Grid, Hidden, Typography } from '@material-ui/core';
 import TableRow from '@material-ui/core/TableRow';
 import Tooltip from '@material-ui/core/Tooltip';
-import { Typography } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import ValidationIcon from './ValidationIcon';
 import NoBorderTableCell from './NoBorderTableCell';
@@ -39,11 +38,15 @@ export interface MaterialTableToolbarProps {
     label: string | Labels;
     labelObject: LabelDescription;
     path: string;
-    addItem(path: string): () => void;
+    uischema: ControlElement;
+    schema: JsonSchema;
+    rootSchema: JsonSchema;
+    createDefaultValue(): void;
+    addItem(path: string, value: any): () => void;
 }
 
 const TableToolbar = (
-    { numColumns, errors, label, labelObject, path, addItem }: MaterialTableToolbarProps
+    { numColumns, createDefaultValue, errors, label, labelObject, path, addItem }: MaterialTableToolbarProps
 ) => (
     <TableRow>
         <NoBorderTableCell colSpan={numColumns}>
@@ -76,7 +79,7 @@ const TableToolbar = (
             >
                 <IconButton
                     aria-label={`Add to ${labelObject.text}`}
-                    onClick={addItem(path)}
+                    onClick={addItem(path, createDefaultValue())}
                 >
                     <AddIcon/>
                 </IconButton>

--- a/packages/material/src/complex/combinators.ts
+++ b/packages/material/src/complex/combinators.ts
@@ -1,0 +1,60 @@
+import {
+  generateDefaultUISchema,
+  JsonSchema,
+  resolveSchema,
+  UISchemaElement
+} from '@jsonforms/core';
+
+export interface CombinatorSubSchemaRenderInfo {
+  schema: JsonSchema;
+  uischema: UISchemaElement;
+  label: string;
+}
+
+type CombinatorKeyword = 'anyOf' | 'oneOf' | 'allOf';
+
+const createLabel = (
+  subSchema: JsonSchema,
+  subSchemaIndex: number,
+  keyword: CombinatorKeyword
+): string => {
+  if (subSchema.title) {
+    return subSchema.title;
+  } else {
+    return keyword + '-' + subSchemaIndex;
+  }
+};
+
+export const resolveSubSchemas = (
+  schema: JsonSchema,
+  rootSchema: JsonSchema,
+  keyword: CombinatorKeyword
+) => {
+  // resolve any $refs, otherwise the generated UI schema can't match the schema???
+  const schemas = schema[keyword] as any[];
+  if (schemas.findIndex(e => e.$ref !== undefined) !== -1) {
+    return {
+      ...schema,
+      [keyword]: (schema[keyword] as any[]).map(e =>
+        e.$ref ? resolveSchema(rootSchema, e.$ref) : e
+      )
+    };
+  }
+  return schema;
+};
+
+export const createCombinatorRenderInfos = (
+  combinatorSubSchemas: JsonSchema[],
+  rootSchema: JsonSchema,
+  keyword: CombinatorKeyword
+): CombinatorSubSchemaRenderInfo[] =>
+  combinatorSubSchemas.map((subSchema, subSchemaIndex) => ({
+    schema: subSchema,
+    uischema: generateDefaultUISchema(
+      subSchema,
+      'VerticalLayout',
+      `#`,
+      rootSchema
+    ),
+    label: createLabel(subSchema, subSchemaIndex, keyword)
+  }));

--- a/packages/material/src/controls/MaterialBooleanControl.tsx
+++ b/packages/material/src/controls/MaterialBooleanControl.tsx
@@ -37,30 +37,23 @@ import { FormControlLabel, Hidden } from '@material-ui/core';
 import MaterialBooleanField from '../fields/MaterialBooleanField';
 
 export const MaterialBooleanControl =
-  ({ label, uischema, schema, visible, parentPath, id }: ControlProps) => {
+  ({ label, uischema, schema, visible, path, id }: ControlProps) => (
+    <Hidden xsUp={!visible}>
+      <FormControlLabel
+        label={label}
+        id={id}
+        control={
+          <MaterialBooleanField
+            uischema={uischema}
+            schema={schema}
+            path={path}
+            id={id + '-input'}
+          />
+        }
+      />
+    </Hidden>
+  );
 
-    return (
-      <Hidden xsUp={!visible}>
-        <FormControlLabel
-          label={label}
-          id={id}
-          control={
-            <MaterialBooleanField
-              uischema={uischema}
-              schema={schema}
-              path={parentPath}
-              id={id + '-input'}
-            />
-          }
-        />
-      </Hidden>
-
-    );
-  };
-
-const ConnectedMaterialBooleanControl = connect(
-  mapStateToControlProps
-)(MaterialBooleanControl);
-
+const ConnectedMaterialBooleanControl = connect(mapStateToControlProps)(MaterialBooleanControl);
 export const materialBooleanControlTester: RankedTester = rankWith(2, isBooleanControl);
 export default ConnectedMaterialBooleanControl;

--- a/packages/material/src/controls/MaterialInputControl.tsx
+++ b/packages/material/src/controls/MaterialInputControl.tsx
@@ -52,7 +52,7 @@ export class MaterialInputControl extends Control<ControlProps, ControlState> {
       schema,
       visible,
       required,
-      parentPath,
+      path,
       config
     } = this.props;
     const isValid = errors.length === 0;
@@ -84,7 +84,7 @@ export class MaterialInputControl extends Control<ControlProps, ControlState> {
         <DispatchField
             uischema={uischema}
             schema={schema}
-            path={parentPath}
+            path={path}
             id={id + '-input'}
             showError={false}
         />

--- a/packages/material/src/controls/MaterialNativeControl.tsx
+++ b/packages/material/src/controls/MaterialNativeControl.tsx
@@ -49,7 +49,7 @@ export class MaterialNativeControl extends Control<ControlProps, ControlState> {
       id,
       errors,
       label,
-      scopedSchema,
+      schema,
       description,
       visible,
       required,
@@ -61,7 +61,7 @@ export class MaterialNativeControl extends Control<ControlProps, ControlState> {
     const isValid = errors.length === 0;
     const trim = config.trim;
     const onChange = (ev: any) => handleChange(path, ev.target.value);
-    const fieldType = scopedSchema.format;
+    const fieldType = schema.format;
     const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused);
 
     return (

--- a/packages/material/src/controls/MaterialRadioGroupControl.tsx
+++ b/packages/material/src/controls/MaterialRadioGroupControl.tsx
@@ -25,26 +25,19 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import {
-    computeLabel,
-    ControlElement,
-    ControlProps,
-    ControlState,
-    formatErrorMessage,
-    isDescriptionHidden,
-    isPlainLabel,
-    mapDispatchToControlProps,
-    mapStateToControlProps,
-    resolveSchema,
+  computeLabel,
+  ControlProps,
+  ControlState,
+  formatErrorMessage,
+  isDescriptionHidden,
+  isPlainLabel,
+  mapDispatchToControlProps,
+  mapStateToControlProps
 } from '@jsonforms/core';
 import { Control } from '@jsonforms/react';
 import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
-import {
-    FormControl,
-    FormControlLabel,
-    FormHelperText,
-    FormLabel
-} from '@material-ui/core';
+import { FormControl, FormControlLabel, FormHelperText, FormLabel } from '@material-ui/core';
 
 export class MaterialRadioGroupControl extends Control<ControlProps, ControlState> {
     render() {
@@ -56,7 +49,6 @@ export class MaterialRadioGroupControl extends Control<ControlProps, ControlStat
             description,
             errors,
             data,
-            uischema,
             schema,
             visible
         } = this.props;
@@ -68,7 +60,7 @@ export class MaterialRadioGroupControl extends Control<ControlProps, ControlStat
         const trim = config.trim;
         const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused);
 
-        const options = resolveSchema(schema, (uischema as ControlElement).scope).enum;
+        const options = schema.enum;
 
         return (
             <FormControl
@@ -109,5 +101,4 @@ export class MaterialRadioGroupControl extends Control<ControlProps, ControlStat
     }
 }
 
-export default connect(mapStateToControlProps, mapDispatchToControlProps)
-    (MaterialRadioGroupControl);
+export default connect(mapStateToControlProps, mapDispatchToControlProps)(MaterialRadioGroupControl);

--- a/packages/material/src/controls/MaterialSliderControl.tsx
+++ b/packages/material/src/controls/MaterialSliderControl.tsx
@@ -51,7 +51,7 @@ export class MaterialSliderControl extends Control<ControlProps, ControlState> {
       enabled,
       errors,
       label,
-      scopedSchema,
+      schema,
       handleChange,
       visible,
       path,
@@ -95,24 +95,24 @@ export class MaterialSliderControl extends Control<ControlProps, ControlState> {
         </Typography>
         <div style={rangeContainerStyle}>
           <Typography style={rangeItemStyle} variant='caption' align='left'>
-            {scopedSchema.minimum}
+            {schema.minimum}
           </Typography>
           <Typography style={rangeItemStyle} variant='caption' align='right'>
-            {scopedSchema.maximum}
+            {schema.maximum}
           </Typography>
         </div>
         <Slider
           style={sliderStyle}
-          min={scopedSchema.minimum}
-          max={scopedSchema.maximum}
-          value={Number(data || scopedSchema.default)}
+          min={schema.minimum}
+          max={schema.maximum}
+          value={Number(data || schema.default)}
           onChange={(_ev, value) => {
             handleChange(path, Number(value));
           }
           }
           id={id + '-input'}
           disabled={!enabled}
-          step={scopedSchema.multipleOf || 1}
+          step={schema.multipleOf || 1}
         />
         <FormHelperText error={!isValid}>
           {!isValid ? formatErrorMessage(errors) : showDescription ? description : null}

--- a/packages/material/src/fields/MaterialNumberFormatField.tsx
+++ b/packages/material/src/fields/MaterialNumberFormatField.tsx
@@ -45,9 +45,9 @@ export const MaterialNumberFormatField = (props: FieldProps & WithClassname & Fo
     isValid,
     path,
     handleChange,
-    scopedSchema
+    schema
   } = props;
-  const maxLength = scopedSchema.maxLength;
+  const maxLength = schema.maxLength;
   let config;
   if (uischema.options && uischema.options.restrict) {
     config = {'maxLength': maxLength};

--- a/packages/material/src/fields/MaterialTextField.tsx
+++ b/packages/material/src/fields/MaterialTextField.tsx
@@ -24,13 +24,13 @@
 */
 import React from 'react';
 import {
-    FieldProps,
-    isStringControl,
-    mapDispatchToFieldProps,
-    mapStateToFieldProps,
-    RankedTester,
-    rankWith,
-    WithClassname,
+  FieldProps,
+  isStringControl,
+  mapDispatchToFieldProps,
+  mapStateToFieldProps,
+  RankedTester,
+  rankWith,
+  WithClassname
 } from '@jsonforms/core';
 import Input from '@material-ui/core/Input';
 import { connect } from 'react-redux';
@@ -46,9 +46,9 @@ export const MaterialTextField = (props: FieldProps & WithClassname) => {
     isValid,
     path,
     handleChange,
-    scopedSchema
+    schema
   } = props;
-  const maxLength = scopedSchema.maxLength;
+  const maxLength = schema.maxLength;
   let inputProps: any;
   if (config.restrict) {
     inputProps = {'maxLength': maxLength};
@@ -76,6 +76,7 @@ export const MaterialTextField = (props: FieldProps & WithClassname) => {
     />
   );
 };
+
 /**
  * Default tester for text-based/string controls.
  * @type {RankedTester}

--- a/packages/material/src/layouts/MaterialArrayLayout.tsx
+++ b/packages/material/src/layouts/MaterialArrayLayout.tsx
@@ -46,7 +46,8 @@ export const MaterialArrayLayout =
      data,
      path,
      label,
-     scopedSchema,
+     schema,
+     createDefaultValue,
      uischema,
      errors,
      addItem,
@@ -54,8 +55,8 @@ export const MaterialArrayLayout =
      removeItems
    }: ArrayControlProps) => {
 
-    const firstPrimitiveProp = scopedSchema.properties ? find(Object.keys(scopedSchema.properties), propName => {
-      const prop = scopedSchema.properties[propName];
+    const firstPrimitiveProp = schema.properties ? find(Object.keys(schema.properties), propName => {
+      const prop = schema.properties[propName];
       return prop.type === 'string' ||
         prop.type === 'number' ||
         prop.type === 'integer';
@@ -83,7 +84,7 @@ export const MaterialArrayLayout =
                   >
                     <IconButton
                       aria-label={`Add to ${label}`}
-                      onClick={addItem(path)}
+                      onClick={addItem(path, createDefaultValue())}
                     >
                       <AddIcon/>
                     </IconButton>
@@ -98,7 +99,7 @@ export const MaterialArrayLayout =
             data ? map(data, (childData, index) => {
 
               const foundUISchema =
-                findUISchema(scopedSchema, uischema.scope, path, undefined, uischema);
+                findUISchema(schema, uischema.scope, path, undefined, uischema);
               const childPath = composePaths(path, `${index}`);
               const childLabel = firstPrimitiveProp ? childData[firstPrimitiveProp] : '';
 
@@ -134,7 +135,7 @@ export const MaterialArrayLayout =
                   </ExpansionPanelSummary>
                   <ExpansionPanelDetails>
                     <ResolvedJsonForms
-                      schema={scopedSchema}
+                      schema={schema}
                       uischema={foundUISchema}
                       path={childPath}
                       key={childPath}

--- a/packages/material/src/layouts/MaterialArrayLayoutRenderer.tsx
+++ b/packages/material/src/layouts/MaterialArrayLayoutRenderer.tsx
@@ -1,19 +1,19 @@
 /*
   The MIT License
-  
+
   Copyright (c) 2018 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
-  
+
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
-  
+
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
-  
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,54 +25,55 @@
 import React from 'react';
 
 import {
-    ArrayControlProps,
-    ControlElement,
-    Helpers,
-    isObjectArrayWithNesting,
-    mapDispatchToArrayControlProps,
-    mapStateToControlProps,
-    RankedTester,
-    rankWith,
-    Resolve
+  ArrayControlProps,
+  ControlElement,
+  Helpers,
+  isObjectArrayWithNesting,
+  mapDispatchToArrayControlProps,
+  mapStateToArrayControlProps,
+  RankedTester,
+  rankWith
 } from '@jsonforms/core';
 import { MaterialArrayLayout } from './MaterialArrayLayout';
 import { connect } from 'react-redux';
 
-export const MaterialArrayLayoutRenderer  =
-  ({
-     schema,
-     uischema,
-     data,
-     path,
-     findUISchema,
-     addItem,
-     removeItems,
-     errors
-   }: ArrayControlProps) => {
+export const MaterialArrayLayoutRenderer  = (
+  {
+    uischema,
+    data,
+    path,
+    findUISchema,
+    addItem,
+    removeItems,
+    errors,
+    createDefaultValue,
+    schema,
+    rootSchema,
+  }: ArrayControlProps) => {
 
-    const controlElement = uischema as ControlElement;
-    const labelDescription = Helpers.createLabelDescriptionFrom(controlElement);
-    const resolvedSchema = Resolve.schema(schema, `${controlElement.scope}/items`);
-    const label = labelDescription.show ? labelDescription.text : '';
+  const controlElement = uischema as ControlElement;
+  const labelDescription = Helpers.createLabelDescriptionFrom(controlElement);
+  const label = labelDescription.show ? labelDescription.text : '';
 
-    return (
-      <MaterialArrayLayout
-        data={data}
-        label={label}
-        path={path}
-        scopedSchema={resolvedSchema}
-        addItem={addItem}
-        removeItems={removeItems}
-        findUISchema={findUISchema}
-        uischema={uischema}
-        schema={schema}
-        errors={errors}
-      />
-    );
-  };
+  return (
+    <MaterialArrayLayout
+      data={data}
+      label={label}
+      path={path}
+      addItem={addItem}
+      removeItems={removeItems}
+      findUISchema={findUISchema}
+      uischema={uischema}
+      schema={schema}
+      errors={errors}
+      rootSchema={rootSchema}
+      createDefaultValue={createDefaultValue}
+    />
+  );
+};
 
 const ConnectedMaterialArrayLayoutRenderer = connect(
-  mapStateToControlProps,
+  mapStateToArrayControlProps,
   mapDispatchToArrayControlProps
 )(MaterialArrayLayoutRenderer);
 

--- a/packages/material/test/renderers/MaterialArrayLayout.test.tsx
+++ b/packages/material/test/renderers/MaterialArrayLayout.test.tsx
@@ -1,19 +1,19 @@
 /*
   The MIT License
-  
+
   Copyright (c) 2018 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
-  
+
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
-  
+
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
-  
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,12 +22,7 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import {
-  Actions,
-  ControlElement,
-  jsonformsReducer,
-  JsonFormsState
-} from '@jsonforms/core';
+import { Actions, ControlElement, jsonformsReducer, JsonFormsState } from '@jsonforms/core';
 import * as React from 'react';
 import { Provider } from 'react-redux';
 import * as TestUtils from 'react-dom/test-utils';
@@ -161,7 +156,10 @@ describe('Material array layout', () => {
     const store = initJsonFormsStore();
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <MaterialArrayLayout schema={schema} uischema={uischema}/>
+        <MaterialArrayLayout
+          schema={schema}
+          uischema={uischema}
+        />
       </Provider>
     ) as React.Component<any, any, any>;
 
@@ -174,7 +172,10 @@ describe('Material array layout', () => {
     const store = initJsonFormsStore();
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <MaterialArrayLayout schema={schema} uischema={uischemaOptions.generate}/>
+        <MaterialArrayLayout
+          schema={schema}
+          uischema={uischemaOptions.generate}
+        />
       </Provider>
     ) as React.Component<any, any, any>;
 
@@ -187,7 +188,10 @@ describe('Material array layout', () => {
     const store = initJsonFormsStore();
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <MaterialArrayLayout schema={schema} uischema={uischemaOptions.inline}/>
+        <MaterialArrayLayout
+          schema={schema}
+          uischema={uischemaOptions.inline}
+        />
       </Provider>
     ) as React.Component<any, any, any>;
 

--- a/packages/material/test/renderers/MaterialBooleanField.test.tsx
+++ b/packages/material/test/renderers/MaterialBooleanField.test.tsx
@@ -60,12 +60,7 @@ export const initJsonFormsStore = (testData: any, testSchema: JsonSchema, testUi
 
 const data = { foo: true };
 const schema = {
-  type: 'object',
-  properties: {
-    foo: {
-      type: 'boolean'
-    }
-  }
+  type: 'boolean'
 };
 const uischema: ControlElement = {
   type: 'Control',
@@ -194,7 +189,11 @@ describe('Material boolean field', () => {
     const store = initJsonFormsStore(data, schema, control);
     const tree = ReactDOM.render(
       <Provider store={store}>
-        <BooleanField schema={schema} uischema={control}/>
+        <BooleanField
+          schema={schema}
+          uischema={control}
+          path='foo'
+        />
       </Provider>,
       container
     ) as React.Component<any, any, any>;
@@ -213,7 +212,11 @@ describe('Material boolean field', () => {
     const store = initJsonFormsStore(data, schema, control);
     const tree = ReactDOM.render(
       <Provider store={store}>
-        <BooleanField schema={schema} uischema={control}/>
+        <BooleanField
+          schema={schema}
+          uischema={control}
+          path='foo'
+        />
       </Provider>,
       container
     ) as React.Component<any, any, any>;
@@ -229,7 +232,11 @@ describe('Material boolean field', () => {
     const store = initJsonFormsStore(data, schema, control);
     const tree = ReactDOM.render(
       <Provider store={store}>
-        <BooleanField schema={schema} uischema={uischema}/>
+        <BooleanField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>,
       container
     ) as React.Component<any, any, any>;
@@ -241,7 +248,11 @@ describe('Material boolean field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = ReactDOM.render(
       <Provider store={store}>
-        <BooleanField schema={schema} uischema={uischema}/>
+        <BooleanField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>,
       container
     ) as React.Component<any, any, any>;
@@ -255,7 +266,11 @@ describe('Material boolean field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = ReactDOM.render(
       <Provider store={store}>
-        <BooleanField schema={schema} uischema={uischema}/>
+        <BooleanField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>,
       container
     ) as React.Component<any, any, any>;
@@ -270,7 +285,11 @@ describe('Material boolean field', () => {
     const store = initJsonFormsStore({'foo': false}, schema, uischema);
     const tree = ReactDOM.render(
       <Provider store={store}>
-        <BooleanField schema={schema} uischema={uischema}/>
+        <BooleanField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>,
       container
     ) as React.Component<any, any, any>;
@@ -284,7 +303,11 @@ describe('Material boolean field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = ReactDOM.render(
       <Provider store={store}>
-        <BooleanField schema={schema} uischema={uischema}/>
+        <BooleanField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>,
       container
     ) as React.Component<any, any, any>;
@@ -297,7 +320,11 @@ describe('Material boolean field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = ReactDOM.render(
       <Provider store={store}>
-        <BooleanField schema={schema} uischema={uischema}/>
+        <BooleanField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>,
       container
     ) as React.Component<any, any, any>;
@@ -310,7 +337,11 @@ describe('Material boolean field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = ReactDOM.render(
       <Provider store={store}>
-        <BooleanField schema={schema} uischema={uischema}/>
+        <BooleanField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>,
       container
     ) as React.Component<any, any, any>;
@@ -323,7 +354,11 @@ describe('Material boolean field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = ReactDOM.render(
       <Provider store={store}>
-        <BooleanField schema={schema} uischema={uischema}/>
+        <BooleanField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>,
       container
     ) as React.Component<any, any, any>;
@@ -336,7 +371,11 @@ describe('Material boolean field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = ReactDOM.render(
       <Provider store={store}>
-        <BooleanField schema={schema} uischema={uischema}/>
+        <BooleanField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>,
       container
     ) as React.Component<any, any, any>;
@@ -349,7 +388,12 @@ describe('Material boolean field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = ReactDOM.render(
       <Provider store={store}>
-        <BooleanField schema={schema} uischema={uischema} enabled={false}/>
+        <BooleanField
+          schema={schema}
+          uischema={uischema}
+          enabled={false}
+          path='foo'
+        />
       </Provider>,
       container
     ) as React.Component<any, any, any>;
@@ -361,7 +405,11 @@ describe('Material boolean field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = ReactDOM.render(
       <Provider store={store}>
-        <BooleanField schema={schema} uischema={uischema}/>
+        <BooleanField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>,
       container
     ) as React.Component<any, any, any>;
@@ -373,7 +421,12 @@ describe('Material boolean field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = ReactDOM.render(
       <Provider store={store}>
-        <BooleanField schema={schema} uischema={uischema} id='myid'/>
+        <BooleanField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+          id='myid'
+        />
       </Provider>,
       container
     ) as React.Component<any, any, any>;

--- a/packages/material/test/renderers/MaterialDateField.test.tsx
+++ b/packages/material/test/renderers/MaterialDateField.test.tsx
@@ -59,13 +59,8 @@ const initJsonFormsStore = (testData: any, testSchema: JsonSchema, testUiSchema:
 
 const data = { 'foo': '1980-06-04' };
 const schema = {
-  type: 'object',
-  properties: {
-    foo: {
-      type: 'string',
-      format: 'date'
-    },
-  },
+    type: 'string',
+    format: 'date'
 };
 const uischema: ControlElement = {
   type: 'Control',
@@ -186,7 +181,11 @@ describe('Material date field', () => {
     const store = initJsonFormsStore(data, schema, control);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <MaterialDateField schema={schema} uischema={control}/>
+        <MaterialDateField
+          schema={schema}
+          uischema={control}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -204,7 +203,11 @@ describe('Material date field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <MaterialDateField schema={schema} uischema={control}/>
+        <MaterialDateField
+          schema={schema}
+          uischema={control}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -219,7 +222,11 @@ describe('Material date field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <MaterialDateField schema={schema} uischema={control}/>
+        <MaterialDateField
+          schema={schema}
+          uischema={control}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -230,7 +237,11 @@ describe('Material date field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <MaterialDateField schema={schema} uischema={uischema}/>
+        <MaterialDateField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
 
@@ -243,7 +254,11 @@ describe('Material date field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <MaterialDateField schema={schema} uischema={uischema}/>
+        <MaterialDateField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -256,7 +271,11 @@ describe('Material date field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <MaterialDateField schema={schema} uischema={uischema}/>
+        <MaterialDateField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -268,7 +287,11 @@ describe('Material date field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <MaterialDateField schema={schema} uischema={uischema}/>
+        <MaterialDateField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -280,7 +303,11 @@ describe('Material date field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <MaterialDateField schema={schema} uischema={uischema}/>
+        <MaterialDateField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -292,7 +319,11 @@ describe('Material date field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <MaterialDateField schema={schema} uischema={uischema}/>
+        <MaterialDateField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -304,7 +335,11 @@ describe('Material date field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <MaterialDateField schema={schema} uischema={uischema}/>
+        <MaterialDateField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -316,7 +351,11 @@ describe('Material date field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <MaterialDateField schema={schema} uischema={uischema}/>
+        <MaterialDateField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -328,7 +367,12 @@ describe('Material date field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <MaterialDateField schema={schema} uischema={uischema} enabled={false}/>
+        <MaterialDateField
+          schema={schema}
+          uischema={uischema}
+          enabled={false}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -339,7 +383,11 @@ describe('Material date field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <MaterialDateField schema={schema} uischema={uischema}/>
+        <MaterialDateField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/material/test/renderers/MaterialEnumField.test.tsx
+++ b/packages/material/test/renderers/MaterialEnumField.test.tsx
@@ -29,8 +29,7 @@ import {
   jsonformsReducer,
   JsonFormsState,
   JsonSchema,
-  UISchemaElement,
-  update
+  UISchemaElement
 } from '@jsonforms/core';
 import MaterialEnumField, { materialEnumFieldTester } from '../../src/fields/MaterialEnumField';
 import { Provider } from 'react-redux';
@@ -40,13 +39,8 @@ import { combineReducers, createStore, Store } from 'redux';
 
 const data =  { nationality: 'JP'};
 const schema = {
-  type: 'object',
-  properties: {
-    nationality: {
-      type: 'string',
-      enum: ['DE', 'IT', 'JP', 'US', 'RU', 'Other']
-    }
-  }
+  type: 'string',
+  enum: ['DE', 'IT', 'JP', 'US', 'RU', 'Other']
 };
 const uischema = {
   type: 'Control',
@@ -97,12 +91,14 @@ describe('Material enum field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <MaterialEnumField schema={schema} uischema={uischema}/>
+        <MaterialEnumField
+          schema={schema}
+          uischema={uischema}
+          path='nationality'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
-
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
-    store.dispatch(update('nationality', () => 'DE'));
-    expect(input.value).toBe('DE');
+    expect(input.value).toBe('JP');
   });
 });

--- a/packages/material/test/renderers/MaterialIntegerField.test.tsx
+++ b/packages/material/test/renderers/MaterialIntegerField.test.tsx
@@ -44,14 +44,9 @@ import { combineReducers, createStore, Store } from 'redux';
 
 const data = {'foo': 42};
 const schema = {
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'integer',
-        minimum: 5
-      },
-    },
-  };
+  type: 'integer',
+  minimum: 5
+};
 const uischema: ControlElement = {
   type: 'Control',
   scope: '#/properties/foo'
@@ -168,7 +163,11 @@ describe('Material integer field', () => {
     const store = initJsonFormsStore(data, schema, control);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <IntegerField schema={schema} uischema={control}/>
+        <IntegerField
+          schema={schema}
+          uischema={control}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -186,7 +185,11 @@ describe('Material integer field', () => {
     const store = initJsonFormsStore(data, schema, control);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <IntegerField schema={schema} uischema={control} />
+        <IntegerField
+          schema={schema}
+          uischema={control}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -201,7 +204,11 @@ describe('Material integer field', () => {
     const store = initJsonFormsStore(data, schema, control);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <IntegerField schema={schema} uischema={control} />
+        <IntegerField
+          schema={schema}
+          uischema={control}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -212,7 +219,11 @@ describe('Material integer field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <IntegerField schema={schema} uischema={uischema}/>
+        <IntegerField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
 
@@ -226,7 +237,11 @@ describe('Material integer field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <IntegerField schema={schema} uischema={uischema}/>
+        <IntegerField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
 
@@ -244,7 +259,11 @@ describe('Material integer field', () => {
     );
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <IntegerField schema={schema} uischema={uischema}/>
+        <IntegerField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -256,7 +275,11 @@ describe('Material integer field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <IntegerField schema={schema} uischema={uischema}/>
+        <IntegerField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -268,7 +291,11 @@ describe('Material integer field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <IntegerField schema={schema} uischema={uischema}/>
+        <IntegerField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -281,7 +308,11 @@ describe('Material integer field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <IntegerField schema={schema} uischema={uischema}/>
+        <IntegerField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -293,7 +324,11 @@ describe('Material integer field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <IntegerField schema={schema} uischema={uischema}/>
+        <IntegerField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -305,7 +340,11 @@ describe('Material integer field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <IntegerField schema={schema} uischema={uischema}/>
+        <IntegerField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     store.dispatch(update(undefined, () => 13));
@@ -317,7 +356,12 @@ describe('Material integer field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <IntegerField schema={schema} uischema={uischema} enabled={false}/>
+        <IntegerField
+          schema={schema}
+          uischema={uischema}
+          enabled={false}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -328,7 +372,11 @@ describe('Material integer field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <IntegerField schema={schema} uischema={uischema}/>
+        <IntegerField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/material/test/renderers/MaterialNumberField.test.tsx
+++ b/packages/material/test/renderers/MaterialNumberField.test.tsx
@@ -59,13 +59,8 @@ const initJsonFormsStore = (testData: any, testSchema: JsonSchema, testUiSchema:
 
 const data = {'foo': 3.14};
 const schema = {
-  type: 'object',
-  properties: {
-    foo: {
-      type: 'number',
-      minimum: 5
-    },
-  },
+  type: 'number',
+  minimum: 5
 };
 const uischema: ControlElement = {
   type: 'Control',
@@ -208,7 +203,11 @@ describe('Material number field', () => {
     const store = initJsonFormsStore(data, schema, control);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <NumberField schema={schema} uischema={control}/>
+        <NumberField
+          schema={schema}
+          uischema={control}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -226,7 +225,11 @@ describe('Material number field', () => {
     const store = initJsonFormsStore(data, schema, control);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <NumberField schema={schema} uischema={uischema}/>
+        <NumberField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -241,7 +244,11 @@ describe('Material number field', () => {
     const store = initJsonFormsStore(data, schema, control);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <NumberField schema={schema} uischema={control}/>
+        <NumberField
+          schema={schema}
+          uischema={control}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -264,7 +271,11 @@ describe('Material number field', () => {
     );
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <NumberField schema={jsonSchema} uischema={uischema}/>
+        <NumberField
+          schema={jsonSchema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
 
@@ -278,7 +289,11 @@ describe('Material number field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <NumberField schema={schema} uischema={uischema}/>
+        <NumberField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -295,7 +310,11 @@ describe('Material number field', () => {
     );
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <NumberField schema={schema} uischema={uischema}/>
+        <NumberField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -308,7 +327,11 @@ describe('Material number field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <NumberField schema={schema} uischema={uischema}/>
+        <NumberField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -320,7 +343,11 @@ describe('Material number field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <NumberField schema={schema} uischema={uischema}/>
+        <NumberField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -332,7 +359,11 @@ describe('Material number field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <NumberField schema={schema} uischema={uischema}/>
+        <NumberField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -344,7 +375,11 @@ describe('Material number field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <NumberField schema={schema} uischema={uischema}/>
+        <NumberField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -356,7 +391,11 @@ describe('Material number field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <NumberField schema={schema} uischema={uischema}/>
+        <NumberField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     store.dispatch(update(undefined, () => 13));
@@ -368,7 +407,12 @@ describe('Material number field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <NumberField schema={schema} uischema={uischema} enabled={false}/>
+        <NumberField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+          enabled={false}
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -379,7 +423,11 @@ describe('Material number field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <NumberField schema={schema} uischema={uischema}/>
+        <NumberField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/material/test/renderers/MaterialTextField.test.tsx
+++ b/packages/material/test/renderers/MaterialTextField.test.tsx
@@ -46,30 +46,16 @@ const DEFAULT_MAX_LENGTH = 524288;
 const DEFAULT_SIZE = 20;
 
 const data =  { 'name': 'Foo' };
-const minLengthSchema = {
-  type: 'object',
-  properties: {
-    name: {
-      type: 'string',
-      minLength: 3
-    }
-  }
+const minLengthSchema ={
+  type: 'string',
+  minLength: 3
 };
 const maxLengthSchema = {
-  type: 'object',
-  properties: {
-    name: {
-      type: 'string',
-      maxLength: 5
-    }
-  }
+  type: 'string',
+  maxLength: 5
 };
-const schema = {
-  type: 'object',
-  properties: {
-    name: { type: 'string' }
-  }
-};
+const schema = { type: 'string' };
+
 const uischema: ControlElement = {
   type: 'Control',
   scope: '#/properties/name'
@@ -211,7 +197,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, minLengthSchema, control);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={minLengthSchema} uischema={control}/>
+        <TextField
+          schema={minLengthSchema}
+          uischema={control}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -227,7 +217,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, schema, control);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={minLengthSchema} uischema={control}/>
+        <TextField
+          schema={minLengthSchema}
+          uischema={control}
+          path={'name'}
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -242,7 +236,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, minLengthSchema, control);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={minLengthSchema} uischema={control}/>
+        <TextField
+          schema={minLengthSchema}
+          uischema={control}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -259,7 +257,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore({ 'name': 'Foo' }, minLengthSchema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={jsonSchema} uischema={uischema}/>
+        <TextField
+          schema={jsonSchema}
+          uischema={uischema}
+          path={'name'}
+        />
       </Provider>
     ) as React.Component<any, any, any>;
 
@@ -271,7 +273,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={minLengthSchema} uischema={uischema}/>
+        <TextField
+          schema={minLengthSchema}
+          uischema={uischema}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
 
@@ -285,7 +291,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={minLengthSchema} uischema={uischema}/>
+        <TextField
+          schema={minLengthSchema}
+          uischema={uischema}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -297,7 +307,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={minLengthSchema} uischema={uischema}/>
+        <TextField
+          schema={minLengthSchema}
+          uischema={uischema}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -309,7 +323,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={minLengthSchema} uischema={uischema}/>
+        <TextField
+          schema={minLengthSchema}
+          uischema={uischema}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -321,7 +339,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={minLengthSchema} uischema={uischema}/>
+        <TextField
+          schema={minLengthSchema}
+          uischema={uischema}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -333,7 +355,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={minLengthSchema} uischema={uischema}/>
+        <TextField
+          schema={minLengthSchema}
+          uischema={uischema}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -345,7 +371,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={minLengthSchema} uischema={uischema}/>
+        <TextField
+          schema={minLengthSchema}
+          uischema={uischema}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -357,7 +387,12 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={minLengthSchema} uischema={uischema} enabled={false}/>
+        <TextField
+          schema={minLengthSchema}
+          uischema={uischema}
+          path='name'
+          enabled={false}
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -368,7 +403,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={minLengthSchema} uischema={uischema}/>
+        <TextField
+          schema={minLengthSchema}
+          uischema={uischema}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -387,7 +426,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, maxLengthSchema, control);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={maxLengthSchema} uischema={control}/>
+        <TextField
+          schema={maxLengthSchema}
+          uischema={control}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -406,7 +449,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, maxLengthSchema, control);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={maxLengthSchema} uischema={control}/>
+        <TextField
+          schema={maxLengthSchema}
+          uischema={control}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -426,7 +473,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, maxLengthSchema, control);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={maxLengthSchema} uischema={control}/>
+        <TextField
+          schema={maxLengthSchema}
+          uischema={control}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -441,7 +492,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, maxLengthSchema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={schema} uischema={uischema}/>
+        <TextField
+          schema={schema}
+          uischema={uischema}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -464,7 +519,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, schema, control);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={schema} uischema={control}/>
+        <TextField
+          schema={schema}
+          uischema={control}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -484,7 +543,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, schema, control);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={schema} uischema={control}/>
+        <TextField
+          schema={schema}
+          uischema={control}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -504,7 +567,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, schema, control);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={schema} uischema={control}/>
+        <TextField
+          schema={schema}
+          uischema={control}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -519,7 +586,11 @@ describe('Material text field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TextField schema={schema} uischema={uischema}/>
+        <TextField
+          schema={schema}
+          uischema={uischema}
+          path='name'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/material/test/renderers/MaterialTimeField.test.tsx
+++ b/packages/material/test/renderers/MaterialTimeField.test.tsx
@@ -45,13 +45,8 @@ import { materialFields, materialRenderers } from '../../src';
 const data = { 'foo': '13:37' };
 
 const schema = {
-  type: 'object',
-  properties: {
-    foo: {
-      type: 'string',
-      format: 'time'
-    },
-  },
+  type: 'string',
+  format: 'time'
 };
 
 const uischema: ControlElement = {
@@ -225,7 +220,11 @@ describe('Material time field', () => {
     const store = initJsonFormsStore(data, schema, control);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TimeField schema={schema} uischema={control}/>
+        <TimeField
+          schema={schema}
+          uischema={control}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -236,7 +235,11 @@ describe('Material time field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TimeField schema={schema} uischema={uischema}/>
+        <TimeField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
 
@@ -249,7 +252,11 @@ describe('Material time field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TimeField schema={schema} uischema={uischema}/>
+        <TimeField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -262,7 +269,11 @@ describe('Material time field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TimeField schema={schema} uischema={uischema}/>
+        <TimeField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -274,7 +285,11 @@ describe('Material time field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TimeField schema={schema} uischema={uischema}/>
+        <TimeField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -286,7 +301,11 @@ describe('Material time field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TimeField schema={schema} uischema={uischema}/>
+        <TimeField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -298,7 +317,11 @@ describe('Material time field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TimeField schema={schema} uischema={uischema}/>
+        <TimeField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -310,7 +333,11 @@ describe('Material time field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TimeField schema={schema} uischema={uischema}/>
+        <TimeField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -322,7 +349,11 @@ describe('Material time field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TimeField schema={schema} uischema={uischema}/>
+        <TimeField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -334,7 +365,12 @@ describe('Material time field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TimeField schema={schema} uischema={uischema} enabled={false}/>
+        <TimeField
+          schema={schema}
+          uischema={uischema}
+          enabled={false}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -345,7 +381,11 @@ describe('Material time field', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const tree = TestUtils.renderIntoDocument(
       <Provider store={store}>
-        <TimeField schema={schema} uischema={uischema}/>
+        <TimeField
+          schema={schema}
+          uischema={uischema}
+          path='foo'
+        />
       </Provider>
     ) as React.Component<any, any, any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/react/test/renderers/JsonForms.test.tsx
+++ b/packages/react/test/renderers/JsonForms.test.tsx
@@ -289,6 +289,7 @@ test('render schema with $ref', () => {
       uischema={fixture.uischema}
       schema={schemaWithRef}
       renderers={renderers}
+      rootSchema={resolvedSchema}
     />
   );
 
@@ -346,6 +347,7 @@ test.skip('updates schema with ref', () => {
       uischema={fixture.uischema}
       schema={fixture.schema}
       renderers={renderers}
+      rootSchema={resolvedSchema}
     />
   );
 

--- a/packages/vanilla/src/complex/TableArrayControl.tsx
+++ b/packages/vanilla/src/complex/TableArrayControl.tsx
@@ -30,17 +30,17 @@ import filter from 'lodash/filter';
 import join from 'lodash/join';
 import React from 'react';
 import {
-    ArrayControlProps,
-    ControlElement,
-    formatErrorMessage,
-    Helpers,
-    isPlainLabel,
-    mapDispatchToArrayControlProps,
-    mapStateToArrayControlProps,
-    Paths,
-    RankedTester,
-    StatePropsOfControl,
-    Test,
+  ArrayControlProps,
+  ControlElement,
+  formatErrorMessage,
+  Helpers,
+  isPlainLabel,
+  mapDispatchToArrayControlProps,
+  mapStateToArrayControlProps,
+  Paths,
+  RankedTester,
+  StatePropsOfControl,
+  Test
 } from '@jsonforms/core';
 import { DispatchField } from '@jsonforms/react';
 import { addVanillaControlProps } from '../util';
@@ -75,7 +75,8 @@ class TableArrayControl extends React.Component<ArrayControlProps & VanillaRende
     const {
       addItem,
       uischema,
-      scopedSchema,
+      schema,
+      createDefaultValue,
       path,
       data,
       visible,
@@ -94,7 +95,7 @@ class TableArrayControl extends React.Component<ArrayControlProps & VanillaRende
     const createControlElement = (key?: string): ControlElement => ({
       type: 'Control',
       label: false,
-      scope: scopedSchema.type === 'object' ? `#/properties/${key}` : '#'
+      scope: schema.type === 'object' ? `#/properties/${key}` : '#'
     });
     const labelObject = createLabelDescriptionFrom(controlElement);
     const isValid = errors.length === 0;
@@ -107,7 +108,7 @@ class TableArrayControl extends React.Component<ArrayControlProps & VanillaRende
           <label className={labelClass}>
             {labelText}
           </label>
-          <button className={buttonClass} onClick={addItem(path)}>
+          <button className={buttonClass} onClick={addItem(path, createDefaultValue())}>
             Add to {labelObject.text}
           </button>
         </header>
@@ -118,12 +119,12 @@ class TableArrayControl extends React.Component<ArrayControlProps & VanillaRende
           <thead>
           <tr>
             {
-              scopedSchema.properties ?
+              schema.properties ?
                 fpflow(
                   fpkeys,
-                  fpfilter(prop => scopedSchema.properties[prop].type !== 'array'),
+                  fpfilter(prop => schema.properties[prop].type !== 'array'),
                   fpmap(prop => <th key={prop}>{prop}</th>)
-                ) (scopedSchema.properties)
+                ) (schema.properties)
                 : <th>Items</th>
             }
             <th>
@@ -146,17 +147,17 @@ class TableArrayControl extends React.Component<ArrayControlProps & VanillaRende
                 return (
                   <tr key={childPath}>
                     {
-                      scopedSchema.properties ?
+                      schema.properties ?
                         fpflow(
                           fpkeys,
-                          fpfilter(prop => scopedSchema.properties[prop].type !== 'array'),
+                          fpfilter(prop => schema.properties[prop].type !== 'array'),
                           fpmap(prop => {
                             const childPropPath = Paths.compose(childPath, prop.toString());
 
                             return (
                               <td key={childPropPath}>
                                 <DispatchField
-                                  schema={scopedSchema}
+                                  schema={schema}
                                   uischema={createControlElement(prop)}
                                   path={childPath}
                                   showError
@@ -164,10 +165,10 @@ class TableArrayControl extends React.Component<ArrayControlProps & VanillaRende
                               </td>
                             );
                           })
-                        )(scopedSchema.properties) :
+                        )(schema.properties) :
                         <td key={Paths.compose(childPath, index.toString())}>
                           <DispatchField
-                            schema={scopedSchema}
+                            schema={schema}
                             uischema={createControlElement()}
                             path={childPath}
                             showError

--- a/packages/vanilla/src/complex/array/ArrayControl.tsx
+++ b/packages/vanilla/src/complex/array/ArrayControl.tsx
@@ -29,50 +29,52 @@ import { ResolvedJsonForms } from '@jsonforms/react';
 import { VanillaRendererProps } from '../../index';
 
 export const ArrayControl  = (
-    {
-        classNames,
-        data,
-        label,
-        path,
-        scopedSchema,
-        addItem,
-        uischema,
-        findUISchema
-    }: ArrayControlProps & VanillaRendererProps
+  {
+    classNames,
+    data,
+    label,
+    path,
+    schema,
+    addItem,
+    uischema,
+    findUISchema,
+    createDefaultValue
+  }: ArrayControlProps & VanillaRendererProps
 ) => {
-    return (
-      <div className={classNames.wrapper}>
-        <fieldset className={classNames.fieldSet}>
-          <legend>
-            <button
-              className={classNames.button}
-              onClick={() => addItem(path)}
-            >
-              +
-            </button>
-            <label className={'array.label'}>
-              {label}
-            </label>
-          </legend>
-          <div className={classNames.children}>
-            {
-              data ? range(0, data.length).map(index => {
 
-                const foundUISchema = findUISchema(scopedSchema, uischema.scope, path);
-                const childPath = composePaths(path, `${index}`);
+  return (
+    <div className={classNames.wrapper}>
+      <fieldset className={classNames.fieldSet}>
+        <legend>
+          <button
+            className={classNames.button}
+            onClick={() => addItem(path, createDefaultValue())}
+          >
+            +
+          </button>
+          <label className={'array.label'}>
+            {label}
+          </label>
+        </legend>
+        <div className={classNames.children}>
+          {
+            data ? range(0, data.length).map(index => {
 
-                return (
-                  <ResolvedJsonForms
-                    schema={scopedSchema}
-                    uischema={foundUISchema || uischema}
-                    path={childPath}
-                    key={childPath}
-                  />
-                );
-              }) : <p>No data</p>
-            }
-          </div>
-        </fieldset>
-      </div>
-    );
-  };
+              const foundUISchema = findUISchema(schema, uischema.scope, path);
+              const childPath = composePaths(path, `${index}`);
+
+              return (
+                <ResolvedJsonForms
+                  schema={schema}
+                  uischema={foundUISchema || uischema}
+                  path={childPath}
+                  key={childPath}
+                />
+              );
+            }) : <p>No data</p>
+          }
+        </div>
+      </fieldset>
+    </div>
+  );
+};

--- a/packages/vanilla/src/complex/array/ArrayControlRenderer.tsx
+++ b/packages/vanilla/src/complex/array/ArrayControlRenderer.tsx
@@ -25,12 +25,11 @@
 import React from 'react';
 
 import {
-    ArrayControlProps,
-    ControlElement,
-    Helpers,
-    mapDispatchToArrayControlProps,
-    mapStateToControlProps,
-    Resolve
+  ArrayControlProps,
+  ControlElement,
+  Helpers,
+  mapDispatchToArrayControlProps,
+  mapStateToArrayControlProps
 } from '@jsonforms/core';
 import { ArrayControl } from './ArrayControl';
 import { addVanillaControlProps } from '../../util';
@@ -43,18 +42,18 @@ const ArrayControlRenderer  =
          uischema,
          data,
          path,
+         rootSchema,
+         createDefaultValue,
          findUISchema,
          addItem,
          getStyle,
          getStyleAsClassName,
-         removeItems
+         removeItems,
      }: ArrayControlProps & VanillaRendererProps) => {
 
         const controlElement = uischema as ControlElement;
         const labelDescription = Helpers.createLabelDescriptionFrom(controlElement);
-        const resolvedSchema = Resolve.schema(schema, `${controlElement.scope}/items`);
         const label = labelDescription.show ? labelDescription.text : '';
-
         const controlClassName =
             `control ${(Helpers.convertToValidClassName(controlElement.scope))}`;
         const fieldSetClassName = getStyleAsClassName('array.layout');
@@ -76,17 +75,18 @@ const ArrayControlRenderer  =
                 data={data}
                 label={label}
                 path={path}
-                scopedSchema={resolvedSchema}
                 addItem={addItem}
                 findUISchema={findUISchema}
                 uischema={uischema}
                 schema={schema}
+                rootSchema={rootSchema}
+                createDefaultValue={createDefaultValue}
             />
         );
     };
 
 const ConnectedArrayControlRenderer = connect(
-    addVanillaControlProps(mapStateToControlProps),
+    addVanillaControlProps(mapStateToArrayControlProps),
     mapDispatchToArrayControlProps
 )(ArrayControlRenderer);
 

--- a/packages/vanilla/src/controls/InputControl.tsx
+++ b/packages/vanilla/src/controls/InputControl.tsx
@@ -63,7 +63,7 @@ export class InputControl extends Control<ControlProps & VanillaRendererProps, C
     const labelText = isPlainLabel(label) ? label : label.default;
     const field = maxBy(fields, r => r.tester(uischema, schema));
     if (field === undefined || field.tester(uischema, schema) === NOT_APPLICABLE) {
-      console.warn('No applicable field found.');
+      console.warn('No applicable field found.', uischema, schema);
       return null;
     } else {
       return (

--- a/packages/vanilla/src/controls/RadioGroupControl.tsx
+++ b/packages/vanilla/src/controls/RadioGroupControl.tsx
@@ -25,16 +25,14 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import {
-    computeLabel,
-    ControlElement,
-    ControlProps,
-    ControlState,
-    formatErrorMessage,
-    isDescriptionHidden,
-    isPlainLabel,
-    mapDispatchToControlProps,
-    mapStateToControlProps,
-    resolveSchema
+  computeLabel,
+  ControlProps,
+  ControlState,
+  formatErrorMessage,
+  isDescriptionHidden,
+  isPlainLabel,
+  mapDispatchToControlProps,
+  mapStateToControlProps
 } from '@jsonforms/core';
 import { Control } from '@jsonforms/react';
 import { addVanillaControlProps } from '../util';
@@ -51,7 +49,6 @@ export class RadioGroupControl extends Control<ControlProps & VanillaRendererPro
             description,
             errors,
             data,
-            uischema,
             schema,
             visible,
         } = this.props;
@@ -64,7 +61,7 @@ export class RadioGroupControl extends Control<ControlProps & VanillaRendererPro
         };
         const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused);
 
-        const options = resolveSchema(schema, (uischema as ControlElement).scope).enum;
+        const options = schema.enum;
 
         return (
             <div
@@ -109,5 +106,5 @@ export class RadioGroupControl extends Control<ControlProps & VanillaRendererPro
 }
 
 export default connect(
-    addVanillaControlProps(mapStateToControlProps), mapDispatchToControlProps)
-    (RadioGroupControl);
+    addVanillaControlProps(mapStateToControlProps), mapDispatchToControlProps
+)(RadioGroupControl);

--- a/packages/vanilla/src/fields/NumberFormatField.tsx
+++ b/packages/vanilla/src/fields/NumberFormatField.tsx
@@ -43,9 +43,9 @@ export const NumberFormatField = (props: FieldProps & VanillaRendererProps & For
     uischema,
     path,
     handleChange,
-    scopedSchema
+    schema
   } = props;
-  const maxLength = scopedSchema.maxLength;
+  const maxLength = schema.maxLength;
   const formattedNumber: string = props.toFormatted(props.data);
 
   const onChange = (ev: any) => {

--- a/packages/vanilla/src/fields/SliderField.tsx
+++ b/packages/vanilla/src/fields/SliderField.tsx
@@ -36,15 +36,15 @@ import {
 import { VanillaRendererProps } from '../index';
 
 export const SliderField = (props: FieldProps & VanillaRendererProps) => {
-  const { data, className, id, enabled, uischema, scopedSchema, path, handleChange } = props;
+  const { data, className, id, enabled, uischema, schema, path, handleChange } = props;
 
   return (
   <div style={{display: 'flex'}}>
     <input
       type='range'
-      max={scopedSchema.maximum}
-      min={scopedSchema.minimum}
-      value={data || scopedSchema.default}
+      max={schema.maximum}
+      min={schema.minimum}
+      value={data || schema.default}
       onChange={(ev: SyntheticEvent<HTMLInputElement>) =>
         handleChange(path, Number(ev.currentTarget.value))
       }
@@ -54,7 +54,7 @@ export const SliderField = (props: FieldProps & VanillaRendererProps) => {
       autoFocus={uischema.options && uischema.options.focus}
       style={{flex: '1'}}
     />
-    <label style={{marginLeft: '0.5em'}}>{data || scopedSchema.default}</label>
+    <label style={{marginLeft: '0.5em'}}>{data || schema.default}</label>
   </div>
   );
 };

--- a/packages/vanilla/src/fields/TextField.tsx
+++ b/packages/vanilla/src/fields/TextField.tsx
@@ -43,11 +43,11 @@ export const TextField = (props: FieldProps & VanillaRendererProps) => {
     id,
     enabled,
     uischema,
-    scopedSchema,
+    schema,
     path,
     handleChange
   } = props;
-  const maxLength = scopedSchema.maxLength;
+  const maxLength = schema.maxLength;
 
   return (
     <input

--- a/packages/vanilla/test/renderers/ArrayControl.test.tsx
+++ b/packages/vanilla/test/renderers/ArrayControl.test.tsx
@@ -31,6 +31,7 @@ import { vanillaRenderers } from '../../src/index';
 import * as TestUtils from 'react-dom/test-utils';
 import { initJsonFormsVanillaStore } from '../vanillaStore';
 import IntegerField, { integerFieldTester } from '../../src/fields/IntegerField';
+import { createDefaultValue } from '@jsonforms/core';
 
 test.beforeEach(t => {
 
@@ -78,7 +79,11 @@ test('render two children', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <ArrayControl schema={t.context.schema} uischema={t.context.uischema}/>
+      <ArrayControl
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        createDefaultValue={() => createDefaultValue(t.context.schema)}
+      />
     </Provider>
   ) as React.Component<any>;
 

--- a/packages/vanilla/test/renderers/BooleanField.test.tsx
+++ b/packages/vanilla/test/renderers/BooleanField.test.tsx
@@ -38,15 +38,8 @@ import { Provider } from 'react-redux';
 import * as TestUtils from 'react-dom/test-utils';
 
 test.beforeEach(t => {
-  t.context.data = { 'foo': true };
-  t.context.schema = {
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'boolean'
-      }
-    }
-  };
+  t.context.data = { foo: true };
+  t.context.schema = { type: 'boolean' };
   t.context.uischema = {
     type: 'Control',
     scope: '#/properties/foo'
@@ -125,7 +118,7 @@ test('autofocus active', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={uischema}/>
+      <BooleanField schema={t.context.schema} uischema={uischema} path='foo'/>
     </Provider>
   ) as React.Component<any>;;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -147,7 +140,7 @@ test('autofocus inactive', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={uischema}/>
+      <BooleanField schema={t.context.schema} uischema={uischema} path='foo'/>
     </Provider>
   ) as React.Component<any>;;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -166,7 +159,7 @@ test('autofocus inactive by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={uischema}/>
+      <BooleanField schema={t.context.schema} uischema={uischema} path='foo'/>
     </Provider>
   ) as React.Component<any>;;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -246,7 +239,7 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
+      <BooleanField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;;
 
@@ -263,7 +256,7 @@ test('update via input event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
+      <BooleanField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;;
 
@@ -282,7 +275,7 @@ test('update via action', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
+      <BooleanField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -299,7 +292,7 @@ test.failing('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
+      <BooleanField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -315,7 +308,7 @@ test.failing('update with null value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
+      <BooleanField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -331,7 +324,7 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
+      <BooleanField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -347,7 +340,7 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
+      <BooleanField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -363,7 +356,7 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
+      <BooleanField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;;
   store.dispatch(update(undefined, () => false));
@@ -394,7 +387,7 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanField schema={t.context.schema} uischema={t.context.uischema}/>
+      <BooleanField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/vanilla/test/renderers/DateField.test.tsx
+++ b/packages/vanilla/test/renderers/DateField.test.tsx
@@ -38,15 +38,10 @@ import { Provider } from 'react-redux';
 import * as TestUtils from 'react-dom/test-utils';
 
 test.beforeEach(t => {
-  t.context.data = { 'foo': '1980-04-04' };
+  t.context.data = { foo: '1980-04-04' };
   t.context.schema = {
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'string',
-        format: 'date'
-      },
-    },
+    type: 'string',
+    format: 'date'
   };
   t.context.uischema = {
     type: 'Control',
@@ -127,7 +122,7 @@ test('autofocus active', t => {
 
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateField schema={t.context.schema} uischema={uischema}/>
+      <DateField schema={t.context.schema} uischema={uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -149,7 +144,7 @@ test('autofocus inactive', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateField schema={t.context.schema} uischema={uischema}/>
+      <DateField schema={t.context.schema} uischema={uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -168,7 +163,7 @@ test('autofocus inactive by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateField schema={t.context.schema} uischema={uischema}/>
+      <DateField schema={t.context.schema} uischema={uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -242,7 +237,7 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
 
@@ -259,7 +254,7 @@ test.cb('update via event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -282,7 +277,7 @@ test.cb('update via action', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -304,7 +299,7 @@ test('update with null value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -320,7 +315,7 @@ test('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -336,7 +331,7 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -352,7 +347,7 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -368,7 +363,7 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -399,7 +394,7 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/vanilla/test/renderers/DateTimeField.test.tsx
+++ b/packages/vanilla/test/renderers/DateTimeField.test.tsx
@@ -40,13 +40,8 @@ import * as TestUtils from 'react-dom/test-utils';
 test.beforeEach(t => {
   t.context.data = { 'foo': '1980-04-04T13:37:00.000Z' };
   t.context.schema = {
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'string',
-        format: 'date-time'
-      },
-    },
+    type: 'string',
+    format: 'date-time'
   };
   t.context.uischema = {
     type: 'Control',
@@ -128,7 +123,11 @@ test('autofocus active', t => {
 
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeField schema={t.context.schema} uischema={uischema}/>
+      <DateTimeField
+        schema={t.context.schema}
+        uischema={uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -150,7 +149,11 @@ test('autofocus inactive', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeField schema={t.context.schema} uischema={uischema}/>
+      <DateTimeField
+        schema={t.context.schema}
+        uischema={uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -169,7 +172,11 @@ test('autofocus inactive by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeField schema={t.context.schema} uischema={uischema}/>
+      <DateTimeField
+        schema={t.context.schema}
+        uischema={uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -243,7 +250,11 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateTimeField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
 
@@ -260,7 +271,11 @@ test.cb('update via event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateTimeField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -283,7 +298,11 @@ test.cb('update via action', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateTimeField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -305,7 +324,11 @@ test('update with null value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateTimeField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -321,7 +344,11 @@ test('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateTimeField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -337,7 +364,11 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateTimeField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -353,7 +384,11 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateTimeField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -369,7 +404,11 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateTimeField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -385,7 +424,12 @@ test('disable', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeField schema={t.context.schema} uischema={t.context.uischema} enabled={false}/>
+      <DateTimeField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+        enabled={false}
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -400,7 +444,11 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <DateTimeField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/vanilla/test/renderers/EnumField.test.tsx
+++ b/packages/vanilla/test/renderers/EnumField.test.tsx
@@ -32,14 +32,9 @@ import * as TestUtils from 'react-dom/test-utils';
 
 test.beforeEach(t => {
   t.context.data = { 'foo': 'a' };
-  t.context.schema = {
-    'type': 'object',
-    'properties': {
-      'foo': {
-        'type': 'string',
-        'enum': ['a', 'b'],
-      },
-    },
+  t.context.schema =  {
+        type: 'string',
+    enum: ['a', 'b'],
   };
   t.context.uischema = {
     type: 'Control',
@@ -140,7 +135,7 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumField schema={t.context.schema} uischema={t.context.uischema}/>
+      <EnumField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
 
@@ -161,7 +156,7 @@ test('update via input event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumField schema={t.context.schema} uischema={t.context.uischema}/>
+      <EnumField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
 
@@ -180,7 +175,7 @@ test('update via action', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumField schema={t.context.schema} uischema={t.context.uischema}/>
+      <EnumField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const select = TestUtils.findRenderedDOMComponentWithTag(tree, 'select') as HTMLSelectElement;
@@ -197,7 +192,7 @@ test('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumField schema={t.context.schema} uischema={t.context.uischema}/>
+      <EnumField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const select = TestUtils.findRenderedDOMComponentWithTag(tree, 'select') as HTMLSelectElement;
@@ -214,7 +209,7 @@ test('update with null value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumField schema={t.context.schema} uischema={t.context.uischema}/>
+      <EnumField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const select = TestUtils.findRenderedDOMComponentWithTag(tree, 'select') as HTMLSelectElement;
@@ -231,7 +226,7 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumField schema={t.context.schema} uischema={t.context.uischema}/>
+      <EnumField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const select = TestUtils.findRenderedDOMComponentWithTag(tree, 'select') as HTMLSelectElement;
@@ -248,7 +243,7 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumField schema={t.context.schema} uischema={t.context.uischema}/>
+      <EnumField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const select = TestUtils.findRenderedDOMComponentWithTag(tree, 'select') as HTMLSelectElement;
@@ -265,7 +260,7 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumField schema={t.context.schema} uischema={t.context.uischema}/>
+      <EnumField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const select = TestUtils.findRenderedDOMComponentWithTag(tree, 'select') as HTMLSelectElement;
@@ -297,7 +292,7 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumField schema={t.context.schema} uischema={t.context.uischema}/>
+      <EnumField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const select = TestUtils.findRenderedDOMComponentWithTag(tree, 'select') as HTMLSelectElement;

--- a/packages/vanilla/test/renderers/IntegerField.test.tsx
+++ b/packages/vanilla/test/renderers/IntegerField.test.tsx
@@ -40,13 +40,8 @@ import * as TestUtils from 'react-dom/test-utils';
 test.beforeEach(t => {
   t.context.data = {'foo': 42};
   t.context.schema = {
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'integer',
-        minimum: 5
-      },
-    },
+    type: 'integer',
+    minimum: 5
   };
   t.context.uischema = {
     type: 'Control',
@@ -127,7 +122,7 @@ test('autofocus active', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerField schema={t.context.schema} uischema={uischema}/>
+      <IntegerField schema={t.context.schema} uischema={uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -150,7 +145,7 @@ test('autofocus inactive', t => {
 
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerField schema={t.context.schema} uischema={uischema}/>
+      <IntegerField schema={t.context.schema} uischema={uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -170,7 +165,7 @@ test('autofocus inactive by default', t => {
 
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerField schema={t.context.schema} uischema={uischema}/>
+      <IntegerField schema={t.context.schema} uischema={uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -217,7 +212,7 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerField schema={t.context.schema} uischema={t.context.uischema}/>
+      <IntegerField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
 
@@ -235,7 +230,7 @@ test('update via input event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerField schema={t.context.schema} uischema={t.context.uischema}/>
+      <IntegerField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
 
@@ -255,7 +250,7 @@ test.cb('update via action', t => {
 
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerField schema={t.context.schema} uischema={t.context.uischema}/>
+      <IntegerField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -277,7 +272,7 @@ test('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerField schema={t.context.schema} uischema={t.context.uischema}/>
+      <IntegerField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -293,7 +288,7 @@ test('update with null value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerField schema={t.context.schema} uischema={t.context.uischema}/>
+      <IntegerField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -310,7 +305,7 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerField schema={t.context.schema} uischema={t.context.uischema}/>
+      <IntegerField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -326,7 +321,7 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerField schema={t.context.schema} uischema={t.context.uischema}/>
+      <IntegerField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -342,7 +337,7 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerField schema={t.context.schema} uischema={t.context.uischema}/>
+      <IntegerField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   store.dispatch(update(undefined, () => 13));
@@ -373,7 +368,7 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerField schema={t.context.schema} uischema={t.context.uischema}/>
+      <IntegerField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/vanilla/test/renderers/NumberField.test.tsx
+++ b/packages/vanilla/test/renderers/NumberField.test.tsx
@@ -40,13 +40,8 @@ import * as TestUtils from 'react-dom/test-utils';
 test.beforeEach(t => {
   t.context.data = {'foo': 3.14};
   t.context.schema = {
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'number',
-        minimum: 5
-      },
-    },
+    type: 'number',
+    minimum: 5
   };
   t.context.uischema = {
     type: 'Control',
@@ -127,7 +122,7 @@ test('autofocus active', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={uischema}/>
+      <NumberField schema={t.context.schema} uischema={uischema} path='foo' />
     </Provider>
   ) as React.Component<any> ;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -150,7 +145,7 @@ test('autofocus inactive', t => {
 
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={uischema}/>
+      <NumberField schema={t.context.schema} uischema={uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -169,7 +164,7 @@ test('autofocus inactive by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={uischema}/>
+      <NumberField schema={t.context.schema} uischema={uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -250,14 +245,7 @@ test('tester with machting schema type', t => {
 });
 
 test('render', t => {
-  const schema: JsonSchema = {
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'number'
-      }
-    }
-  };
+  const schema: JsonSchema = { type: 'number' };
   const store = initJsonFormsStore({
     data: { 'foo': 3.14 },
     schema,
@@ -265,7 +253,7 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberField schema={schema} uischema={t.context.uischema}/>
+      <NumberField schema={schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
 
@@ -283,7 +271,7 @@ test('update via input event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={t.context.uischema}/>
+      <NumberField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -294,13 +282,13 @@ test('update via input event', t => {
 
 test('update via action', t => {
   const store = initJsonFormsStore({
-    data: { 'foo': 2.72 },
+    data: { foo: 2.72 },
     schema: t.context.schema,
     uischema: t.context.uischema
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={t.context.uischema}/>
+      <NumberField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -317,7 +305,7 @@ test('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={t.context.uischema}/>
+      <NumberField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -333,7 +321,7 @@ test('update with null value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={t.context.uischema}/>
+      <NumberField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -349,7 +337,7 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={t.context.uischema}/>
+      <NumberField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -365,7 +353,7 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={t.context.uischema}/>
+      <NumberField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -381,7 +369,7 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={t.context.uischema}/>
+      <NumberField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   store.dispatch(update(undefined, () => 13));
@@ -412,7 +400,7 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberField schema={t.context.schema} uischema={t.context.uischema}/>
+      <NumberField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/vanilla/test/renderers/SliderField.test.tsx
+++ b/packages/vanilla/test/renderers/SliderField.test.tsx
@@ -40,15 +40,10 @@ import * as TestUtils from 'react-dom/test-utils';
 test.beforeEach(t => {
   t.context.data = {'foo': 5};
   t.context.schema = {
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'number',
-        maximum: 10,
-        minimum: 2,
-        default: 6
-      },
-    },
+    type: 'number',
+    maximum: 10,
+    minimum: 2,
+    default: 6
   };
   t.context.uischema = {
     type: 'Control',
@@ -128,7 +123,11 @@ test('autofocus active', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderField schema={t.context.schema} uischema={uischema}/>
+      <SliderField
+        schema={t.context.schema}
+        uischema={uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -148,7 +147,11 @@ test('autofocus inactive', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderField schema={t.context.schema} uischema={uischema}/>
+      <SliderField
+        schema={t.context.schema}
+        uischema={uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -164,7 +167,11 @@ test('autofocus inactive by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderField schema={t.context.schema} uischema={uischema}/>
+      <SliderField
+        schema={t.context.schema}
+        uischema={uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -368,7 +375,11 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderField schema={schema} uischema={t.context.uischema}/>
+      <SliderField
+        schema={schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -384,7 +395,11 @@ test('update via input event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderField schema={t.context.schema} uischema={t.context.uischema}/>
+      <SliderField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -401,7 +416,11 @@ test('update via action', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderField schema={t.context.schema} uischema={t.context.uischema}/>
+      <SliderField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -418,7 +437,11 @@ test.failing('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderField schema={t.context.schema} uischema={t.context.uischema}/>
+      <SliderField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -434,7 +457,11 @@ test.failing('update with null value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderField schema={t.context.schema} uischema={t.context.uischema}/>
+      <SliderField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -450,7 +477,11 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderField schema={t.context.schema} uischema={t.context.uischema}/>
+      <SliderField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -466,7 +497,11 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderField schema={t.context.schema} uischema={t.context.uischema}/>
+      <SliderField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -482,7 +517,11 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderField schema={t.context.schema} uischema={t.context.uischema}/>
+      <SliderField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   store.dispatch(update(undefined, () => 13));
@@ -498,7 +537,12 @@ test('disable', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderField schema={t.context.schema} uischema={t.context.uischema} enabled={false}/>
+      <SliderField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+        enabled={false}
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -513,7 +557,11 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderField schema={t.context.schema} uischema={t.context.uischema}/>
+      <SliderField
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        path='foo'
+      />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/vanilla/test/renderers/TableArrayControl.test.tsx
+++ b/packages/vanilla/test/renderers/TableArrayControl.test.tsx
@@ -29,6 +29,7 @@ import test from 'ava';
 import { Provider } from 'react-redux';
 import {
   ControlElement,
+  createDefaultValue,
   getData,
   HorizontalLayout,
   update
@@ -83,7 +84,11 @@ test('render two children', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl schema={t.context.schema} uischema={t.context.uischema}/>
+      <TableArrayControl
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        createDefaultValue={() => createDefaultValue(t.context.schema)}
+      />
     </Provider>
   ) as React.Component<any>;
 
@@ -146,7 +151,11 @@ test('render empty data', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl schema={t.context.schema} uischema={t.context.uischema}/>
+      <TableArrayControl
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        createDefaultValue={() => createDefaultValue(t.context.schema)}
+      />
     </Provider>
   ) as React.Component<any>;
 
@@ -200,7 +209,11 @@ test('render new child (empty init data)', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl schema={t.context.schema} uischema={t.context.uischema}/>
+      <TableArrayControl
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        createDefaultValue={() => createDefaultValue(t.context.schema)}
+      />
     </Provider>
   ) as React.Component<any>;
 
@@ -220,7 +233,11 @@ test('render new child (undefined data)', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl schema={t.context.schema} uischema={t.context.uischema}/>
+      <TableArrayControl
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        createDefaultValue={() => createDefaultValue(t.context.schema)}
+      />
     </Provider>
   ) as React.Component<any>;
 
@@ -240,7 +257,11 @@ test('render new child (null data)', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl schema={t.context.schema} uischema={t.context.uischema}/>
+      <TableArrayControl
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        createDefaultValue={() => createDefaultValue(t.context.schema)}
+      />
     </Provider>
   ) as React.Component<any>;
 
@@ -260,7 +281,11 @@ test('render new child', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl schema={t.context.schema} uischema={t.context.uischema}/>
+      <TableArrayControl
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        createDefaultValue={() => createDefaultValue(t.context.schema)}
+      />
     </Provider>
   ) as React.Component<any>;
 
@@ -293,7 +318,11 @@ test('render primitives ', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl schema={schema} uischema={uischema}/>
+      <TableArrayControl
+        schema={schema}
+        uischema={uischema}
+        createDefaultValue={() => createDefaultValue(t.context.schema)}
+      />
     </Provider>
   ) as React.Component<any>;
   const rows = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'tr');
@@ -310,7 +339,11 @@ test('update via action', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl schema={t.context.schema} uischema={t.context.uischema}/>
+      <TableArrayControl
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        createDefaultValue={() => createDefaultValue(t.context.schema)}
+      />
     </Provider>
   ) as React.Component<any>;
 
@@ -441,6 +474,7 @@ test('hide', t => {
         schema={t.context.schema}
         uischema={t.context.uischema}
         visible={false}
+        createDefaultValue={() => createDefaultValue(t.context.schema)}
       />
     </Provider>
   ) as React.Component<any>;
@@ -457,7 +491,11 @@ test('show by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl schema={t.context.schema} uischema={t.context.uischema}/>
+      <TableArrayControl
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        createDefaultValue={() => createDefaultValue(t.context.schema)}
+      />
     </Provider>
   ) as React.Component<any>;
   const control = TestUtils.findRenderedDOMComponentWithClass(tree, 'control') as HTMLElement;
@@ -472,7 +510,11 @@ test('single error', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl schema={t.context.schema} uischema={t.context.uischema}/>
+      <TableArrayControl
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        createDefaultValue={() => createDefaultValue(t.context.schema)}
+      />
     </Provider>
   ) as React.Component<any>;
   const validation = TestUtils.findRenderedDOMComponentWithClass(tree, 'validation');
@@ -488,7 +530,11 @@ test('multiple errors', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl schema={t.context.schema} uischema={t.context.uischema}/>
+      <TableArrayControl
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        createDefaultValue={() => createDefaultValue(t.context.schema)}
+      />
     </Provider>
   ) as React.Component<any>;
   const validation = TestUtils.findRenderedDOMComponentWithClass(tree, 'validation');
@@ -504,7 +550,11 @@ test('empty errors by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl schema={t.context.schema} uischema={t.context.uischema}/>
+      <TableArrayControl
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        createDefaultValue={() => createDefaultValue(t.context.schema)}
+      />
     </Provider>
   ) as React.Component<any>;
   const validation = TestUtils.findRenderedDOMComponentWithClass(tree, 'validation');
@@ -519,7 +569,11 @@ test('reset validation message', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl schema={t.context.schema} uischema={t.context.uischema}/>
+      <TableArrayControl
+        schema={t.context.schema}
+        uischema={t.context.uischema}
+        createDefaultValue={() => createDefaultValue(t.context.schema)}
+      />
     </Provider>
   ) as React.Component<any>;
   const validation = TestUtils.findRenderedDOMComponentWithClass(tree, 'validation');

--- a/packages/vanilla/test/renderers/TextAreaField.test.tsx
+++ b/packages/vanilla/test/renderers/TextAreaField.test.tsx
@@ -40,13 +40,8 @@ import * as TestUtils from 'react-dom/test-utils';
 test.beforeEach(t => {
   t.context.data = {'name': 'Foo'};
   t.context.schema = {
-    type: 'object',
-    properties: {
-      name: {
-        type: 'string',
-        minLength: 3
-      }
-    }
+    type: 'string',
+    minLength: 3
   };
   t.context.uischema = {
     type: 'Control',
@@ -126,7 +121,7 @@ test('autofocus active', t => {
     });
     const tree: React.Component<any> = TestUtils.renderIntoDocument(
         <Provider store={store}>
-          <TextAreaField schema={t.context.schema} uischema={uischema}/>
+          <TextAreaField schema={t.context.schema} uischema={uischema} path='name' />
         </Provider>
     ) as React.Component<any>;
     const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'textarea') as HTMLInputElement;
@@ -148,7 +143,7 @@ test('autofocus inactive', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaField schema={t.context.schema} uischema={uischema}/>
+      <TextAreaField schema={t.context.schema} uischema={uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'textarea') as HTMLInputElement;
@@ -167,7 +162,7 @@ test('autofocus inactive by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaField schema={t.context.schema} uischema={uischema}/>
+      <TextAreaField schema={t.context.schema} uischema={uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'textarea') as HTMLInputElement;
@@ -190,7 +185,7 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
       <Provider store={store}>
-          <TextAreaField schema={t.context.schema} uischema={t.context.uischema}/>
+          <TextAreaField schema={t.context.schema} uischema={t.context.uischema} path='name' />
       </Provider>
   ) as React.Component<any>;
   const textarea = TestUtils.findRenderedDOMComponentWithTag(
@@ -208,7 +203,7 @@ test('update via input event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TextAreaField schema={t.context.schema} uischema={t.context.uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
 
@@ -229,7 +224,7 @@ test.cb('update via action', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TextAreaField schema={t.context.schema} uischema={t.context.uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
   const textarea = TestUtils.findRenderedDOMComponentWithTag(
@@ -251,7 +246,7 @@ test('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TextAreaField schema={t.context.schema} uischema={t.context.uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
   const textArea = TestUtils.findRenderedDOMComponentWithTag(
@@ -270,7 +265,7 @@ test('update with null value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TextAreaField schema={t.context.schema} uischema={t.context.uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
   const textArea = TestUtils.findRenderedDOMComponentWithTag(
@@ -289,7 +284,7 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TextAreaField schema={t.context.schema} uischema={t.context.uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
   const textArea = TestUtils.findRenderedDOMComponentWithTag(
@@ -308,7 +303,7 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TextAreaField schema={t.context.schema} uischema={t.context.uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
   const textArea = TestUtils.findRenderedDOMComponentWithTag(
@@ -327,7 +322,7 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TextAreaField schema={t.context.schema} uischema={t.context.uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
   const textArea = TestUtils.findRenderedDOMComponentWithTag(
@@ -364,7 +359,7 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TextAreaField schema={t.context.schema} uischema={t.context.uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
   const textArea = TestUtils.findRenderedDOMComponentWithTag(

--- a/packages/vanilla/test/renderers/TextField.test.tsx
+++ b/packages/vanilla/test/renderers/TextField.test.tsx
@@ -43,29 +43,14 @@ const defaultSize = 20;
 test.beforeEach(t => {
   t.context.data =  { 'name': 'Foo' };
   t.context.minLengthSchema = {
-    type: 'object',
-    properties: {
-      name: {
-        type: 'string',
-        minLength: 3
-      }
-    }
+    type: 'string',
+    minLength: 3
   };
   t.context.maxLengthSchema = {
-    type: 'object',
-    properties: {
-      name: {
-        type: 'string',
-        maxLength: 5
-      }
-    }
+    type: 'string',
+    maxLength: 5
   };
-  t.context.schema = {
-    type: 'object',
-    properties: {
-      name: { type: 'string'}
-    }
-  };
+  t.context.schema = { type: 'string' };
   t.context.uischema = {
     type: 'Control',
     scope: '#/properties/name'
@@ -131,7 +116,7 @@ test('autofocus active', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.minLengthSchema} uischema={uischema}/>
+      <TextField schema={t.context.minLengthSchema} uischema={uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -151,7 +136,7 @@ test('autofocus inactive', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.minLengthSchema} uischema={uischema}/>
+      <TextField schema={t.context.minLengthSchema} uischema={uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -166,7 +151,7 @@ test('autofocus inactive by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema}/>
+      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -194,7 +179,7 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={schema} uischema={t.context.uischema}/>
+      <TextField schema={schema} uischema={t.context.uischema} path='name'/>
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -209,7 +194,7 @@ test('update via input event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema}/>
+      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name'/>
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -226,7 +211,7 @@ test.cb('update via action', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema}/>
+      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -248,7 +233,7 @@ test('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema}/>
+      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name'/>
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -264,7 +249,7 @@ test('update with null value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema}/>
+      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name'/>
     </Provider>
   ) as React.Component<any>;;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -280,7 +265,7 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema}/>
+      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name'/>
     </Provider>
   ) as React.Component<any>;;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -296,9 +281,9 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema}/>
+      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name'/>
     </Provider>
-  ) as React.Component<any>;;
+  ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
   store.dispatch(update(null, () => 'Bar'));
   t.is(input.value, 'Foo');
@@ -312,9 +297,9 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema}/>
+      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name'/>
     </Provider>
-  ) as React.Component<any>;;
+  ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
   store.dispatch(update(undefined, () => 'Bar'));
   t.is(input.value, 'Foo');
@@ -328,7 +313,7 @@ test('disable', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema} enabled={false}/>
+      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name' enabled={false}/>
     </Provider>
   ) as React.Component<any>;;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -343,7 +328,7 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema}/>
+      <TextField schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name' />
     </Provider>
   ) as React.Component<any>;;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -367,9 +352,9 @@ test('use maxLength for attributes size and maxlength', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.maxLengthSchema} uischema={uischema}/>
+      <TextField schema={t.context.maxLengthSchema} uischema={uischema} path='name' />
     </Provider>
-  ) as React.Component<any>;;
+  ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
   t.is(input.maxLength, 5);
   t.is(input.size, 5);
@@ -392,7 +377,7 @@ test('use maxLength for attribute size only', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.maxLengthSchema} uischema={uischema}/>
+      <TextField schema={t.context.maxLengthSchema} uischema={uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -417,7 +402,7 @@ test('use maxLength for attribute max length only', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.maxLengthSchema} uischema={uischema}/>
+      <TextField schema={t.context.maxLengthSchema} uischema={uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -433,7 +418,7 @@ test('do not use maxLength by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.maxLengthSchema} uischema={t.context.uischema}/>
+      <TextField schema={t.context.maxLengthSchema} uischema={t.context.uischema} path='name'/>
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -458,7 +443,7 @@ test('maxLength not specified, attributes should have default values (trim && re
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.schema} uischema={uischema}/>
+      <TextField schema={t.context.schema} uischema={uischema} path='name'/>
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -483,7 +468,7 @@ test('maxLength not specified, attributes should have default values (trim)', t 
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.schema} uischema={uischema}/>
+      <TextField schema={t.context.schema} uischema={uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -508,7 +493,7 @@ test('maxLength not specified, attributes should have default values (restrict)'
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.schema} uischema={uischema}/>
+      <TextField schema={t.context.schema} uischema={uischema} path='name'/>
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -524,7 +509,7 @@ test('maxLength not specified, attributes should have default values', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TextField schema={t.context.schema} uischema={t.context.uischema} path='name' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/vanilla/test/renderers/TimeField.test.tsx
+++ b/packages/vanilla/test/renderers/TimeField.test.tsx
@@ -40,13 +40,8 @@ import * as TestUtils from 'react-dom/test-utils';
 test.beforeEach(t => {
   t.context.data = { 'foo': '13:37' };
   t.context.schema = {
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'string',
-        format: 'time'
-      },
-    },
+    type: 'string',
+    format: 'time'
   };
   t.context.uischema = {
     type: 'Control',
@@ -127,7 +122,7 @@ test('autofocus active', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeField schema={t.context.schema} uischema={uischema}/>
+      <TimeField schema={t.context.schema} uischema={uischema} path='foo'/>
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -149,7 +144,7 @@ test('autofocus inactive', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeField schema={t.context.schema} uischema={uischema}/>
+      <TimeField schema={t.context.schema} uischema={uischema} path='foo'/>
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -168,7 +163,7 @@ test('autofocus inactive by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeField schema={t.context.schema} uischema={uischema}/>
+      <TimeField schema={t.context.schema} uischema={uischema} path='foo'/>
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -243,7 +238,7 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TimeField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
 
@@ -261,7 +256,7 @@ test.cb('update via event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TimeField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -279,7 +274,7 @@ test.cb('update via action', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TimeField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -296,7 +291,7 @@ test('update with null value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TimeField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -313,7 +308,7 @@ test('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TimeField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -330,7 +325,7 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TimeField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -347,7 +342,7 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TimeField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -364,7 +359,7 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TimeField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -381,7 +376,7 @@ test('disable', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeField schema={t.context.schema} uischema={t.context.uischema} enabled={false}/>
+      <TimeField schema={t.context.schema} uischema={t.context.uischema} path='foo' enabled={false}/>
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -397,7 +392,7 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeField schema={t.context.schema} uischema={t.context.uischema}/>
+      <TimeField schema={t.context.schema} uischema={t.context.uischema} path='foo' />
     </Provider>
   ) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;


### PR DESCRIPTION
Sorry, this change got a bit out-of-hand because of updating the tests. If necessary, I can split it up into multipe commits.

* Re-structure combinator renderers, so that subschemas are passed to
  sub-sequent JsonForms calls
* Consistent usage of schema & rootSchema, remove scopedSchema prop
* Refactor mapStateToFieldProps, it relies on being props being passed down now