### PR TITLE
Consistently use react ui Hidden element

### DIFF
--- a/packages/material/src/additional/MaterialLabelRenderer.tsx
+++ b/packages/material/src/additional/MaterialLabelRenderer.tsx
@@ -32,8 +32,10 @@ import {
   uiTypeIs
 } from '@jsonforms/core';
 import { StatelessRenderer } from '@jsonforms/react';
-
-import Typography from '@material-ui/core/Typography';
+import {
+  Hidden,
+  Typography
+} from '@material-ui/core';
 import { connect } from 'react-redux';
 
 /**
@@ -48,14 +50,12 @@ export const materialLabelRendererTester: RankedTester = rankWith(1, uiTypeIs('L
 export const MaterialLabelRenderer: StatelessRenderer<RendererProps> =
   ({ uischema, visible }) => {
     const labelElement: LabelElement = uischema as LabelElement;
-    const style: {[x: string]: any} = {};
-    if (!visible) {
-      style.display = 'none';
-    }
     return (
-      <Typography variant='h6' style={style}>
-        {labelElement.text !== undefined && labelElement.text !== null && labelElement.text}
-      </Typography>
+      <Hidden xsUp={!visible}>
+        <Typography variant='h6'>
+          {labelElement.text !== undefined && labelElement.text !== null && labelElement.text}
+        </Typography>
+      </Hidden>
     );
   };
 

--- a/packages/material/src/controls/MaterialInputControl.tsx
+++ b/packages/material/src/controls/MaterialInputControl.tsx
@@ -32,7 +32,7 @@ import {
 } from '@jsonforms/core';
 import { Control } from '@jsonforms/react';
 
-import { InputLabel } from '@material-ui/core';
+import { Hidden, InputLabel } from '@material-ui/core';
 import { FormControl, FormHelperText } from '@material-ui/core';
 import merge from 'lodash/merge';
 
@@ -56,10 +56,6 @@ export abstract class MaterialInputControl extends Control<ControlProps & WithIn
     const isValid = errors.length === 0;
     const mergedConfig = merge({}, config, uischema.options);
     const trim = mergedConfig.trim;
-    const style: { [x: string]: any } = {};
-    if (!visible) {
-      style.display = 'none';
-    }
     const inputLabelStyle: { [x: string]: any } = {
       whiteSpace: 'nowrap',
       overflow: 'hidden',
@@ -75,34 +71,35 @@ export abstract class MaterialInputControl extends Control<ControlProps & WithIn
     );
     const InnerComponent = input;
     return (
-      <FormControl
-        style={style}
-        fullWidth={!trim}
-        onFocus={this.onFocus}
-        onBlur={this.onBlur}
-        id={id}
-      >
-        <InputLabel
-          htmlFor={id + '-input'}
-          error={!isValid}
-          style={inputLabelStyle}
+      <Hidden xsUp={!visible}>
+        <FormControl
+          fullWidth={!trim}
+          onFocus={this.onFocus}
+          onBlur={this.onBlur}
+          id={id}
         >
-          {computeLabel(isPlainLabel(label) ? label : label.default, required)}
-        </InputLabel>
-        <InnerComponent
-          {...this.props}
-          id={id + '-input'}
-          isValid={isValid}
-          visible={visible}
-        />
-        <FormHelperText error={!isValid}>
-          {!isValid
-            ? errors
-            : showDescription
-            ? description
-            : null}
-        </FormHelperText>
-      </FormControl>
+          <InputLabel
+            htmlFor={id + '-input'}
+            error={!isValid}
+            style={inputLabelStyle}
+          >
+            {computeLabel(isPlainLabel(label) ? label : label.default, required)}
+          </InputLabel>
+          <InnerComponent
+            {...this.props}
+            id={id + '-input'}
+            isValid={isValid}
+            visible={visible}
+          />
+          <FormHelperText error={!isValid}>
+            {!isValid
+              ? errors
+              : showDescription
+              ? description
+              : null}
+          </FormHelperText>
+        </FormControl>
+      </Hidden>
     );
   }
 }

--- a/packages/material/src/controls/MaterialRadioGroupControl.tsx
+++ b/packages/material/src/controls/MaterialRadioGroupControl.tsx
@@ -56,10 +56,6 @@ export class MaterialRadioGroupControl extends Control<ControlProps, ControlStat
             visible
         } = this.props;
         const isValid = errors.length === 0;
-        const style: { [x: string]: any } = {};
-        if (!visible) {
-            style.display = 'none';
-        }
         const mergedConfig = merge({}, config, this.props.uischema.options);
         const trim = mergedConfig.trim;
         const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused);

--- a/packages/material/test/renderers/MaterialInputControl.test.tsx
+++ b/packages/material/test/renderers/MaterialInputControl.test.tsx
@@ -162,8 +162,8 @@ describe('Material input control', () => {
         <TestControl schema={schema} uischema={uischema} visible={false} />
       </Provider>
     );
-    const control = wrapper.find('div').first();
-    expect(getComputedStyle(control.getDOMNode()).display).toBe('none');
+    const inputs = wrapper.find('input');
+    expect(inputs.length).toBe(0);
   });
 
   it('should be shown by default', () => {

--- a/packages/material/test/renderers/MaterialLabelRenderer.test.tsx
+++ b/packages/material/test/renderers/MaterialLabelRenderer.test.tsx
@@ -103,8 +103,8 @@ describe('Material Label Renderer', () => {
         />
       </Provider>
     );
-    const label = wrapper.find('h6').first();
-    expect(getComputedStyle(label.getDOMNode()).display).toBe('none');
+    const labels = wrapper.find('h6');
+    expect(labels.length).toBe(0);
   });
 
   it('should be shown by default', () => {


### PR DESCRIPTION
Consistently use react ui 'Hidden' element within the material renderers
instead of relying on custom CSS

Implements #1307