### PR TITLE
Improve typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -874,157 +874,161 @@
 			}
 		},
 		"@webassemblyjs/ast": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
-			"integrity": "sha512-ZEzy4vjvTzScC+SH8RBssQUawpaInUdMTYwYYLh54/s8TuT0gBLuyUnppKsVyZEi876VmmStKsUs28UxPgdvrA==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
+			"integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
 			"requires": {
-				"@webassemblyjs/helper-module-context": "1.7.11",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-				"@webassemblyjs/wast-parser": "1.7.11"
+				"@webassemblyjs/helper-module-context": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/wast-parser": "1.8.5"
 			}
 		},
 		"@webassemblyjs/floating-point-hex-parser": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.11.tgz",
-			"integrity": "sha512-zY8dSNyYcgzNRNT666/zOoAyImshm3ycKdoLsyDw/Bwo6+/uktb7p4xyApuef1dwEBo/U/SYQzbGBvV+nru2Xg=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
+			"integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ=="
 		},
 		"@webassemblyjs/helper-api-error": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.11.tgz",
-			"integrity": "sha512-7r1qXLmiglC+wPNkGuXCvkmalyEstKVwcueZRP2GNC2PAvxbLYwLLPr14rcdJaE4UtHxQKfFkuDFuv91ipqvXg=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
+			"integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA=="
 		},
 		"@webassemblyjs/helper-buffer": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.11.tgz",
-			"integrity": "sha512-MynuervdylPPh3ix+mKZloTcL06P8tenNH3sx6s0qE8SLR6DdwnfgA7Hc9NSYeob2jrW5Vql6GVlsQzKQCa13w=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
+			"integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q=="
 		},
 		"@webassemblyjs/helper-code-frame": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.11.tgz",
-			"integrity": "sha512-T8ESC9KMXFTXA5urJcyor5cn6qWeZ4/zLPyWeEXZ03hj/x9weSokGNkVCdnhSabKGYWxElSdgJ+sFa9G/RdHNw==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
+			"integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
 			"requires": {
-				"@webassemblyjs/wast-printer": "1.7.11"
+				"@webassemblyjs/wast-printer": "1.8.5"
 			}
 		},
 		"@webassemblyjs/helper-fsm": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.11.tgz",
-			"integrity": "sha512-nsAQWNP1+8Z6tkzdYlXT0kxfa2Z1tRTARd8wYnc/e3Zv3VydVVnaeePgqUzFrpkGUyhUUxOl5ML7f1NuT+gC0A=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
+			"integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow=="
 		},
 		"@webassemblyjs/helper-module-context": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.11.tgz",
-			"integrity": "sha512-JxfD5DX8Ygq4PvXDucq0M+sbUFA7BJAv/GGl9ITovqE+idGX+J3QSzJYz+LwQmL7fC3Rs+utvWoJxDb6pmC0qg=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
+			"integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
+			"requires": {
+				"@webassemblyjs/ast": "1.8.5",
+				"mamacro": "^0.0.3"
+			}
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.11.tgz",
-			"integrity": "sha512-cMXeVS9rhoXsI9LLL4tJxBgVD/KMOKXuFqYb5oCJ/opScWpkCMEz9EJtkonaNcnLv2R3K5jIeS4TRj/drde1JQ=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
+			"integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ=="
 		},
 		"@webassemblyjs/helper-wasm-section": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.11.tgz",
-			"integrity": "sha512-8ZRY5iZbZdtNFE5UFunB8mmBEAbSI3guwbrsCl4fWdfRiAcvqQpeqd5KHhSWLL5wuxo53zcaGZDBU64qgn4I4Q==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
+			"integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-buffer": "1.7.11",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-				"@webassemblyjs/wasm-gen": "1.7.11"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-buffer": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/wasm-gen": "1.8.5"
 			}
 		},
 		"@webassemblyjs/ieee754": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.11.tgz",
-			"integrity": "sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
+			"integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.11.tgz",
-			"integrity": "sha512-vuGmgZjjp3zjcerQg+JA+tGOncOnJLWVkt8Aze5eWQLwTQGNgVLcyOTqgSCxWTR4J42ijHbBxnuRaL1Rv7XMdw==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
+			"integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
 			"requires": {
-				"@xtuc/long": "4.2.1"
+				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/utf8": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.11.tgz",
-			"integrity": "sha512-C6GFkc7aErQIAH+BMrIdVSmW+6HSe20wg57HEC1uqJP8E/xpMjXqQUxkQw07MhNDSDcGpxI9G5JSNOQCqJk4sA=="
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
+			"integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw=="
 		},
 		"@webassemblyjs/wasm-edit": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.11.tgz",
-			"integrity": "sha512-FUd97guNGsCZQgeTPKdgxJhBXkUbMTY6hFPf2Y4OedXd48H97J+sOY2Ltaq6WGVpIH8o/TGOVNiVz/SbpEMJGg==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
+			"integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-buffer": "1.7.11",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-				"@webassemblyjs/helper-wasm-section": "1.7.11",
-				"@webassemblyjs/wasm-gen": "1.7.11",
-				"@webassemblyjs/wasm-opt": "1.7.11",
-				"@webassemblyjs/wasm-parser": "1.7.11",
-				"@webassemblyjs/wast-printer": "1.7.11"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-buffer": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/helper-wasm-section": "1.8.5",
+				"@webassemblyjs/wasm-gen": "1.8.5",
+				"@webassemblyjs/wasm-opt": "1.8.5",
+				"@webassemblyjs/wasm-parser": "1.8.5",
+				"@webassemblyjs/wast-printer": "1.8.5"
 			}
 		},
 		"@webassemblyjs/wasm-gen": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.11.tgz",
-			"integrity": "sha512-U/KDYp7fgAZX5KPfq4NOupK/BmhDc5Kjy2GIqstMhvvdJRcER/kUsMThpWeRP8BMn4LXaKhSTggIJPOeYHwISA==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
+			"integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-				"@webassemblyjs/ieee754": "1.7.11",
-				"@webassemblyjs/leb128": "1.7.11",
-				"@webassemblyjs/utf8": "1.7.11"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/ieee754": "1.8.5",
+				"@webassemblyjs/leb128": "1.8.5",
+				"@webassemblyjs/utf8": "1.8.5"
 			}
 		},
 		"@webassemblyjs/wasm-opt": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.11.tgz",
-			"integrity": "sha512-XynkOwQyiRidh0GLua7SkeHvAPXQV/RxsUeERILmAInZegApOUAIJfRuPYe2F7RcjOC9tW3Cb9juPvAC/sCqvg==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
+			"integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-buffer": "1.7.11",
-				"@webassemblyjs/wasm-gen": "1.7.11",
-				"@webassemblyjs/wasm-parser": "1.7.11"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-buffer": "1.8.5",
+				"@webassemblyjs/wasm-gen": "1.8.5",
+				"@webassemblyjs/wasm-parser": "1.8.5"
 			}
 		},
 		"@webassemblyjs/wasm-parser": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.11.tgz",
-			"integrity": "sha512-6lmXRTrrZjYD8Ng8xRyvyXQJYUQKYSXhJqXOBLw24rdiXsHAOlvw5PhesjdcaMadU/pyPQOJ5dHreMjBxwnQKg==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
+			"integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-api-error": "1.7.11",
-				"@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-				"@webassemblyjs/ieee754": "1.7.11",
-				"@webassemblyjs/leb128": "1.7.11",
-				"@webassemblyjs/utf8": "1.7.11"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-api-error": "1.8.5",
+				"@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+				"@webassemblyjs/ieee754": "1.8.5",
+				"@webassemblyjs/leb128": "1.8.5",
+				"@webassemblyjs/utf8": "1.8.5"
 			}
 		},
 		"@webassemblyjs/wast-parser": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.11.tgz",
