### PR TITLE
errorAt and subErrorAt now expect a schema

### DIFF
--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -26,6 +26,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import set from 'lodash/set';
 import get from 'lodash/get';
 import filter from 'lodash/filter';
+import isEqual from 'lodash/isEqual';
 import { Ajv, ErrorObject, ValidateFunction } from 'ajv';
 import {
   INIT,
@@ -190,20 +191,22 @@ export const coreReducer = (
 export const extractData = (state: JsonFormsCore) => get(state, 'data');
 export const extractSchema = (state: JsonFormsCore) => get(state, 'schema');
 export const extractUiSchema = (state: JsonFormsCore) => get(state, 'uischema');
-export const errorAt = (instancePath: string) => (
+export const errorAt = (instancePath: string, schema: JsonSchema) => (
+  state: JsonFormsCore
+): ErrorObject[] =>
+  filter(
+    state.errors,
+    error =>
+      error.dataPath === instancePath && isEqual(error.parentSchema, schema)
+  );
+export const subErrorsAt = (instancePath: string, schema: JsonSchema) => (
   state: JsonFormsCore
 ): ErrorObject[] => {
-  return filter(
-    state.errors,
-    (error: ErrorObject) => error.dataPath === instancePath
-  );
-};
-export const subErrorsAt = (instancePath: string) => (
-  state: JsonFormsCore
-): any[] => {
   const path = `${instancePath}.`;
 
-  return filter(state.errors, (error: ErrorObject) =>
-    error.dataPath.startsWith(path)
+  return filter(
+    state.errors,
+    error =>
+      error.dataPath.startsWith(path) && isEqual(error.parentSchema, schema)
   );
 };

--- a/packages/core/src/reducers/index.ts
+++ b/packages/core/src/reducers/index.ts
@@ -123,12 +123,14 @@ export const findUISchema = (state: JsonFormsState) => (
   return uiSchema;
 };
 
-export const getErrorAt = (instancePath: string) => (state: JsonFormsState) => {
-  return errorAt(instancePath)(state.jsonforms.core);
-};
-export const getSubErrorsAt = (instancePath: string) => (
+export const getErrorAt = (instancePath: string, schema: JsonSchema) => (
   state: JsonFormsState
-) => subErrorsAt(instancePath)(state.jsonforms.core);
+) => {
+  return errorAt(instancePath, schema)(state.jsonforms.core);
+};
+export const getSubErrorsAt = (instancePath: string, schema: JsonSchema) => (
+  state: JsonFormsState
+) => subErrorsAt(instancePath, schema)(state.jsonforms.core);
 
 export const getConfig = (state: JsonFormsState) => state.jsonforms.config;
 

--- a/packages/core/src/util/field.ts
+++ b/packages/core/src/util/field.ts
@@ -113,7 +113,7 @@ export const mapStateToFieldProps = (
   const enabled = has(ownProps, 'enabled')
     ? ownProps.enabled
     : isEnabled(uischema, rootData);
-  const errors = getErrorAt(path)(state).map(error => error.message);
+  const errors = getErrorAt(path, schema)(state).map(error => error.message);
   const isValid = isEmpty(errors);
   const defaultConfig = cloneDeep(getConfig(state));
   const config = merge(defaultConfig, ownProps.uischema.options);

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -364,7 +364,6 @@ export const mapStateToControlProps = (
     : isEnabled(uischema, rootData, ownProps.path);
   const labelDesc = createLabelDescriptionFrom(uischema);
   const label = labelDesc.show ? labelDesc.text : '';
-  const errors = union(getErrorAt(path)(state).map(error => error.message));
   const controlElement = uischema as ControlElement;
   const id = ownProps.id;
   const rootSchema = getSchema(state);
@@ -376,6 +375,7 @@ export const mapStateToControlProps = (
     controlElement.scope,
     rootSchema
   );
+  const errors = union(getErrorAt(path, resolvedSchema)(state).map(error => error.message));
   const description =
     resolvedSchema !== undefined ? resolvedSchema.description : '';
   const defaultConfig = cloneDeep(getConfig(state));
@@ -441,7 +441,7 @@ export const mapStateToArrayControlProps = (
   );
 
   const resolvedSchema = Resolve.schema(schema, 'items', props.rootSchema);
-  const childErrors = getSubErrorsAt(path)(state);
+  const childErrors = getSubErrorsAt(path, resolvedSchema)(state);
 
   return {
     ...props,

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -375,7 +375,9 @@ export const mapStateToControlProps = (
     controlElement.scope,
     rootSchema
   );
-  const errors = union(getErrorAt(path, resolvedSchema)(state).map(error => error.message));
+  const errors = union(
+    getErrorAt(path, resolvedSchema)(state).map(error => error.message)
+  );
   const description =
     resolvedSchema !== undefined ? resolvedSchema.description : '';
   const defaultConfig = cloneDeep(getConfig(state));

--- a/packages/core/src/util/validator.ts
+++ b/packages/core/src/util/validator.ts
@@ -8,6 +8,7 @@ export const createAjv = (options?: Options) => {
     allErrors: true,
     jsonPointers: true,
     errorDataPath: 'property',
+    verbose: true,
     ...options
   });
   ajv.addFormat('time', '^([0-1][0-9]|2[0-3]):[0-5][0-9]$');

--- a/packages/core/test/reducers/core.test.ts
+++ b/packages/core/test/reducers/core.test.ts
@@ -26,6 +26,8 @@ import test from 'ava';
 import { coreReducer } from '../../src/reducers';
 import { init } from '../../src/actions';
 import { JsonSchema } from '../../src/models/jsonSchema';
+import { errorAt, JsonFormsCore, subErrorsAt } from '../../src/reducers/core';
+import cloneDeep = require('lodash/cloneDeep');
 
 test('core reducer should support v7', t => {
   const schema: JsonSchema = {
@@ -47,4 +49,200 @@ test('core reducer should support v7', t => {
     )
   );
   t.is(after.errors.length, 1);
+});
+
+test('errorAt filters by path', t => {
+  const schema: JsonSchema = {
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'string',
+        const: 'bar'
+      }
+    }
+  };
+  const state: JsonFormsCore = {
+    data: undefined,
+    schema: undefined,
+    uischema: undefined,
+    errors: [
+      {
+        keyword: '',
+        dataPath: 'bar',
+        schemaPath: '',
+        message: '',
+        params: {},
+        schema: undefined,
+        parentSchema: cloneDeep(schema.properties.foo)
+      },
+      {
+        keyword: '',
+        dataPath: 'foo',
+        schemaPath: '',
+        message: '',
+        params: {},
+        schema: undefined,
+        parentSchema: cloneDeep(schema.properties.foo)
+      },
+      {
+        keyword: '',
+        dataPath: 'foo.bar',
+        schemaPath: '',
+        message: '',
+        params: {},
+        schema: undefined,
+        parentSchema: cloneDeep(schema.properties.foo)
+      },
+    ]
+  };
+  const filtered = errorAt('foo', schema.properties.foo)(state);
+  t.is(filtered.length, 1);
+  t.deepEqual(filtered[0], state.errors[1]);
+});
+
+test('errorAt filters by schema', t => {
+  const schema: JsonSchema = {
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'string',
+        const: 'bar'
+      }
+    }
+  };
+  const state: JsonFormsCore = {
+    data: undefined,
+    schema: undefined,
+    uischema: undefined,
+    errors: [
+      {
+        keyword: '',
+        dataPath: 'bar',
+        schemaPath: '',
+        message: '',
+        params: {},
+        schema: undefined,
+        parentSchema: cloneDeep(schema.properties.foo)
+      },
+      {
+        keyword: '',
+        dataPath: 'foo',
+        schemaPath: '',
+        message: '',
+        params: {},
+        schema: undefined,
+        parentSchema: cloneDeep(schema.properties.foo)
+      },
+      {
+        keyword: '',
+        dataPath: 'foo',
+        schemaPath: '',
+        message: '',
+        params: {},
+        schema: undefined,
+        parentSchema: {type: 'string', enum: ['bar']}
+      },
+    ]
+  };
+  const filtered = errorAt('foo', schema.properties.foo)(state);
+  t.is(filtered.length, 1);
+  t.deepEqual(filtered[0], state.errors[1]);
+});
+
+test('subErrorsAt filters by path', t => {
+  const schema: JsonSchema = {
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'string',
+        const: 'bar'
+      }
+    }
+  };
+  const state: JsonFormsCore = {
+    data: undefined,
+    schema: undefined,
+    uischema: undefined,
+    errors: [
+      {
+        keyword: '',
+        dataPath: 'bar',
+        schemaPath: '',
+        message: '',
+        params: {},
+        schema: undefined,
+        parentSchema: cloneDeep(schema.properties.foo)
+      },
+      {
+        keyword: '',
+        dataPath: 'foo',
+        schemaPath: '',
+        message: '',
+        params: {},
+        schema: undefined,
+        parentSchema: cloneDeep(schema.properties.foo)
+      },
+      {
+        keyword: '',
+        dataPath: 'foo.bar',
+        schemaPath: '',
+        message: '',
+        params: {},
+        schema: undefined,
+        parentSchema: cloneDeep(schema.properties.foo)
+      },
+    ]
+  };
+  const filtered = subErrorsAt('foo', schema.properties.foo)(state);
+  t.is(filtered.length, 1);
+  t.deepEqual(filtered[0], state.errors[2]);
+});
+
+test('subErrorsAt filters by schema', t => {
+  const schema: JsonSchema = {
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'string',
+        const: 'bar'
+      }
+    }
+  };
+  const state: JsonFormsCore = {
+    data: undefined,
+    schema: undefined,
+    uischema: undefined,
+    errors: [
+      {
+        keyword: '',
+        dataPath: 'foo',
+        schemaPath: '',
+        message: '',
+        params: {},
+        schema: undefined,
+        parentSchema: cloneDeep(schema.properties.foo)
+      },
+      {
+        keyword: '',
+        dataPath: 'foo.bar',
+        schemaPath: '',
+        message: '',
+        params: {},
+        schema: undefined,
+        parentSchema: {type: 'string', enum: ['bar']}
+      },
+      {
+        keyword: '',
+        dataPath: 'foo.bar',
+        schemaPath: '',
+        message: '',
+        params: {},
+        schema: undefined,
+        parentSchema: cloneDeep(schema.properties.foo)
+      },
+    ]
+  };
+  const filtered = subErrorsAt('foo', schema.properties.foo)(state);
+  t.is(filtered.length, 1);
+  t.deepEqual(filtered[0], state.errors[2]);
 });

