### PR TITLE
Register the radio control and use RankedTester to detect format: radio

### DIFF
--- a/packages/material/src/controls/MaterialRadioGroupControl.tsx
+++ b/packages/material/src/controls/MaterialRadioGroupControl.tsx
@@ -31,6 +31,9 @@ import {
   formatErrorMessage,
   isDescriptionHidden,
   isPlainLabel,
+  rankWith,
+  RankedTester,
+  optionIs,
   mapDispatchToControlProps,
   mapStateToControlProps
 } from '@jsonforms/core';
@@ -102,4 +105,5 @@ export class MaterialRadioGroupControl extends Control<ControlProps, ControlStat
     }
 }
 
+export const materialRadioGroupControlTester: RankedTester = rankWith(2, optionIs('format', 'radio'));
 export default connect(mapStateToControlProps, mapDispatchToControlProps)(MaterialRadioGroupControl);

--- a/packages/material/src/controls/index.ts
+++ b/packages/material/src/controls/index.ts
@@ -40,6 +40,9 @@ import MaterialDateTimeControl, {
 import MaterialSliderControl, {
   materialSliderControlTester
 } from './MaterialSliderControl';
+import MaterialRadioGroupControl, {
+  materialRadioGroupControlTester
+} from './MaterialRadioGroupControl';
 
 export {
   MaterialBooleanControl,
@@ -53,5 +56,7 @@ export {
   MaterialDateTimeControl,
   materialDateTimeControlTester,
   MaterialSliderControl,
-  materialSliderControlTester
+  materialSliderControlTester,
+  MaterialRadioGroupControl,
+  materialRadioGroupControlTester
 };

--- a/packages/material/src/index.ts
+++ b/packages/material/src/index.ts
@@ -54,7 +54,9 @@ import {
   MaterialNativeControl,
   materialNativeControlTester,
   MaterialSliderControl,
-  materialSliderControlTester
+  materialSliderControlTester,
+  MaterialRadioGroupControl,
+  materialRadioGroupControlTester
 } from './controls';
 import {
   MaterialArrayLayout,
@@ -112,6 +114,10 @@ export const materialRenderers: JsonFormsRendererRegistryEntry[] = [
   { tester: materialAllOfControlTester, renderer: MaterialAllOfRenderer },
   { tester: materialAnyOfControlTester, renderer: MaterialAnyOfRenderer },
   { tester: materialOneOfControlTester, renderer: MaterialOneOfRenderer },
+  {
+    tester: materialRadioGroupControlTester,
+    renderer: MaterialRadioGroupControl
+  },
   // layouts
   { tester: materialGroupTester, renderer: MaterialGroupLayout },
   {


### PR DESCRIPTION
The radio controller was developed but wasn’t exported with a result I could use.

Export materialRadioGroupControlTester with rankedTester to be called by:

```
options {
    Format: "radio"
}
```

Register MaterialRadioGroupControl and  MaterialRadioGroupControlTester on `packages/material/src/controls/index.ts` and `packages/material/src/index.ts` in order to be globally available

Please let me know if any specific tests need to be added and/or point me in the right direction if this doesn't pass the test criteria.