-			"integrity": "sha512-lEyVCg2np15tS+dm7+JJTNhNWq9yTZvi3qEhAIIOaofcYlUp0UR5/tVqOwa/gXYr3gjwSZqw+/lS9dscyLelbQ==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
+			"integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/floating-point-hex-parser": "1.7.11",
-				"@webassemblyjs/helper-api-error": "1.7.11",
-				"@webassemblyjs/helper-code-frame": "1.7.11",
-				"@webassemblyjs/helper-fsm": "1.7.11",
-				"@xtuc/long": "4.2.1"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/floating-point-hex-parser": "1.8.5",
+				"@webassemblyjs/helper-api-error": "1.8.5",
+				"@webassemblyjs/helper-code-frame": "1.8.5",
+				"@webassemblyjs/helper-fsm": "1.8.5",
+				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webassemblyjs/wast-printer": {
-			"version": "1.7.11",
-			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.11.tgz",
-			"integrity": "sha512-m5vkAsuJ32QpkdkDOUPGSltrg8Cuk3KBx4YrmAGQwCZPRdUHXxG4phIOuuycLemHFr74sWL9Wthqss4fzdzSwg==",
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
+			"integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/wast-parser": "1.7.11",
-				"@xtuc/long": "4.2.1"
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/wast-parser": "1.8.5",
+				"@xtuc/long": "4.2.2"
 			}
 		},
 		"@webcomponents/webcomponentsjs": {
@@ -1038,9 +1042,9 @@
 			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
 		},
 		"@xtuc/long": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz",
-			"integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g=="
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
 		},
 		"JSONStream": {
 			"version": "1.3.5",
@@ -1196,9 +1200,9 @@
 			}
 		},
 		"ansi-colors": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-			"integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw=="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+			"integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
 		},
 		"ansi-escapes": {
 			"version": "3.1.0",
@@ -3414,11 +3418,18 @@
 			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
 		},
 		"compressible": {
-			"version": "2.0.15",
-			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
-			"integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.16.tgz",
+			"integrity": "sha512-JQfEOdnI7dASwCuSPWIeVYwc/zMsu/+tRhoUvEfXz2gxOA2DNjmG5vhtFdBlhWPPGo+RdT9S3tgc/uH5qgDiiA==",
 			"requires": {
-				"mime-db": ">= 1.36.0 < 2"
+				"mime-db": ">= 1.38.0 < 2"
+			},
+			"dependencies": {
+				"mime-db": {
+					"version": "1.38.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+					"integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+				}
 			}
 		},
 		"compression": {
@@ -4734,11 +4745,11 @@
 			"integrity": "sha512-/TnecbwXEdycfbsM2++O3eGiatEFHjjNciHEwJclM+T5Kd94qD1AP+2elP/Mq0L5b9VZJao5znR01Mz6eX8Seg=="
 		},
 		"default-gateway": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.2.tgz",
-			"integrity": "sha512-lAc4i9QJR0YHSDFdzeBQKfZ1SRDG3hsJNEkrpcZa8QhBfidLAilT60BDEIVUUGqosFp425KOgB3uYqcnQrWafQ==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.1.2.tgz",
+			"integrity": "sha512-xhJUAp3u02JsBGovj0V6B6uYhKCUOmiNc8xGmReUwGu77NmvcpxPVB0pCielxMFumO7CmXBG02XjM8HB97k8Hw==",
 			"requires": {
-				"execa": "^0.10.0",
+				"execa": "^1.0.0",
 				"ip-regex": "^2.1.0"
 			},
 			"dependencies": {
@@ -4755,17 +4766,25 @@
 					}
 				},
 				"execa": {
-					"version": "0.10.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-					"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 					"requires": {
 						"cross-spawn": "^6.0.0",
-						"get-stream": "^3.0.0",
+						"get-stream": "^4.0.0",
 						"is-stream": "^1.1.0",
 						"npm-run-path": "^2.0.0",
 						"p-finally": "^1.0.0",
 						"signal-exit": "^3.0.0",
 						"strip-eof": "^1.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"requires": {
+						"pump": "^3.0.0"
 					}
 				}
 			}
@@ -5576,9 +5595,9 @@
 			}
 		},
 		"eslint-scope": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-			"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.2.tgz",
+			"integrity": "sha512-5q1+B/ogmHl8+paxtOKx38Z8LtWkVGuNt3+GQNErqwLl6ViNp/gdJGMCjZNxZ8j/VYjDNZ2Fo+eQc1TAVPIzbg==",
 			"requires": {
 				"esrecurse": "^4.1.0",
 				"estraverse": "^4.1.1"
@@ -7958,14 +7977,14 @@
 			}
 		},
 		"http-proxy-middleware": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
-			"integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+			"integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
 			"requires": {
-				"http-proxy": "^1.16.2",
+				"http-proxy": "^1.17.0",
 				"is-glob": "^4.0.0",
-				"lodash": "^4.17.5",
-				"micromatch": "^3.1.9"
+				"lodash": "^4.17.11",
+				"micromatch": "^3.1.10"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -8434,12 +8453,19 @@
 			}
 		},
 		"internal-ip": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.1.tgz",
-			"integrity": "sha512-NXXgESC2nNVtU+pqmC9e6R8B1GpKxzsAQhffvh5AL79qKnodd+L7tnEQmTiUAVngqLalPbSqRA7XGIEL5nCd0Q==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.2.0.tgz",
+			"integrity": "sha512-ZY8Rk+hlvFeuMmG5uH1MXhhdeMntmIaxaInvAmzMq/SHV8rv4Kh+6GiQNNDQd0wZFrcO+FiTBo8lui/osKOyJw==",
 			"requires": {
-				"default-gateway": "^2.6.0",
-				"ipaddr.js": "^1.5.2"
+				"default-gateway": "^4.0.1",
+				"ipaddr.js": "^1.9.0"
+			},
+			"dependencies": {
+				"ipaddr.js": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+					"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+				}
 			}
 		},
 		"interpret": {
@@ -10294,9 +10320,12 @@
 			}
 		},
 		"karma-jasmine": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-1.1.2.tgz",
-			"integrity": "sha1-OU8rJf+0pkS5rabyLUQ+L9CIhsM="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-2.0.1.tgz",
+			"integrity": "sha512-iuC0hmr9b+SNn1DaUD2QEYtUxkS1J+bSJSn7ejdEexs7P8EYvA1CWkEdrDQ+8jVH3AgWlCNwjYsT1chjcNW9lA==",
+			"requires": {
+				"jasmine-core": "^3.3"
+			}
 		},
 		"karma-jasmine-html-reporter": {
 			"version": "1.4.0",
@@ -10864,6 +10893,11 @@
 			"requires": {
 				"tmpl": "1.0.x"
 			}
+		},
+		"mamacro": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
+			"integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA=="
 		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
@@ -14396,9 +14430,9 @@
 			}
 		},
 		"on-headers": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+			"integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
 		},
 		"once": {
 			"version": "1.4.0",
@@ -17437,9 +17471,9 @@
 					}
 				},
 				"readable-stream": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-					"integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
+					"integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -17912,13 +17946,13 @@
 			}
 		},
 		"terser": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-3.14.1.tgz",