--- a/packages/core/test/reducers/core.test.ts
+++ b/packages/core/test/reducers/core.test.ts
@@ -218,12 +218,12 @@ test('errorAt filters oneOf simple', t => {
           {
             title: 'Numbers',
             type: 'string',
-              enum: ['One', 'Two', 'Three']
+            enum: ['One', 'Two', 'Three']
           },
           {
             title: 'Colours',
             type: 'string',
-              enum: ['Red', 'Green', 'Blue']
+            enum: ['Red', 'Green', 'Blue']
           }
         ]
       }
@@ -271,9 +271,9 @@ test('errorAt filters oneOf objects', t => {
             type: 'object',
             properties: {
               colour: {
-              title: 'Type',
-              type: 'string',
-              enum: ['Red', 'Green', 'Blue']
+                title: 'Type',
+                type: 'string',
+                enum: ['Red', 'Green', 'Blue']
               }
             },
             additionalProperties: false
@@ -283,7 +283,7 @@ test('errorAt filters oneOf objects', t => {
     },
     additionalProperties: false
   };
-  const data = { coloursOrNumbers: {colour: 'Foo'} };
+  const data = { coloursOrNumbers: { colour: 'Foo' } };
   const v = ajv.compile(schema);
   const errors = sanitizeErrors(v, data);
 
@@ -324,9 +324,9 @@ test('errorAt filters oneOf objects same properties', t => {
             type: 'object',
             properties: {
               colourOrNumber: {
-              title: 'Type',
-              type: 'string',
-              enum: ['Red', 'Green', 'Blue']
+                title: 'Type',
+                type: 'string',
+                enum: ['Red', 'Green', 'Blue']
               }
             }
           }
@@ -334,7 +334,7 @@ test('errorAt filters oneOf objects same properties', t => {
       }
     }
   };
-  const data = { coloursOrNumbers: {colourOrNumber: 'Foo'} };
+  const data = { coloursOrNumbers: { colourOrNumber: 'Foo' } };
   const v = ajv.compile(schema);
   const errors = sanitizeErrors(v, data);
 

--- a/packages/core/test/util/renderer.test.ts
+++ b/packages/core/test/util/renderer.test.ts
@@ -348,7 +348,7 @@ test('mapStateToControlProps - no duplicate error messages', t => {
     { uischema: coreUISchema }
   );
   // 'should be string' should only appear once
-  t.is(props.errors.length, 1);
+  t.is(props.errors.length, 3);
 });
 
 test('mapStateToControlProps - id', t => {

--- a/packages/core/test/util/renderer.test.ts
+++ b/packages/core/test/util/renderer.test.ts
@@ -318,7 +318,8 @@ test('mapStateToControlProps - errors', t => {
     message: 'Duff beer',
     keyword: 'whatever',
     schemaPath: '',
-    params: undefined
+    params: undefined,
+    parentSchema: { type: 'string' }
   };
   clonedState.jsonforms.core.errors = [error];
   const props = mapStateToControlProps(clonedState, ownProps);
@@ -347,7 +348,7 @@ test('mapStateToControlProps - no duplicate error messages', t => {
     { uischema: coreUISchema }
   );
   // 'should be string' should only appear once
-  t.is(props.errors.length, 3);
+  t.is(props.errors.length, 1);
 });
 
 test('mapStateToControlProps - id', t => {

--- a/packages/examples/src/oneOf.ts
+++ b/packages/examples/src/oneOf.ts
@@ -56,111 +56,148 @@ const data = {
   }
 };
 
-const schema2 = {
-  'type': 'object',
-  'properties': {
-     'coloursOrNumbers': {
-        'oneOf': [
-          //  {
-          //     '$ref': '#/definitions/colours'
-          //  },
-          //  {
-          //     '$ref': '#/definitions/numbers'
-          //  },
-          //  {
-          //     '$ref': '#/definitions/shapes'
-          //  }
-          {
-            '$ref': '#/definitions/foo'
-         },
-         {
-            '$ref': '#/definitions/bar'
-         },
-         {
-            '$ref': '#/definitions/fooBar'
-         }
-        ]
-     }
-  },
-  'definitions': {
-    'foo': {
-        properties: {
-          fooInner: {
-            'title': 'Colours',
-         'type': 'string',
-         'enum': [
-            'Red',
-            'Green',
-            'Blue'
-         ],
-      }
-    }, required: ['fooInner']
-   },
-   'bar': {
-    properties: {
-      barInner: {
-    'title': 'Numbers',
-    'type': 'string',
-    'enum': [
-      'One',
-      'Two',
-      'Three'
-   ],
-  }}, required: ['barInner']
-},
-'fooBar': {
+const schema_1265_array = {
+  type: 'object',
   properties: {
-    foobarInner: {
-  'title': 'Shapes',
-  'type': 'string',
-  'enum': [
-    'Circle',
-    'Triangle',
-    'Square'
- ], }}, required: ['foobarInner']
-},
-     'colours': {
-        'title': 'Colours',
-        'type': 'array',
-        'items': {
-           'title': 'Type',
-           'type': 'string',
-           'enum': [
-              'Red',
-              'Green',
-              'Blue'
-           ],
-           'minItems': 1
+    coloursOrNumbers: {
+      oneOf: [
+        {
+          $ref: '#/definitions/colours'
+        },
+        {
+          $ref: '#/definitions/numbers'
+        },
+        {
+          $ref: '#/definitions/shapes'
         }
-     },
-     'numbers': {
-        'title': 'Numbers',
-        'type': 'array',
-        'items': {
-           'title': 'Type',
-           'type': 'string',
-           'enum': [
-              'One',
-              'Two',
-              'Three'
-           ],
-           'minItems': 1
+      ]
+    }
+  },
+  definitions: {
+    colours: {
+      title: 'Colours',
+      type: 'array',
+      items: {
+        title: 'Type',
+        type: 'string',
+        enum: ['Red', 'Green', 'Blue'],
+        minItems: 1
+      }
+    },
+    numbers: {
+      title: 'Numbers',
+      type: 'array',
+      items: {
+        title: 'Type',
+        type: 'string',
+        enum: ['One', 'Two', 'Three'],
+        minItems: 1
+      }
+    },
+    shapes: {
+      title: 'Shapes',
+      type: 'array',
+      items: {
+        title: 'Type',
+        type: 'string',
+        enum: ['Circle', 'Triangle', 'Square'],
+        minItems: 1
+      }
+    }
+  }
+};
+
+const schema_1265_object = {
+  type: 'object',
+  properties: {
+    coloursOrNumbers: {
+      oneOf: [
+        {
+          $ref: '#/definitions/colours'
+        },
+        {
+          $ref: '#/definitions/numbers'
+        },
+        {
+          $ref: '#/definitions/shapes'
         }
-     },
-     'shapes': {
-        'title': 'Shapes',
-        'type': 'array',
-        'items': {
-           'title': 'Type',
-           'type': 'string',
-           'enum': [
-              'Circle',
-              'Triangle',
-              'Square'
-           ],
-           'minItems': 1
+      ]
+    }
+  },
+  additionalProperties: false,
+  definitions: {
+    colours: {
+      title: 'Colours',
+      type: 'object',
+      properties: {
+        colour: {
+          title: 'Type',
+          type: 'string',
+          enum: ['Red', 'Green', 'Blue']
         }
-     }
+      },
+      additionalProperties: false
+    },
+    numbers: {
+      title: 'Numbers',
+      type: 'object',
+      properties: {
+        number: {
+          title: 'Type',
+          type: 'string',
+          enum: ['One', 'Two', 'Three']
+        }
+      },
+      additionalProperties: false
+    },
+    shapes: {
+      title: 'Shapes',
+      type: 'object',
+      properties: {
+        shape: {
+          title: 'Type',
+          type: 'string',
+          enum: ['Circle', 'Triangle', 'Square']
+        }
+      },
+      additionalProperties: false
+    }
+  }
+};
+
+const schema_1265_simple = {
+  type: 'object',
+  properties: {
+    coloursOrNumbers: {
+      oneOf: [
+        {
+          $ref: '#/definitions/colours'
+        },
+        {
+          $ref: '#/definitions/numbers'
+        },
+        {
+          $ref: '#/definitions/shapes'
+        }
+      ]
+    }
+  },
+  definitions: {
+    colours: {
+      title: 'Colours',
+      type: 'string',
+      enum: ['Red', 'Green', 'Blue']
+    },
+    numbers: {
+      title: 'Numbers',
+      type: 'string',
+      enum: ['One', 'Two', 'Three']
+    },
+    shapes: {
+      title: 'Shapes',
+      type: 'string',
+      enum: ['Circle', 'Triangle', 'Square']
+    }
   }
 };
 
@@ -173,10 +210,24 @@ registerExamples([
     uischema
   },
   {
-    name: '1265',
-    label: '1265',
-    data: {coloursOrNumbers: {}},
-    schema: schema2,
+    name: '1265_array',
+    label: '1265 Array',
+    data: { coloursOrNumbers: ['Foo'] },
+    schema: schema_1265_array,
+    uischema: undefined
+  },
+  {
+    name: '1265_object',
+    label: '1265 Object',
+    data: { coloursOrNumbers: { colour: 'Foo' } },
+    schema: schema_1265_object,
+    uischema: undefined
+  },
+  {
+    name: '1265_simple',
+    label: '1265 Simple',
+    data: { coloursOrNumbers: 'Foo' },
+    schema: schema_1265_simple,
     uischema: undefined
   }
 ]);

--- a/packages/examples/src/oneOf.ts
+++ b/packages/examples/src/oneOf.ts
@@ -56,6 +56,114 @@ const data = {
   }
 };
 
+const schema2 = {
+  'type': 'object',
+  'properties': {
+     'coloursOrNumbers': {
+        'oneOf': [
+          //  {
+          //     '$ref': '#/definitions/colours'
+          //  },
+          //  {
+          //     '$ref': '#/definitions/numbers'
+          //  },
+          //  {
+          //     '$ref': '#/definitions/shapes'
+          //  }
+          {
+            '$ref': '#/definitions/foo'
+         },
+         {
+            '$ref': '#/definitions/bar'
+         },
+         {
+            '$ref': '#/definitions/fooBar'
+         }
+        ]
+     }
+  },
+  'definitions': {
+    'foo': {
+        properties: {
+          fooInner: {
+            'title': 'Colours',
+         'type': 'string',
+         'enum': [
+            'Red',
+            'Green',
+            'Blue'
+         ],
+      }
+    }, required: ['fooInner']
+   },
+   'bar': {
+    properties: {
+      barInner: {
+    'title': 'Numbers',
+    'type': 'string',
+    'enum': [
+      'One',
+      'Two',
+      'Three'
+   ],
+  }}, required: ['barInner']
+},
+'fooBar': {
+  properties: {
+    foobarInner: {
+  'title': 'Shapes',
+  'type': 'string',
+  'enum': [
+    'Circle',
+    'Triangle',
+    'Square'
+ ], }}, required: ['foobarInner']
+},
+     'colours': {
+        'title': 'Colours',
+        'type': 'array',
+        'items': {
+           'title': 'Type',
+           'type': 'string',
+           'enum': [
+              'Red',
+              'Green',
+              'Blue'
+           ],
+           'minItems': 1
+        }
+     },
+     'numbers': {
+        'title': 'Numbers',
+        'type': 'array',
+        'items': {
+           'title': 'Type',
+           'type': 'string',
+           'enum': [
+              'One',
+              'Two',
+              'Three'
+           ],
+           'minItems': 1
+        }
+     },
+     'shapes': {
+        'title': 'Shapes',
+        'type': 'array',
+        'items': {
+           'title': 'Type',
+           'type': 'string',
+           'enum': [
+              'Circle',
+              'Triangle',
+              'Square'
+           ],
+           'minItems': 1
+        }
+     }
+  }
+};
+
 registerExamples([
   {
     name: 'oneOf',
@@ -63,5 +171,12 @@ registerExamples([
     data,
     schema,
     uischema
+  },
+  {
+    name: '1265',
+    label: '1265',
+    data: {coloursOrNumbers: {}},
+    schema: schema2,
+    uischema: undefined
   }
 ]);

--- a/packages/examples/src/person.ts
+++ b/packages/examples/src/person.ts
@@ -152,6 +152,49 @@ export const data = {
   postalCode: '12345'
 };
 
+const schema2 = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string'
+    },
+    personalData: {
+      type: 'object',
+      properties: {
+        middleName: {
+          type: 'string'
+        },
+        lastName: {
+          type: 'string'
+        }
+      },
+      required: ['middleName', 'lastName']
+    }
+  },
+  required: ['name']
+};
+const uischema2 = {
+  type: 'HorizontalLayout',
+  elements: [
+    {
+      type: 'Control',
+      scope: '#/properties/name'
+    },
+    {
+      type: 'Control',
+      scope: '#/properties/personalData/properties/middleName'
+    },
+    {
+      type: 'Control',
+      scope: '#/properties/personalData/properties/lastName'
+    }
+  ]
+};
+const data2 = {
+  name: 'John Doe',
+  personalData: {}
+};
+
 registerExamples([
   {
     name: 'person',
@@ -159,5 +202,12 @@ registerExamples([
     data,
     schema,
     uischema
+  },
+  {
+    name: 'person2',
+    label: 'Person2',
+    data: data2,
+    schema: schema2,
+    uischema: uischema2
   }
 ]);

--- a/packages/examples/src/person.ts
+++ b/packages/examples/src/person.ts
@@ -152,49 +152,6 @@ export const data = {
   postalCode: '12345'
 };
 
-const schema2 = {
-  type: 'object',
-  properties: {
-    name: {
-      type: 'string'
-    },
-    personalData: {
-      type: 'object',
-      properties: {
-        middleName: {
-          type: 'string'
-        },
-        lastName: {
-          type: 'string'
-        }
-      },
-      required: ['middleName', 'lastName']
-    }
-  },
-  required: ['name']
-};
-const uischema2 = {
-  type: 'HorizontalLayout',
-  elements: [
-    {
-      type: 'Control',
-      scope: '#/properties/name'
-    },
-    {
-      type: 'Control',
-      scope: '#/properties/personalData/properties/middleName'
-    },
-    {
-      type: 'Control',
-      scope: '#/properties/personalData/properties/lastName'
-    }
-  ]
-};
-const data2 = {
-  name: 'John Doe',
-  personalData: {}
-};
-
 registerExamples([
   {
     name: 'person',
@@ -202,12 +159,5 @@ registerExamples([
     data,
     schema,
     uischema
-  },
-  {
-    name: 'person2',
-    label: 'Person2',
-    data: data2,
-    schema: schema2,
-    uischema: uischema2
   }
 ]);

--- a/packages/material-tree-renderer/src/tree/TreeWithDetailRenderer.tsx
+++ b/packages/material-tree-renderer/src/tree/TreeWithDetailRenderer.tsx
@@ -396,7 +396,7 @@ const mapStateToProps = (state: JsonFormsState, ownProps: OwnPropsOfTreeControl 
     labelProviders: ownProps.labelProviders,
     rootSchema: getSchema(state),
     id: createId('tree'),
-    errors: union(getErrorAt(path)(state).map(error => error.message))
+    errors: union(getErrorAt(path, resolvedSchema || rootSchema)(state).map(error => error.message))
   };
 };
 


### PR DESCRIPTION
* AJV is now configured with `verbose` flag
* errorAt checks the parentSchema of error against provided schema
* subErrorAt checks the parentSchema of error against provided schema
* added test cases for both methods

Fixes #1265