### PR TITLE
clone oldData when reducing core.data to avoid state mutation in updater

### DIFF
--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -210,7 +210,7 @@ export const coreReducer = (
         };
       } else {
         const oldData: any = get(state.data, action.path);
-        let newData = action.updater(oldData);
+        let newData = action.updater(cloneDeep(oldData));
         if (newData === '') {
           newData = undefined;
         }


### PR DESCRIPTION
I've run across a scenario when editing an array of objects, the updater function is mutating a piece of the state object and causing undesired side-effects. Adding a cloneDeep here solves the problem.