-			"integrity": "sha512-NSo3E99QDbYSMeJaEk9YW2lTg3qS9V0aKGlb+PlOrei1X02r1wSBHCNX/O+yeTRFSWPKPIGj6MqvvdqV4rnVGw==",
+			"version": "3.16.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-3.16.1.tgz",
+			"integrity": "sha512-JDJjgleBROeek2iBcSNzOHLKsB/MdDf+E/BOAJ0Tk9r7p9/fVobfv7LMJ/g/k3v9SXdmjZnIlFd5nfn/Rt0Xow==",
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1",
-				"source-map-support": "~0.5.6"
+				"source-map-support": "~0.5.9"
 			},
 			"dependencies": {
 				"source-map": {
@@ -17929,16 +17963,16 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.1.tgz",
-			"integrity": "sha512-GGSt+gbT0oKcMDmPx4SRSfJPE1XaN3kQRWG4ghxKQw9cn5G9x6aCKSsgYdvyM0na9NJ4Drv0RG6jbBByZ5CMjw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz",
+			"integrity": "sha512-GOK7q85oAb/5kE12fMuLdn2btOS9OBZn4VsecpHDywoUC/jLhSAKOiYo0ezx7ss2EXPMzyEWFoE0s1WLE+4+oA==",
 			"requires": {
 				"cacache": "^11.0.2",
 				"find-cache-dir": "^2.0.0",
 				"schema-utils": "^1.0.0",
 				"serialize-javascript": "^1.4.0",
 				"source-map": "^0.6.1",
-				"terser": "^3.8.1",
+				"terser": "^3.16.1",
 				"webpack-sources": "^1.1.0",
 				"worker-farm": "^1.5.2"
 			},
@@ -17971,9 +18005,9 @@
 					}
 				},
 				"p-limit": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-					"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
 					"requires": {
 						"p-try": "^2.0.0"
 					}
@@ -19723,14 +19757,14 @@
 			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"webpack": {
-			"version": "4.29.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.29.0.tgz",
-			"integrity": "sha512-pxdGG0keDBtamE1mNvT5zyBdx+7wkh6mh7uzMOo/uRQ/fhsdj5FXkh/j5mapzs060forql1oXqXN9HJGju+y7w==",
+			"version": "4.29.6",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.29.6.tgz",
+			"integrity": "sha512-MwBwpiE1BQpMDkbnUUaW6K8RFZjljJHArC6tWQJoFm0oQtfoSebtg4Y7/QHnJ/SddtjYLHaKGX64CFjG5rehJw==",
 			"requires": {
-				"@webassemblyjs/ast": "1.7.11",
-				"@webassemblyjs/helper-module-context": "1.7.11",
-				"@webassemblyjs/wasm-edit": "1.7.11",
-				"@webassemblyjs/wasm-parser": "1.7.11",
+				"@webassemblyjs/ast": "1.8.5",
+				"@webassemblyjs/helper-module-context": "1.8.5",
+				"@webassemblyjs/wasm-edit": "1.8.5",
+				"@webassemblyjs/wasm-parser": "1.8.5",
 				"acorn": "^6.0.5",
 				"acorn-dynamic-import": "^4.0.0",
 				"ajv": "^6.1.0",
@@ -19746,7 +19780,7 @@
 				"mkdirp": "~0.5.0",
 				"neo-async": "^2.5.0",
 				"node-libs-browser": "^2.0.0",
-				"schema-utils": "^0.4.4",
+				"schema-utils": "^1.0.0",
 				"tapable": "^1.1.0",
 				"terser-webpack-plugin": "^1.1.0",
 				"watchpack": "^1.5.0",
@@ -20013,6 +20047,16 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-errors": "^1.0.0",
+						"ajv-keywords": "^3.1.0"
+					}
 				}
 			}
 		},
@@ -20225,22 +20269,22 @@
 			}
 		},
 		"webpack-dev-server": {
-			"version": "3.1.14",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.14.tgz",
-			"integrity": "sha512-mGXDgz5SlTxcF3hUpfC8hrQ11yhAttuUQWf1Wmb+6zo3x6rb7b9mIfuQvAPLdfDRCGRGvakBWHdHOa0I9p/EVQ==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.2.1.tgz",
+			"integrity": "sha512-sjuE4mnmx6JOh9kvSbPYw3u/6uxCLHNWfhWaIPwcXWsvWOPN+nc5baq4i9jui3oOBRXGonK9+OI0jVkaz6/rCw==",
 			"requires": {
 				"ansi-html": "0.0.7",
 				"bonjour": "^3.5.0",
 				"chokidar": "^2.0.0",
 				"compression": "^1.5.2",
 				"connect-history-api-fallback": "^1.3.0",
-				"debug": "^3.1.0",
+				"debug": "^4.1.1",
 				"del": "^3.0.0",
 				"express": "^4.16.2",
 				"html-entities": "^1.2.0",
-				"http-proxy-middleware": "~0.18.0",
+				"http-proxy-middleware": "^0.19.1",
 				"import-local": "^2.0.0",
-				"internal-ip": "^3.0.1",
+				"internal-ip": "^4.2.0",
 				"ip": "^1.1.5",
 				"killable": "^1.0.0",
 				"loglevel": "^1.4.1",
@@ -20254,9 +20298,9 @@
 				"sockjs-client": "1.3.0",
 				"spdy": "^4.0.0",
 				"strip-ansi": "^3.0.0",
-				"supports-color": "^5.1.0",
+				"supports-color": "^6.1.0",
 				"url": "^0.11.0",
-				"webpack-dev-middleware": "3.4.0",
+				"webpack-dev-middleware": "^3.5.1",
 				"webpack-log": "^2.0.0",
 				"yargs": "12.0.2"
 			},
@@ -20268,6 +20312,16 @@
 					"requires": {
 						"micromatch": "^3.1.4",
 						"normalize-path": "^2.1.1"
+					},
+					"dependencies": {
+						"normalize-path": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+							"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+							"requires": {
+								"remove-trailing-separator": "^1.0.1"
+							}
+						}
 					}
 				},
 				"arr-diff": {
@@ -20313,23 +20367,22 @@
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"chokidar": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-					"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.2.tgz",
+					"integrity": "sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==",
 					"requires": {
 						"anymatch": "^2.0.0",
-						"async-each": "^1.0.0",
-						"braces": "^2.3.0",
-						"fsevents": "^1.2.2",
+						"async-each": "^1.0.1",
+						"braces": "^2.3.2",
+						"fsevents": "^1.2.7",
 						"glob-parent": "^3.1.0",
-						"inherits": "^2.0.1",
+						"inherits": "^2.0.3",
 						"is-binary-path": "^1.0.0",
 						"is-glob": "^4.0.0",
-						"lodash.debounce": "^4.0.8",
-						"normalize-path": "^2.1.1",
+						"normalize-path": "^3.0.0",
 						"path-is-absolute": "^1.0.0",
-						"readdirp": "^2.0.0",
-						"upath": "^1.0.5"
+						"readdirp": "^2.2.1",
+						"upath": "^1.1.0"
 					}
 				},
 				"cliui": {
@@ -20367,6 +20420,21 @@
 						"semver": "^5.5.0",
 						"shebang-command": "^1.2.0",
 						"which": "^1.2.9"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"requires": {
+						"ms": "^2.1.1"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+						}
 					}
 				},
 				"decamelize": {
@@ -20584,6 +20652,11 @@
 						}
 					}
 				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
 				"import-local": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
@@ -20683,13 +20756,13 @@
 					}
 				},
 				"mem": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
-					"integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
+					"integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
 					"requires": {
 						"map-age-cleaner": "^0.1.1",
 						"mimic-fn": "^1.0.0",
-						"p-is-promise": "^1.1.0"
+						"p-is-promise": "^2.0.0"
 					}
 				},
 				"micromatch": {
@@ -20722,6 +20795,11 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				},
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+				},
 				"os-locale": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
@@ -20732,10 +20810,15 @@
 						"mem": "^4.0.0"
 					}
 				},
+				"p-is-promise": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+					"integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
+				},
 				"p-limit": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-					"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
 					"requires": {
 						"p-try": "^2.0.0"
 					}
@@ -20784,12 +20867,20 @@
 						"ansi-regex": "^2.0.0"
 					}
 				},
-				"webpack-dev-middleware": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.4.0.tgz",
-					"integrity": "sha512-Q9Iyc0X9dP9bAsYskAVJ/hmIZZQwf/3Sy4xCAZgL5cUkjZmUZLt4l5HpbST/Pdgjn3u6pE7u5OdGd1apgzRujA==",
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"requires": {
-						"memory-fs": "~0.4.1",
+						"has-flag": "^3.0.0"
+					}
+				},
+				"webpack-dev-middleware": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.6.0.tgz",
+					"integrity": "sha512-oeXA3m+5gbYbDBGo4SvKpAHJJEGMoekUbHgo1RK7CP1sz7/WOSeu/dWJtSTk+rzDCLkPwQhGocgIq6lQqOyOwg==",
+					"requires": {
+						"memory-fs": "^0.4.1",
 						"mime": "^2.3.1",
 						"range-parser": "^1.0.3",
 						"webpack-log": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
 		"tslint-loader": "^3.5.3",
 		"tslint-react": "^3.2.0",
 		"typedoc": "^0.12.0",
-		"typescript": "^3.0.0",
-		"webpack": "^4.28.1",
-		"webpack-merge": "^4.1.1"
+		"typescript": "^3.1.0",
+		"webpack": "^4.29.6",
+		"webpack-merge": "^4.2.1"
 	}
 }

--- a/packages/angular-material/package.json
+++ b/packages/angular-material/package.json
@@ -88,11 +88,11 @@
     "istanbul-instrumenter-loader": "^3.0.1",
     "jasmine": "^3.2.0",
     "jasmine-spec-reporter": "^4.2.1",
-    "karma": "^3.0.0",
+    "karma": "^3.1.1",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage-istanbul-reporter": "^2.0.4",
-    "karma-jasmine": "^1.1.2",
-    "karma-jasmine-html-reporter": "^1.3.1",
+    "karma-jasmine": "^2.0.1",
+    "karma-jasmine-html-reporter": "^1.4.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^3.0.5",
     "null-loader": "^0.1.1",
@@ -103,7 +103,7 @@
     "ts-loader": "^5.3.3",
     "ts-node": "^7.0.1",
     "webpack-cli": "^3.2.1",
-    "webpack-dev-server": "^3.1.14",
+    "webpack-dev-server": "^3.2.1",
     "zone.js": "^0.8.26"
   }
 }

--- a/packages/angular-material/src/other/label.renderer.ts
+++ b/packages/angular-material/src/other/label.renderer.ts
@@ -4,6 +4,7 @@ import { Component } from '@angular/core';
 import { JsonFormsBaseRenderer } from '@jsonforms/angular';
 import { Subscription } from 'rxjs/Subscription';
 import {
+  getData,
   isVisible,
   JsonFormsState,
   LabelElement,
@@ -58,7 +59,7 @@ const mapStateToProps = (
 ) => {
   const visible = has(ownProps, 'visible')
     ? ownProps.visible
-    : isVisible(ownProps, state);
+    : isVisible(ownProps.uischema, getData(state));
 
   return {
     visible

--- a/packages/angular-material/src/other/master-detail/master.ts
+++ b/packages/angular-material/src/other/master-detail/master.ts
@@ -1,7 +1,7 @@
 import some from 'lodash/some';
 import get from 'lodash/get';
 import { Component } from '@angular/core';
-import { JsonFormsControl } from '@jsonforms/angular';
+import { JsonFormsArrayControl } from '@jsonforms/angular';
 import { NgRedux } from '@angular-redux/store';
 import {
   ArrayControlProps,
@@ -104,7 +104,7 @@ export const removeSchemaKeywords = (path: string) => {
     `
   ]
 })
-export class MasterListComponent extends JsonFormsControl {
+export class MasterListComponent extends JsonFormsArrayControl {
   masterItems: any[];
   selectedItem: any;
   selectedItemIdx: number;

--- a/packages/angular-test/package.json
+++ b/packages/angular-test/package.json
@@ -11,11 +11,10 @@
   "devDependencies": {
     "jasmine": "^3.2.0",
     "jasmine-spec-reporter": "^4.2.1",
-    "karma": "^3.0.0",
+    "karma": "^3.1.1",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage-istanbul-reporter": "^2.0.4",
-    "karma-jasmine": "^1.1.2",
-    "karma-jasmine-html-reporter": "^1.3.1",
+    "karma-jasmine": "^2.0.1",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^3.0.5"
   },

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -55,6 +55,6 @@
     "copy-webpack-plugin": "^4.5.1",
     "redux": "^3.0.0",
     "rxjs": "^5.5.7",
-    "webpack-dev-server": "^3.1.14"
+    "webpack-dev-server": "^3.2.1"
   }
 }

--- a/packages/angular/src/abstract-control.ts
+++ b/packages/angular/src/abstract-control.ts
@@ -1,0 +1,162 @@
+/*
+  The MIT License
+
+  Copyright (c) 2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import {
+  Actions,
+  composeWithUi,
+  computeLabel,
+  ControlElement,
+  isPlainLabel,
+  JsonFormsState,
+  JsonSchema,
+  OwnPropsOfControl,
+  StatePropsOfControl
+} from '@jsonforms/core';
+import { Input, OnDestroy, OnInit } from '@angular/core';
+import { NgRedux } from '@angular-redux/store';
+import {
+  AbstractControl,
+  FormControl,
+  ValidationErrors,
+  ValidatorFn
+} from '@angular/forms';
+import { Subscription } from 'rxjs';
+
+import { JsonFormsBaseRenderer } from './base.renderer';
+
+export abstract class JsonFormsAbstractControl<
+  Props extends StatePropsOfControl
+> extends JsonFormsBaseRenderer<ControlElement> implements OnInit, OnDestroy {
+  @Input() id: string;
+  @Input() disabled: boolean;
+  @Input() visible: boolean;
+
+  form: FormControl;
+  subscription: Subscription;
+  data: any;
+  label: string;
+  description: string;
+  error: string | null;
+  scopedSchema: JsonSchema;
+  rootSchema: JsonSchema;
+  enabled: boolean;
+  hidden: boolean;
+
+  constructor(protected ngRedux: NgRedux<JsonFormsState>) {
+    super();
+    this.form = new FormControl(
+      {
+        value: '',
+        disabled: true
+      },
+      {
+        updateOn: 'change',
+        validators: this.validator.bind(this)
+      }
+    );
+  }
+
+  getEventValue = (event: any) => event.value;
+
+  onChange(ev: any) {
+    const path = composeWithUi(this.uischema, this.path);
+    this.ngRedux.dispatch(Actions.update(path, () => this.getEventValue(ev)));
+    this.triggerValidation();
+  }
+
+  ngOnInit() {
+    this.subscription = this.ngRedux
+      .select()
+      .subscribe((state: JsonFormsState) => {
+        const props = this.mapToProps(state);
+        const {
+          data,
+          enabled,
+          errors,
+          label,
+          required,
+          schema,
+          rootSchema,
+          visible
+        } = props;
+        this.label = computeLabel(
+          isPlainLabel(label) ? label : label.default,
+          required
+        );
+        this.data = data;
+        this.error = errors ? errors.join('\n') : null;
+        this.enabled = enabled;
+        this.enabled ? this.form.enable() : this.form.disable();
+        this.hidden = !visible;
+        this.scopedSchema = schema;
+        this.rootSchema = rootSchema;
+        this.description =
+          this.scopedSchema !== undefined ? this.scopedSchema.description : '';
+        this.id = props.id;
+        this.form.setValue(data);
+        this.mapAdditionalProps(props);
+      });
+    this.triggerValidation();
+  }
+
+  validator: ValidatorFn = (_c: AbstractControl): ValidationErrors | null => {
+    return this.error ? { error: this.error } : null;
+  };
+
+  // @ts-ignore
+  mapAdditionalProps(props: Props) {
+    // do nothing by default
+  }
+
+  ngOnDestroy() {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
+  }
+
+  protected getOwnProps(): OwnPropsOfControl {
+    const props: OwnPropsOfControl = {
+      uischema: this.uischema,
+      schema: this.schema,
+      path: this.path,
+      id: this.id
+    };
+    if (this.disabled !== undefined) {
+      props.enabled = !this.disabled;
+    }
+    if (this.visible !== undefined) {
+      props.visible = this.visible;
+    }
+    return props;
+  }
+
+  protected abstract mapToProps(state: JsonFormsState): Props;
+
+  protected triggerValidation() {
+    // these cause the correct update of the error underline, seems to be
+    // related to ionic-team/ionic#11640
+    this.form.markAsTouched();
+    this.form.updateValueAndValidity();
+  }
+}

--- a/packages/angular/src/array-control.ts
+++ b/packages/angular/src/array-control.ts
@@ -1,7 +1,7 @@
 /*
   The MIT License
 
-  Copyright (c) 2018 EclipseSource Munich
+  Copyright (c) 2019 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,44 +22,21 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import React from 'react';
 import {
-  LabelElement,
-  mapStateToLayoutProps,
-  RankedTester,
-  rankWith,
-  rendererDefaultProps,
-  RendererProps,
-  uiTypeIs
+  ArrayControlProps,
+  JsonFormsState,
+  mapDispatchToArrayControlProps,
+  mapStateToArrayControlProps
 } from '@jsonforms/core';
-import { StatelessRenderer } from '@jsonforms/react';
+import { OnDestroy, OnInit } from '@angular/core';
+import { JsonFormsAbstractControl } from './abstract-control';
 
-import Typography from '@material-ui/core/Typography';
-import { connect } from 'react-redux';
-
-/**
- * Default tester for a label.
- * @type {RankedTester}
- */
-export const materialLabelRendererTester: RankedTester = rankWith(1, uiTypeIs('Label'));
-
-/**
- * Default renderer for a label.
- */
-export const MaterialLabelRenderer: StatelessRenderer<RendererProps> & { defaultProps: Partial<RendererProps> } =
-  ({ uischema, visible }) => {
-    const labelElement: LabelElement = uischema as LabelElement;
-    const style: {[x: string]: any} = {};
-    if (!visible) {
-      style.display = 'none';
-    }
-    return (
-      <Typography variant='h6' style={style}>
-        {labelElement.text !== undefined && labelElement.text !== null && labelElement.text}
-      </Typography>
-    );
-  };
-
-MaterialLabelRenderer.defaultProps = rendererDefaultProps;
-
-export default connect(mapStateToLayoutProps)(MaterialLabelRenderer);
+export class JsonFormsArrayControl
+  extends JsonFormsAbstractControl<ArrayControlProps>
+  implements OnInit, OnDestroy {
+  protected mapToProps(state: JsonFormsState): ArrayControlProps {
+    const props = mapStateToArrayControlProps(state, this.getOwnProps());
+    const dispatch = mapDispatchToArrayControlProps(this.ngRedux.dispatch);
+    return { ...props, ...dispatch };
+  }
+}

--- a/packages/angular/src/control.ts
+++ b/packages/angular/src/control.ts
@@ -1,143 +1,41 @@
+/*
+  The MIT License
+
+  Copyright (c) 2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
 import {
-  Actions,
-  composeWithUi,
-  computeLabel,
-  ControlElement,
   ControlProps,
-  isPlainLabel,
   JsonFormsState,
-  JsonSchema,
   mapDispatchToControlProps,
-  mapStateToControlProps,
-  OwnPropsOfControl
+  mapStateToControlProps
 } from '@jsonforms/core';
-import { Input, OnDestroy, OnInit } from '@angular/core';
-import { NgRedux } from '@angular-redux/store';
-import {
-  AbstractControl,
-  FormControl,
-  ValidationErrors,
-  ValidatorFn
-} from '@angular/forms';
-import { Subscription } from 'rxjs';
+import { OnDestroy, OnInit } from '@angular/core';
+import { JsonFormsAbstractControl } from './abstract-control';
 
-import { JsonFormsBaseRenderer } from './base.renderer';
-
-export class JsonFormsControl extends JsonFormsBaseRenderer<ControlElement>
+export class JsonFormsControl extends JsonFormsAbstractControl<ControlProps>
   implements OnInit, OnDestroy {
-  @Input() id: string;
-  @Input() disabled: boolean;
-  @Input() visible: boolean;
-
-  form: FormControl;
-  subscription: Subscription;
-  data: any;
-  label: string;
-  description: string;
-  error: string | null;
-  scopedSchema: JsonSchema;
-  rootSchema: JsonSchema;
-  enabled: boolean;
-  hidden: boolean;
-
-  constructor(protected ngRedux: NgRedux<JsonFormsState>) {
-    super();
-    this.form = new FormControl(
-      {
-        value: '',
-        disabled: true
-      },
-      {
-        updateOn: 'change',
-        validators: this.validator.bind(this)
-      }
-    );
-  }
-
-  getEventValue = (event: any) => event.value;
-
-  onChange(ev: any) {
-    const path = composeWithUi(this.uischema, this.path);
-    this.ngRedux.dispatch(Actions.update(path, () => this.getEventValue(ev)));
-    this.triggerValidation();
-  }
-
-  ngOnInit() {
-    this.subscription = this.ngRedux
-      .select()
-      .subscribe((state: JsonFormsState) => {
-        const props = this.mapToProps(state);
-        const {
-          data,
-          enabled,
-          errors,
-          label,
-          required,
-          schema,
-          rootSchema,
-          visible
-        } = props;
-        this.label = computeLabel(
-          isPlainLabel(label) ? label : label.default,
-          required
-        );
-        this.data = data;
-        this.error = errors ? errors.join('\n') : null;
-        this.enabled = enabled;
-        this.enabled ? this.form.enable() : this.form.disable();
-        this.hidden = !visible;
-        this.scopedSchema = schema;
-        this.rootSchema = rootSchema;
-        this.description =
-          this.scopedSchema !== undefined ? this.scopedSchema.description : '';
-        this.id = props.id;
-        this.form.setValue(data);
-        this.mapAdditionalProps(props);
-      });
-    this.triggerValidation();
-  }
-
-  validator: ValidatorFn = (_c: AbstractControl): ValidationErrors | null => {
-    return this.error ? { error: this.error } : null;
-  };
-
-  // @ts-ignore
-  mapAdditionalProps(props: ControlProps) {
-    // do nothing by default
-  }
-
-  ngOnDestroy() {
-    if (this.subscription) {
-      this.subscription.unsubscribe();
-    }
-  }
-
-  protected getOwnProps(): OwnPropsOfControl {
-    const props: OwnPropsOfControl = {
-      uischema: this.uischema,
-      schema: this.schema,
-      path: this.path,
-      id: this.id
-    };
-    if (this.disabled !== undefined) {
-      props.enabled = !this.disabled;
-    }
-    if (this.visible !== undefined) {
-      props.visible = this.visible;
-    }
-    return props;
-  }
-
   protected mapToProps(state: JsonFormsState): ControlProps {
     const props = mapStateToControlProps(state, this.getOwnProps());
     const dispatch = mapDispatchToControlProps(this.ngRedux.dispatch);
     return { ...props, ...dispatch };
-  }
-
-  protected triggerValidation() {
-    // these cause the correct update of the error underline, seems to be
-    // related to ionic-team/ionic#11640
-    this.form.markAsTouched();
-    this.form.updateValueAndValidity();
   }
 }

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,7 +1,7 @@
 /*
   The MIT License
   
-  Copyright (c) 2018 EclipseSource Munich
+  Copyright (c) 2019 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
   
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -24,6 +24,7 @@
 */
 export * from './base.renderer';
 export * from './control';
+export * from './array-control';
 export * from './jsonforms.component';
 export * from './jsonforms.module';
 export * from './unknown.component';

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -192,7 +192,7 @@ export const extractSchema = (state: JsonFormsCore) => get(state, 'schema');
 export const extractUiSchema = (state: JsonFormsCore) => get(state, 'uischema');
 export const errorAt = (instancePath: string) => (
   state: JsonFormsCore
-): any[] => {
+): ErrorObject[] => {
   return filter(
     state.errors,
     (error: ErrorObject) => error.dataPath === instancePath

--- a/packages/core/src/util/field.ts
+++ b/packages/core/src/util/field.ts
@@ -90,7 +90,7 @@ export interface FieldProps extends StatePropsOfField, DispatchPropsOfField {}
  * @param field the field to be registered
  * @returns {any}
  */
-export interface DispatchFieldStateProps extends FieldProps {
+export interface DispatchFieldStateProps extends StatePropsOfField {
   fields?: JsonFormsFieldRendererRegistryEntry[];
 }
 
@@ -106,12 +106,13 @@ export const mapStateToFieldProps = (
   ownProps: OwnPropsOfField
 ): StatePropsOfField => {
   const { id, schema, path, uischema } = ownProps;
+  const rootData = getData(state);
   const visible = has(ownProps, 'visible')
     ? ownProps.visible
-    : isVisible(ownProps, state);
+    : isVisible(uischema, rootData);
   const enabled = has(ownProps, 'enabled')
     ? ownProps.enabled
-    : isEnabled(ownProps, state);
+    : isEnabled(uischema, rootData);
   const errors = getErrorAt(path)(state).map(error => error.message);
   const isValid = isEmpty(errors);
   const defaultConfig = cloneDeep(getConfig(state));
@@ -119,7 +120,7 @@ export const mapStateToFieldProps = (
   const rootSchema = getSchema(state);
 
   return {
-    data: Resolve.data(getData(state), path),
+    data: Resolve.data(rootData, path),
     visible,
     enabled,
     id,

--- a/packages/core/src/util/index.ts
+++ b/packages/core/src/util/index.ts
@@ -25,12 +25,7 @@
 import isEmpty from 'lodash/isEmpty';
 import isArray from 'lodash/isArray';
 import head from 'lodash/head';
-import {
-  JsonFormsState,
-  JsonSchema,
-  Scopable,
-  StatePropsOfRenderer
-} from '../';
+import { JsonSchema, Scopable, UISchemaElement } from '../';
 import { resolveData, resolveSchema } from './resolvers';
 import {
   compose as composePaths,
@@ -127,11 +122,11 @@ export { composePaths, composeWithUi, Paths, toDataPath };
 
 // Runtime --
 const Runtime = {
-  isEnabled(props: StatePropsOfRenderer, state: JsonFormsState): boolean {
-    return isEnabled(props, state);
+  isEnabled(uischema: UISchemaElement, data: any): boolean {
+    return isEnabled(uischema, data);
   },
-  isVisible(props: StatePropsOfRenderer, state: JsonFormsState): boolean {
-    return isVisible(props, state);
+  isVisible(uischema: UISchemaElement, data: any): boolean {
+    return isVisible(uischema, data);
   }
 };
 export { isEnabled, isVisible, Runtime, deriveType };

--- a/packages/core/src/util/runtime.ts
+++ b/packages/core/src/util/runtime.ts
@@ -23,8 +23,6 @@
   THE SOFTWARE.
 */
 import has from 'lodash/has';
-// TODO: pass in uischema and data instead of props and state
-import { getData } from '../reducers';
 import {
   AndCondition,
   Condition,
@@ -38,8 +36,6 @@ import {
 import { resolveData } from './resolvers';
 import { composeWithUi } from './path';
 import { createAjv } from './validator';
-import { StatePropsOfRenderer } from './renderer';
-import { JsonFormsState } from '../store';
 
 const ajv = createAjv();
 
@@ -133,24 +129,24 @@ export const evalEnablement = (
 };
 
 export const isVisible = (
-  props: StatePropsOfRenderer,
-  state: JsonFormsState,
+  uischema: UISchemaElement,
+  data: any,
   path: string = undefined
 ): boolean => {
-  if (props.uischema.rule) {
-    return evalVisibility(props.uischema, getData(state), path);
+  if (uischema.rule) {
+    return evalVisibility(uischema, data, path);
   }
 
   return true;
 };
 
 export const isEnabled = (
-  props: StatePropsOfRenderer,
-  state: JsonFormsState,
+  uischema: UISchemaElement,
+  data: any,
   path: string = undefined
 ): boolean => {
-  if (props.uischema.rule) {
-    return evalEnablement(props.uischema, getData(state), path);
+  if (uischema.rule) {
+    return evalEnablement(uischema, data, path);
   }
 
   return true;

--- a/packages/core/test/util/renderer.test.ts
+++ b/packages/core/test/util/renderer.test.ts
@@ -277,7 +277,6 @@ test('mapStateToControlProps - compose path with ownProps.path', t => {
   };
   const props = mapStateToControlProps(createState(coreUISchema), ownProps);
   t.is(props.path, 'yo.firstName');
-  t.is(props.parentPath, 'yo');
 });
 
 test('mapStateToControlProps - derive label', t => {

--- a/packages/ionic/package.json
+++ b/packages/ionic/package.json
@@ -75,11 +75,11 @@
     "istanbul-instrumenter-loader": "^3.0.1",
     "jasmine": "^3.2.0",
     "jasmine-spec-reporter": "^4.2.1",
-    "karma": "^3.0.0",
+    "karma": "^3.1.1",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage-istanbul-reporter": "^2.0.4",
-    "karma-jasmine": "^1.1.2",
-    "karma-jasmine-html-reporter": "^1.3.1",
+    "karma-jasmine": "^2.0.1",
+    "karma-jasmine-html-reporter": "^1.4.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^3.0.5",
     "ng-packagr": "^3.0.3",
@@ -88,6 +88,6 @@
     "request": "^2.88.0",
     "ts-loader": "^5.3.3",
     "ts-node": "^7.0.1",
-    "webpack-dev-server": "^3.1.14"
+    "webpack-dev-server": "^3.2.1"
   }
 }

--- a/packages/ionic/src/other/list-with-detail/list-with-detail-control.ts
+++ b/packages/ionic/src/other/list-with-detail/list-with-detail-control.ts
@@ -17,12 +17,12 @@ import {
   UISchemaElement,
   uiTypeIs
 } from '@jsonforms/core';
-import { JsonFormsControl } from '@jsonforms/angular';
 import { Nav, Platform } from 'ionic-angular';
 import { NgRedux } from '@angular-redux/store';
 import { MasterPage } from './pages/master/master';
 import { DetailPage } from './pages/detail/detail';
 import { removeSchemaKeywords } from '../../common';
+import { JsonFormsArrayControl } from '../../../../angular/src/array-control';
 
 export interface MasterItem {
   label: string;
@@ -54,7 +54,7 @@ const isMasterPage = (page: any) => {
     </ion-split-pane>
   `
 })
-export class ListWithDetailControl extends JsonFormsControl {
+export class ListWithDetailControl extends JsonFormsArrayControl {
   @ViewChild('masterNav') masterNav: Nav;
   @ViewChild('detailNav') detailNav: Nav;
   masterPage: any;

--- a/packages/material-tree-renderer/package.json
+++ b/packages/material-tree-renderer/package.json
@@ -73,6 +73,6 @@
     "ncp": "^2.0.0",
     "react-dom": "^16.4.0",
     "ts-jest": "^23.0.0",
-    "webpack-dev-server": "^3.1.14"
+    "webpack-dev-server": "^3.2.1"
   }
 }

--- a/packages/material/package.json
+++ b/packages/material/package.json
@@ -84,6 +84,6 @@
     "ts-jest": "^23.0.0",
     "ts-loader": "^5.3.3",
     "tslint-loader": "^3.5.3",
-    "webpack-dev-server": "^3.1.14"
+    "webpack-dev-server": "^3.2.1"
   }
 }

--- a/packages/material/src/complex/MaterialObjectRenderer.tsx
+++ b/packages/material/src/complex/MaterialObjectRenderer.tsx
@@ -7,6 +7,7 @@ import {
   isObjectControl,
   JsonFormsState,
   JsonSchema,
+  mapDispatchToControlProps,
   mapStateToControlProps,
   OwnPropsOfControl,
   RankedTester,
@@ -64,7 +65,8 @@ const mapStateToObjectControlProps = (state: JsonFormsState, ownProps: OwnPropsO
 };
 
 const ConnectedMaterialObjectRenderer = connect(
-    mapStateToObjectControlProps
+  mapStateToObjectControlProps,
+  mapDispatchToControlProps
 )(MaterialObjectRenderer);
 
 export const materialObjectControlTester: RankedTester = rankWith(2, isObjectControl);

--- a/packages/material/src/controls/MaterialInputControl.tsx
+++ b/packages/material/src/controls/MaterialInputControl.tsx
@@ -32,6 +32,7 @@ import {
   isControl,
   isDescriptionHidden,
   isPlainLabel,
+  mapDispatchToControlProps,
   mapStateToControlProps,
   RankedTester,
   rankWith
@@ -107,4 +108,4 @@ export class MaterialInputControl extends Control<ControlProps, ControlState> {
   }
 }
 export const materialInputControlTester: RankedTester = rankWith(1, isControl);
-export default connect(mapStateToControlProps)(MaterialInputControl);
+export default connect(mapStateToControlProps, mapDispatchToControlProps)(MaterialInputControl);

--- a/packages/material/src/layouts/MaterialArrayLayoutRenderer.tsx
+++ b/packages/material/src/layouts/MaterialArrayLayoutRenderer.tsx
@@ -49,6 +49,9 @@ export const MaterialArrayLayoutRenderer  = (
     createDefaultValue,
     schema,
     rootSchema,
+    id,
+    enabled,
+    visible
   }: ArrayControlProps) => {
 
   const controlElement = uischema as ControlElement;
@@ -68,6 +71,9 @@ export const MaterialArrayLayoutRenderer  = (
       errors={errors}
       rootSchema={rootSchema}
       createDefaultValue={createDefaultValue}
+      id={id}
+      enabled={enabled}
+      visible={visible}
     />
   );
 };

--- a/packages/react/src/Control.ts
+++ b/packages/react/src/Control.ts
@@ -1,19 +1,19 @@
 /*
   The MIT License
-  
+
   Copyright (c) 2018 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
-  
+
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
-  
+
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
-  
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -32,7 +32,7 @@
     "source-map-loader": "^0.2.3",
     "ts-loader": "^5.3.3",
     "tslint-loader": "^3.5.3",
-    "webpack-dev-server": "^3.1.14"
+    "webpack-dev-server": "^3.2.1"
   },
   "ava": {
     "verbose": true,

--- a/packages/vanilla/src/complex/LabelRenderer.tsx
+++ b/packages/vanilla/src/complex/LabelRenderer.tsx
@@ -1,19 +1,19 @@
 /*
   The MIT License
-  
-  Copyright (c) 2018 EclipseSource Munich
+
+  Copyright (c) 2019 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
-  
+
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
-  
+
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
-  
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,20 +22,19 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import has from 'lodash/has';
-import React from 'react';
+import React, { FunctionComponent } from 'react';
 import {
-    isVisible, JsonFormsState,
-    LabelElement, OwnPropsOfRenderer,
-    RankedTester,
-    rankWith,
-    RendererProps,
-    uiTypeIs,
+  LabelElement,
+  mapStateToLayoutProps,
+  RankedTester,
+  rankWith,
+  rendererDefaultProps,
+  RendererProps,
+  uiTypeIs
 } from '@jsonforms/core';
-import { getStyle as findStyle, getStyleAsClassName as findStyleAsClassName } from '../reducers';
-import { VanillaRendererProps } from '../index';
-import { StatelessRenderer } from '@jsonforms/react';
+import { addVanillaLayoutProps } from '../util';
 import { connect } from 'react-redux';
+import { VanillaRendererProps } from '../index';
 
 /**
  * Default tester for a label.
@@ -46,7 +45,7 @@ export const labelRendererTester: RankedTester = rankWith(1, uiTypeIs('Label'));
 /**
  * Default renderer for a label.
  */
-export const LabelRenderer: StatelessRenderer<RendererProps & VanillaRendererProps> =
+export const LabelRenderer:  FunctionComponent<RendererProps & VanillaRendererProps> & { defaultProps: Partial<RendererProps> } =
   ({ uischema, visible, getStyleAsClassName }) => {
     const labelElement: LabelElement = uischema as LabelElement;
     const classNames = getStyleAsClassName('label-control');
@@ -62,14 +61,6 @@ export const LabelRenderer: StatelessRenderer<RendererProps & VanillaRendererPro
     );
   };
 
-const mapStateToProps = (state: JsonFormsState, ownProps: OwnPropsOfRenderer) => {
-  const visible = has(ownProps, 'visible') ? ownProps.visible :  isVisible(ownProps, state);
+LabelRenderer.defaultProps = rendererDefaultProps;
 
-  return {
-    visible,
-    getStyle: findStyle(state),
-    getStyleAsClassName: findStyleAsClassName(state),
-  };
-};
-
-export default connect(mapStateToProps, null)(LabelRenderer);
+export default connect(addVanillaLayoutProps(mapStateToLayoutProps))(LabelRenderer);

--- a/packages/vanilla/src/complex/array/ArrayControlRenderer.tsx
+++ b/packages/vanilla/src/complex/array/ArrayControlRenderer.tsx
@@ -49,6 +49,10 @@ const ArrayControlRenderer  =
          getStyle,
          getStyleAsClassName,
          removeItems,
+         id,
+         visible,
+         enabled,
+         errors
      }: ArrayControlProps & VanillaRendererProps) => {
 
         const controlElement = uischema as ControlElement;
@@ -68,6 +72,7 @@ const ArrayControlRenderer  =
 
         return (
             <ArrayControl
+                errors={errors}
                 getStyle={getStyle}
                 getStyleAsClassName={getStyleAsClassName}
                 removeItems={removeItems}
@@ -81,6 +86,9 @@ const ArrayControlRenderer  =
                 schema={schema}
                 rootSchema={rootSchema}
                 createDefaultValue={createDefaultValue}
+                id={id}
+                visible={visible}
+                enabled={enabled}
             />
         );
     };

--- a/packages/vanilla/src/controls/InputControl.tsx
+++ b/packages/vanilla/src/controls/InputControl.tsx
@@ -32,6 +32,7 @@ import {
   isControl,
   isDescriptionHidden,
   isPlainLabel,
+  mapDispatchToControlProps,
   mapStateToControlProps,
   NOT_APPLICABLE,
   RankedTester,
@@ -112,7 +113,8 @@ export class InputControl extends Control<
 export const inputControlTester: RankedTester = rankWith(1, isControl);
 
 export const ConnectedInputControl = connect(
-  addVanillaControlProps(mapStateToControlProps)
+  addVanillaControlProps(mapStateToControlProps),
+  mapDispatchToControlProps
 )(InputControl);
 
 export default ConnectedInputControl;

--- a/packages/vanilla/src/layouts/GroupLayout.tsx
+++ b/packages/vanilla/src/layouts/GroupLayout.tsx
@@ -23,15 +23,16 @@
   THE SOFTWARE.
 */
 import isEmpty from 'lodash/isEmpty';
-import React from 'react';
+import React, { FunctionComponent } from 'react';
 import { connect } from 'react-redux';
 import {
-    GroupLayout,
-    mapStateToLayoutProps,
-    RankedTester,
-    rankWith,
-    RendererProps,
-    uiTypeIs,
+  GroupLayout,
+  mapStateToLayoutProps,
+  RankedTester,
+  rankWith,
+  rendererDefaultProps,
+  RendererProps,
+  uiTypeIs
 } from '@jsonforms/core';
 import { addVanillaLayoutProps } from '../util';
 import { renderChildren } from './util';
@@ -44,7 +45,7 @@ import { VanillaRendererProps } from '../index';
  */
 export const groupTester: RankedTester = rankWith(1, uiTypeIs('Group'));
 
-export const GroupLayoutRenderer = (
+export const GroupLayoutRenderer: FunctionComponent<RendererProps & VanillaRendererProps> & {defaultProps: Partial<RendererProps>} = (
   {
     schema,
     uischema,
@@ -76,9 +77,10 @@ export const GroupLayoutRenderer = (
   );
 };
 
+GroupLayoutRenderer.defaultProps = rendererDefaultProps;
+
 const ConnectedGroupLayout =  connect(
-  addVanillaLayoutProps(mapStateToLayoutProps),
-  null
+  addVanillaLayoutProps(mapStateToLayoutProps)
 )(GroupLayoutRenderer);
 
 export default ConnectedGroupLayout;

--- a/packages/vanilla/src/layouts/HorizontalLayout.tsx
+++ b/packages/vanilla/src/layouts/HorizontalLayout.tsx
@@ -22,15 +22,15 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import React from 'react';
+import React, { FunctionComponent } from 'react';
 import { connect } from 'react-redux';
 import {
-    HorizontalLayout,
-    mapStateToLayoutProps,
-    RankedTester,
-    rankWith,
-    RendererProps,
-    uiTypeIs,
+  HorizontalLayout,
+  mapStateToLayoutProps,
+  RankedTester,
+  rankWith, rendererDefaultProps,
+  RendererProps,
+  uiTypeIs
 } from '@jsonforms/core';
 import { addVanillaLayoutProps } from '../util';
 import { JsonFormsLayout } from './JsonFormsLayout';
@@ -43,16 +43,17 @@ import { VanillaRendererProps } from '../index';
  */
 export const horizontalLayoutTester: RankedTester = rankWith(1, uiTypeIs('HorizontalLayout'));
 
-const HorizontalLayoutRenderer = (props: RendererProps & VanillaRendererProps) => {
-
-  const {
+const HorizontalLayoutRenderer: FunctionComponent<RendererProps & VanillaRendererProps> & {defaultProps: Partial<RendererProps>} = (
+  {
     schema,
     uischema,
-    path,
-    visible,
     getStyle,
     getStyleAsClassName,
-  } = props;
+    enabled,
+    visible,
+    path
+  }: RendererProps & VanillaRendererProps
+) => {
 
   const horizontalLayout = uischema as HorizontalLayout;
   const elementsSize = horizontalLayout.elements ? horizontalLayout.elements.length : 0;
@@ -65,6 +66,8 @@ const HorizontalLayoutRenderer = (props: RendererProps & VanillaRendererProps) =
     <JsonFormsLayout
       className={layoutClassName}
       visible={visible}
+      enabled={enabled}
+      path={path}
       uischema={uischema}
       schema={schema}
       getStyle={getStyle}
@@ -75,9 +78,10 @@ const HorizontalLayoutRenderer = (props: RendererProps & VanillaRendererProps) =
   );
 };
 
+HorizontalLayoutRenderer.defaultProps = rendererDefaultProps;
+
 const ConnectedHorizontalLayout = connect(
-  addVanillaLayoutProps(mapStateToLayoutProps),
-  null
+  addVanillaLayoutProps(mapStateToLayoutProps)
 )(HorizontalLayoutRenderer);
 
 export default ConnectedHorizontalLayout;

--- a/packages/vanilla/src/layouts/VerticalLayout.tsx
+++ b/packages/vanilla/src/layouts/VerticalLayout.tsx
@@ -22,14 +22,15 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import React from 'react';
+import React, { FunctionComponent } from 'react';
 import {
     mapStateToLayoutProps,
     RankedTester,
     rankWith,
+    rendererDefaultProps,
     RendererProps,
     uiTypeIs,
-    VerticalLayout,
+  VerticalLayout
 } from '@jsonforms/core';
 import { connect } from 'react-redux';
 import { addVanillaLayoutProps } from '../util';
@@ -43,12 +44,13 @@ import { VanillaRendererProps } from '../index';
  */
 export const verticalLayoutTester: RankedTester = rankWith(1, uiTypeIs('VerticalLayout'));
 
-export const VerticalLayoutRenderer  = (
+export const VerticalLayoutRenderer: FunctionComponent<RendererProps & VanillaRendererProps> & {defaultProps: Partial<RendererProps>}  = (
   {
     schema,
     uischema,
     path,
     visible,
+    enabled,
     getStyle,
     getStyleAsClassName
   }: RendererProps & VanillaRendererProps) => {
@@ -66,6 +68,8 @@ export const VerticalLayoutRenderer  = (
       uischema={uischema}
       schema={schema}
       visible={visible}
+      enabled={enabled}
+      path={path}
       getStyle={getStyle}
       getStyleAsClassName={getStyleAsClassName}
     >
@@ -74,7 +78,8 @@ export const VerticalLayoutRenderer  = (
   );
 };
 
+VerticalLayoutRenderer.defaultProps = rendererDefaultProps;
+
 export default connect(
-  addVanillaLayoutProps(mapStateToLayoutProps),
-  null
+  addVanillaLayoutProps(mapStateToLayoutProps)
 )(VerticalLayoutRenderer);


### PR DESCRIPTION
Addresses #1275 by improving typings:

* Split own & stated-based props (no optionals anymore)
* Change type of 1st parameter in `isVisible`/`isEnabled`
* Provide default renderer props
* Remove parentPath prop
* Add type annotation to `errorAt`
* Replace `resolvedRootData` with `data` in mui-tree
* Differentiate between array control and regular control in angular package