### PR TITLE
Provide context-based API

### DIFF
--- a/packages/angular-material/src/controls/number.renderer.ts
+++ b/packages/angular-material/src/controls/number.renderer.ts
@@ -74,7 +74,6 @@ export class NumberControlRenderer extends JsonFormsControl {
     const data = this.oldValue
       ? ev.target.value.replace(this.oldValue, '')
       : ev.target.value;
-    console.log(data);
     // ignore these
     if (
       data === '.' ||

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -139,7 +139,7 @@ const hasAjvOption = (option: any): option is InitActionOptions => {
 export const coreReducer = (
   state: JsonFormsCore = initState,
   action: ValidCoreActions
-) => {
+): JsonFormsCore => {
   switch (action.type) {
     case INIT: {
       const thisAjv = getOrCreateAjv(state, action);
@@ -234,17 +234,17 @@ export const extractData = (state: JsonFormsCore) => get(state, 'data');
 export const extractSchema = (state: JsonFormsCore) => get(state, 'schema');
 export const extractUiSchema = (state: JsonFormsCore) => get(state, 'uischema');
 
-const errorsAt = (
+export const errorsAt = (
   instancePath: string,
   schema: JsonSchema,
   matchPath: (path: string) => boolean
-) => (state: JsonFormsCore): ErrorObject[] => {
+) => (errors: ErrorObject[]): ErrorObject[] => {
   const combinatorPaths = filter(
-    state.errors,
+    errors,
     error => error.keyword === 'oneOf' || error.keyword === 'anyOf'
   ).map(error => error.dataPath);
 
-  return filter(state.errors, error => {
+  return filter(errors, error => {
     let result = matchPath(error.dataPath);
     if (combinatorPaths.findIndex(p => instancePath.startsWith(p)) !== -1) {
       result = result && isEqual(error.parentSchema, schema);
@@ -253,10 +253,17 @@ const errorsAt = (
   });
 };
 
+const getErrorsAt = (
+  instancePath: string,
+  schema: JsonSchema,
+  matchPath: (path: string) => boolean
+) => (state: JsonFormsCore): ErrorObject[] =>
+  errorsAt(instancePath, schema, matchPath)(state.errors);
+
 export const errorAt = (instancePath: string, schema: JsonSchema) =>
-  errorsAt(instancePath, schema, path => path === instancePath);
+  getErrorsAt(instancePath, schema, path => path === instancePath);
 export const subErrorsAt = (instancePath: string, schema: JsonSchema) =>
-  errorsAt(instancePath, schema, path => path.startsWith(instancePath));
+  getErrorsAt(instancePath, schema, path => path.startsWith(instancePath));
 
 export const extractRefParserOptions = (state: JsonFormsCore) =>
   get(state, 'refParserOptions');

--- a/packages/core/src/reducers/index.ts
+++ b/packages/core/src/reducers/index.ts
@@ -36,10 +36,12 @@ import { configReducer } from './config';
 import {
   coreReducer,
   errorAt,
+  errorsAt,
   extractData,
   extractRefParserOptions,
   extractSchema,
   extractUiSchema,
+  JsonFormsCore,
   subErrorsAt
 } from './core';
 import { JsonFormsState, JsonFormsSubStates } from '../store';
@@ -60,6 +62,7 @@ import { ControlElement, UISchemaElement } from '../models/uischema';
 import { Generate } from '../generators';
 
 export { rendererReducer, cellReducer, coreReducer, UISchemaTester };
+export { JsonFormsCore };
 
 export const jsonformsReducer = (
   additionalReducers = {}
@@ -137,6 +140,9 @@ export const getErrorAt = (instancePath: string, schema: JsonSchema) => (
 ) => {
   return errorAt(instancePath, schema)(state.jsonforms.core);
 };
+
+export { errorsAt };
+
 export const getSubErrorsAt = (instancePath: string, schema: JsonSchema) => (
   state: JsonFormsState
 ) => subErrorsAt(instancePath, schema)(state.jsonforms.core);

--- a/packages/core/src/util/cell.ts
+++ b/packages/core/src/util/cell.ts
@@ -178,14 +178,9 @@ export const mapDispatchToCellProps: (
 export const defaultMapDispatchToControlProps =
   // TODO: ownProps types
   (dispatch: Dispatch<AnyAction>, ownProps: any): DispatchPropsOfControl => {
-    const dispatchControlProps: DispatchPropsOfControl = mapDispatchToCellProps(
-      dispatch
-    );
+    const { handleChange } = mapDispatchToCellProps(dispatch);
 
     return {
-      handleChange:
-        ownProps.handleChange !== undefined
-          ? ownProps.handleChange
-          : dispatchControlProps.handleChange
+      handleChange: ownProps.handleChange || handleChange
     };
   };

--- a/packages/example/src/App.tsx
+++ b/packages/example/src/App.tsx
@@ -24,8 +24,8 @@
 */
 
 import React, { Component, CSSProperties } from 'react';
+import { JsonFormsDispatch, JsonFormsReduxContext } from '@jsonforms/react';
 import './App.css';
-import { JsonForms } from '@jsonforms/react';
 import { AppProps, initializedConnect } from './reduxUtil';
 
 const preStyle: CSSProperties = {
@@ -34,42 +34,44 @@ const preStyle: CSSProperties = {
 class App extends Component<AppProps> {
   render() {
     return (
-      <div>
-        <div className='App'>
-          <header className='App-header'>
-            <img src='assets/logo.svg' className='App-logo' alt='logo' />
-            <h1 className='App-title'>Welcome to JSON Forms with React</h1>
-            <p className='App-intro'>More Forms. Less Code.</p>
-          </header>
-        </div>
+      <JsonFormsReduxContext>
+        <div>
+          <div className='App'>
+            <header className='App-header'>
+              <img src='assets/logo.svg' className='App-logo' alt='logo' />
+              <h1 className='App-title'>Welcome to JSON Forms with React</h1>
+              <p className='App-intro'>More Forms. Less Code.</p>
+            </header>
+          </div>
 
-        <h4 className='data-title'>Examples</h4>
-        <div className='data-content'>
-          <select
-            value={this.props.selectedExample.name || ''}
-            onChange={ev => this.props.changeExample(ev.currentTarget.value)}
-          >
-            {this.props.examples.map(optionValue => (
-              <option
-                value={optionValue.name}
-                label={optionValue.label}
-                key={optionValue.name}
-              >
-                {optionValue.label}
-              </option>
-            ))}
-          </select>
-        </div>
+          <h4 className='data-title'>Examples</h4>
+          <div className='data-content'>
+            <select
+              value={this.props.selectedExample.name || ''}
+              onChange={ev => this.props.changeExample(ev.currentTarget.value)}
+            >
+              {this.props.examples.map(optionValue => (
+                <option
+                  value={optionValue.name}
+                  label={optionValue.label}
+                  key={optionValue.name}
+                >
+                  {optionValue.label}
+                </option>
+              ))}
+            </select>
+          </div>
 
-        <h4 className='data-title'>Bound data</h4>
-        <div className='data-content'>
-          <pre style={preStyle}>{this.props.dataAsString}</pre>
+          <h4 className='data-title'>Bound data</h4>
+          <div className='data-content'>
+            <pre style={preStyle}>{this.props.dataAsString}</pre>
+          </div>
+          <div className='demoform'>
+            {this.props.getExtensionComponent()}
+            <JsonFormsDispatch />
+          </div>
         </div>
-        <div className='demoform'>
-          {this.props.getExtensionComponent()}
-          <JsonForms />
-        </div>
-      </div>
+      </JsonFormsReduxContext>
     );
   }
 }

--- a/packages/material-tree-renderer/src/tree/ExpandArray.tsx
+++ b/packages/material-tree-renderer/src/tree/ExpandArray.tsx
@@ -28,20 +28,21 @@ import isEmpty from 'lodash/isEmpty';
 import React from 'react';
 import { connect } from 'react-redux';
 import {
-    getData,
-    JsonFormsState,
-    Paths,
-    resolveData
+  getData,
+  JsonFormsState,
+  Paths,
+  resolveData
 } from '@jsonforms/core';
 import ObjectListItem from './ObjectListItem';
-const { DropTarget }  = require('react-dnd');
+const { DropTarget } = require('react-dnd');
 import {
   canDropDraggedItem,
   CSS_DELAY,
   DragInfo,
   DropResult,
   mapDispatchToTreeListProps,
-  Types } from './dnd.util';
+  Types
+} from './dnd.util';
 import { Property } from '../services/property.util';
 import { matchContainerProperty } from '../helpers/container.util';
 import {
@@ -140,7 +141,7 @@ export interface ExandArrayContainerState {
 
 const styles: StyleRulesCallback<'currentTarget' | 'validTarget' | 'invalidTarget'> = () => ({
   currentTarget: {
-    borderWidth:  'medium'
+    borderWidth: 'medium'
   },
   validTarget: {
     borderStyle: 'dashed',
@@ -157,18 +158,18 @@ const styles: StyleRulesCallback<'currentTarget' | 'validTarget' | 'invalidTarge
 
 class ExpandArrayContainer extends
   React.Component<ExpandArrayContainerProps &
-                  WithStyles<'currentTarget' | 'validTarget' | 'invalidTarget'>,
-                  any> {
+  WithStyles<'currentTarget' | 'validTarget' | 'invalidTarget'>,
+  any> {
 
   constructor(props: ExpandArrayContainerProps &
-                  WithStyles<'currentTarget' | 'validTarget' | 'invalidTarget'>) {
+    WithStyles<'currentTarget' | 'validTarget' | 'invalidTarget'>) {
     super(props);
     this.state = { setCss: false };
   }
 
   componentWillReceiveProps(nextProps: ExpandArrayContainerProps) {
     if (this.props.isDragging && !nextProps.isDragging) {
-      this.setState( { setCss: false });
+      this.setState({ setCss: false });
     } else if (!this.props.isDragging && nextProps.isDragging) {
       setTimeout(() => this.setState({ setCss: true }), CSS_DELAY);
     }
@@ -232,7 +233,7 @@ const mapStateToProps = (state: JsonFormsState) => ({
 /**
  * Injects drag and drop related properties into an expanded array
  */
-    // TODO: typings
+// TODO: typings
 const collect = (dndConnect: any, monitor: any) => {
   return {
     connectDropTarget: dndConnect.dropTarget(),
@@ -267,9 +268,6 @@ const arrayDropTarget = {
     if (monitor.didDrop()) {
       return monitor.getDropResult();
     }
-
-    // TODO remove console.log
-    console.log('valid drop of data at: ' + props.path);
 
     const dropInfo: DropResult = {
       isHandled: true,

--- a/packages/material-tree-renderer/src/tree/TreeWithDetailRenderer.tsx
+++ b/packages/material-tree-renderer/src/tree/TreeWithDetailRenderer.tsx
@@ -42,7 +42,7 @@ import {
   Resolve,
   Runtime, StatePropsOfControl, UISchemaElement, UISchemaTester
 } from '@jsonforms/core';
-import { ResolvedJsonForms } from '@jsonforms/react';
+import { JsonFormsDispatch } from '@jsonforms/react';
 /* tslint:disable:next-line */
 const HTML5Backend = require('react-dnd-html5-backend');
 const { DragDropContext } = require('react-dnd');
@@ -129,58 +129,58 @@ const styles: StyleRulesCallback<'treeMasterDetailContent' |
   'treeMasterDetail' |
   'treeMasterDetailMaster' |
   'treeMasterDetailDetail'> = () => ({
-  treeMasterDetailContent: {
-    paddingTop: '1em',
-    paddingBottom: '1em'
-  },
-  // tslint:disable-next-line: object-literal-key-quotes
-  treeMasterDetail: {
-    display: 'flex',
-    flexDirection: 'column',
-    // tslint:disable-next-line:object-literal-key-quotes
-    '& $treeMasterDetailContent': {
+    treeMasterDetailContent: {
+      paddingTop: '1em',
+      paddingBottom: '1em'
+    },
+    // tslint:disable-next-line: object-literal-key-quotes
+    treeMasterDetail: {
       display: 'flex',
-      flexDirection: 'row'
-    }
-  },
-  // tslint:disable-next-line: object-literal-key-quotes
-  treeMasterDetailMaster: {
-    flex: 1,
-    padding: '0.5em',
-    height: 'auto',
-    borderRight: '0.2em solid lightgrey',
-    borderWidth: 'thin',
-    // tslint:disable-next-line:object-literal-key-quotes
-    '& ul': {
-      listStyleType: 'none',
-      margin: 0,
-      padding: 0,
-      position: 'relative',
-      overflow: 'hidden',
+      flexDirection: 'column',
       // tslint:disable-next-line:object-literal-key-quotes
-      '&:after': {
-        content: '""',
-        position: 'absolute',
-        left: '0.2em',
-        height: '0.6em',
-        bottom: '0'
-      }, // tslint:disable-next-line:object-literal-key-quotes
-      '&:last-child::after': {
-        display: 'none'
+      '& $treeMasterDetailContent': {
+        display: 'flex',
+        flexDirection: 'row'
+      }
+    },
+    // tslint:disable-next-line: object-literal-key-quotes
+    treeMasterDetailMaster: {
+      flex: 1,
+      padding: '0.5em',
+      height: 'auto',
+      borderRight: '0.2em solid lightgrey',
+      borderWidth: 'thin',
+      // tslint:disable-next-line:object-literal-key-quotes
+      '& ul': {
+        listStyleType: 'none',
+        margin: 0,
+        padding: 0,
+        position: 'relative',
+        overflow: 'hidden',
+        // tslint:disable-next-line:object-literal-key-quotes
+        '&:after': {
+          content: '""',
+          position: 'absolute',
+          left: '0.2em',
+          height: '0.6em',
+          bottom: '0'
+        }, // tslint:disable-next-line:object-literal-key-quotes
+        '&:last-child::after': {
+          display: 'none'
+        }
+      }
+    },
+    // tslint:disable-next-line: object-literal-key-quotes
+    treeMasterDetailDetail: {
+      flex: 3,
+      padding: '0.5em',
+      paddingLeft: '1em',
+      // tslint:disable-next-line:object-literal-key-quotes
+      '&:first-child': {
+        marginRight: '0.25em'
       }
     }
-  },
-  // tslint:disable-next-line: object-literal-key-quotes
-  treeMasterDetailDetail: {
-    flex: 3,
-    padding: '0.5em',
-    paddingLeft: '1em',
-    // tslint:disable-next-line:object-literal-key-quotes
-    '&:first-child': {
-      marginRight: '0.25em'
-    }
-  }
-});
+  });
 
 export interface TreeWithDetailState extends ControlState {
   selected: {
@@ -218,11 +218,11 @@ export interface TreeWithDetailProps
 
 export class TreeWithDetailRenderer extends React.Component
   <TreeWithDetailProps &
-    WithStyles<'treeMasterDetailContent' |
-      'treeMasterDetail'|
-      'treeMasterDetailMaster' |
-      'treeMasterDetailDetail'>,
-    TreeWithDetailState> {
+  WithStyles<'treeMasterDetailContent' |
+    'treeMasterDetail' |
+    'treeMasterDetailMaster' |
+    'treeMasterDetailDetail'>,
+  TreeWithDetailState> {
 
   componentWillMount() {
     const { uischema, data, schema } = this.props;
@@ -349,7 +349,7 @@ export class TreeWithDetailRenderer extends React.Component
           <div className={classes.treeMasterDetailDetail}>
             {
               this.state.selected ?
-                <ResolvedJsonForms
+                <JsonFormsDispatch
                   schema={this.state.selected.schema}
                   path={this.state.selected.path}
                   uischema={detailUiSchema}
@@ -399,8 +399,8 @@ export interface OwnPropsOfTreeControl extends OwnPropsOfControl {
 const mapStateToProps = (state: JsonFormsState, ownProps: OwnPropsOfTreeControl & WithImageProvider & WithLabelProviders): StatePropsOfTreeWithDetail => {
   const rootData = getData(state);
   const path = Paths.compose(ownProps.path, Paths.fromScopable(ownProps.uischema));
-  const visible = has(ownProps, 'visible') ? ownProps.visible :  Runtime.isVisible(ownProps.uischema, rootData);
-  const enabled = has(ownProps, 'enabled') ? ownProps.enabled :  Runtime.isEnabled(ownProps.uischema, rootData);
+  const visible = has(ownProps, 'visible') ? ownProps.visible : Runtime.isVisible(ownProps.uischema, rootData);
+  const enabled = has(ownProps, 'enabled') ? ownProps.enabled : Runtime.isEnabled(ownProps.uischema, rootData);
   const rootSchema = getSchema(state);
   const resolvedSchema = Resolve.schema(
     ownProps.schema,
@@ -413,7 +413,7 @@ const mapStateToProps = (state: JsonFormsState, ownProps: OwnPropsOfTreeControl 
     label: get(ownProps.uischema, 'label') as string,
     data: Resolve.data(rootData, path),
     uischema: ownProps.uischema,
-    schema:  resolvedSchema || rootSchema,
+    schema: resolvedSchema || rootSchema,
     uischemas: state.jsonforms.uischemas,
     path,
     visible,

--- a/packages/material/src/additional/ListWithDetailMasterItem.tsx
+++ b/packages/material/src/additional/ListWithDetailMasterItem.tsx
@@ -22,25 +22,40 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import React from 'react';
+import { StatePropsOfMasterItem } from '@jsonforms/core';
+import { withJsonFormsMasterListItemProps } from '@jsonforms/react';
 import {
-  EnumCellProps,
-  isEnumControl,
-  RankedTester,
-  rankWith,
-  WithClassname
-} from '@jsonforms/core';
-import { withJsonFormsEnumCellProps } from '@jsonforms/react';
-import { MuiSelect } from '../mui-controls/MuiSelect';
+    Avatar,
+    IconButton,
+    ListItem,
+    ListItemAvatar,
+    ListItemSecondaryAction,
+    ListItemText,
+} from '@material-ui/core';
+import DeleteIcon from '@material-ui/icons/Delete';
+import React from 'react';
 
-export const MaterialEnumCell = (props: EnumCellProps & WithClassname) => (
-  <MuiSelect {...props} />
-);
+const ListWithDetailMasterItem = ({ index, childLabel, selected, handleSelect, removeItem, path }: StatePropsOfMasterItem) => {
+    return (
+        <ListItem
+            button
+            selected={selected}
+            onClick={handleSelect(index)}
+        >
+            <ListItemAvatar>
+                <Avatar aria-label='Index'>{index + 1}</Avatar>
+            </ListItemAvatar>
+            <ListItemText primary={childLabel} />
+            <ListItemSecondaryAction>
+                <IconButton
+                    aria-label='Delete'
+                    onClick={removeItem(path, index)}
+                >
+                    <DeleteIcon />
+                </IconButton>
+            </ListItemSecondaryAction>
+        </ListItem>
+    );
+};
 
-/**
- * Default tester for enum controls.
- * @type {RankedTester}
- */
-export const materialEnumCellTester: RankedTester = rankWith(2, isEnumControl);
-
-export default withJsonFormsEnumCellProps(MaterialEnumCell);
+export default withJsonFormsMasterListItemProps(ListWithDetailMasterItem);

--- a/packages/material/src/additional/MaterialLabelRenderer.tsx
+++ b/packages/material/src/additional/MaterialLabelRenderer.tsx
@@ -25,18 +25,16 @@
 import React from 'react';
 import {
   LabelElement,
-  mapStateToLayoutProps,
+  OwnPropsOfRenderer,
   RankedTester,
   rankWith,
-  RendererProps,
-  uiTypeIs
+  uiTypeIs,
 } from '@jsonforms/core';
-import { StatelessRenderer } from '@jsonforms/react';
+import { withJsonFormsLayoutProps } from '@jsonforms/react';
 import {
   Hidden,
   Typography
 } from '@material-ui/core';
-import { connect } from 'react-redux';
 
 /**
  * Default tester for a label.
@@ -47,16 +45,15 @@ export const materialLabelRendererTester: RankedTester = rankWith(1, uiTypeIs('L
 /**
  * Default renderer for a label.
  */
-export const MaterialLabelRenderer: StatelessRenderer<RendererProps> =
-  ({ uischema, visible }) => {
-    const labelElement: LabelElement = uischema as LabelElement;
-    return (
-      <Hidden xsUp={!visible}>
-        <Typography variant='h6'>
-          {labelElement.text !== undefined && labelElement.text !== null && labelElement.text}
-        </Typography>
-      </Hidden>
-    );
-  };
+export const MaterialLabelRenderer = ({ uischema, visible }: OwnPropsOfRenderer) => {
+  const labelElement: LabelElement = uischema as LabelElement;
+  return (
+    <Hidden xsUp={!visible}>
+      <Typography variant='h6'>
+        {labelElement.text !== undefined && labelElement.text !== null && labelElement.text}
+      </Typography>
+    </Hidden>
+  );
+};
 
-export default connect(mapStateToLayoutProps)(MaterialLabelRenderer);
+export default withJsonFormsLayoutProps(MaterialLabelRenderer);

--- a/packages/material/src/additional/MaterialListWithDetailRenderer.tsx
+++ b/packages/material/src/additional/MaterialListWithDetailRenderer.tsx
@@ -29,211 +29,96 @@ import {
   computeLabel,
   createDefaultValue,
   findUISchema,
-  getData,
   isObjectArray,
   isPlainLabel,
-  JsonFormsState,
-  JsonSchema,
-  mapDispatchToArrayControlProps,
-  mapStateToArrayLayoutProps,
   RankedTester,
   rankWith,
-  Resolve,
   uiTypeIs
 } from '@jsonforms/core';
-import { ResolvedJsonForms } from '@jsonforms/react';
+import { JsonFormsDispatch, withJsonFormsArrayLayoutProps } from '@jsonforms/react';
 import {
-  Avatar,
   Grid,
   Hidden,
-  IconButton,
   List,
-  ListItem,
-  ListItemAvatar,
-  ListItemSecondaryAction,
-  ListItemText,
   Typography
 } from '@material-ui/core';
-import DeleteIcon from '@material-ui/icons/Delete';
-import find from 'lodash/find';
 import map from 'lodash/map';
 import range from 'lodash/range';
-import React from 'react';
-import { connect } from 'react-redux';
+import React, { useCallback, useState } from 'react';
 import { ArrayLayoutToolbar } from '../layouts/ArrayToolbar';
+import ListWithDetailMasterItem from './ListWithDetailMasterItem';
 
-interface MaterialListWithDetailRendererState {
-  selectedIndex: number;
-}
-export class MaterialListWithDetailRenderer extends React.Component<
-  ArrayLayoutProps,
-  MaterialListWithDetailRendererState
-> {
-  state: MaterialListWithDetailRendererState = {
-    selectedIndex: undefined
-  };
-  addItem = (path: string, value: any) => this.props.addItem(path, value);
-  removeItem = (path: string, value: number) => () => {
-    this.props.removeItems(path, [value])();
-    if (this.state.selectedIndex === value) {
-      this.state.selectedIndex = undefined;
-    } else if (this.state.selectedIndex > value) {
-      this.state.selectedIndex--;
-    }
-  };
-  handleListItemClick = (index: number) => () => {
-    this.setState({ selectedIndex: index });
-  };
-  createDefaultValue = () => createDefaultValue(this.props.schema);
-  render() {
-    const { required, visible, errors, path, data, schema, label } = this.props;
+export const MaterialListWithDetailRenderer =
+  ({ uischemas, schema, uischema, path, errors, visible, label, required, removeItems, addItem, data, renderers }: ArrayLayoutProps) => {
+    const [selectedIndex, setSelectedIndex] = useState(undefined);
+    const handleRemoveItem = useCallback((p: string, value: any) => () => {
+      removeItems(p, [value])();
+      if (selectedIndex === value) {
+        setSelectedIndex(undefined);
+      } else if (selectedIndex > value) {
+        setSelectedIndex(selectedIndex - 1);
+      }
+    }, [removeItems, setSelectedIndex]);
+    const handleListItemClick = useCallback((index: number) => () => setSelectedIndex(index), [setSelectedIndex]);
+    const handleCreateDefaultValue = useCallback(() => createDefaultValue(schema), [createDefaultValue]);
+    const foundUISchema = findUISchema(
+      uischemas,
+      schema,
+      uischema.scope,
+      path,
+      undefined,
+      uischema
+    );
+
     return (
       <Hidden xsUp={!visible}>
         <ArrayLayoutToolbar
-          label={computeLabel(
-            isPlainLabel(label) ? label : label.default,
-            required
-          )}
+          label={computeLabel(isPlainLabel(label) ? label : label.default, required)}
           errors={errors}
           path={path}
-          addItem={this.addItem}
-          createDefault={this.createDefaultValue}
+          addItem={addItem}
+          createDefault={handleCreateDefaultValue}
         />
         <Grid container direction='row' spacing={16}>
           <Grid item xs={3}>
             <List>
-              {data > 0 ? (
+              {data > 0 ?
                 map(range(data), index => (
-                  <ConnectedListWithDetailMasterItem
+                  <ListWithDetailMasterItem
                     index={index}
                     path={path}
                     schema={schema}
-                    handleSelect={this.handleListItemClick}
-                    removeItem={this.removeItem}
-                    selected={this.state.selectedIndex === index}
+                    handleSelect={handleListItemClick}
+                    removeItem={handleRemoveItem}
+                    selected={selectedIndex === index}
                     key={index}
                   />
                 ))
-              ) : (
-                <p>No data</p>
-              )}
+                : <p>No data</p>
+              }
             </List>
           </Grid>
           <Grid item xs>
-            {this.renderDetail()}
+            {
+              selectedIndex !== undefined ?
+                <JsonFormsDispatch
+                  renderers={renderers}
+                  visible={visible}
+                  schema={schema}
+                  uischema={foundUISchema}
+                  path={composePaths(path, `${selectedIndex}`)}
+                /> :
+                <Typography variant='h6'>No Selection</Typography>
+            }
           </Grid>
         </Grid>
       </Hidden>
     );
-  }
-  private renderDetail(): any {
-    const { uischemas, schema, uischema, path } = this.props;
-    if (this.state.selectedIndex !== undefined) {
-      const foundUISchema = findUISchema(
-        uischemas,
-        schema,
-        uischema.scope,
-        path,
-        undefined,
-        uischema
-      );
-      return (
-        <ResolvedJsonForms
-          uischema={foundUISchema}
-          schema={schema}
-          path={composePaths(path, `${this.state.selectedIndex}`)}
-        />
-      );
-    }
-    return <Typography variant='h6'>No Selection</Typography>;
-  }
-}
-const ConnectedMaterialListWithDetailRenderer = connect(
-  mapStateToArrayLayoutProps,
-  mapDispatchToArrayControlProps
-)(MaterialListWithDetailRenderer);
-
-export default ConnectedMaterialListWithDetailRenderer;
-ConnectedMaterialListWithDetailRenderer.displayName =
-  'MaterialListWithDetailRenderer';
+  };
 
 export const materialListWithDetailTester: RankedTester = rankWith(
   4,
   and(uiTypeIs('ListWithDetail'), isObjectArray)
 );
 
-interface OwnPropsOfMasterListItem {
-  index: number;
-  selected: boolean;
-  path: string;
-  schema: JsonSchema;
-  handleSelect(index: number): () => void;
-  removeItem(path: string, value: number): () => void;
-}
-interface StatePropsOfMasterItem extends OwnPropsOfMasterListItem {
-  childLabel: string;
-}
-class ListWithDetailMasterItem extends React.Component<
-  ListWithDetailMasterItemProps,
-  any
-> {
-  render() {
-    const {
-      selected,
-      handleSelect,
-      index,
-      childLabel,
-      removeItem,
-      path
-    } = this.props;
-    return (
-      <ListItem button selected={selected} onClick={handleSelect(index)}>
-        <ListItemAvatar>
-          <Avatar aria-label='Index'>{index + 1}</Avatar>
-        </ListItemAvatar>
-        <ListItemText primary={childLabel} />
-        <ListItemSecondaryAction>
-          <IconButton aria-label='Delete' onClick={removeItem(path, index)}>
-            <DeleteIcon />
-          </IconButton>
-        </ListItemSecondaryAction>
-      </ListItem>
-    );
-  }
-}
-
-/**
- * Map state to control props.
- * @param state the store's state
- * @param ownProps any own props
- * @returns {StatePropsOfControl} state props for a control
- */
-export const mapStateToMasterListItemProps = (
-  state: JsonFormsState,
-  ownProps: OwnPropsOfMasterListItem
-): StatePropsOfMasterItem => {
-  const { schema, path, index } = ownProps;
-  const firstPrimitiveProp = schema.properties
-    ? find(Object.keys(schema.properties), propName => {
-        const prop = schema.properties[propName];
-        return (
-          prop.type === 'string' ||
-          prop.type === 'number' ||
-          prop.type === 'integer'
-        );
-      })
-    : undefined;
-  const childPath = composePaths(path, `${index}`);
-  const childData = Resolve.data(getData(state), childPath);
-  const childLabel = firstPrimitiveProp ? childData[firstPrimitiveProp] : '';
-
-  return {
-    ...ownProps,
-    childLabel
-  };
-};
-export interface ListWithDetailMasterItemProps extends StatePropsOfMasterItem {}
-
-const ConnectedListWithDetailMasterItem = connect(
-  mapStateToMasterListItemProps
-)(ListWithDetailMasterItem);
+export default withJsonFormsArrayLayoutProps(MaterialListWithDetailRenderer);

--- a/packages/material/src/cells/MaterialBooleanCell.tsx
+++ b/packages/material/src/cells/MaterialBooleanCell.tsx
@@ -23,16 +23,14 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { connect } from 'react-redux';
 import {
   CellProps,
   isBooleanControl,
-  mapDispatchToCellProps,
-  mapStateToCellProps,
   RankedTester,
   rankWith,
   WithClassname
 } from '@jsonforms/core';
+import { withJsonFormsCellProps } from '@jsonforms/react';
 import { MuiCheckbox } from '../mui-controls/MuiCheckbox';
 
 export const MaterialBooleanCell = (props: CellProps & WithClassname) => {
@@ -44,7 +42,4 @@ export const materialBooleanCellTester: RankedTester = rankWith(
   isBooleanControl
 );
 
-export default connect(
-  mapStateToCellProps,
-  mapDispatchToCellProps
-)(MaterialBooleanCell);
+export default withJsonFormsCellProps(MaterialBooleanCell);

--- a/packages/material/src/cells/MaterialDateCell.tsx
+++ b/packages/material/src/cells/MaterialDateCell.tsx
@@ -23,16 +23,14 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { connect } from 'react-redux';
 import {
-    CellProps,
-    isDateControl,
-    mapDispatchToCellProps,
-    mapStateToCellProps,
-    RankedTester,
-    rankWith,
-    WithClassname
+  CellProps,
+  isDateControl,
+  RankedTester,
+  rankWith,
+  WithClassname
 } from '@jsonforms/core';
+import { withJsonFormsCellProps } from '@jsonforms/react';
 import Input from '@material-ui/core/Input';
 
 export const MaterialDateCell = (props: CellProps & WithClassname) => {
@@ -52,4 +50,5 @@ export const MaterialDateCell = (props: CellProps & WithClassname) => {
   );
 };
 export const materialDateCellTester: RankedTester = rankWith(2, isDateControl);
-export default connect(mapStateToCellProps, mapDispatchToCellProps)(MaterialDateCell);
+
+export default withJsonFormsCellProps(MaterialDateCell);

--- a/packages/material/src/cells/MaterialIntegerCell.tsx
+++ b/packages/material/src/cells/MaterialIntegerCell.tsx
@@ -23,16 +23,14 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { connect } from 'react-redux';
 import {
   CellProps,
   isIntegerControl,
-  mapDispatchToCellProps,
-  mapStateToCellProps,
   RankedTester,
   rankWith,
   WithClassname
 } from '@jsonforms/core';
+import { withJsonFormsCellProps } from '@jsonforms/react';
 import { MuiInputInteger } from '../mui-controls/MuiInputInteger';
 
 export const MaterialIntegerCell = (props: CellProps & WithClassname) => (
@@ -42,7 +40,5 @@ export const materialIntegerCellTester: RankedTester = rankWith(
   2,
   isIntegerControl
 );
-export default connect(
-  mapStateToCellProps,
-  mapDispatchToCellProps
-)(MaterialIntegerCell);
+
+export default withJsonFormsCellProps(MaterialIntegerCell);

--- a/packages/material/src/cells/MaterialNumberCell.tsx
+++ b/packages/material/src/cells/MaterialNumberCell.tsx
@@ -23,16 +23,14 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { connect } from 'react-redux';
 import {
   CellProps,
   isNumberControl,
-  mapDispatchToCellProps,
-  mapStateToCellProps,
   RankedTester,
   rankWith,
   WithClassname
 } from '@jsonforms/core';
+import { withJsonFormsCellProps } from '@jsonforms/react';
 import { MuiInputNumber } from '../mui-controls/MuiInputNumber';
 
 export const MaterialNumberCell = (props: CellProps & WithClassname) => (
@@ -46,7 +44,4 @@ export const materialNumberCellTester: RankedTester = rankWith(
   2,
   isNumberControl
 );
-export default connect(
-  mapStateToCellProps,
-  mapDispatchToCellProps
-)(MaterialNumberCell);
+export default withJsonFormsCellProps(MaterialNumberCell);

--- a/packages/material/src/cells/MaterialNumberFormatCell.tsx
+++ b/packages/material/src/cells/MaterialNumberFormatCell.tsx
@@ -27,13 +27,11 @@ import {
   CellProps,
   Formatted,
   isNumberFormatControl,
-  mapDispatchToCellProps,
-  mapStateToCellProps,
   RankedTester,
   rankWith,
   WithClassname
 } from '@jsonforms/core';
-import { connect } from 'react-redux';
+import { withJsonFormsCellProps } from '@jsonforms/react';
 import { MuiInputNumberFormat } from '../mui-controls/MuiInputNumberFormat';
 
 export const MaterialNumberFormatCell = (
@@ -47,7 +45,5 @@ export const materialNumberFormatCellTester: RankedTester = rankWith(
   4,
   isNumberFormatControl
 );
-export default connect(
-  mapStateToCellProps,
-  mapDispatchToCellProps
-)(MaterialNumberFormatCell);
+
+export default withJsonFormsCellProps(MaterialNumberFormatCell);

--- a/packages/material/src/cells/MaterialTextCell.tsx
+++ b/packages/material/src/cells/MaterialTextCell.tsx
@@ -26,13 +26,11 @@ import React from 'react';
 import {
   CellProps,
   isStringControl,
-  mapDispatchToCellProps,
-  mapStateToCellProps,
   RankedTester,
   rankWith,
   WithClassname
 } from '@jsonforms/core';
-import { connect } from 'react-redux';
+import { withJsonFormsCellProps } from '@jsonforms/react';
 import { MuiInputText } from '../mui-controls/MuiInputText';
 
 export const MaterialTextCell = (props: CellProps & WithClassname) => (
@@ -47,7 +45,5 @@ export const materialTextCellTester: RankedTester = rankWith(
   1,
   isStringControl
 );
-export default connect(
-  mapStateToCellProps,
-  mapDispatchToCellProps
-)(MaterialTextCell);
+
+export default withJsonFormsCellProps(MaterialTextCell);

--- a/packages/material/src/cells/MaterialTimeCell.tsx
+++ b/packages/material/src/cells/MaterialTimeCell.tsx
@@ -23,23 +23,18 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { connect } from 'react-redux';
 import {
   CellProps,
   isTimeControl,
-  mapDispatchToCellProps,
-  mapStateToCellProps,
   RankedTester,
   rankWith,
   WithClassname
 } from '@jsonforms/core';
+import { withJsonFormsCellProps } from '@jsonforms/react';
 import { MuiInputTime } from '../mui-controls/MuiInputTime';
 
 export const MaterialTimeCell = (props: CellProps & WithClassname) => (
   <MuiInputTime {...props} />
 );
 export const materialTimeCellTester: RankedTester = rankWith(2, isTimeControl);
-export default connect(
-  mapStateToCellProps,
-  mapDispatchToCellProps
-)(MaterialTimeCell);
+export default withJsonFormsCellProps(MaterialTimeCell);

--- a/packages/material/src/complex/CombinatorProperties.tsx
+++ b/packages/material/src/complex/CombinatorProperties.tsx
@@ -25,7 +25,7 @@
 import React from 'react';
 import _ from 'lodash';
 import { Generate, JsonSchema, Layout, UISchemaElement } from '@jsonforms/core';
-import { ResolvedJsonForms } from '@jsonforms/react';
+import { JsonFormsDispatch } from '@jsonforms/react';
 
 interface CombinatorPropertiesProps {
   schema: JsonSchema;
@@ -51,7 +51,7 @@ export class CombinatorProperties extends React.Component<CombinatorPropertiesPr
 
     if (isLayoutWithElements) {
       return (
-        <ResolvedJsonForms
+        <JsonFormsDispatch
           schema={otherProps}
           path={path}
           uischema={foundUISchema}

--- a/packages/material/src/complex/MaterialAllOfRenderer.tsx
+++ b/packages/material/src/complex/MaterialAllOfRenderer.tsx
@@ -23,56 +23,39 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { connect } from 'react-redux';
 import { Hidden } from '@material-ui/core';
 
 import {
   createCombinatorRenderInfos,
   isAllOfControl,
   JsonSchema,
-  mapStateToAllOfProps,
   RankedTester,
   rankWith,
   resolveSubSchemas,
-  StatePropsOfCombinator
-} from '@jsonforms/core';
-import { ResolvedJsonForms } from '@jsonforms/react';
-
-class MaterialAllOfRenderer extends React.Component<
   StatePropsOfCombinator,
-  any
-> {
-  render() {
-    const { schema, rootSchema, path, visible } = this.props;
+} from '@jsonforms/core';
+import { JsonFormsDispatch, withJsonFormsAllOfProps } from '@jsonforms/react';
 
-    const _schema = resolveSubSchemas(schema, rootSchema, 'allOf');
-    const allOfRenderInfos = createCombinatorRenderInfos(
-      (_schema as JsonSchema).allOf,
-      rootSchema,
-      'allOf'
-    );
+const MaterialAllOfRenderer = ({ schema, rootSchema, visible, renderers, path }: StatePropsOfCombinator) => {
+  const _schema = resolveSubSchemas(schema, rootSchema, 'allOf');
+  const allOfRenderInfos = createCombinatorRenderInfos((_schema as JsonSchema).allOf, rootSchema, 'allOf');
 
-    return (
-      <Hidden xsUp={!visible}>
-        {allOfRenderInfos.map((allOfRenderInfo, allOfIndex) => (
-          <ResolvedJsonForms
+  return (
+    <Hidden xsUp={!visible}>
+      {
+        allOfRenderInfos.map((allOfRenderInfo, allOfIndex) => (
+          <JsonFormsDispatch
             key={allOfIndex}
             schema={allOfRenderInfo.schema}
             uischema={allOfRenderInfo.uischema}
             path={path}
+            renderers={renderers}
           />
-        ))}
-      </Hidden>
-    );
-  }
-}
+        ))
+      }
+    </Hidden>
+  );
+};
 
-const ConnectedMaterialAllOfRenderer = connect(mapStateToAllOfProps)(
-  MaterialAllOfRenderer
-);
-
-export const materialAllOfControlTester: RankedTester = rankWith(
-  3,
-  isAllOfControl
-);
-export default ConnectedMaterialAllOfRenderer;
+export const materialAllOfControlTester: RankedTester = rankWith(3, isAllOfControl);
+export default withJsonFormsAllOfProps(MaterialAllOfRenderer);

--- a/packages/material/src/complex/MaterialAnyOfRenderer.tsx
+++ b/packages/material/src/complex/MaterialAnyOfRenderer.tsx
@@ -22,56 +22,28 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import React from 'react';
-import { connect } from 'react-redux';
+import React, { useCallback, useState } from 'react';
 
 import {
   createCombinatorRenderInfos,
   isAnyOfControl,
   JsonSchema,
-  mapStateToAnyOfProps,
   RankedTester,
   rankWith,
   resolveSubSchemas,
-  StatePropsOfCombinator
-} from '@jsonforms/core';
-import { ResolvedJsonForms } from '@jsonforms/react';
-import CombinatorProperties from './CombinatorProperties';
-import { Hidden, Tab, Tabs } from '@material-ui/core';
-
-interface MaterialAnyOfState {
-  selectedAnyOf: number;
-}
-
-class MaterialAnyOfRenderer extends React.Component<
   StatePropsOfCombinator,
-  MaterialAnyOfState
-> {
-  state: MaterialAnyOfState = {
-    selectedAnyOf: 0
-  };
+} from '@jsonforms/core';
+import { JsonFormsDispatch, withJsonFormsAnyOfProps } from '@jsonforms/react';
+import { Hidden, Tab, Tabs } from '@material-ui/core';
+import CombinatorProperties from './CombinatorProperties';
 
-  constructor(props: StatePropsOfCombinator) {
-    super(props);
-    const { indexOfFittingSchema } = this.props;
-    if (indexOfFittingSchema) {
-      this.state.selectedAnyOf = indexOfFittingSchema;
-    }
-  }
-
-  handleChange = (_event: any, value: number) => {
-    this.setState({ selectedAnyOf: value });
-  };
-
-  render() {
+const MaterialAnyOfRenderer =
+  ({ schema, rootSchema, indexOfFittingSchema, visible, path, renderers }: StatePropsOfCombinator) => {
+    const [selectedAnyOf, setSelectedAnyOf] = useState(indexOfFittingSchema || 0);
+    const handleChange = useCallback((_ev: any, value: number) => setSelectedAnyOf(value), [setSelectedAnyOf]);
     const anyOf = 'anyOf';
-    const { path, schema, rootSchema, visible } = this.props;
     const _schema = resolveSubSchemas(schema, rootSchema, anyOf);
-    const anyOfRenderInfos = createCombinatorRenderInfos(
-      (_schema as JsonSchema).anyOf,
-      rootSchema,
-      anyOf
-    );
+    const anyOfRenderInfos = createCombinatorRenderInfos((_schema as JsonSchema).anyOf, rootSchema, anyOf);
 
     return (
       <Hidden xsUp={!visible}>
@@ -80,33 +52,24 @@ class MaterialAnyOfRenderer extends React.Component<
           combinatorKeyword={'anyOf'}
           path={path}
         />
-        <Tabs value={this.state.selectedAnyOf} onChange={this.handleChange}>
-          {anyOfRenderInfos.map(anyOfRenderInfo => (
-            <Tab key={anyOfRenderInfo.label} label={anyOfRenderInfo.label} />
-          ))}
+        <Tabs value={selectedAnyOf} onChange={handleChange}>
+          {anyOfRenderInfos.map(anyOfRenderInfo => <Tab key={anyOfRenderInfo.label} label={anyOfRenderInfo.label} />)}
         </Tabs>
-        {anyOfRenderInfos.map(
-          (anyOfRenderInfo, anyOfIndex) =>
-            this.state.selectedAnyOf === anyOfIndex && (
-              <ResolvedJsonForms
-                key={anyOfIndex}
-                schema={anyOfRenderInfo.schema}
-                uischema={anyOfRenderInfo.uischema}
-                path={path}
-              />
-            )
-        )}
+        {
+          anyOfRenderInfos.map((anyOfRenderInfo, anyOfIndex) => (
+            selectedAnyOf === anyOfIndex &&
+            <JsonFormsDispatch
+              key={anyOfIndex}
+              schema={anyOfRenderInfo.schema}
+              uischema={anyOfRenderInfo.uischema}
+              path={path}
+              renderers={renderers}
+            />
+          ))
+        }
       </Hidden>
     );
-  }
-}
+  };
 
-const ConnectedMaterialAnyOfRenderer = connect(mapStateToAnyOfProps)(
-  MaterialAnyOfRenderer
-);
-ConnectedMaterialAnyOfRenderer.displayName = 'MaterialAnyOfRenderer';
-export const materialAnyOfControlTester: RankedTester = rankWith(
-  3,
-  isAnyOfControl
-);
-export default ConnectedMaterialAnyOfRenderer;
+export const materialAnyOfControlTester: RankedTester = rankWith(3, isAnyOfControl);
+export default withJsonFormsAnyOfProps(MaterialAnyOfRenderer);

--- a/packages/material/src/complex/MaterialObjectRenderer.tsx
+++ b/packages/material/src/complex/MaterialObjectRenderer.tsx
@@ -25,52 +25,37 @@
 import isEmpty from 'lodash/isEmpty';
 import startCase from 'lodash/startCase';
 import {
-  ControlWithDetailProps,
-  findUISchema,
-  GroupLayout,
-  isObjectControl,
-  mapDispatchToControlProps,
-  mapStateToControlWithDetailProps,
-  RankedTester,
-  rankWith
+    findUISchema,
+    GroupLayout,
+    isObjectControl,
+    RankedTester,
+    rankWith,
+    StatePropsOfControlWithDetail,
 } from '@jsonforms/core';
-import { ResolvedJsonForms } from '@jsonforms/react';
+import { JsonFormsDispatch, withJsonFormsDetailProps } from '@jsonforms/react';
 import { Hidden } from '@material-ui/core';
 import React from 'react';
-import { connect } from 'react-redux';
 
-class MaterialObjectRenderer extends React.Component<ControlWithDetailProps, any> {
-    render() {
-        const {
-            uischemas,
-            schema,
-            path,
-            visible,
-        } = this.props;
+const MaterialObjectRenderer = ({ renderers, uischemas, schema, path, visible }: StatePropsOfControlWithDetail) => {
 
-        const detailUiSchema = findUISchema(uischemas, schema, undefined, path, 'Group');
-        if (isEmpty(path)) {
-            detailUiSchema.type = 'VerticalLayout';
-        } else {
-            (detailUiSchema as GroupLayout).label = startCase(path);
-        }
-        return (
-            <Hidden xsUp={!visible}>
-                <ResolvedJsonForms
-                    visible={visible}
-                    schema={schema}
-                    uischema={detailUiSchema}
-                    path={path}
-                />
-            </Hidden>
-        );
+    const detailUiSchema = findUISchema(uischemas, schema, undefined, path, 'Group');
+    if (isEmpty(path)) {
+        detailUiSchema.type = 'VerticalLayout';
+    } else {
+        (detailUiSchema as GroupLayout).label = startCase(path);
     }
-}
-
-const ConnectedMaterialObjectRenderer = connect(
-  mapStateToControlWithDetailProps,
-  mapDispatchToControlProps
-)(MaterialObjectRenderer);
+    return (
+        <Hidden xsUp={!visible}>
+            <JsonFormsDispatch
+                visible={visible}
+                schema={schema}
+                uischema={detailUiSchema}
+                path={path}
+                renderers={renderers}
+            />
+        </Hidden>
+    );
+};
 
 export const materialObjectControlTester: RankedTester = rankWith(2, isObjectControl);
-export default ConnectedMaterialObjectRenderer;
+export default withJsonFormsDetailProps(MaterialObjectRenderer);

--- a/packages/material/src/complex/MaterialOneOfRenderer.tsx
+++ b/packages/material/src/complex/MaterialOneOfRenderer.tsx
@@ -22,19 +22,19 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import {
-  CombinatorRendererProps,
   createCombinatorRenderInfos,
   createDefaultValue,
   isOneOfControl,
   JsonSchema,
-  mapDispatchToControlProps,
-  mapStateToOneOfProps,
+  OwnPropsOfControl,
   RankedTester,
   rankWith,
-  resolveSubSchemas
+  resolveSubSchemas,
+  DispatchPropsOfControl,
+  StatePropsOfCombinator,
 } from '@jsonforms/core';
 import {
   Button,
@@ -47,69 +47,41 @@ import {
   Tab,
   Tabs
 } from '@material-ui/core';
-import { connect } from 'react-redux';
-import { ResolvedJsonForms } from '@jsonforms/react';
+import {
+  JsonFormsDispatch,
+  withJsonFormsOneOfProps
+} from '@jsonforms/react';
 import CombinatorProperties from './CombinatorProperties';
 
-interface MaterialOneOfState {
-  open: boolean;
-  proceed: boolean;
-  selectedOneOf: number;
-  newOneOfIndex?: any;
+export interface OwnOneOfProps extends OwnPropsOfControl {
+  indexOfFittingSchema?: number;
 }
 
-class MaterialOneOfRenderer extends React.Component<CombinatorRendererProps, MaterialOneOfState> {
-
-  state: MaterialOneOfState = {
-    open: false,
-    proceed: false,
-    selectedOneOf: 0,
-    newOneOfIndex: 0
-  };
-  constructor(props: CombinatorRendererProps) {
-    super(props);
-    const {indexOfFittingSchema} = this.props;
-    if (indexOfFittingSchema) {
-      this.state.selectedOneOf = indexOfFittingSchema;
-    }
-  }
-  handleClose = () => {
-    this.setState({ open: false });
-  };
-
-  cancel = () => {
-    this.setState({
-      open: false,
-      proceed: false
-    });
-  };
-
-  confirm = () => {
-    const { path, schema, handleChange } = this.props;
-    handleChange(
-      path,
-      createDefaultValue(schema.oneOf[this.state.newOneOfIndex])
-    );
-    this.setState({
-      open: false,
-      proceed: true,
-      selectedOneOf: this.state.newOneOfIndex
-    });
-  };
-
-  handleTabChange = (_event: any, newOneOfIndex: number) => {
-    this.setState({
-      open: true,
-      newOneOfIndex
-    });
-  };
-
-  render() {
-
-    const oneOf = 'oneOf';
-    const { schema, path, rootSchema, id, visible } = this.props;
+const oneOf = 'oneOf';
+const MaterialOneOfRenderer =
+  ({ handleChange, schema, path, renderers, rootSchema, id, visible, indexOfFittingSchema }: StatePropsOfCombinator & DispatchPropsOfControl) => {
+    const [open, setOpen] = useState(false);
+    const [selectedIndex, setSelectedIndex] = useState(indexOfFittingSchema || 0);
+    const [newSelectedIndex, setNewSelectedIndex] = useState(0);
+    const handleClose = useCallback(() => setOpen(false), [setOpen]);
+    const cancel = useCallback(() => {
+      setOpen(false);
+    }, [setOpen]);
+    const handleTabChange = useCallback((_event: any, newOneOfIndex: number) => {
+      setOpen(true);
+      setNewSelectedIndex(newOneOfIndex);
+    }, [setOpen, setSelectedIndex]);
+    //const { handleChange } = ctxDispatchToControlProps(dispatch);
     const _schema = resolveSubSchemas(schema, rootSchema, oneOf);
     const oneOfRenderInfos = createCombinatorRenderInfos((_schema as JsonSchema).oneOf, rootSchema, oneOf);
+    const confirm = useCallback(() => {
+      handleChange(
+        path,
+        createDefaultValue(schema.oneOf[newSelectedIndex])
+      );
+      setOpen(false);
+      setSelectedIndex(newSelectedIndex);
+    }, [handleChange, createDefaultValue, newSelectedIndex]);
 
     return (
       <Hidden xsUp={!visible}>
@@ -118,24 +90,25 @@ class MaterialOneOfRenderer extends React.Component<CombinatorRendererProps, Mat
           combinatorKeyword={'oneOf'}
           path={path}
         />
-        <Tabs value={this.state.selectedOneOf} onChange={this.handleTabChange}>
-          {oneOfRenderInfos.map(oneOfRenderInfo => <Tab key={oneOfRenderInfo.label} label={oneOfRenderInfo.label}/>)}
+        <Tabs value={selectedIndex} onChange={handleTabChange}>
+          {oneOfRenderInfos.map(oneOfRenderInfo => <Tab key={oneOfRenderInfo.label} label={oneOfRenderInfo.label} />)}
         </Tabs>
         {
           oneOfRenderInfos.map((oneOfRenderInfo, oneOfIndex) => (
-            this.state.selectedOneOf === oneOfIndex && (
-              <ResolvedJsonForms
+            selectedIndex === oneOfIndex && (
+              <JsonFormsDispatch
                 key={oneOfIndex}
                 schema={oneOfRenderInfo.schema}
                 uischema={oneOfRenderInfo.uischema}
                 path={path}
+                renderers={renderers}
               />
             )
           ))
         }
         <Dialog
-          open={this.state.open}
-          onClose={this.handleClose}
+          open={open}
+          onClose={handleClose}
           aria-labelledby='alert-dialog-title'
           aria-describedby='alert-dialog-description'
         >
@@ -147,24 +120,17 @@ class MaterialOneOfRenderer extends React.Component<CombinatorRendererProps, Mat
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button onClick={this.cancel} color='primary'>
+            <Button onClick={cancel} color='primary'>
               No
             </Button>
-            <Button onClick={this.confirm} color='primary' autoFocus id={`oneOf-${id}-confirm-yes`}>
+            <Button onClick={confirm} color='primary' autoFocus id={`oneOf-${id}-confirm-yes`}>
               Yes
             </Button>
           </DialogActions>
         </Dialog>
       </Hidden>
     );
+  };
 
-  }
-}
-
-const ConnectedMaterialOneOfRenderer = connect(
-  mapStateToOneOfProps,
-  mapDispatchToControlProps
-)(MaterialOneOfRenderer);
-ConnectedMaterialOneOfRenderer.displayName = 'MaterialOneOfRenderer';
 export const materialOneOfControlTester: RankedTester = rankWith(3, isOneOfControl);
-export default ConnectedMaterialOneOfRenderer;
+export default withJsonFormsOneOfProps(MaterialOneOfRenderer);

--- a/packages/material/src/controls/MaterialAnyOfStringOrEnumControl.tsx
+++ b/packages/material/src/controls/MaterialAnyOfStringOrEnumControl.tsx
@@ -28,28 +28,25 @@ import {
   ControlState,
   EnumCellProps,
   JsonSchema,
-  mapDispatchToControlProps,
-  mapStateToControlProps,
   RankedTester,
   rankWith,
   schemaMatches,
   uiTypeIs,
   WithClassname
 } from '@jsonforms/core';
-import { Control } from '@jsonforms/react';
+import { Control, withJsonFormsControlProps } from '@jsonforms/react';
 import { Input } from '@material-ui/core';
 import { InputBaseComponentProps } from '@material-ui/core/InputBase';
 import merge from 'lodash/merge';
 import React from 'react';
-import { connect } from 'react-redux';
 import { MaterialInputControl } from './MaterialInputControl';
 
 const findEnumSchema = (schemas: JsonSchema[]) =>
-    schemas.find(
-      s => s.enum !== undefined && (s.type === 'string' || s.type === undefined)
-    );
-  const findTextSchema = (schemas: JsonSchema[]) =>
-    schemas.find(s => s.type === 'string' && s.enum === undefined);
+  schemas.find(
+    s => s.enum !== undefined && (s.type === 'string' || s.type === undefined)
+  );
+const findTextSchema = (schemas: JsonSchema[]) =>
+  schemas.find(s => s.type === 'string' && s.enum === undefined);
 
 const MuiAutocompleteInputText = (props: EnumCellProps & WithClassname) => {
   const {
@@ -129,7 +126,4 @@ export const materialAnyOfStringOrEnumControlTester: RankedTester = rankWith(
   5,
   simpleAnyOf
 );
-export default connect(
-  mapStateToControlProps,
-  mapDispatchToControlProps
-)(MaterialAnyOfStringOrEnumControl);
+export default withJsonFormsControlProps(MaterialAnyOfStringOrEnumControl);

--- a/packages/material/src/controls/MaterialBooleanControl.tsx
+++ b/packages/material/src/controls/MaterialBooleanControl.tsx
@@ -24,47 +24,45 @@
 */
 import isEmpty from 'lodash/isEmpty';
 import React from 'react';
-import { connect } from 'react-redux';
 import {
-  ControlProps,
   isBooleanControl,
-  mapDispatchToControlProps,
-  mapStateToControlProps,
   RankedTester,
   rankWith,
+  ControlProps,
 } from '@jsonforms/core';
-
+import { withJsonFormsControlProps } from '@jsonforms/react';
 import { FormControlLabel, Hidden } from '@material-ui/core';
 import { MuiCheckbox } from '../mui-controls/MuiCheckbox';
 
-export const MaterialBooleanControl = ({
-  label,
-  id,
-  visible,
-  ...props
-}: ControlProps) => (
-  <Hidden xsUp={!visible}>
-    <FormControlLabel
-      label={label}
-      id={id}
-      control={
-        <MuiCheckbox
-          id={id + '-input'}
-          isValid={isEmpty(props.errors)}
-          visible={visible}
-          {...props}
+export const MaterialBooleanControl =
+  ({ data, visible, label, id, enabled, uischema, schema, rootSchema, handleChange, errors, path }: ControlProps) => {
+    return (
+      <Hidden xsUp={!visible}>
+        <FormControlLabel
+          label={label}
+          id={id}
+          control={
+            <MuiCheckbox
+              id={`${id}-input`}
+              isValid={isEmpty(errors)}
+              data={data}
+              enabled={enabled}
+              visible={visible}
+              path={path}
+              uischema={uischema}
+              schema={schema}
+              rootSchema={rootSchema}
+              handleChange={handleChange}
+              errors={errors}
+            />
+          }
         />
-      }
-    />
-  </Hidden>
-);
+      </Hidden>
+    );
+  };
 
-const ConnectedMaterialBooleanControl = connect(
-  mapStateToControlProps,
-  mapDispatchToControlProps
-)(MaterialBooleanControl);
 export const materialBooleanControlTester: RankedTester = rankWith(
   2,
   isBooleanControl
 );
-export default ConnectedMaterialBooleanControl;
+export default withJsonFormsControlProps(MaterialBooleanControl);

--- a/packages/material/src/controls/MaterialDateControl.tsx
+++ b/packages/material/src/controls/MaterialDateControl.tsx
@@ -25,20 +25,17 @@
 import startsWith from 'lodash/startsWith';
 import React from 'react';
 import {
-  computeLabel,
-  ControlState,
-  DispatchPropsOfControl,
-  isDateControl,
-  isDescriptionHidden,
-  isPlainLabel, JsonFormsState,
-  mapDispatchToControlProps,
-  mapStateToControlProps,
-  OwnPropsOfControl,
-  RankedTester,
-  rankWith,
-  StatePropsOfControl
+    computeLabel,
+    ControlState,
+    DispatchPropsOfControl,
+    isDateControl,
+    isDescriptionHidden,
+    isPlainLabel, 
+    RankedTester,
+    rankWith,
+    StatePropsOfControl
 } from '@jsonforms/core';
-import { Control } from '@jsonforms/react';
+import { Control, withJsonFormsControlProps } from '@jsonforms/react';
 import { Hidden } from '@material-ui/core';
 import KeyboardArrowLeftIcon from '@material-ui/icons/KeyboardArrowLeft';
 import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
@@ -47,7 +44,6 @@ import moment from 'moment';
 import { Moment } from 'moment';
 import { DatePicker, MuiPickersUtilsProvider } from 'material-ui-pickers';
 import MomentUtils from '@date-io/moment';
-import { connect } from 'react-redux';
 
 export interface DateControl {
     momentLocale?: Moment;
@@ -60,9 +56,6 @@ export class MaterialDateControl extends Control<StatePropsOfDateControl & Dispa
             id,
             errors,
             label,
-            defaultLabel,
-            cancelLabel,
-            clearLabel,
             uischema,
             visible,
             enabled,
@@ -72,6 +65,9 @@ export class MaterialDateControl extends Control<StatePropsOfDateControl & Dispa
             data,
             momentLocale
         } = this.props;
+        const defaultLabel = label as string;
+        const cancelLabel = '%cancel';
+        const clearLabel = '%clear';
         const isValid = errors.length === 0;
         const trim = uischema.options && uischema.options.trim;
         const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused);
@@ -135,20 +131,6 @@ export class MaterialDateControl extends Control<StatePropsOfDateControl & Dispa
     }
 }
 
-export const addLabelProps =
-    (mapStateToProps: (s: JsonFormsState, p: OwnPropsOfControl) => StatePropsOfControl) =>
-        (state: JsonFormsState, ownProps: OwnPropsOfControl): StatePropsOfDateControl => {
-            const stateProps = mapStateToProps(state, ownProps);
-
-            return {
-                ...stateProps,
-                // TODO cast
-                defaultLabel: stateProps.label as string,
-                cancelLabel: '%cancel',
-                clearLabel: '%clear',
-            };
-        };
-
 export interface StatePropsOfDateControl extends StatePropsOfControl {
     defaultLabel: string;
     cancelLabel: string;
@@ -156,7 +138,5 @@ export interface StatePropsOfDateControl extends StatePropsOfControl {
 }
 
 export const materialDateControlTester: RankedTester = rankWith(4, isDateControl);
-export default connect(
-    addLabelProps(mapStateToControlProps),
-    mapDispatchToControlProps
-)(MaterialDateControl);
+
+export default withJsonFormsControlProps(MaterialDateControl);

--- a/packages/material/src/controls/MaterialDateTimeControl.tsx
+++ b/packages/material/src/controls/MaterialDateTimeControl.tsx
@@ -23,7 +23,6 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { connect } from 'react-redux';
 import merge from 'lodash/merge';
 import {
   computeLabel,
@@ -31,12 +30,10 @@ import {
   ControlState,
   isDateTimeControl,
   isPlainLabel,
-  mapDispatchToControlProps,
-  mapStateToControlProps,
   RankedTester,
   rankWith,
 } from '@jsonforms/core';
-import { Control } from '@jsonforms/react';
+import { Control, withJsonFormsControlProps } from '@jsonforms/react';
 import moment from 'moment';
 import { Hidden } from '@material-ui/core';
 import KeyboardArrowLeftIcon from '@material-ui/icons/KeyboardArrowLeft';
@@ -105,7 +102,7 @@ export class MaterialDateTimeControl extends Control<ControlProps, ControlState>
     );
   }
 }
+
 export const materialDateTimeControlTester: RankedTester = rankWith(2, isDateTimeControl);
-export default connect(
-  mapStateToControlProps, mapDispatchToControlProps
-)(MaterialDateTimeControl);
+
+export default withJsonFormsControlProps(MaterialDateTimeControl);

--- a/packages/material/src/controls/MaterialEnumControl.tsx
+++ b/packages/material/src/controls/MaterialEnumControl.tsx
@@ -25,33 +25,25 @@
 import React from 'react';
 import {
   ControlProps,
-  ControlState,
   isEnumControl,
-  mapDispatchToControlProps,
-  mapStateToEnumControlProps,
+  OwnPropsOfEnum,
   RankedTester,
-  rankWith
+  rankWith,
 } from '@jsonforms/core';
-import { connect } from 'react-redux';
+import { withJsonFormsEnumProps } from '@jsonforms/react';
 import { MuiSelect } from '../mui-controls/MuiSelect';
 import { MaterialInputControl } from './MaterialInputControl';
-import { Control } from '@jsonforms/react';
 
-export class MaterialEnumControl extends Control<ControlProps, ControlState> {
-  render() {
-    return (
-      <MaterialInputControl
-        {...this.props}
-        input={MuiSelect}
-      />
-    );
-  }
-}
+export const MaterialEnumControl = (props: ControlProps & OwnPropsOfEnum) => (
+  <MaterialInputControl
+    {...props}
+    input={MuiSelect}
+  />
+);
+
 export const materialEnumControlTester: RankedTester = rankWith(
   2,
   isEnumControl
 );
-export default connect(
-  mapStateToEnumControlProps,
-  mapDispatchToControlProps
-)(MaterialEnumControl);
+
+export default withJsonFormsEnumProps(MaterialEnumControl);

--- a/packages/material/src/controls/MaterialIntegerControl.tsx
+++ b/packages/material/src/controls/MaterialIntegerControl.tsx
@@ -32,18 +32,32 @@ import {
   RankedTester,
   rankWith
 } from '@jsonforms/core';
-import { connect } from 'react-redux';
 import { MuiInputInteger } from '../mui-controls/MuiInputInteger';
 import { MaterialInputControl } from './MaterialInputControl';
-import { Control } from '@jsonforms/react';
+import { Control, JsonFormsContext } from '@jsonforms/react';
 
-export class MaterialIntegerControl extends Control<ControlProps, ControlState> {
+export class MaterialIntegerControl extends Control<
+  ControlProps,
+  ControlState
+> {
   render() {
     return (
-      <MaterialInputControl
-        {...this.props}
-        input={MuiInputInteger}
-      />
+      <JsonFormsContext.Consumer>
+        {({ core, dispatch }: any) => {
+          const stateProps = mapStateToControlProps(
+            { jsonforms: { core } },
+            this.props
+          );
+          const dispatchProps = mapDispatchToControlProps(dispatch);
+          return (
+            <MaterialInputControl
+              {...stateProps}
+              {...dispatchProps}
+              input={MuiInputInteger}
+            />
+          );
+        }}
+      </JsonFormsContext.Consumer>
     );
   }
 }
@@ -51,7 +65,4 @@ export const materialIntegerControlTester: RankedTester = rankWith(
   2,
   isIntegerControl
 );
-export default connect(
-  mapStateToControlProps,
-  mapDispatchToControlProps
-)(MaterialIntegerControl);
+export default MaterialIntegerControl;

--- a/packages/material/src/controls/MaterialNativeControl.tsx
+++ b/packages/material/src/controls/MaterialNativeControl.tsx
@@ -23,7 +23,6 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { connect } from 'react-redux';
 import {
   computeLabel,
   ControlProps,
@@ -32,14 +31,12 @@ import {
   isDescriptionHidden,
   isPlainLabel,
   isTimeControl,
-  mapDispatchToControlProps,
-  mapStateToControlProps,
   or,
   RankedTester,
   rankWith
 } from '@jsonforms/core';
 import { Hidden } from '@material-ui/core';
-import { Control } from '@jsonforms/react';
+import { Control, withJsonFormsControlProps } from '@jsonforms/react';
 import TextField from '@material-ui/core/TextField';
 import merge from 'lodash/merge';
 
@@ -90,7 +87,4 @@ export const materialNativeControlTester: RankedTester = rankWith(
   or(isDateControl, isTimeControl)
 );
 
-export default connect(
-  mapStateToControlProps,
-  mapDispatchToControlProps
-)(MaterialNativeControl);
+export default withJsonFormsControlProps(MaterialNativeControl);

--- a/packages/material/src/controls/MaterialNumberControl.tsx
+++ b/packages/material/src/controls/MaterialNumberControl.tsx
@@ -25,33 +25,21 @@
 import React from 'react';
 import {
   ControlProps,
-  ControlState,
   isNumberControl,
-  mapDispatchToControlProps,
-  mapStateToControlProps,
   RankedTester,
   rankWith
 } from '@jsonforms/core';
-import { connect } from 'react-redux';
 import { MuiInputNumber } from '../mui-controls/MuiInputNumber';
 import { MaterialInputControl } from './MaterialInputControl';
-import { Control } from '@jsonforms/react';
+import { withJsonFormsControlProps } from '@jsonforms/react';
 
-export class MaterialNumberControl extends Control<ControlProps, ControlState> {
-  render() {
-    return (
-      <MaterialInputControl
-        {...this.props}
-        input={MuiInputNumber}
-      />
-    );
-  }
-}
+export const MaterialNumberControl = (props: ControlProps) => (
+  <MaterialInputControl {...props} input={MuiInputNumber} />
+);
+
 export const materialNumberControlTester: RankedTester = rankWith(
   2,
   isNumberControl
 );
-export default connect(
-  mapStateToControlProps,
-  mapDispatchToControlProps
-)(MaterialNumberControl);
+
+export default withJsonFormsControlProps(MaterialNumberControl);

--- a/packages/material/src/controls/MaterialRadioGroupControl.tsx
+++ b/packages/material/src/controls/MaterialRadioGroupControl.tsx
@@ -24,34 +24,22 @@
 */
 import merge from 'lodash/merge';
 import React from 'react';
-import { connect } from 'react-redux';
 import {
   computeLabel,
   ControlProps,
   ControlState,
   isDescriptionHidden,
   isPlainLabel,
-  mapDispatchToControlProps,
-  mapStateToControlProps,
-  optionIs,
+  rankWith,
   RankedTester,
-  rankWith
+  optionIs
 } from '@jsonforms/core';
-import { Control } from '@jsonforms/react';
+import { Control, withJsonFormsControlProps } from '@jsonforms/react';
 import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
-import {
-  FormControl,
-  FormControlLabel,
-  FormHelperText,
-  FormLabel,
-  Hidden
-} from '@material-ui/core';
+import { FormControl, FormControlLabel, FormHelperText, FormLabel, Hidden } from '@material-ui/core';
 
-export class MaterialRadioGroupControl extends Control<
-  ControlProps,
-  ControlState
-> {
+export class MaterialRadioGroupControl extends Control<ControlProps, ControlState> {
   render() {
     const {
       config,
@@ -67,17 +55,16 @@ export class MaterialRadioGroupControl extends Control<
     const isValid = errors.length === 0;
     const mergedConfig = merge({}, config, this.props.uischema.options);
     const trim = mergedConfig.trim;
-    const showDescription = !isDescriptionHidden(
-      visible,
-      description,
-      this.state.isFocused
-    );
+    const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused);
 
     const options = schema.enum;
 
     return (
       <Hidden xsUp={!visible}>
-        <FormControl component={'fieldset' as 'div'} fullWidth={!trim}>
+        <FormControl
+          component={'fieldset' as 'div'}
+          fullWidth={!trim}
+        >
           <FormLabel
             htmlFor={id}
             error={!isValid}
@@ -104,7 +91,11 @@ export class MaterialRadioGroupControl extends Control<
             ))}
           </RadioGroup>
           <FormHelperText error={!isValid}>
-            {!isValid ? errors : showDescription ? description : null}
+            {!isValid
+              ? errors
+              : showDescription
+                ? description
+                : null}
           </FormHelperText>
         </FormControl>
       </Hidden>
@@ -112,11 +103,5 @@ export class MaterialRadioGroupControl extends Control<
   }
 }
 
-export const materialRadioGroupControlTester: RankedTester = rankWith(
-  2,
-  optionIs('format', 'radio')
-);
-export default connect(
-  mapStateToControlProps,
-  mapDispatchToControlProps
-)(MaterialRadioGroupControl);
+export const materialRadioGroupControlTester: RankedTester = rankWith(2, optionIs('format', 'radio'));
+export default withJsonFormsControlProps(MaterialRadioGroupControl);

--- a/packages/material/src/controls/MaterialSliderControl.tsx
+++ b/packages/material/src/controls/MaterialSliderControl.tsx
@@ -23,7 +23,6 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { connect } from 'react-redux';
 import {
   computeLabel,
   ControlProps,
@@ -31,12 +30,10 @@ import {
   isDescriptionHidden,
   isPlainLabel,
   isRangeControl,
-  mapDispatchToControlProps,
-  mapStateToControlProps,
   RankedTester,
   rankWith
 } from '@jsonforms/core';
-import { Control } from '@jsonforms/react';
+import { Control, withJsonFormsControlProps } from '@jsonforms/react';
 
 import { FormControl, FormHelperText, Hidden, Typography } from '@material-ui/core';
 import Slider from '@material-ui/lab/Slider';
@@ -119,6 +116,5 @@ export class MaterialSliderControl extends Control<ControlProps, ControlState> {
   }
 }
 export const materialSliderControlTester: RankedTester = rankWith(4, isRangeControl);
-export default connect(
-  mapStateToControlProps, mapDispatchToControlProps
-)(MaterialSliderControl);
+
+export default withJsonFormsControlProps(MaterialSliderControl);

--- a/packages/material/src/controls/MaterialTextControl.tsx
+++ b/packages/material/src/controls/MaterialTextControl.tsx
@@ -25,33 +25,20 @@
 import React from 'react';
 import {
   ControlProps,
-  ControlState,
   isStringControl,
-  mapDispatchToControlProps,
-  mapStateToControlProps,
   RankedTester,
   rankWith
 } from '@jsonforms/core';
-import { connect } from 'react-redux';
+import { withJsonFormsControlProps } from '@jsonforms/react';
 import { MuiInputText } from '../mui-controls/MuiInputText';
 import { MaterialInputControl } from './MaterialInputControl';
-import { Control } from '@jsonforms/react';
 
-export class MaterialTextControl extends Control<ControlProps, ControlState> {
-  render() {
-    return (
-      <MaterialInputControl
-        {...this.props}
-        input={MuiInputText}
-      />
-    );
-  }
-}
+export const MaterialTextControl = (props: ControlProps) => (
+  <MaterialInputControl {...props} input={MuiInputText} />
+);
+
 export const materialTextControlTester: RankedTester = rankWith(
   1,
   isStringControl
 );
-export default connect(
-  mapStateToControlProps,
-  mapDispatchToControlProps
-)(MaterialTextControl);
+export default withJsonFormsControlProps(MaterialTextControl);

--- a/packages/material/src/layouts/MaterialArrayLayoutRenderer.tsx
+++ b/packages/material/src/layouts/MaterialArrayLayoutRenderer.tsx
@@ -22,50 +22,40 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import {
   ArrayLayoutProps,
   isObjectArrayWithNesting,
-  mapDispatchToArrayControlProps,
-  mapStateToArrayLayoutProps,
   RankedTester,
   rankWith
 } from '@jsonforms/core';
-import { MaterialArrayLayout } from './MaterialArrayLayout';
-import { connect } from 'react-redux';
 import { Hidden } from '@material-ui/core';
+import { MaterialArrayLayout } from './MaterialArrayLayout';
+import { withJsonFormsArrayLayoutProps } from '@jsonforms/react';
 
-export class MaterialArrayLayoutRenderer extends React.Component<ArrayLayoutProps, any> {
-  addItem = (path: string, value: any) => this.props.addItem(path, value);
-  render() {
+export const MaterialArrayLayoutRenderer =
+  ({ visible, enabled, id, uischema, schema, label, rootSchema, renderers, data, path, errors, addItem }: ArrayLayoutProps) => {
+    const addItemCb = useCallback((p: string, value: any) => addItem(p, value), [addItem]);
     return (
-      <Hidden xsUp={!this.props.visible}>
+      <Hidden xsUp={!visible}>
         <MaterialArrayLayout
-          label={this.props.label}
-          uischema={this.props.uischema}
-          schema={this.props.schema}
-          id={this.props.id}
-          rootSchema={this.props.rootSchema}
-          errors={this.props.errors}
-          enabled={this.props.enabled}
-          visible={this.props.visible}
-          data={this.props.data}
-          path={this.props.path}
-          addItem={this.addItem}
-          renderers={this.props.renderers}
+          label={label}
+          uischema={uischema}
+          schema={schema}
+          id={id}
+          rootSchema={rootSchema}
+          errors={errors}
+          enabled={enabled}
+          visible={visible}
+          data={data}
+          path={path}
+          addItem={addItemCb}
+          renderers={renderers}
         />
       </Hidden>
     );
-  }
-}
-
-const ConnectedMaterialArrayLayoutRenderer = connect(
-  mapStateToArrayLayoutProps,
-  mapDispatchToArrayControlProps
-)(MaterialArrayLayoutRenderer);
-
-export default ConnectedMaterialArrayLayoutRenderer;
-ConnectedMaterialArrayLayoutRenderer.displayName = 'MaterialArrayLayoutRenderer';
+  };
 
 export const materialArrayLayoutTester: RankedTester = rankWith(4, isObjectArrayWithNesting);
+export default withJsonFormsArrayLayoutProps(MaterialArrayLayoutRenderer);

--- a/packages/material/src/layouts/MaterialGroupLayout.tsx
+++ b/packages/material/src/layouts/MaterialGroupLayout.tsx
@@ -24,28 +24,41 @@
 */
 import isEmpty from 'lodash/isEmpty';
 import React from 'react';
-import { connect } from 'react-redux';
 import { Card, CardContent, CardHeader, Hidden } from '@material-ui/core';
 import {
   GroupLayout,
-  mapStateToLayoutProps,
+  LayoutProps,
   RankedTester,
   rankWith,
-  StatePropsOfLayout,
   uiTypeIs,
-  withIncreasedRank
+  withIncreasedRank,
 } from '@jsonforms/core';
 import {
   MaterialLayoutRenderer,
   MaterialLayoutRendererProps
 } from '../util/layout';
+import { withJsonFormsLayoutProps } from '@jsonforms/react';
 
 export const groupTester: RankedTester = rankWith(1, uiTypeIs('Group'));
-
 const style: { [x: string]: any } = { marginBottom: '10px' };
-export const MaterializedGroupLayoutRenderer = (props: StatePropsOfLayout) => {
-  const { uischema, schema, path, visible, renderers } = props;
 
+const GroupComponent = React.memo(({ visible, uischema, ...props }: MaterialLayoutRendererProps) => {
+  const groupLayout = uischema as GroupLayout;
+  return (
+    <Hidden xsUp={!visible}>
+      <Card style={style}>
+        {!isEmpty(groupLayout.label) && (
+          <CardHeader title={groupLayout.label} />
+        )}
+        <CardContent>
+          <MaterialLayoutRenderer {...props} visible={visible} elements={groupLayout.elements} />
+        </CardContent>
+      </Card>
+    </Hidden>
+  );
+});
+
+export const MaterializedGroupLayoutRenderer = ({ uischema, schema, path, visible, renderers }: LayoutProps) => {
   const groupLayout = uischema as GroupLayout;
 
   return (
@@ -61,24 +74,7 @@ export const MaterializedGroupLayoutRenderer = (props: StatePropsOfLayout) => {
   );
 };
 
-const GroupComponent = React.memo((props: MaterialLayoutRendererProps) => {
-  const { visible, uischema } = props;
-  const groupLayout = uischema as GroupLayout;
-  return (
-    <Hidden xsUp={!visible}>
-      <Card style={style}>
-        {!isEmpty(groupLayout.label) && (
-          <CardHeader title={groupLayout.label} />
-        )}
-        <CardContent>
-          <MaterialLayoutRenderer {...props} />
-        </CardContent>
-      </Card>
-    </Hidden>
-  );
-});
-
-export default connect(mapStateToLayoutProps)(MaterializedGroupLayoutRenderer);
+export default withJsonFormsLayoutProps(MaterializedGroupLayoutRenderer);
 
 export const materialGroupTester: RankedTester = withIncreasedRank(
   1,

--- a/packages/material/src/layouts/MaterialHorizontalLayout.tsx
+++ b/packages/material/src/layouts/MaterialHorizontalLayout.tsx
@@ -23,16 +23,18 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { connect } from 'react-redux';
 import {
   HorizontalLayout,
-  mapStateToLayoutProps,
+  LayoutProps,
   RankedTester,
   rankWith,
-  StatePropsOfLayout,
-  uiTypeIs
+  uiTypeIs,
 } from '@jsonforms/core';
-import { MaterialLayoutRenderer, MaterialLayoutRendererProps } from '../util/layout';
+import { withJsonFormsLayoutProps } from '@jsonforms/react';
+import {
+  MaterialLayoutRenderer,
+  MaterialLayoutRendererProps
+} from '../util/layout';
 
 /**
  * Default tester for a horizontal layout.
@@ -43,11 +45,10 @@ export const materialHorizontalLayoutTester: RankedTester = rankWith(
   uiTypeIs('HorizontalLayout')
 );
 
-export const MaterialHorizontalLayoutRenderer = (
-  { schema, uischema, path, visible, renderers }: StatePropsOfLayout) => {
-  const horizontalLayout = uischema as HorizontalLayout;
+export const MaterialHorizontalLayoutRenderer = ({ uischema, renderers, schema, path, visible }: LayoutProps) => {
+  const layout = uischema as HorizontalLayout;
   const childProps: MaterialLayoutRendererProps = {
-    elements: horizontalLayout.elements,
+    elements: layout.elements,
     schema,
     path,
     direction: 'row',
@@ -57,7 +58,4 @@ export const MaterialHorizontalLayoutRenderer = (
   return <MaterialLayoutRenderer {...childProps} renderers={renderers} />;
 };
 
-const ConnectedMaterialHorizontalLayoutRendered = connect(
-  mapStateToLayoutProps
-)(MaterialHorizontalLayoutRenderer);
-export default ConnectedMaterialHorizontalLayoutRendered;
+export default withJsonFormsLayoutProps(MaterialHorizontalLayoutRenderer);

--- a/packages/material/src/layouts/MaterialVerticalLayout.tsx
+++ b/packages/material/src/layouts/MaterialVerticalLayout.tsx
@@ -23,25 +23,29 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { connect } from 'react-redux';
 import {
-  mapStateToLayoutProps,
+  LayoutProps,
   RankedTester,
   rankWith,
-  StatePropsOfLayout,
   uiTypeIs,
-  VerticalLayout
+  VerticalLayout,
 } from '@jsonforms/core';
-import { MaterialLayoutRenderer, MaterialLayoutRendererProps } from '../util/layout';
+import {
+  MaterialLayoutRenderer,
+  MaterialLayoutRendererProps
+} from '../util/layout';
+import { withJsonFormsLayoutProps } from '@jsonforms/react';
 
 /**
  * Default tester for a vertical layout.
  * @type {RankedTester}
  */
-export const materialVerticalLayoutTester: RankedTester = rankWith(1, uiTypeIs('VerticalLayout'));
+export const materialVerticalLayoutTester: RankedTester = rankWith(
+  1,
+  uiTypeIs('VerticalLayout')
+);
 
-export const MaterialVerticalLayoutRenderer  = (
-  { schema, uischema, path, visible, renderers }: StatePropsOfLayout) => {
+export const MaterialVerticalLayoutRenderer = ({ uischema, schema, path, visible, renderers }: LayoutProps) => {
   const verticalLayout = uischema as VerticalLayout;
   const childProps: MaterialLayoutRendererProps = {
     elements: verticalLayout.elements,
@@ -54,6 +58,4 @@ export const MaterialVerticalLayoutRenderer  = (
   return <MaterialLayoutRenderer {...childProps} renderers={renderers} />;
 };
 
-export default connect(
-  mapStateToLayoutProps
-)(MaterialVerticalLayoutRenderer);
+export default withJsonFormsLayoutProps(MaterialVerticalLayoutRenderer);

--- a/packages/material/src/util/layout.tsx
+++ b/packages/material/src/util/layout.tsx
@@ -25,47 +25,55 @@
 import isEmpty from 'lodash/isEmpty';
 import React from 'react';
 import {
-    JsonFormsRendererRegistryEntry,
-    JsonSchema,
-    OwnPropsOfRenderer,
+  JsonFormsRendererRegistryEntry,
+  JsonSchema,
+  OwnPropsOfRenderer,
   UISchemaElement
 } from '@jsonforms/core';
-import { ResolvedJsonForms } from '@jsonforms/react';
+import { JsonFormsDispatch } from '@jsonforms/react';
 import { Grid, Hidden } from '@material-ui/core';
 
 export const renderLayoutElements = (
-    elements: UISchemaElement[],
-    schema: JsonSchema,
-    path: string,
-    renderers?: JsonFormsRendererRegistryEntry[]
-  ) =>
-  elements.map((child, index) =>
-      (
-        <Grid item key={`${path}-${index}`} xs>
-          <ResolvedJsonForms
-            uischema={child}
-            schema={schema}
-            path={path}
-            renderers={renderers}
-          />
-        </Grid>
-      )
-  );
+  elements: UISchemaElement[],
+  schema: JsonSchema,
+  path: string,
+  renderers?: JsonFormsRendererRegistryEntry[]
+) => {
+  return elements.map((child, index) => (
+    <Grid item key={`${path}-${index}`} xs>
+      <JsonFormsDispatch
+        uischema={child}
+        schema={schema}
+        path={path}
+        renderers={renderers}
+      />
+    </Grid>
+  ));
+};
 
 export interface MaterialLayoutRendererProps extends OwnPropsOfRenderer {
-    elements: UISchemaElement[];
-    direction: 'row'|'column';
-    renderers?: JsonFormsRendererRegistryEntry[];
+  elements: UISchemaElement[];
+  direction: 'row' | 'column';
+  renderers?: JsonFormsRendererRegistryEntry[];
 }
-export const MaterialLayoutRenderer = (
-  {visible, elements, schema, path, direction, renderers }: MaterialLayoutRendererProps) => {
-
+export const MaterialLayoutRenderer = ({
+  visible,
+  elements,
+  schema,
+  path,
+  direction,
+  renderers
+}: MaterialLayoutRendererProps) => {
   if (isEmpty(elements)) {
     return null;
   } else {
     return (
       <Hidden xsUp={!visible}>
-        <Grid container direction={direction} spacing={direction === 'row' ? 16 : 0}>
+        <Grid
+          container
+          direction={direction}
+          spacing={direction === 'row' ? 16 : 0}
+        >
           {renderLayoutElements(elements, schema, path, renderers)}
         </Grid>
       </Hidden>

--- a/packages/material/test/renderers/MaterialAllOfRenderer.test.tsx
+++ b/packages/material/test/renderers/MaterialAllOfRenderer.test.tsx
@@ -23,13 +23,14 @@
   THE SOFTWARE.
 */
 import React, { Reducer } from 'react';
-import { Provider } from 'react-redux';
 
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { Actions, ControlElement, jsonformsReducer, JsonFormsState } from '@jsonforms/core';
 import { MaterialAllOfRenderer, materialRenderers } from '../../src';
 import { AnyAction, combineReducers, createStore, Store } from 'redux';
+import { JsonFormsReduxContext } from '@jsonforms/react';
+import { Provider } from 'react-redux';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -75,10 +76,15 @@ describe('Material allOf renderer', () => {
       label: 'Value',
       scope: '#/properties/value'
     };
-    store.dispatch(Actions.init({data: undefined}, schema, uischema));
+    store.dispatch(Actions.init({ data: undefined }, schema, uischema));
     wrapper = mount(
       <Provider store={store}>
-        <MaterialAllOfRenderer schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialAllOfRenderer
+            schema={schema}
+            uischema={uischema}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const inputs = wrapper.find('input');
@@ -109,10 +115,16 @@ describe('Material allOf renderer', () => {
       label: 'Value',
       scope: '#/properties/value'
     };
-    store.dispatch(Actions.init({data: undefined}, schema, uischema));
+    store.dispatch(Actions.init({ data: undefined }, schema, uischema));
     wrapper = mount(
       <Provider store={store}>
-        <MaterialAllOfRenderer schema={schema} uischema={uischema} visible={false}/>
+        <JsonFormsReduxContext>
+          <MaterialAllOfRenderer
+            schema={schema}
+            uischema={uischema}
+            visible={false}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const inputs = wrapper.find('input');

--- a/packages/material/test/renderers/MaterialAnyOfRenderer.test.tsx
+++ b/packages/material/test/renderers/MaterialAnyOfRenderer.test.tsx
@@ -30,7 +30,7 @@ import Adapter from 'enzyme-adapter-react-16';
 import { Actions, ControlElement, getData, jsonformsReducer, JsonFormsState } from '@jsonforms/core';
 import { MaterialAnyOfRenderer, materialCells, materialRenderers } from '../../src';
 import { AnyAction, combineReducers, createStore, Reducer, Store } from 'redux';
-import { JsonForms } from '@jsonforms/react';
+import { JsonFormsReduxContext, JsonFormsDispatch } from '@jsonforms/react';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -93,14 +93,16 @@ describe('Material anyOf renderer', () => {
       label: 'Value',
       scope: '#/properties/value'
     };
-    store.dispatch(Actions.init({data: undefined}, schema, uischema));
+    store.dispatch(Actions.init({ data: undefined }, schema, uischema));
     wrapper = mount(
       <Provider store={store}>
-        <MaterialAnyOfRenderer schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialAnyOfRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
-    input.simulate('change', { target: { value: 'test' }});
+    input.simulate('change', { target: { value: 'test' } });
     wrapper.update();
     expect(store.getState().jsonforms.core.data).toEqual({
       value: 'test'
@@ -159,7 +161,9 @@ describe('Material anyOf renderer', () => {
 
     wrapper = mount(
       <Provider store={store}>
-        <JsonForms schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <JsonFormsDispatch schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -227,11 +231,13 @@ describe('Material anyOf renderer', () => {
     };
 
     const store = initStore();
-    store.dispatch(Actions.init( {}, schema, uischema));
+    store.dispatch(Actions.init({}, schema, uischema));
 
     wrapper = mount(
       <Provider store={store}>
-        <JsonForms schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <JsonFormsDispatch schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -241,15 +247,15 @@ describe('Material anyOf renderer', () => {
 
     selectanyOfTab(wrapper, 1);
     clickAddButton(wrapper, 1);
-    wrapper.find('input').first().simulate('change', { target: { value: 5 }});
+    wrapper.find('input').first().simulate('change', { target: { value: 5 } });
     wrapper.update();
     selectanyOfTab(wrapper, 0);
 
     const input = wrapper.find('input').first();
-    input.simulate('change', { target: { value: 'test' }});
+    input.simulate('change', { target: { value: 'test' } });
     wrapper.update();
 
-    expect(getData(store.getState())).toEqual({ myThingsAndOrYourThings: [ {age: 5, name: 'test'} ]});
+    expect(getData(store.getState())).toEqual({ myThingsAndOrYourThings: [{ age: 5, name: 'test' }] });
 
   });
 
@@ -277,10 +283,16 @@ describe('Material anyOf renderer', () => {
       label: 'Value',
       scope: '#/properties/value'
     };
-    store.dispatch(Actions.init({data: undefined}, schema, uischema));
+    store.dispatch(Actions.init({ data: undefined }, schema, uischema));
     wrapper = mount(
       <Provider store={store}>
-        <MaterialAnyOfRenderer schema={schema} uischema={uischema} visible={false} />
+        <JsonFormsReduxContext>
+          <MaterialAnyOfRenderer
+            schema={schema}
+            uischema={uischema}
+            visible={false}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const inputs = wrapper.find('input');

--- a/packages/material/test/renderers/MaterialArrayControl.test.tsx
+++ b/packages/material/test/renderers/MaterialArrayControl.test.tsx
@@ -37,6 +37,7 @@ import { AnyAction, combineReducers, createStore, Reducer, Store } from 'redux';
 import { materialCells, materialRenderers } from '../../src';
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -103,22 +104,19 @@ export const initJsonFormsStore = (customData?: any): Store<JsonFormsState> => {
   const s: JsonFormsState = {
     jsonforms: {
       renderers: materialRenderers,
-      cells: materialCells
+      cells: materialCells,
     }
   };
-  const reducer: Reducer<JsonFormsState, AnyAction> = combineReducers({
-    jsonforms: jsonformsReducer()
-  });
+  const reducer: Reducer<JsonFormsState, AnyAction> = combineReducers({ jsonforms: jsonformsReducer() });
   const store: Store<JsonFormsState> = createStore(reducer, s);
   const { data, schema, uischema } = fixture;
-  store.dispatch(
-    Actions.init(customData ? customData : data, schema, uischema)
-  );
+  store.dispatch(Actions.init(customData ? customData : data, schema, uischema));
 
   return store;
 };
 
 describe('Material array control', () => {
+
   let wrapper: ReactWrapper;
 
   afterEach(() => wrapper.unmount());
@@ -127,10 +125,9 @@ describe('Material array control', () => {
     const store = initJsonFormsStore();
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayControlRenderer
-          schema={fixture.schema}
-          uischema={fixture.uischema}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayControlRenderer schema={fixture.schema} uischema={fixture.uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -144,10 +141,9 @@ describe('Material array control', () => {
 
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayControlRenderer
-          schema={fixture.schema}
-          uischema={fixture.uischema}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayControlRenderer schema={fixture.schema} uischema={fixture.uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -180,7 +176,9 @@ describe('Material array control', () => {
 
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayControlRenderer schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <MaterialArrayControlRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -214,7 +212,9 @@ describe('Material array control', () => {
 
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayControlRenderer schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <MaterialArrayControlRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -227,10 +227,9 @@ describe('Material array control', () => {
     const store = initJsonFormsStore();
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayControlRenderer
-          schema={fixture.schema}
-          uischema={fixture.uischema}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayControlRenderer schema={fixture.schema} uischema={fixture.uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -285,7 +284,9 @@ describe('Material array control', () => {
 
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayControlRenderer schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <MaterialArrayControlRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -337,11 +338,13 @@ describe('Material array control', () => {
 
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayControlRenderer
-          schema={schema}
-          uischema={uischema}
-          visible={false}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayControlRenderer
+            schema={schema}
+            uischema={uischema}
+            visible={false}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -357,10 +360,12 @@ describe('Material array control', () => {
     store.dispatch(Actions.init(data, fixture2.schema, fixture2.uischema));
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayControlRenderer
-          schema={fixture2.schema}
-          uischema={fixture2.uischema}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayControlRenderer
+            schema={fixture2.schema}
+            uischema={fixture2.uischema}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     // up button
@@ -379,13 +384,15 @@ describe('Material array control', () => {
     );
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayControlRenderer
-          schema={fixture2.schema}
-          uischema={fixture2.uischema}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayControlRenderer
+            schema={fixture2.schema}
+            uischema={fixture2.uischema}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
-    //first row is header in table
+    // first row is header in table
     const downButton = wrapper
       .find('tr')
       .at(1)
@@ -403,13 +410,15 @@ describe('Material array control', () => {
     );
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayControlRenderer
-          schema={fixture2.schema}
-          uischema={fixture2.uischema}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayControlRenderer
+            schema={fixture2.schema}
+            uischema={fixture2.uischema}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
-    //first row is header in table
+    // first row is header in table
     const upButton = wrapper
       .find('tr')
       .at(3)
@@ -427,13 +436,15 @@ describe('Material array control', () => {
     );
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayControlRenderer
-          schema={fixture2.schema}
-          uischema={fixture2.uischema}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayControlRenderer
+            schema={fixture2.schema}
+            uischema={fixture2.uischema}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
-    //first row is header in table
+    // first row is header in table
     const upButton = wrapper
       .find('tr')
       .at(1)
@@ -449,13 +460,15 @@ describe('Material array control', () => {
     );
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayControlRenderer
-          schema={fixture2.schema}
-          uischema={fixture2.uischema}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayControlRenderer
+            schema={fixture2.schema}
+            uischema={fixture2.uischema}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
-    //first row is header in table
+    // first row is header in table
     // first buttton is up arrow, second button is down arrow
     const downButton = wrapper
       .find('tr')

--- a/packages/material/test/renderers/MaterialArrayLayout.test.tsx
+++ b/packages/material/test/renderers/MaterialArrayLayout.test.tsx
@@ -39,6 +39,7 @@ import {
 } from '../../src/layouts';
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -178,7 +179,12 @@ describe('Material array layout', () => {
     const store = initJsonFormsStore();
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayLayout schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <MaterialArrayLayout
+            schema={schema}
+            uischema={uischema}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -191,10 +197,12 @@ describe('Material array layout', () => {
     const store = initJsonFormsStore();
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayLayout
-          schema={schema}
-          uischema={uischemaOptions.generate}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayLayout
+            schema={schema}
+            uischema={uischemaOptions.generate}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -207,10 +215,12 @@ describe('Material array layout', () => {
     const store = initJsonFormsStore();
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayLayout
-          schema={schema}
-          uischema={uischemaOptions.inline}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayLayout
+            schema={schema}
+            uischema={uischemaOptions.inline}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -223,11 +233,13 @@ describe('Material array layout', () => {
     const store = initJsonFormsStore();
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayLayout
-          schema={schema}
-          uischema={uischema}
-          visible={false}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayLayout
+            schema={schema}
+            uischema={uischema}
+            visible={false}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -240,11 +252,13 @@ describe('Material array layout', () => {
     const store = initJsonFormsStore();
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayLayout
-          schema={schema}
-          uischema={uischema}
-          renderers={[]}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayLayout
+            schema={schema}
+            uischema={uischema}
+            renderers={[]}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -260,7 +274,12 @@ describe('Material array layout', () => {
     const store = initJsonFormsStore();
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayLayout schema={schema} uischema={uischemaWithLabel} />
+        <JsonFormsReduxContext>
+          <MaterialArrayLayout
+            schema={schema}
+            uischema={uischemaWithLabel}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -289,10 +308,12 @@ describe('Material array layout', () => {
     store.dispatch(Actions.init(data, schema, uischemaWithSortOption));
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayLayout
-          schema={schema}
-          uischema={uischemaWithSortOption}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayLayout
+            schema={schema}
+            uischema={uischemaWithSortOption}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -318,10 +339,12 @@ describe('Material array layout', () => {
     store.dispatch(Actions.init(data, schema, uischemaWithSortOption));
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayLayout
-          schema={schema}
-          uischema={uischemaWithSortOption}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayLayout
+            schema={schema}
+            uischema={uischemaWithSortOption}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     // getting up button of second item in expension panel;
@@ -346,10 +369,12 @@ describe('Material array layout', () => {
     store.dispatch(Actions.init(data, schema, uischemaWithSortOption));
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayLayout
-          schema={schema}
-          uischema={uischemaWithSortOption}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayLayout
+            schema={schema}
+            uischema={uischemaWithSortOption}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     // getting up button of second item in expension panel;
@@ -374,10 +399,12 @@ describe('Material array layout', () => {
     store.dispatch(Actions.init(data, schema, uischemaWithSortOption));
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayLayout
-          schema={schema}
-          uischema={uischemaWithSortOption}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayLayout
+            schema={schema}
+            uischema={uischemaWithSortOption}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     // getting up button of second item in expension panel;
@@ -393,10 +420,12 @@ describe('Material array layout', () => {
     store.dispatch(Actions.init(data, schema, uischemaWithSortOption));
     wrapper = mount(
       <Provider store={store}>
-        <MaterialArrayLayout
-          schema={schema}
-          uischema={uischemaWithSortOption}
-        />
+        <JsonFormsReduxContext>
+          <MaterialArrayLayout
+            schema={schema}
+            uischema={uischemaWithSortOption}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     // getting up button of second item in expension panel;

--- a/packages/material/test/renderers/MaterialBooleanCell.test.tsx
+++ b/packages/material/test/renderers/MaterialBooleanCell.test.tsx
@@ -40,6 +40,7 @@ import { materialRenderers } from '../../src';
 
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -74,12 +75,12 @@ describe('Material boolean cell tester', () => {
   it('should fail', () => {
     expect(materialBooleanCellTester(undefined, undefined)).toBe(NOT_APPLICABLE);
     expect(materialBooleanCellTester(null, undefined)).toBe(NOT_APPLICABLE);
-    expect(materialBooleanCellTester({type: 'Foo'}, undefined)).toBe(NOT_APPLICABLE);
-    expect(materialBooleanCellTester({type: 'Control'}, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialBooleanCellTester({ type: 'Foo' }, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialBooleanCellTester({ type: 'Control' }, undefined)).toBe(NOT_APPLICABLE);
     expect(
       materialBooleanCellTester(
         control,
-        {type: 'object', properties: {foo: {type: 'string'}}}
+        { type: 'object', properties: { foo: { type: 'string' } } }
       )
     ).toBe(NOT_APPLICABLE);
     expect(
@@ -142,11 +143,13 @@ describe('Material boolean cell', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <BooleanCell
-          schema={schema}
-          uischema={control}
-          path='foo'
-        />
+        <JsonFormsReduxContext>
+          <BooleanCell
+            schema={schema}
+            uischema={control}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -164,11 +167,13 @@ describe('Material boolean cell', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <BooleanCell
-          schema={schema}
-          uischema={control}
-          path='foo'
-        />
+        <JsonFormsReduxContext>
+          <BooleanCell
+            schema={schema}
+            uischema={control}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -183,11 +188,13 @@ describe('Material boolean cell', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <BooleanCell
-          schema={schema}
-          uischema={uischema}
-          path='foo'
-        />
+        <JsonFormsReduxContext>
+          <BooleanCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -198,11 +205,13 @@ describe('Material boolean cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <BooleanCell
-          schema={schema}
-          uischema={uischema}
-          path='foo'
-        />
+        <JsonFormsReduxContext>
+          <BooleanCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -215,11 +224,13 @@ describe('Material boolean cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <BooleanCell
-          schema={schema}
-          uischema={uischema}
-          path='foo'
-        />
+        <JsonFormsReduxContext>
+          <BooleanCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -232,11 +243,13 @@ describe('Material boolean cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <BooleanCell
-          schema={schema}
-          uischema={uischema}
-          path='foo'
-        />
+        <JsonFormsReduxContext>
+          <BooleanCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('foo', () => false));
@@ -250,11 +263,13 @@ describe('Material boolean cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <BooleanCell
-          schema={schema}
-          uischema={uischema}
-          path='foo'
-        />
+        <JsonFormsReduxContext>
+          <BooleanCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('foo', () => undefined));
@@ -267,11 +282,13 @@ describe('Material boolean cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <BooleanCell
-          schema={schema}
-          uischema={uischema}
-          path='foo'
-        />
+        <JsonFormsReduxContext>
+          <BooleanCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('foo', () => null));
@@ -284,11 +301,13 @@ describe('Material boolean cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <BooleanCell
-          schema={schema}
-          uischema={uischema}
-          path='foo'
-        />
+        <JsonFormsReduxContext>
+          <BooleanCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -300,11 +319,13 @@ describe('Material boolean cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <BooleanCell
-          schema={schema}
-          uischema={uischema}
-          path='foo'
-        />
+        <JsonFormsReduxContext>
+          <BooleanCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>,
     );
     const input = wrapper.find('input').first();
@@ -316,11 +337,13 @@ describe('Material boolean cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <BooleanCell
-          schema={schema}
-          uischema={uischema}
-          path='foo'
-        />
+        <JsonFormsReduxContext>
+          <BooleanCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update(undefined, () => false));

--- a/packages/material/test/renderers/MaterialCategorizationLayout.test.tsx
+++ b/packages/material/test/renderers/MaterialCategorizationLayout.test.tsx
@@ -24,7 +24,6 @@
 */
 
 import React from 'react';
-import { Provider } from 'react-redux';
 import {
   Actions,
   Categorization,
@@ -36,6 +35,7 @@ import {
   RuleEffect,
   SchemaBasedCondition
 } from '@jsonforms/core';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 import Enzyme, { mount } from 'enzyme';
 
 import { AnyAction, combineReducers, createStore, Reducer, Store } from 'redux';
@@ -46,6 +46,7 @@ import MaterialCategorizationLayoutRenderer, {
 import { MaterialLayoutRenderer, materialRenderers } from '../../src';
 import { Tab } from '@material-ui/core';
 import Adapter from 'enzyme-adapter-react-16';
+import { Provider } from 'react-redux';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -89,8 +90,8 @@ describe('Material categorization layout tester', () => {
   it('should not fail when given undefined data', () => {
     expect(materialCategorizationTester(undefined, undefined)).toBe(-1);
     expect(materialCategorizationTester(null, undefined)).toBe(-1);
-    expect(materialCategorizationTester({type: 'Foo'}, undefined)).toBe(-1);
-    expect(materialCategorizationTester({type: 'Categorization'}, undefined)).toBe(-1);
+    expect(materialCategorizationTester({ type: 'Foo' }, undefined)).toBe(-1);
+    expect(materialCategorizationTester({ type: 'Categorization' }, undefined)).toBe(-1);
   });
 
   it('should not fail with null elements and no schema', () => {
@@ -122,7 +123,7 @@ describe('Material categorization layout tester', () => {
   });
 
   it('should succeed with a single category and no schema', () => {
-    const categorization =  {
+    const categorization = {
       type: 'Categorization',
       elements: [
         {
@@ -223,12 +224,14 @@ describe('Material categorization stepper layout', () => {
     const store = initJsonFormsStore(fixture);
     const wrapper = mount(
       <Provider store={store}>
-        <MaterialCategorizationLayoutRenderer
-          {...layoutDefaultProps}
-          schema={fixture.schema}
-          uischema={uischema}
-        />
-      </Provider>
+        <JsonFormsReduxContext>
+          <MaterialCategorizationLayoutRenderer
+            {...layoutDefaultProps}
+            schema={fixture.schema}
+            uischema={uischema}
+          />
+        </JsonFormsReduxContext>
+      </Provider >
     );
     const steps = wrapper.find(Tab);
     expect(steps.length).toBe(2);
@@ -236,7 +239,7 @@ describe('Material categorization stepper layout', () => {
   });
 
   it('should render on click', () => {
-    const data = {'name': 'Foo'};
+    const data = { 'name': 'Foo' };
     const nameControl: ControlElement = {
       type: 'Control',
       scope: '#/properties/name'
@@ -281,11 +284,13 @@ describe('Material categorization stepper layout', () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <MaterialCategorizationLayoutRenderer
-          {...layoutDefaultProps}
-          schema={fixture.schema}
-          uischema={uischema}
-        />
+        <JsonFormsReduxContext>
+          <MaterialCategorizationLayoutRenderer
+            {...layoutDefaultProps}
+            schema={fixture.schema}
+            uischema={uischema}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const beforeClick = wrapper.find(CategorizationLayoutRenderer).state().activeCategory;
@@ -302,12 +307,14 @@ describe('Material categorization stepper layout', () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <MaterialCategorizationLayoutRenderer
-          {...layoutDefaultProps}
-          schema={fixture.schema}
-          uischema={fixture.uischema}
-          visible={false}
-        />
+        <JsonFormsReduxContext>
+          <MaterialCategorizationLayoutRenderer
+            {...layoutDefaultProps}
+            schema={fixture.schema}
+            uischema={fixture.uischema}
+            visible={false}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -319,11 +326,13 @@ describe('Material categorization stepper layout', () => {
     const store = initJsonFormsStore(fixture);
     const wrapper = mount(
       <Provider store={store}>
-        <MaterialCategorizationLayoutRenderer
-          {...layoutDefaultProps}
-          schema={fixture.schema}
-          uischema={fixture.uischema}
-        />
+        <JsonFormsReduxContext>
+          <MaterialCategorizationLayoutRenderer
+            {...layoutDefaultProps}
+            schema={fixture.schema}
+            uischema={fixture.uischema}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -360,11 +369,13 @@ describe('Material categorization stepper layout', () => {
     const store = initJsonFormsStore(fixture);
     const wrapper = mount(
       <Provider store={store}>
-        <MaterialCategorizationLayoutRenderer
-          {...layoutDefaultProps}
-          schema={fixture.schema}
-          uischema={uischema}
-        />
+        <JsonFormsReduxContext>
+          <MaterialCategorizationLayoutRenderer
+            {...layoutDefaultProps}
+            schema={fixture.schema}
+            uischema={uischema}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -377,12 +388,14 @@ describe('Material categorization stepper layout', () => {
     const renderers: any[] = [];
     const wrapper = mount(
       <Provider store={store}>
-        <MaterialCategorizationLayoutRenderer
-          {...layoutDefaultProps}
-          schema={fixture.schema}
-          uischema={fixture.uischema}
-          renderers={renderers}
-        />
+        <JsonFormsReduxContext>
+          <MaterialCategorizationLayoutRenderer
+            {...layoutDefaultProps}
+            schema={fixture.schema}
+            uischema={fixture.uischema}
+            renderers={renderers}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 

--- a/packages/material/test/renderers/MaterialCategorizationStepperLayout.test.tsx
+++ b/packages/material/test/renderers/MaterialCategorizationStepperLayout.test.tsx
@@ -36,11 +36,11 @@ import {
   RuleEffect,
   SchemaBasedCondition
 } from '@jsonforms/core';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 import Enzyme, { mount } from 'enzyme';
 
 import { combineReducers, createStore, Store } from 'redux';
 import MaterialCategorizationStepperLayoutRenderer, {
-  MaterialCategorizationStepperLayoutRenderer as CategorizationStepperRenderer,
   materialCategorizationStepperTester
 } from '../../src/layouts/MaterialCategorizationStepperLayout';
 import { MaterialLayoutRenderer, materialRenderers } from '../../src';
@@ -88,8 +88,8 @@ describe('Material categorization stepper layout tester', () => {
   it('should not fail when given undefined data', () => {
     expect(materialCategorizationStepperTester(undefined, undefined)).toBe(-1);
     expect(materialCategorizationStepperTester(null, undefined)).toBe(-1);
-    expect(materialCategorizationStepperTester({type: 'Foo'}, undefined)).toBe(-1);
-    expect(materialCategorizationStepperTester({type: 'Categorization'}, undefined)).toBe(-1);
+    expect(materialCategorizationStepperTester({ type: 'Foo' }, undefined)).toBe(-1);
+    expect(materialCategorizationStepperTester({ type: 'Categorization' }, undefined)).toBe(-1);
   });
 
   it('should not fail with null elements and no schema', () => {
@@ -121,7 +121,7 @@ describe('Material categorization stepper layout tester', () => {
   });
 
   it('should not apply to a single category and no schema', () => {
-    const categorization =  {
+    const categorization = {
       type: 'Categorization',
       elements: [
         {
@@ -235,7 +235,7 @@ describe('Material categorization stepper layout', () => {
   });
 
   it('should render on click', () => {
-    const data = {'name': 'Foo'};
+    const data = { 'name': 'Foo' };
     const nameControl: ControlElement = {
       type: 'Control',
       scope: '#/properties/name'
@@ -280,16 +280,18 @@ describe('Material categorization stepper layout', () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <MaterialCategorizationStepperLayoutRenderer
-          {...layoutDefaultProps}
-          schema={fixture.schema}
-          uischema={uischema}
-        />
+        <JsonFormsReduxContext>
+          <MaterialCategorizationStepperLayoutRenderer
+            {...layoutDefaultProps}
+            schema={fixture.schema}
+            uischema={uischema}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
-    const beforeClick = wrapper.find(CategorizationStepperRenderer).state().activeCategory;
+    const beforeClick = wrapper.find(Stepper).props().activeStep;
     wrapper.find(StepButton).at(1).simulate('click');
-    const afterClick = wrapper.find(CategorizationStepperRenderer).state().activeCategory;
+    const afterClick = wrapper.find(Stepper).props().activeStep;
 
     expect(beforeClick).toBe(0);
     expect(afterClick).toBe(1);

--- a/packages/material/test/renderers/MaterialDateCell.test.tsx
+++ b/packages/material/test/renderers/MaterialDateCell.test.tsx
@@ -34,6 +34,7 @@ import {
   UISchemaElement,
   update
 } from '@jsonforms/core';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 import MaterialDateCell, {
   materialDateCellTester
 } from '../../src/cells/MaterialDateCell';
@@ -138,7 +139,13 @@ describe('Material date cell', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateCell schema={schema} uischema={control} path='foo' />
+        <JsonFormsReduxContext>
+          <MaterialDateCell
+            schema={schema}
+            uischema={control}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -156,7 +163,13 @@ describe('Material date cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateCell schema={schema} uischema={control} path='foo' />
+        <JsonFormsReduxContext>
+          <MaterialDateCell
+            schema={schema}
+            uischema={control}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -171,7 +184,13 @@ describe('Material date cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateCell schema={schema} uischema={control} path='foo' />
+        <JsonFormsReduxContext>
+          <MaterialDateCell
+            schema={schema}
+            uischema={control}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -182,7 +201,13 @@ describe('Material date cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <MaterialDateCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -195,7 +220,13 @@ describe('Material date cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <MaterialDateCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -207,7 +238,13 @@ describe('Material date cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <MaterialDateCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(update('foo', () => '1961-04-12'));
@@ -220,7 +257,13 @@ describe('Material date cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <MaterialDateCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(update('foo', () => null));
@@ -233,7 +276,13 @@ describe('Material date cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <MaterialDateCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(update('foo', () => undefined));
@@ -246,7 +295,13 @@ describe('Material date cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <MaterialDateCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -258,7 +313,13 @@ describe('Material date cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <MaterialDateCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(update(null, () => '1961-04-12'));
@@ -270,7 +331,13 @@ describe('Material date cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <MaterialDateCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -282,12 +349,14 @@ describe('Material date cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateCell
-          schema={schema}
-          uischema={uischema}
-          enabled={false}
-          path='foo'
-        />
+        <JsonFormsReduxContext>
+          <MaterialDateCell
+            schema={schema}
+            uischema={uischema}
+            enabled={false}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -298,7 +367,13 @@ describe('Material date cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <MaterialDateCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();

--- a/packages/material/test/renderers/MaterialDateControl.test.tsx
+++ b/packages/material/test/renderers/MaterialDateControl.test.tsx
@@ -40,6 +40,7 @@ import { materialRenderers } from '../../src';
 
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -76,15 +77,15 @@ describe('Material date control tester', () => {
   test('should fail', () => {
     expect(materialDateControlTester(undefined, undefined)).toBe(NOT_APPLICABLE);
     expect(materialDateControlTester(null, undefined)).toBe(NOT_APPLICABLE);
-    expect(materialDateControlTester({type: 'Foo'}, undefined)).toBe(NOT_APPLICABLE);
-    expect(materialDateControlTester({type: 'Control'}, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialDateControlTester({ type: 'Foo' }, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialDateControlTester({ type: 'Control' }, undefined)).toBe(NOT_APPLICABLE);
     expect(
       materialDateControlTester(
         uischema,
         {
           type: 'object',
           properties: {
-            foo: {type: 'string'},
+            foo: { type: 'string' },
           },
         },
       )
@@ -95,7 +96,7 @@ describe('Material date control tester', () => {
         {
           type: 'object',
           properties: {
-            foo: {type: 'string'},
+            foo: { type: 'string' },
             bar: {
               type: 'string',
               format: 'date',
@@ -141,7 +142,9 @@ describe('Material date control', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateControl schema={schema} uischema={control}/>
+        <JsonFormsReduxContext>
+          <MaterialDateControl schema={schema} uischema={control} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -159,7 +162,9 @@ describe('Material date control', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateControl schema={schema} uischema={control}/>
+        <JsonFormsReduxContext>
+          <MaterialDateControl schema={schema} uischema={control} />
+        </JsonFormsReduxContext>
       </Provider>,
     );
     const input = wrapper.find('input').first();
@@ -174,7 +179,9 @@ describe('Material date control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateControl schema={schema} uischema={control}/>
+        <JsonFormsReduxContext>
+          <MaterialDateControl schema={schema} uischema={control} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -185,7 +192,9 @@ describe('Material date control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -198,7 +207,9 @@ describe('Material date control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -210,7 +221,9 @@ describe('Material date control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('foo', () => '1961-04-12'));
@@ -223,7 +236,9 @@ describe('Material date control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>,
     );
     store.dispatch(Actions.update('foo', () => null));
@@ -236,7 +251,9 @@ describe('Material date control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('foo', () => undefined));
@@ -249,7 +266,9 @@ describe('Material date control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>,
     );
     store.dispatch(Actions.update('bar', () => 'Bar'));
@@ -262,7 +281,9 @@ describe('Material date control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update(null, () => '1961-04-12'));
@@ -275,7 +296,9 @@ describe('Material date control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update(undefined, () => '1961-04-12'));
@@ -288,7 +311,9 @@ describe('Material date control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateControl schema={schema} uischema={uischema} enabled={false}/>
+        <JsonFormsReduxContext>
+          <MaterialDateControl schema={schema} uischema={uischema} enabled={false} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -299,7 +324,9 @@ describe('Material date control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -310,7 +337,9 @@ describe('Material date control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateControl schema={schema} uischema={uischema} id='#/properties/foo'/>
+        <JsonFormsReduxContext>
+          <MaterialDateControl schema={schema} uischema={uischema} id='#/properties/foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -322,7 +351,9 @@ describe('Material date control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateControl schema={schema} uischema={uischema} visible={false}/>
+        <JsonFormsReduxContext>
+          <MaterialDateControl schema={schema} uischema={uischema} visible={false} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const inputs = wrapper.find('input');

--- a/packages/material/test/renderers/MaterialDateTimeControl.test.tsx
+++ b/packages/material/test/renderers/MaterialDateTimeControl.test.tsx
@@ -40,6 +40,7 @@ import { materialRenderers } from '../../src';
 
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -75,15 +76,15 @@ describe('Material date time control tester', () => {
   it('should fail', () => {
     expect(materialDateTimeControlTester(undefined, undefined)).toBe(NOT_APPLICABLE);
     expect(materialDateTimeControlTester(null, undefined)).toBe(NOT_APPLICABLE);
-    expect(materialDateTimeControlTester({type: 'Foo'}, undefined)).toBe(NOT_APPLICABLE);
-    expect(materialDateTimeControlTester({type: 'Control'}, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialDateTimeControlTester({ type: 'Foo' }, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialDateTimeControlTester({ type: 'Control' }, undefined)).toBe(NOT_APPLICABLE);
     expect(
       materialDateTimeControlTester(
         uischema,
         {
           type: 'object',
           properties: {
-            foo: {type: 'string'},
+            foo: { type: 'string' },
           },
         },
       )
@@ -94,7 +95,7 @@ describe('Material date time control tester', () => {
         {
           type: 'object',
           properties: {
-            foo: {type: 'string'},
+            foo: { type: 'string' },
             bar: {
               type: 'string',
               format: 'date-time',
@@ -142,7 +143,9 @@ describe('Material date time control', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateTimeControl schema={schema} uischema={control}/>
+        <JsonFormsReduxContext>
+          <MaterialDateTimeControl schema={schema} uischema={control} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -160,7 +163,9 @@ describe('Material date time control', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateTimeControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateTimeControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>,
     );
     const input = wrapper.find('input').first();
@@ -175,7 +180,9 @@ describe('Material date time control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateTimeControl schema={schema} uischema={control}/>
+        <JsonFormsReduxContext>
+          <MaterialDateTimeControl schema={schema} uischema={control} />
+        </JsonFormsReduxContext>
       </Provider>,
     );
     const input = wrapper.find('input').first();
@@ -186,7 +193,9 @@ describe('Material date time control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateTimeControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateTimeControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -199,7 +208,9 @@ describe('Material date time control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateTimeControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateTimeControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>,
     );
     const input = wrapper.find('input').first();
@@ -211,7 +222,9 @@ describe('Material date time control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateTimeControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateTimeControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>,
     );
     store.dispatch(Actions.update('foo', () => moment('1961-04-12 20:15').format()));
@@ -224,7 +237,9 @@ describe('Material date time control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateTimeControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateTimeControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('foo', () => null));
@@ -237,7 +252,9 @@ describe('Material date time control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateTimeControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateTimeControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('foo', () => undefined));
@@ -250,7 +267,9 @@ describe('Material date time control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateTimeControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateTimeControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>,
     );
     store.dispatch(Actions.update('bar', () => 'Bar'));
@@ -263,7 +282,9 @@ describe('Material date time control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateTimeControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateTimeControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update(null, () => '12.04.1961 20:15'));
@@ -276,7 +297,9 @@ describe('Material date time control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateTimeControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateTimeControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update(undefined, () => '12.04.1961 20:15'));
@@ -289,11 +312,13 @@ describe('Material date time control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateTimeControl
-          schema={schema}
-          uischema={uischema}
-          enabled={false}
-        />
+        <JsonFormsReduxContext>
+          <MaterialDateTimeControl
+            schema={schema}
+            uischema={uischema}
+            enabled={false}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -304,7 +329,9 @@ describe('Material date time control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateTimeControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <MaterialDateTimeControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>,
     );
     const input = wrapper.find('input').first();
@@ -315,7 +342,9 @@ describe('Material date time control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateTimeControl schema={schema} uischema={uischema} id='#/properties/foo'/>
+        <JsonFormsReduxContext>
+          <MaterialDateTimeControl schema={schema} uischema={uischema} id='#/properties/foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -327,7 +356,9 @@ describe('Material date time control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialDateTimeControl schema={schema} uischema={uischema} visible={false}/>
+        <JsonFormsReduxContext>
+          <MaterialDateTimeControl schema={schema} uischema={uischema} visible={false} />
+        </JsonFormsReduxContext>
       </Provider>,
     );
     const inputs = wrapper.find('input');

--- a/packages/material/test/renderers/MaterialEnumCell.test.tsx
+++ b/packages/material/test/renderers/MaterialEnumCell.test.tsx
@@ -40,6 +40,7 @@ import { AnyAction, combineReducers, createStore, Reducer, Store } from 'redux';
 
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -48,7 +49,7 @@ const schema = {
   type: 'string',
   enum: ['DE', 'IT', 'JP', 'US', 'RU', 'Other']
 };
-const uischema = {
+const uischema: ControlElement = {
   type: 'Control',
   scope: '#/properties/nationality'
 };
@@ -96,11 +97,13 @@ describe('Material enum cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     const wrapper = mount(
       <Provider store={store}>
-        <MaterialEnumCell
-          schema={schema}
-          uischema={uischema}
-          path='nationality'
-        />
+        <JsonFormsReduxContext>
+          <MaterialEnumCell
+            schema={schema}
+            uischema={uischema}
+            path='nationality'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input');

--- a/packages/material/test/renderers/MaterialInputControl.test.tsx
+++ b/packages/material/test/renderers/MaterialInputControl.test.tsx
@@ -44,11 +44,11 @@ import {
   rankWith,
   UISchemaElement
 } from '@jsonforms/core';
+import { Control, JsonFormsReduxContext } from '@jsonforms/react';
 import '../../src/cells';
 import { MaterialInputControl } from '../../src/controls/MaterialInputControl';
 import MaterialHorizontalLayoutRenderer from '../../src/layouts/MaterialHorizontalLayout';
 import { MuiInputText } from '../../src/mui-controls';
-import { Control } from '@jsonforms/react';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -105,7 +105,9 @@ describe('Material input control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TestControl schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <TestControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -132,7 +134,9 @@ describe('Material input control', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <TestControl schema={schema} uischema={control} />
+        <JsonFormsReduxContext>
+          <TestControl schema={schema} uischema={control} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -154,7 +158,9 @@ describe('Material input control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TestControl schema={schema} uischema={uischema} visible={false} />
+        <JsonFormsReduxContext>
+          <TestControl schema={schema} uischema={uischema} visible={false} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const inputs = wrapper.find('input');
@@ -165,7 +171,9 @@ describe('Material input control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TestControl schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <TestControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const control = wrapper.find('div').first();
@@ -176,7 +184,9 @@ describe('Material input control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TestControl schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <TestControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -189,7 +199,9 @@ describe('Material input control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TestControl schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <TestControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('foo', () => 3));
@@ -201,7 +213,9 @@ describe('Material input control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TestControl schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <TestControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const validation = wrapper.find('p').first();
@@ -212,7 +226,9 @@ describe('Material input control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TestControl schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <TestControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('foo', () => 3));
@@ -269,10 +285,12 @@ describe('Material input control', () => {
     );
     wrapper = mount(
       <Provider store={store}>
-        <MaterialHorizontalLayoutRenderer
-          schema={jsonSchema}
-          uischema={layout}
-        />
+        <JsonFormsReduxContext>
+          <MaterialHorizontalLayoutRenderer
+            schema={jsonSchema}
+            uischema={layout}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const validation = wrapper.find('p');
@@ -301,7 +319,9 @@ describe('Material input control', () => {
     const store = initJsonFormsStore({}, jsonSchema, control);
     wrapper = mount(
       <Provider store={store}>
-        <TestControl schema={jsonSchema} uischema={control} />
+        <JsonFormsReduxContext>
+          <TestControl schema={jsonSchema} uischema={control} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const label = wrapper.find('label').first();
@@ -326,7 +346,9 @@ describe('Material input control', () => {
     const store = initJsonFormsStore({}, jsonSchema, control);
     wrapper = mount(
       <Provider store={store}>
-        <TestControl schema={jsonSchema} uischema={control} />
+        <JsonFormsReduxContext>
+          <TestControl schema={jsonSchema} uischema={control} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const label = wrapper.find('label').first();

--- a/packages/material/test/renderers/MaterialIntegerCell.test.tsx
+++ b/packages/material/test/renderers/MaterialIntegerCell.test.tsx
@@ -42,6 +42,7 @@ import { AnyAction, combineReducers, createStore, Reducer, Store } from 'redux';
 
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -130,7 +131,9 @@ describe('Material integer cells', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <IntegerCell schema={schema} uischema={control} path='foo' />
+        <JsonFormsReduxContext>
+          <IntegerCell schema={schema} uischema={control} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -148,7 +151,9 @@ describe('Material integer cells', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <IntegerCell schema={schema} uischema={control} path='foo' />
+        <JsonFormsReduxContext>
+          <IntegerCell schema={schema} uischema={control} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input');
@@ -163,7 +168,9 @@ describe('Material integer cells', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <IntegerCell schema={schema} uischema={control} path='foo' />
+        <JsonFormsReduxContext>
+          <IntegerCell schema={schema} uischema={control} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -174,7 +181,9 @@ describe('Material integer cells', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -188,7 +197,9 @@ describe('Material integer cells', () => {
     const store = initJsonFormsStore({ foo: 0 }, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -202,7 +213,9 @@ describe('Material integer cells', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -215,7 +228,9 @@ describe('Material integer cells', () => {
     const store = initJsonFormsStore({ foo: 13 }, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('foo', () => 42));
@@ -228,7 +243,9 @@ describe('Material integer cells', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('foo', () => undefined));
@@ -241,7 +258,9 @@ describe('Material integer cells', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('foo', () => null));
@@ -254,7 +273,9 @@ describe('Material integer cells', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('bar', () => 11));
@@ -267,7 +288,9 @@ describe('Material integer cells', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update(null, () => 13));
@@ -280,7 +303,9 @@ describe('Material integer cells', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update(undefined, () => 13));
@@ -293,12 +318,14 @@ describe('Material integer cells', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <IntegerCell
-          schema={schema}
-          uischema={uischema}
-          enabled={false}
-          path='foo'
-        />
+        <JsonFormsReduxContext>
+          <IntegerCell
+            schema={schema}
+            uischema={uischema}
+            enabled={false}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -309,7 +336,9 @@ describe('Material integer cells', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <IntegerCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();

--- a/packages/material/test/renderers/MaterialLabelRenderer.test.tsx
+++ b/packages/material/test/renderers/MaterialLabelRenderer.test.tsx
@@ -40,6 +40,7 @@ import { materialRenderers } from '../../src';
 import { AnyAction, combineReducers, createStore, Reducer, Store } from 'redux';
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -85,6 +86,7 @@ describe('Material Label Renderer tester', () => {
 });
 
 describe('Material Label Renderer', () => {
+
   let wrapper: ReactWrapper;
 
   afterEach(() => wrapper.unmount());
@@ -93,7 +95,9 @@ describe('Material Label Renderer', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialLabelRenderer schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <MaterialLabelRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -105,11 +109,13 @@ describe('Material Label Renderer', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialLabelRenderer
-          schema={schema}
-          uischema={uischema}
-          visible={false}
-        />
+        <JsonFormsReduxContext>
+          <MaterialLabelRenderer
+            schema={schema}
+            uischema={uischema}
+            visible={false}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const labels = wrapper.find('h6');
@@ -120,7 +126,12 @@ describe('Material Label Renderer', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialLabelRenderer schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <MaterialLabelRenderer
+            schema={schema}
+            uischema={uischema}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const label = wrapper.find('h6').first();

--- a/packages/material/test/renderers/MaterialListWithDetailRenderer.test.tsx
+++ b/packages/material/test/renderers/MaterialListWithDetailRenderer.test.tsx
@@ -38,6 +38,8 @@ import MaterialListWithDetailRenderer, {
 } from '../../src/additional/MaterialListWithDetailRenderer';
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { JsonFormsReduxContext } from '@jsonforms/react';
+import { ListItem } from '@material-ui/core';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -148,7 +150,9 @@ describe('Material list with detail renderer', () => {
     const store = initJsonFormsStore();
     wrapper = mount(
       <Provider store={store}>
-        <MaterialListWithDetailRenderer schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <MaterialListWithDetailRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -159,7 +163,9 @@ describe('Material list with detail renderer', () => {
     const store = initJsonFormsStore([]);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialListWithDetailRenderer schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <MaterialListWithDetailRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -174,11 +180,13 @@ describe('Material list with detail renderer', () => {
     const store = initJsonFormsStore();
     wrapper = mount(
       <Provider store={store}>
-        <MaterialListWithDetailRenderer
-          schema={schema}
-          uischema={uischema}
-          visible={false}
-        />
+        <JsonFormsReduxContext>
+          <MaterialListWithDetailRenderer
+            schema={schema}
+            uischema={uischema}
+            visible={false}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -190,7 +198,9 @@ describe('Material list with detail renderer', () => {
     const store = initJsonFormsStore();
     wrapper = mount(
       <Provider store={store}>
-        <MaterialListWithDetailRenderer schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <MaterialListWithDetailRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -212,10 +222,9 @@ describe('Material list with detail renderer', () => {
     const store = initJsonFormsStore();
     wrapper = mount(
       <Provider store={store}>
-        <MaterialListWithDetailRenderer
-          schema={schema}
-          uischema={uischemaWithLabel}
-        />
+        <JsonFormsReduxContext>
+          <MaterialListWithDetailRenderer schema={schema} uischema={uischemaWithLabel} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -226,15 +235,14 @@ describe('Material list with detail renderer', () => {
   it('schema title for list', () => {
     const titleSchema = {
       ...schema,
-      title: 'My awesome title'
+      title: "My awesome title"
     };
     const store = initJsonFormsStore();
     wrapper = mount(
       <Provider store={store}>
-        <MaterialListWithDetailRenderer
-          schema={titleSchema}
-          uischema={uischema}
-        />
+        <JsonFormsReduxContext>
+          <MaterialListWithDetailRenderer schema={titleSchema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -246,7 +254,9 @@ describe('Material list with detail renderer', () => {
     const store = initJsonFormsStore();
     wrapper = mount(
       <Provider store={store}>
-        <MaterialListWithDetailRenderer schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <MaterialListWithDetailRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -264,12 +274,16 @@ describe('Material list with detail renderer', () => {
     const store = initJsonFormsStore();
     wrapper = mount(
       <Provider store={store}>
-        <MaterialListWithDetailRenderer schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <MaterialListWithDetailRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
     const addButton = wrapper.find('button').at(0);
     addButton.simulate('click');
+
+    wrapper.update();
 
     const lis = wrapper.find('li');
     expect(lis).toHaveLength(3);
@@ -279,14 +293,19 @@ describe('Material list with detail renderer', () => {
     const store = initJsonFormsStore();
     wrapper = mount(
       <Provider store={store}>
-        <MaterialListWithDetailRenderer schema={schema} uischema={uischema} />
-      </Provider>
+        <JsonFormsReduxContext>
+          <MaterialListWithDetailRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
+      </Provider >
     );
 
-    const addButton = wrapper.find('button').at(1);
-    addButton.simulate('click');
+    expect(wrapper.find(ListItem)).toHaveLength(2);
 
-    const lis = wrapper.find('li');
+    const removeButton = wrapper.find('button').at(1);
+    removeButton.simulate('click');
+    wrapper.update();
+
+    const lis = wrapper.find(ListItem);
     expect(lis).toHaveLength(1);
   });
 });

--- a/packages/material/test/renderers/MaterialNumberCell.test.tsx
+++ b/packages/material/test/renderers/MaterialNumberCell.test.tsx
@@ -41,6 +41,7 @@ import { materialRenderers } from '../../src';
 import { combineReducers, createStore, Store } from 'redux';
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -153,7 +154,9 @@ describe('Material number cells', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <NumberCell schema={schema} uischema={control} path='foo' />
+        <JsonFormsReduxContext>
+          <NumberCell schema={schema} uischema={control} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const inputs = wrapper.find('input');
@@ -171,7 +174,9 @@ describe('Material number cells', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <NumberCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <NumberCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const inputs = wrapper.find('input');
@@ -186,7 +191,9 @@ describe('Material number cells', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <NumberCell schema={schema} uischema={control} path='foo' />
+        <JsonFormsReduxContext>
+          <NumberCell schema={schema} uischema={control} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const inputs = wrapper.find('input');
@@ -205,7 +212,9 @@ describe('Material number cells', () => {
     const store = initJsonFormsStore({ foo: 3.14 }, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <NumberCell schema={jsonSchema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <NumberCell schema={jsonSchema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -227,7 +236,9 @@ describe('Material number cells', () => {
     const store = initJsonFormsStore({ foo: 0 }, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <NumberCell schema={jsonSchema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <NumberCell schema={jsonSchema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -241,7 +252,9 @@ describe('Material number cells', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <NumberCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <NumberCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input');
@@ -253,7 +266,9 @@ describe('Material number cells', () => {
     const store = initJsonFormsStore({ foo: 2.72 }, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <NumberCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <NumberCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -272,7 +287,9 @@ describe('Material number cells', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <NumberCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <NumberCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('foo', () => undefined));
@@ -285,7 +302,9 @@ describe('Material number cells', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <NumberCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <NumberCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('foo', () => null));
@@ -298,7 +317,9 @@ describe('Material number cells', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <NumberCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <NumberCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('bar', () => 11));
@@ -310,7 +331,9 @@ describe('Material number cells', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <NumberCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <NumberCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update(null, () => 2.72));
@@ -323,7 +346,9 @@ describe('Material number cells', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <NumberCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <NumberCell schema={schema} uischema={uischema} path='foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update(undefined, () => 13));

--- a/packages/material/test/renderers/MaterialObjectControl.test.tsx
+++ b/packages/material/test/renderers/MaterialObjectControl.test.tsx
@@ -32,12 +32,13 @@ import {
   UISchemaElement
 } from '@jsonforms/core';
 import * as React from 'react';
-import { Provider } from 'react-redux';
 import { AnyAction, combineReducers, createStore, Reducer, Store } from 'redux';
 import { materialRenderers } from '../../src';
 import MaterialObjectRenderer, { materialObjectControlTester } from '../../src/complex/MaterialObjectRenderer';
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { JsonFormsReduxContext } from '@jsonforms/react';
+import { Provider } from 'react-redux';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -137,8 +138,10 @@ describe('Material object control', () => {
     const store = initJsonFormsStore(data, schema, uischema1);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialObjectRenderer schema={schema} uischema={uischema1} />
-      </Provider>,
+        <JsonFormsReduxContext>
+          <MaterialObjectRenderer schema={schema} uischema={uischema1} />
+        </JsonFormsReduxContext>
+      </Provider>
     );
 
     const inputs = wrapper.find('input');
@@ -153,8 +156,10 @@ describe('Material object control', () => {
     const store = initJsonFormsStore(data, schema, uischema1);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialObjectRenderer schema={schema} uischema={uischema2} />
-      </Provider>,
+        <JsonFormsReduxContext>
+          <MaterialObjectRenderer schema={schema} uischema={uischema2} />
+        </JsonFormsReduxContext>
+      </Provider>
     );
 
     const inputs = wrapper.find('input');
@@ -167,8 +172,10 @@ describe('Material object control', () => {
     const store = initJsonFormsStore(data, schema, uischema2);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialObjectRenderer schema={schema} uischema={uischema2} />
-      </Provider>,
+        <JsonFormsReduxContext>
+          <MaterialObjectRenderer schema={schema} uischema={uischema2} />
+        </JsonFormsReduxContext>
+      </Provider>
     );
     const inputs = wrapper.find('input');
     expect(inputs.first().props().disabled).toBeFalsy();
@@ -178,7 +185,9 @@ describe('Material object control', () => {
     const store = initJsonFormsStore(data, schema, uischema2);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialObjectRenderer schema={schema} uischema={uischema2} visible={false} />
+        <JsonFormsReduxContext>
+          <MaterialObjectRenderer schema={schema} uischema={uischema2} visible={false} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const inputs = wrapper.find('input');
@@ -189,8 +198,10 @@ describe('Material object control', () => {
     const store = initJsonFormsStore(data, schema, uischema2);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialObjectRenderer schema={schema} uischema={uischema2} />
-      </Provider>,
+        <JsonFormsReduxContext>
+          <MaterialObjectRenderer schema={schema} uischema={uischema2} />
+        </JsonFormsReduxContext>
+      </Provider>
     );
     const inputs = wrapper.find('input');
     expect(inputs.first().props().hidden).toBeFalsy();

--- a/packages/material/test/renderers/MaterialOneOfRenderer.test.tsx
+++ b/packages/material/test/renderers/MaterialOneOfRenderer.test.tsx
@@ -31,7 +31,7 @@ import Adapter from 'enzyme-adapter-react-16';
 import { Actions, ControlElement, getData, jsonformsReducer, JsonFormsState } from '@jsonforms/core';
 import { materialCells, MaterialOneOfRenderer, materialRenderers } from '../../src';
 import { combineReducers, createStore, Store } from 'redux';
-import { JsonForms } from '@jsonforms/react';
+import { JsonFormsDispatch, JsonFormsReduxContext } from '@jsonforms/react';
 import { Tab } from '@material-ui/core';
 
 Enzyme.configure({ adapter: new Adapter() });
@@ -52,7 +52,7 @@ const initStore = () => {
 };
 
 const clickAddButton = (wrapper: ReactWrapper, times: number) => {
-// click add button
+  // click add button
   const buttons = wrapper.find('button');
   const addButton = buttons.at(2);
   for (let i = 0; i < times; i++) {
@@ -103,10 +103,12 @@ describe('Material oneOf renderer', () => {
       label: 'Value',
       scope: '#/properties/value'
     };
-    store.dispatch(Actions.init({data: undefined}, schema, uischema));
+    store.dispatch(Actions.init({ data: undefined }, schema, uischema));
     wrapper = mount(
       <Provider store={store}>
-        <MaterialOneOfRenderer schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <MaterialOneOfRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -137,10 +139,12 @@ describe('Material oneOf renderer', () => {
       label: 'Value',
       scope: '#/properties/value'
     };
-    store.dispatch(Actions.init({value: 5}, schema, uischema));
+    store.dispatch(Actions.init({ value: 5 }, schema, uischema));
     wrapper = mount(
       <Provider store={store}>
-        <MaterialOneOfRenderer schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <MaterialOneOfRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -158,7 +162,7 @@ describe('Material oneOf renderer', () => {
               title: 'String',
               type: 'object',
               properties: {
-                foo: {type: 'string'}
+                foo: { type: 'string' }
               },
               additionalProperties: false
             },
@@ -166,7 +170,7 @@ describe('Material oneOf renderer', () => {
               title: 'Number',
               type: 'object',
               properties: {
-                bar: {type: 'string'}
+                bar: { type: 'string' }
               },
               additionalProperties: false
             }
@@ -179,10 +183,12 @@ describe('Material oneOf renderer', () => {
       label: 'Value',
       scope: '#/properties/value'
     };
-    store.dispatch(Actions.init({value: {bar: 'bar'}}, schema, uischema));
+    store.dispatch(Actions.init({ value: { bar: 'bar' } }, schema, uischema));
     wrapper = mount(
       <Provider store={store}>
-        <MaterialOneOfRenderer schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <MaterialOneOfRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -200,7 +206,7 @@ describe('Material oneOf renderer', () => {
               title: 'String',
               type: 'object',
               properties: {
-                foo: {type: 'string'}
+                foo: { type: 'string' }
               },
               required: ['foo']
             },
@@ -208,7 +214,7 @@ describe('Material oneOf renderer', () => {
               title: 'Number',
               type: 'object',
               properties: {
-                bar: {type: 'string'}
+                bar: { type: 'string' }
               },
               required: ['bar']
             }
@@ -221,11 +227,13 @@ describe('Material oneOf renderer', () => {
       label: 'Value',
       scope: '#/properties/value'
     };
-    store.dispatch(Actions.init({value: {bar: 'bar'}}, schema, uischema));
+    store.dispatch(Actions.init({ value: { bar: 'bar' } }, schema, uischema));
     wrapper = mount(
       <Provider store={store}>
-        <MaterialOneOfRenderer schema={schema} uischema={uischema} />
-      </Provider>
+        <JsonFormsReduxContext>
+          <MaterialOneOfRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
+      </Provider >
     );
 
     const secondTab = wrapper.find(Tab).at(1);
@@ -256,14 +264,16 @@ describe('Material oneOf renderer', () => {
       label: 'Value',
       scope: '#/properties/value'
     };
-    store.dispatch(Actions.init({data: undefined}, schema, uischema));
+    store.dispatch(Actions.init({ data: undefined }, schema, uischema));
     wrapper = mount(
       <Provider store={store}>
-        <MaterialOneOfRenderer schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <MaterialOneOfRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
-    input.simulate('change', { target: { value: 'test' }});
+    input.simulate('change', { target: { value: 'test' } });
     wrapper.update();
     expect(store.getState().jsonforms.core.data).toEqual({
       value: 'test'
@@ -309,7 +319,9 @@ describe('Material oneOf renderer', () => {
 
     wrapper = mount(
       <Provider store={store}>
-        <JsonForms schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <JsonFormsDispatch schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -375,7 +387,9 @@ describe('Material oneOf renderer', () => {
 
     wrapper = mount(
       <Provider store={store}>
-        <JsonForms schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <JsonFormsDispatch schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -444,7 +458,9 @@ describe('Material oneOf renderer', () => {
 
     wrapper = mount(
       <Provider store={store}>
-        <JsonForms schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <JsonFormsDispatch schema={store.getState().jsonforms.core.schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -457,9 +473,9 @@ describe('Material oneOf renderer', () => {
     selectOneOfTab(wrapper, 0);
 
     const input = wrapper.find('input').first();
-    input.simulate('change', { target: { value: 'test' }});
+    input.simulate('change', { target: { value: 'test' } });
     wrapper.update();
-    expect(getData(store.getState())).toEqual({ thingOrThings: { thing: 'test' }});
+    expect(getData(store.getState())).toEqual({ thingOrThings: { thing: 'test' } });
   });
 
   it('should be hideable', () => {
@@ -486,10 +502,12 @@ describe('Material oneOf renderer', () => {
       label: 'Value',
       scope: '#/properties/value'
     };
-    store.dispatch(Actions.init({data: undefined}, schema, uischema));
+    store.dispatch(Actions.init({ data: undefined }, schema, uischema));
     wrapper = mount(
       <Provider store={store}>
-        <MaterialOneOfRenderer schema={schema} uischema={uischema} visible={false} />
+        <JsonFormsReduxContext>
+          <MaterialOneOfRenderer schema={schema} uischema={uischema} visible={false} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const inputs = wrapper.find('input');

--- a/packages/material/test/renderers/MaterialRadioGroupControl.test.tsx
+++ b/packages/material/test/renderers/MaterialRadioGroupControl.test.tsx
@@ -40,6 +40,7 @@ import { materialRenderers } from '../../src';
 import { AnyAction, combineReducers, createStore, Reducer, Store } from 'redux';
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 Enzyme.configure({ adapter: new Adapter() });
 
 const data = { foo: 'D' };
@@ -90,7 +91,9 @@ describe('Material radio group control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialRadioGroupControl schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <MaterialRadioGroupControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -108,7 +111,9 @@ describe('Material radio group control', () => {
 
     wrapper = mount(
       <Provider store={store}>
-        <MaterialRadioGroupControl schema={schema} uischema={uischema} />
+        <JsonFormsReduxContext>
+          <MaterialRadioGroupControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const currentlyChecked = wrapper.find('input[type="radio"][checked=true]');
@@ -120,11 +125,9 @@ describe('Material radio group control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <MaterialRadioGroupControl
-          schema={schema}
-          uischema={uischema}
-          visible={false}
-        />
+        <JsonFormsReduxContext>
+          <MaterialRadioGroupControl schema={schema} uischema={uischema} visible={false} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 

--- a/packages/material/test/renderers/MaterialSliderControl.test.tsx
+++ b/packages/material/test/renderers/MaterialSliderControl.test.tsx
@@ -40,10 +40,11 @@ import Slider from '@material-ui/lab/Slider';
 
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-const data = {'foo': 5};
+const data = { 'foo': 5 };
 const schema = {
   type: 'object',
   properties: {
@@ -80,8 +81,8 @@ describe('Material slider tester', () => {
   it('should fail', () => {
     expect(materialSliderControlTester(undefined, undefined)).toBe(NOT_APPLICABLE);
     expect(materialSliderControlTester(null, undefined)).toBe(NOT_APPLICABLE);
-    expect(materialSliderControlTester({type: 'Foo'}, undefined)).toBe(NOT_APPLICABLE);
-    expect(materialSliderControlTester({type: 'Control'}, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialSliderControlTester({ type: 'Foo' }, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialSliderControlTester({ type: 'Control' }, undefined)).toBe(NOT_APPLICABLE);
   });
 
   it('should fail with wrong schema type', () => {
@@ -91,7 +92,7 @@ describe('Material slider tester', () => {
         {
           type: 'object',
           properties: {
-            foo: {type: 'string'}
+            foo: { type: 'string' }
           }
         }
       )
@@ -105,8 +106,8 @@ describe('Material slider tester', () => {
         {
           type: 'object',
           properties: {
-            foo: {type: 'string'},
-            bar: {type: 'number'}
+            foo: { type: 'string' },
+            bar: { type: 'number' }
           }
         }
       )
@@ -120,7 +121,7 @@ describe('Material slider tester', () => {
         {
           type: 'object',
           properties: {
-            foo: {type: 'number'}
+            foo: { type: 'number' }
           }
         }
       )
@@ -239,7 +240,9 @@ describe('Material slider control', () => {
     const store = initJsonFormsStore({ foo: 5 }, jsonSchema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <SliderControl schema={jsonSchema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <SliderControl schema={jsonSchema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -251,7 +254,9 @@ describe('Material slider control', () => {
     const store = initJsonFormsStore({ foo: 3 }, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <SliderControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <SliderControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     let slider = wrapper.find(Slider).first();
@@ -278,7 +283,9 @@ describe('Material slider control', () => {
     const store = initJsonFormsStore({ foo: 6 }, schemaWithMultipleOf, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <SliderControl schema={schemaWithMultipleOf} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <SliderControl schema={schemaWithMultipleOf} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find(Slider).first();
@@ -289,7 +296,9 @@ describe('Material slider control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <SliderControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <SliderControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('foo', () => undefined));
@@ -302,7 +311,9 @@ describe('Material slider control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <SliderControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <SliderControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('foo', () => null));
@@ -315,7 +326,9 @@ describe('Material slider control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <SliderControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <SliderControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update('bar', () => 11));
@@ -328,7 +341,9 @@ describe('Material slider control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <SliderControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <SliderControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update(null, () => 3));
@@ -341,7 +356,9 @@ describe('Material slider control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <SliderControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <SliderControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(Actions.update(undefined, () => 13));
@@ -354,7 +371,9 @@ describe('Material slider control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <SliderControl schema={schema} uischema={uischema} enabled={false}/>
+        <JsonFormsReduxContext>
+          <SliderControl schema={schema} uischema={uischema} enabled={false} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find(Slider).first();
@@ -365,7 +384,9 @@ describe('Material slider control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <SliderControl schema={schema} uischema={uischema}/>
+        <JsonFormsReduxContext>
+          <SliderControl schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find(Slider).first();
@@ -376,7 +397,9 @@ describe('Material slider control', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <SliderControl schema={schema} uischema={uischema} id='#/properties/foo'/>
+        <JsonFormsReduxContext>
+          <SliderControl schema={schema} uischema={uischema} id='#/properties/foo' />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const divs = wrapper.find('div');
@@ -401,7 +424,9 @@ describe('Material slider control', () => {
     const store = initJsonFormsStore({ foo: 5 }, jsonSchema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <SliderControl schema={jsonSchema} uischema={uischema} visible={false}/>
+        <JsonFormsReduxContext>
+          <SliderControl schema={jsonSchema} uischema={uischema} visible={false} />
+        </JsonFormsReduxContext>
       </Provider>
     );
 

--- a/packages/material/test/renderers/MaterialTextCell.test.tsx
+++ b/packages/material/test/renderers/MaterialTextCell.test.tsx
@@ -41,13 +41,14 @@ import { combineReducers, createStore, Store } from 'redux';
 
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 
 Enzyme.configure({ adapter: new Adapter() });
 
 const DEFAULT_MAX_LENGTH = 524288;
 const DEFAULT_SIZE = 20;
 
-const data =  { 'name': 'Foo' };
+const data = { 'name': 'Foo' };
 const minLengthSchema = {
   type: 'string',
   minLength: 3
@@ -76,11 +77,11 @@ const initJsonFormsStore = (testData: any, testSchema: JsonSchema, testUiSchema:
 };
 
 describe('Material text cell tester', () => {
-  it('should fail', () =>  {
+  it('should fail', () => {
     expect(materialTextCellTester(undefined, undefined)).toBe(NOT_APPLICABLE);
     expect(materialTextCellTester(null, undefined)).toBe(NOT_APPLICABLE);
-    expect(materialTextCellTester({type: 'Foo'}, undefined)).toBe(NOT_APPLICABLE);
-    expect(materialTextCellTester({type: 'Control'}, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialTextCellTester({ type: 'Foo' }, undefined)).toBe(NOT_APPLICABLE);
+    expect(materialTextCellTester({ type: 'Control' }, undefined)).toBe(NOT_APPLICABLE);
   });
   it('should fail with wrong schema type', () => {
     const control: ControlElement = {
@@ -152,7 +153,7 @@ describe('Material text cell', () => {
 
   afterEach(() => wrapper.unmount());
 
-  it('should autofocus via option', () =>  {
+  it('should autofocus via option', () => {
     const control: ControlElement = {
       type: 'Control',
       scope: '#/properties/name',
@@ -172,7 +173,7 @@ describe('Material text cell', () => {
     expect(input.props().autoFocus).toBeTruthy();
   });
 
-  it('should not autofocus via option', () =>  {
+  it('should not autofocus via option', () => {
     const control: ControlElement = {
       type: 'Control',
       scope: '#/properties/name',
@@ -192,7 +193,7 @@ describe('Material text cell', () => {
     expect(input.props().autoFocus).toBeFalsy();
   });
 
-  it('should not autofocus by default', () =>  {
+  it('should not autofocus by default', () => {
     const control: ControlElement = {
       type: 'Control',
       scope: '#/properties/name'
@@ -211,7 +212,7 @@ describe('Material text cell', () => {
     expect(document.activeElement).not.toBe(input);
   });
 
-  it('should render', () =>  {
+  it('should render', () => {
     const jsonSchema: JsonSchema = {
       type: 'object',
       properties: {
@@ -221,11 +222,13 @@ describe('Material text cell', () => {
     const store = initJsonFormsStore({ 'name': 'Foo' }, minLengthSchema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TextCell
-          schema={jsonSchema}
-          uischema={uischema}
-          path={'name'}
-        />
+        <JsonFormsReduxContext>
+          <TextCell
+            schema={jsonSchema}
+            uischema={uischema}
+            path={'name'}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -233,15 +236,17 @@ describe('Material text cell', () => {
     expect(input.props().value).toBe('Foo');
   });
 
-  it('should update via input event', () =>  {
+  it('should update via input event', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TextCell
-          schema={minLengthSchema}
-          uischema={uischema}
-          path='name'
-        />
+        <JsonFormsReduxContext>
+          <TextCell
+            schema={minLengthSchema}
+            uischema={uischema}
+            path='name'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -250,15 +255,17 @@ describe('Material text cell', () => {
     expect(getData(store.getState()).name).toBe('Bar');
   });
 
-  it('should update via action', () =>  {
+  it('should update via action', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TextCell
-          schema={minLengthSchema}
-          uischema={uischema}
-          path='name'
-        />
+        <JsonFormsReduxContext>
+          <TextCell
+            schema={minLengthSchema}
+            uischema={uischema}
+            path='name'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(update('name', () => 'Bar'));
@@ -267,15 +274,17 @@ describe('Material text cell', () => {
     expect(input.props().value).toBe('Bar');
   });
 
-  it('should update with undefined value', () =>  {
+  it('should update with undefined value', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TextCell
-          schema={minLengthSchema}
-          uischema={uischema}
-          path='name'
-        />
+        <JsonFormsReduxContext>
+          <TextCell
+            schema={minLengthSchema}
+            uischema={uischema}
+            path='name'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(update('name', () => undefined));
@@ -284,15 +293,17 @@ describe('Material text cell', () => {
     expect(input.props().value).toBe('');
   });
 
-  it('should update with null value', () =>  {
+  it('should update with null value', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TextCell
-          schema={minLengthSchema}
-          uischema={uischema}
-          path='name'
-        />
+        <JsonFormsReduxContext>
+          <TextCell
+            schema={minLengthSchema}
+            uischema={uischema}
+            path='name'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(update('name', () => null));
@@ -301,15 +312,17 @@ describe('Material text cell', () => {
     expect(input.props().value).toBe('');
   });
 
-  it('should not update if wrong ref', () =>  {
+  it('should not update if wrong ref', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TextCell
-          schema={minLengthSchema}
-          uischema={uischema}
-          path='name'
-        />
+        <JsonFormsReduxContext>
+          <TextCell
+            schema={minLengthSchema}
+            uischema={uischema}
+            path='name'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(update('firstname', () => 'Bar'));
@@ -318,15 +331,17 @@ describe('Material text cell', () => {
     expect(input.props().value).toBe('Foo');
   });
 
-  it('should not update if null ref', () =>  {
+  it('should not update if null ref', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TextCell
-          schema={minLengthSchema}
-          uischema={uischema}
-          path='name'
-        />
+        <JsonFormsReduxContext>
+          <TextCell
+            schema={minLengthSchema}
+            uischema={uischema}
+            path='name'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(update(null, () => 'Bar'));
@@ -335,15 +350,17 @@ describe('Material text cell', () => {
     expect(input.props().value).toBe('Foo');
   });
 
-  it('should not update if undefined ref', () =>  {
+  it('should not update if undefined ref', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TextCell
-          schema={minLengthSchema}
-          uischema={uischema}
-          path='name'
-        />
+        <JsonFormsReduxContext>
+          <TextCell
+            schema={minLengthSchema}
+            uischema={uischema}
+            path='name'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(update(undefined, () => 'Bar'));
@@ -352,38 +369,42 @@ describe('Material text cell', () => {
     expect(input.props().value).toBe('Foo');
   });
 
-  it('can be disabled', () =>  {
+  it('can be disabled', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TextCell
-          schema={minLengthSchema}
-          uischema={uischema}
-          path='name'
-          enabled={false}
-        />
+        <JsonFormsReduxContext>
+          <TextCell
+            schema={minLengthSchema}
+            uischema={uischema}
+            path='name'
+            enabled={false}
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
     expect(input.props().disabled).toBeTruthy();
   });
 
-  it('should be enabled by default', () =>  {
+  it('should be enabled by default', () => {
     const store = initJsonFormsStore(data, minLengthSchema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TextCell
-          schema={minLengthSchema}
-          uischema={uischema}
-          path='name'
-        />
+        <JsonFormsReduxContext>
+          <TextCell
+            schema={minLengthSchema}
+            uischema={uischema}
+            path='name'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
     expect(input.props().disabled).toBeFalsy();
   });
 
-  it('should use maxLength for size and maxlength attributes', () =>  {
+  it('should use maxLength for size and maxlength attributes', () => {
     const control: ControlElement = {
       type: 'Control',
       scope: '#/properties/name',
@@ -395,11 +416,13 @@ describe('Material text cell', () => {
     const store = initJsonFormsStore(data, maxLengthSchema, control);
     wrapper = mount(
       <Provider store={store}>
-        <TextCell
-          schema={maxLengthSchema}
-          uischema={control}
-          path='name'
-        />
+        <JsonFormsReduxContext>
+          <TextCell
+            schema={maxLengthSchema}
+            uischema={control}
+            path='name'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -408,7 +431,7 @@ describe('Material text cell', () => {
     expect(input.props().size).toBe(5);
   });
 
-  it('should use maxLength for size attribute', () =>  {
+  it('should use maxLength for size attribute', () => {
     const control: ControlElement = {
       type: 'Control',
       scope: '#/properties/name',
@@ -417,11 +440,13 @@ describe('Material text cell', () => {
     const store = initJsonFormsStore(data, maxLengthSchema, control);
     wrapper = mount(
       <Provider store={store}>
-        <TextCell
-          schema={maxLengthSchema}
-          uischema={control}
-          path='name'
-        />
+        <JsonFormsReduxContext>
+          <TextCell
+            schema={maxLengthSchema}
+            uischema={control}
+            path='name'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first().getDOMNode() as HTMLInputElement;
@@ -432,7 +457,7 @@ describe('Material text cell', () => {
     expect(input.size).toBe(5);
   });
 
-  it('should use maxLength for maxlength attribute', () =>  {
+  it('should use maxLength for maxlength attribute', () => {
     const control: ControlElement = {
       type: 'Control',
       scope: '#/properties/name',
@@ -441,11 +466,13 @@ describe('Material text cell', () => {
     const store = initJsonFormsStore(data, maxLengthSchema, control);
     wrapper = mount(
       <Provider store={store}>
-        <TextCell
-          schema={maxLengthSchema}
-          uischema={control}
-          path='name'
-        />
+        <JsonFormsReduxContext>
+          <TextCell
+            schema={maxLengthSchema}
+            uischema={control}
+            path='name'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first().getDOMNode() as HTMLInputElement;
@@ -456,15 +483,17 @@ describe('Material text cell', () => {
     expect(input.size).toBe(DEFAULT_SIZE);
   });
 
-  it('should not use maxLength by default', () =>  {
+  it('should not use maxLength by default', () => {
     const store = initJsonFormsStore(data, maxLengthSchema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TextCell
-          schema={schema}
-          uischema={uischema}
-          path='name'
-        />
+        <JsonFormsReduxContext>
+          <TextCell
+            schema={schema}
+            uischema={uischema}
+            path='name'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first().getDOMNode() as HTMLInputElement;
@@ -475,7 +504,7 @@ describe('Material text cell', () => {
     expect(input.size).toBe(DEFAULT_SIZE);
   });
 
-  it('should have default values for trim and restrict', () =>  {
+  it('should have default values for trim and restrict', () => {
     const control: ControlElement = {
       type: 'Control',
       scope: '#/properties/name',
@@ -487,11 +516,13 @@ describe('Material text cell', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <TextCell
-          schema={schema}
-          uischema={control}
-          path='name'
-        />
+        <JsonFormsReduxContext>
+          <TextCell
+            schema={schema}
+            uischema={control}
+            path='name'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first().getDOMNode() as HTMLInputElement;
@@ -502,7 +533,7 @@ describe('Material text cell', () => {
     expect(input.size).toBe(DEFAULT_SIZE);
   });
 
-  it('should have a default value for trim', () =>  {
+  it('should have a default value for trim', () => {
     const control: ControlElement = {
       type: 'Control',
       scope: '#/properties/name',
@@ -511,11 +542,13 @@ describe('Material text cell', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <TextCell
-          schema={schema}
-          uischema={control}
-          path='name'
-        />
+        <JsonFormsReduxContext>
+          <TextCell
+            schema={schema}
+            uischema={control}
+            path='name'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -527,7 +560,7 @@ describe('Material text cell', () => {
     expect(input.size).toBe(DEFAULT_SIZE);
   });
 
-  it('should have default values for restrict', () =>  {
+  it('should have default values for restrict', () => {
     const control: ControlElement = {
       type: 'Control',
       scope: '#/properties/name',
@@ -536,11 +569,13 @@ describe('Material text cell', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <TextCell
-          schema={schema}
-          uischema={control}
-          path='name'
-        />
+        <JsonFormsReduxContext>
+          <TextCell
+            schema={schema}
+            uischema={control}
+            path='name'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -552,7 +587,7 @@ describe('Material text cell', () => {
     expect(input.size).toBe(DEFAULT_SIZE);
   });
 
-  it('should have default values for attributes', () =>  {
+  it('should have default values for attributes', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>

--- a/packages/material/test/renderers/MaterialTimeCell.test.tsx
+++ b/packages/material/test/renderers/MaterialTimeCell.test.tsx
@@ -43,6 +43,7 @@ import { materialRenderers } from '../../src';
 
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -145,7 +146,9 @@ describe('Material time cell', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <TimeCell schema={schema} uischema={control} />
+        <JsonFormsReduxContext>
+          <TimeCell schema={schema} uischema={control} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -163,7 +166,9 @@ describe('Material time cell', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <TimeCell schema={schema} uischema={control} />
+        <JsonFormsReduxContext>
+          <TimeCell schema={schema} uischema={control} />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -178,7 +183,11 @@ describe('Material time cell', () => {
     const store = initJsonFormsStore(data, schema, control);
     wrapper = mount(
       <Provider store={store}>
-        <TimeCell schema={schema} uischema={control} path='foo' />
+        <TimeCell
+          schema={schema}
+          uischema={control}
+          path='foo'
+        />
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -189,7 +198,13 @@ describe('Material time cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TimeCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <TimeCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
 
@@ -202,7 +217,13 @@ describe('Material time cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TimeCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <TimeCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -214,7 +235,13 @@ describe('Material time cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TimeCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <TimeCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(update('foo', () => '20:15'));
@@ -227,7 +254,13 @@ describe('Material time cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TimeCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <TimeCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(update('foo', () => null));
@@ -240,7 +273,13 @@ describe('Material time cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TimeCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <TimeCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(update('foo', () => undefined));
@@ -253,7 +292,13 @@ describe('Material time cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TimeCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <TimeCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(update('bar', () => 'Bar'));
@@ -266,7 +311,13 @@ describe('Material time cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TimeCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <TimeCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(update(null, () => '20:15'));
@@ -279,7 +330,13 @@ describe('Material time cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TimeCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <TimeCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     store.dispatch(update(undefined, () => '20:15'));
@@ -292,12 +349,14 @@ describe('Material time cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TimeCell
-          schema={schema}
-          uischema={uischema}
-          enabled={false}
-          path='foo'
-        />
+        <JsonFormsReduxContext>
+          <TimeCell
+            schema={schema}
+            uischema={uischema}
+            enabled={false}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();
@@ -308,7 +367,13 @@ describe('Material time cell', () => {
     const store = initJsonFormsStore(data, schema, uischema);
     wrapper = mount(
       <Provider store={store}>
-        <TimeCell schema={schema} uischema={uischema} path='foo' />
+        <JsonFormsReduxContext>
+          <TimeCell
+            schema={schema}
+            uischema={uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
       </Provider>
     );
     const input = wrapper.find('input').first();

--- a/packages/react/__mocks__/react.js
+++ b/packages/react/__mocks__/react.js
@@ -1,0 +1,2 @@
+const React = require('react')
+module.exports = Object.assign({}, React, { useEffect: React.useLayoutEffect })

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "@jsonforms/core": "^2.2.3",
-    "react": "^16.4.0",
+    "react": "^16.8.6",
     "react-redux": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/react/src/JsonFormsContext.tsx
+++ b/packages/react/src/JsonFormsContext.tsx
@@ -1,0 +1,311 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+import React, { ComponentType, Dispatch, ReducerAction, useContext, useEffect, useReducer } from 'react';
+import {
+  Actions,
+  ArrayLayoutProps,
+  CellProps,
+  ControlProps,
+  coreReducer,
+  DispatchPropsOfControl,
+  EnumCellProps,
+  JsonFormsCore,
+  JsonFormsState,
+  JsonFormsSubStates,
+  LayoutProps,
+  mapDispatchToArrayControlProps,
+  mapStateToAllOfProps,
+  mapStateToAnyOfProps,
+  mapStateToArrayControlProps,
+  mapStateToArrayLayoutProps,
+  mapStateToCellProps,
+  mapStateToControlProps,
+  mapStateToControlWithDetailProps,
+  mapStateToJsonFormsRendererProps,
+  mapStateToLayoutProps,
+  mapStateToMasterListItemProps,
+  mapStateToOneOfProps,
+  OwnPropsOfCell,
+  OwnPropsOfControl,
+  OwnPropsOfEnum,
+  OwnPropsOfEnumCell,
+  OwnPropsOfJsonFormsRenderer,
+  OwnPropsOfMasterListItem,
+  rendererReducer,
+  StatePropsOfCombinator,
+  StatePropsOfControlWithDetail,
+  StatePropsOfMasterItem,
+  update
+} from '@jsonforms/core';
+import { connect } from 'react-redux';
+
+const initialCoreState: JsonFormsCore = {
+  data: {},
+  schema: {},
+  uischema: undefined,
+  errors: [],
+  validator: () => true,
+  ajv: undefined,
+  refParserOptions: undefined
+};
+
+export interface JsonFormsStateContext extends JsonFormsSubStates {
+  dispatch?: Dispatch<ReducerAction<typeof coreReducer>>;
+}
+
+export const JsonFormsContext = React.createContext<JsonFormsStateContext>({
+  core: initialCoreState,
+  renderers: []
+});
+
+export const JsonFormsStateProvider = ({ children, initState }: any) => {
+  const [core, dispatch] = useReducer(coreReducer, initState.core);
+  const [renderers] = useReducer(rendererReducer, initState.renderers);
+  const { data, schema, uischema } = initState.core;
+  useEffect(() => {
+    dispatch(Actions.init(data, schema, uischema));
+  }, []);
+  return (
+    <JsonFormsContext.Provider
+      value={{
+        core,
+        renderers,
+        // only core dispatch available
+        dispatch
+      }}
+    >
+      {children}
+    </JsonFormsContext.Provider>
+  );
+};
+
+export const useJsonForms = (): JsonFormsStateContext =>
+  useContext(JsonFormsContext);
+
+export interface JsonFormsReduxContextProps extends JsonFormsSubStates {
+  children: any;
+  dispatch: Dispatch<ReducerAction<any>>;
+}
+
+const JsonFormsReduxProvider = ({ children, dispatch, ...other }: JsonFormsReduxContextProps) => {
+  return (
+    <JsonFormsContext.Provider
+      value={{
+        dispatch,
+        ...other
+      }}
+    >
+      {children}
+    </JsonFormsContext.Provider>
+  );
+};
+
+export const JsonFormsReduxContext = connect(
+  (state: JsonFormsState) => ({
+    ...state.jsonforms
+  })
+)(JsonFormsReduxProvider);
+
+export const ctxToArrayLayoutProps = (ctx: JsonFormsStateContext, props: OwnPropsOfControl) =>
+  mapStateToArrayLayoutProps({ jsonforms: { ...ctx } }, props);
+
+export const ctxToArrayControlProps = (ctx: JsonFormsStateContext, props: OwnPropsOfControl) =>
+  mapStateToArrayControlProps({ jsonforms: { ...ctx } }, props);
+
+export const ctxToLayoutProps = (ctx: JsonFormsStateContext, props: OwnPropsOfJsonFormsRenderer): LayoutProps =>
+  mapStateToLayoutProps({ jsonforms: { ...ctx } }, props);
+
+export const ctxToControlProps = (ctx: JsonFormsStateContext, props: OwnPropsOfControl) =>
+  mapStateToControlProps({ jsonforms: { ...ctx } }, props);
+
+export const ctxToControlWithDetailProps = (
+  ctx: JsonFormsStateContext,
+  props: OwnPropsOfControl
+): StatePropsOfControlWithDetail =>
+  mapStateToControlWithDetailProps({ jsonforms: { ...ctx } }, props);
+
+export const ctxToAllOfProps = (
+  ctx: JsonFormsStateContext,
+  ownProps: OwnPropsOfControl
+) => {
+  const props = mapStateToAllOfProps({ jsonforms: { ...ctx } }, ownProps);
+  return {
+    ...props
+  };
+};
+
+export const ctxDispatchToControlProps = (dispatch: Dispatch<ReducerAction<any>>): DispatchPropsOfControl => ({
+  handleChange(path, value) {
+    dispatch(update(path, () => value));
+  }
+});
+
+export const ctxToAnyOfProps = (
+  ctx: JsonFormsStateContext,
+  ownProps: OwnPropsOfControl
+) => {
+  const props = mapStateToAnyOfProps({ jsonforms: { ...ctx } }, ownProps);
+  const { handleChange } = ctxDispatchToControlProps(ctx.dispatch);
+  return {
+    ...props,
+    handleChange
+  };
+};
+
+export const ctxToOneOfProps = (
+  ctx: JsonFormsStateContext,
+  ownProps: OwnPropsOfControl
+): StatePropsOfCombinator & DispatchPropsOfControl => {
+  const props = mapStateToOneOfProps({ jsonforms: { ...ctx } }, ownProps);
+  const { handleChange } = ctxDispatchToControlProps(ctx.dispatch)
+  return {
+    ...props,
+    handleChange
+  };
+}
+
+export const ctxToJsonFormsDispatchProps = (
+  ctx: JsonFormsStateContext,
+  ownProps: OwnPropsOfJsonFormsRenderer
+) => mapStateToJsonFormsRendererProps({ jsonforms: { ...ctx } }, ownProps);
+
+export const ctxDispatchToArrayControlProps = (dispatch: Dispatch<ReducerAction<any>>) =>
+  mapDispatchToArrayControlProps(dispatch as any);
+
+export const ctxToMasterListItemProps = (
+  ctx: JsonFormsStateContext,
+  ownProps: OwnPropsOfMasterListItem
+) => mapStateToMasterListItemProps({ jsonforms: { ...ctx } }, ownProps);
+
+export const ctxToCellProps = (
+  ctx: JsonFormsStateContext,
+  ownProps: OwnPropsOfCell
+) => {
+  return mapStateToCellProps({ jsonforms: { ...ctx } }, ownProps);
+}
+
+export const withJsonFormsLayoutProps = (Component: ComponentType<LayoutProps>): ComponentType<OwnPropsOfJsonFormsRenderer> => (props: LayoutProps) => {
+  const ctx = useJsonForms();
+  const layoutProps = ctxToLayoutProps(ctx, props);
+  return (
+    <Component {...props} {...layoutProps} renderers={ctx.renderers} />
+  );
+};
+
+export const withJsonFormsControlProps =
+  (Component: ComponentType<ControlProps>): ComponentType<OwnPropsOfControl> => (props: ControlProps) => {
+    const ctx = useJsonForms();
+    const controlProps = ctxToControlProps(ctx, props);
+    const { handleChange } = ctxDispatchToControlProps(ctx.dispatch);
+    return (<Component {...props} {...controlProps} handleChange={handleChange} />);
+  };
+
+export const withJsonFormsOneOfProps =
+  (Component: ComponentType<StatePropsOfCombinator>): ComponentType<OwnPropsOfControl> => (props: StatePropsOfCombinator) => {
+    const ctx = useJsonForms();
+    const oneOfProps = ctxToOneOfProps(ctx, props);
+    return (<Component {...oneOfProps} />);
+  };
+
+export const withJsonFormsAnyOfProps =
+  (Component: ComponentType<StatePropsOfCombinator>): ComponentType<OwnPropsOfControl> => (props: StatePropsOfCombinator) => {
+    const ctx = useJsonForms();
+    const anyOfProps = ctxToAnyOfProps(ctx, props);
+    return (<Component {...anyOfProps} />);
+  };
+
+export const withJsonFormsAllOfProps =
+  (Component: ComponentType<StatePropsOfCombinator>): ComponentType<OwnPropsOfControl> => (props: StatePropsOfCombinator) => {
+    const ctx = useJsonForms();
+    const allOfProps = ctxToAllOfProps(ctx, props);
+    return (<Component {...allOfProps} />);
+  };
+
+export const withJsonFormsDetailProps =
+  (Component: ComponentType<StatePropsOfControlWithDetail>): ComponentType<OwnPropsOfControl> => (props: StatePropsOfControlWithDetail) => {
+    const ctx = useJsonForms();
+    const detailProps = ctxToControlWithDetailProps(ctx, props);
+
+    return (<Component {...detailProps} />);
+  };
+
+export const withJsonFormsArrayLayoutProps =
+  (Component: ComponentType<ArrayLayoutProps>): ComponentType<OwnPropsOfControl> => (props: ArrayLayoutProps) => {
+    const ctx = useJsonForms();
+    const stateProps = ctxToArrayLayoutProps(ctx, props);
+    const dispatchProps = ctxDispatchToArrayControlProps(ctx.dispatch);
+
+    return (<Component {...props} {...stateProps} {...dispatchProps} />);
+  };
+
+export const withJsonFormsArrayControlProps =
+  (Component: ComponentType<ArrayLayoutProps>): ComponentType<OwnPropsOfControl> => (props: ArrayLayoutProps) => {
+    const ctx = useJsonForms();
+    const stateProps = ctxToArrayControlProps(ctx, props);
+    const dispatchProps = ctxDispatchToArrayControlProps(ctx.dispatch);
+
+    return (<Component {...props} {...stateProps} {...dispatchProps} />);
+  };
+
+
+export const withJsonFormsMasterListItemProps =
+  (Component: ComponentType<StatePropsOfMasterItem>): ComponentType<OwnPropsOfMasterListItem> => (props: StatePropsOfMasterItem) => {
+    const ctx = useJsonForms();
+    const stateProps = ctxToMasterListItemProps(ctx, props);
+
+    return (<Component {...stateProps} />);
+  };
+
+export const withJsonFormsCellProps =
+  (Component: ComponentType<CellProps>): ComponentType<OwnPropsOfCell> => (props: CellProps) => {
+    const ctx = useJsonForms();
+    const cellProps = ctxToCellProps(ctx, props);
+    const dispatchProps = ctxDispatchToControlProps(ctx.dispatch)
+
+    return (<Component {...props} {...dispatchProps} {...cellProps} />);
+  };
+
+export const withJsonFormsEnumCellProps =
+  (Component: ComponentType<EnumCellProps>): ComponentType<OwnPropsOfEnumCell> => (props: EnumCellProps) => {
+    const ctx = useJsonForms();
+    const cellProps = ctxToCellProps(ctx, props);
+    const dispatchProps = ctxDispatchToControlProps(ctx.dispatch);
+    const options =
+      props.options !== undefined ? props.options : props.schema.enum;
+
+    return (<Component {...props} {...dispatchProps} {...cellProps} options={options} />);
+  };
+
+export const withJsonFormsEnumProps =
+  (Component: ComponentType<ControlProps & OwnPropsOfEnum>): ComponentType<OwnPropsOfControl & OwnPropsOfEnum> => (props: ControlProps & OwnPropsOfEnum) => {
+    const ctx = useJsonForms();
+    const stateProps = ctxToControlProps(ctx, props);
+    const dispatchProps = ctxDispatchToControlProps(ctx.dispatch);
+    const options =
+      props.options !== undefined ? props.options : stateProps.schema.enum;
+
+    return (<Component {...props} {...dispatchProps} {...stateProps} options={options} />);
+  };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -27,4 +27,5 @@ export * from './Control';
 export * from './JsonForms';
 export * from './DispatchCell';
 export * from './Renderer';
+export * from './JsonFormsContext';
 export * from './UnknownRenderer';

--- a/packages/react/test/renderers/JsonForms.test.tsx
+++ b/packages/react/test/renderers/JsonForms.test.tsx
@@ -40,11 +40,12 @@ import {
 } from '@jsonforms/core';
 import Enzyme from 'enzyme';
 import { mount, shallow } from 'enzyme';
-import { StatelessRenderer } from '../../src/Renderer';
 import RefParser from 'json-schema-ref-parser';
+import { StatelessRenderer } from '../../src/Renderer';
 
 import Adapter from 'enzyme-adapter-react-16';
-import { JsonForms, JsonFormsDispatchRenderer } from '../../src/JsonForms';
+import { JsonFormsDispatchRenderer, JsonFormsDispatch, JsonForms } from '../../src/JsonForms';
+import { JsonFormsReduxContext, useJsonForms } from '../../src/JsonFormsContext';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -121,7 +122,9 @@ test('JsonForms renderer should report about missing renderer', () => {
 
   const wrapper = mount(
     <Provider store={store}>
-      <JsonForms />
+      <JsonFormsReduxContext>
+        <JsonFormsDispatch />
+      </JsonFormsReduxContext>
     </Provider>
   );
 
@@ -138,7 +141,9 @@ test('JsonForms renderer should pick most applicable renderer', () => {
   store.dispatch(registerRenderer(() => 5, CustomRenderer2));
   const wrapper = mount(
     <Provider store={store}>
-      <JsonForms uischema={fixture.uischema} schema={fixture.schema} />
+      <JsonFormsReduxContext>
+        <JsonFormsDispatch />
+      </JsonFormsReduxContext>
     </Provider>
   );
 
@@ -160,7 +165,9 @@ test('JsonForms renderer should not consider any de-registered renderers', () =>
   store.dispatch(unregisterRenderer(tester3, CustomRenderer2));
   const wrapper = mount(
     <Provider store={store}>
-      <JsonForms />
+      <JsonFormsReduxContext>
+        <JsonFormsDispatch />
+      </JsonFormsReduxContext>
     </Provider>
   );
 
@@ -182,7 +189,7 @@ test('ids should be unique within the same form', () => {
   const FakeLayout = (props: RendererProps) => {
     const layout = props.uischema as Layout;
     const children = layout.elements.map((e, idx) => (
-      <JsonForms
+      <JsonFormsDispatch
         uischema={e}
         schema={fixture.schema}
         path={props.path}
@@ -227,8 +234,10 @@ test('ids should be unique within the same form', () => {
 
   const wrapper = mount(
     <Provider store={store}>
-      <JsonForms uischema={uischema2} schema={fixture.schema} />
-    </Provider>
+      <JsonFormsReduxContext>
+        <JsonFormsDispatch uischema={uischema2} schema={fixture.schema} />
+      </JsonFormsReduxContext>
+    </Provider>,
   );
 
   expect(ids.indexOf('#/properties/foo') > -1).toBeTruthy();
@@ -264,8 +273,7 @@ test('render schema with $ref', () => {
     }
   };
 
-  const tester = (_uischema: UISchemaElement, s: JsonSchema) =>
-    s.properties.foo.type === 'number' ? 1 : -1;
+  const tester = (_uischema: UISchemaElement, s: JsonSchema) => s.properties.foo.type === 'number' ? 1 : -1;
 
   const renderers = [
     {
@@ -374,14 +382,67 @@ test('JsonForms renderer should pick most applicable renderer via ownProps', () 
   store.dispatch(registerRenderer(() => 5, CustomRenderer2));
   const wrapper = mount(
     <Provider store={store}>
-      <JsonForms
-        uischema={fixture.uischema}
-        schema={fixture.schema}
-        renderers={[{ tester: () => 3, renderer: CustomRenderer3 }]}
-      />
+      <JsonFormsReduxContext>
+        <JsonFormsDispatch
+          uischema={fixture.uischema}
+          schema={fixture.schema}
+          renderers={[{ tester: () => 3, renderer: CustomRenderer3 }]}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   );
 
-  expect(wrapper.find('h3').text()).toBe('test');
+  expect(wrapper.find('h1').text()).toBe('test');
+  wrapper.unmount();
+});
+
+test('JsonForms should support two isolated components', () => {
+  const schema1 = {
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'string',
+        minLength: 1
+      }
+    }
+  };
+  const schema2 = {
+    type: 'object',
+    properties: {
+      bar: {
+        type: 'number',
+        minimum: 1
+      }
+    }
+  };
+  const customRenderer1 = () => {
+    const ctx = useJsonForms();
+    const errors = ctx.core.errors;
+    return (<h1>{errors ? errors.length : 0}</h1>);
+  }
+  const customRenderer2 = () => {
+    const ctx = useJsonForms();
+    const errors = ctx.core.errors;
+    return (<h2>{errors ? errors.length : 0}</h2>);
+  }
+  const wrapper = mount(
+    <div>
+      <JsonForms
+        data={{ foo: '' }}
+        uischema={{ type: 'Control', scope: '#/properties/foo' }}
+        schema={schema1}
+        renderers={[{ tester: () => 3, renderer: customRenderer1 }]}
+      />
+      <JsonForms
+        data={{ bar: 0 }}
+        schema={schema2}
+        uischema={{ type: 'Control', scope: '#/properties/bar' }}
+        renderers={[{ tester: () => 3, renderer: customRenderer2 }]}
+      />
+    </div>
+  );
+
+  expect(wrapper.find('h2').text()).toBe('1');
+  expect(wrapper.find('h1').text()).toBe('1');
   wrapper.unmount();
 });

--- a/packages/test/src/FakeLayout.tsx
+++ b/packages/test/src/FakeLayout.tsx
@@ -31,7 +31,7 @@ import {
   RendererProps,
   Test,
 } from '@jsonforms/core';
-import { JsonForms } from '@jsonforms/react';
+import { JsonFormsDispatch } from '@jsonforms/react';
 import { connect } from 'react-redux';
 
 const {
@@ -53,11 +53,11 @@ export const fakeLayoutTester: RankedTester = rankWith(
 );
 
 const FakeLayout = (props: RendererProps) => {
-  const {uischema, schema, path} = props;
+  const { uischema, schema, path } = props;
   const layout = uischema as Layout;
 
   const children = layout.elements.map((e, idx) => (
-    <JsonForms
+    <JsonFormsDispatch
       uischema={e}
       schema={schema}
       path={path}

--- a/packages/vanilla/src/cells/BooleanCell.tsx
+++ b/packages/vanilla/src/cells/BooleanCell.tsx
@@ -23,44 +23,39 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { connect } from 'react-redux';
 import {
   CellProps,
   isBooleanControl,
-  mapDispatchToCellProps,
-  mapStateToCellProps,
   RankedTester,
   rankWith,
 } from '@jsonforms/core';
+import { withJsonFormsCellProps } from '@jsonforms/react';
 import { StatelessComponent, SyntheticEvent } from 'react';
-import { addVanillaCellProps } from '../util';
 import { VanillaRendererProps } from '../index';
 
 export const BooleanCell: StatelessComponent<CellProps> =
-    (props: CellProps & VanillaRendererProps) => {
-        const { data, className, id, enabled, uischema, path, handleChange } = props;
+  (props: CellProps & VanillaRendererProps) => {
+    const { data, className, id, enabled, uischema, path, handleChange } = props;
 
-        return (
-            <input
-                type='checkbox'
-                checked={data || ''}
-                onChange={(ev: SyntheticEvent<HTMLInputElement>) =>
-                    handleChange(path, ev.currentTarget.checked)
-                }
-                className={className}
-                id={id}
-                disabled={!enabled}
-                autoFocus={uischema.options && uischema.options.focus}
-            />
-        );
-    };
+    return (
+      <input
+        type='checkbox'
+        checked={data || ''}
+        onChange={(ev: SyntheticEvent<HTMLInputElement>) =>
+          handleChange(path, ev.currentTarget.checked)
+        }
+        className={className}
+        id={id}
+        disabled={!enabled}
+        autoFocus={uischema.options && uischema.options.focus}
+      />
+    );
+  };
 
 /**
  * Default tester for boolean controls.
  * @type {RankedTester}
  */
 export const booleanCellTester: RankedTester = rankWith(2, isBooleanControl);
-export default connect(
-  addVanillaCellProps(mapStateToCellProps),
-  mapDispatchToCellProps
-)(BooleanCell);
+
+export default withJsonFormsCellProps(BooleanCell);

--- a/packages/vanilla/src/cells/DateCell.tsx
+++ b/packages/vanilla/src/cells/DateCell.tsx
@@ -24,34 +24,31 @@
 */
 import React from 'react';
 import {
-    CellProps,
-    isDateControl,
-    mapDispatchToCellProps,
-    mapStateToCellProps,
-    RankedTester,
-    rankWith,
+  CellProps,
+  isDateControl,
+  RankedTester,
+  rankWith,
 } from '@jsonforms/core';
+import { withJsonFormsCellProps } from '@jsonforms/react';
 import { SyntheticEvent } from 'react';
 import { VanillaRendererProps } from '../index';
-import { connect } from 'react-redux';
-import { addVanillaCellProps } from '../util';
 
 export const DateCell = (props: CellProps & VanillaRendererProps) => {
-    const { data, className, id, enabled, uischema, path, handleChange } = props;
+  const { data, className, id, enabled, uischema, path, handleChange } = props;
 
-    return (
-      <input
-        type='date'
-        value={data || ''}
-        onChange={(ev: SyntheticEvent<HTMLInputElement>) =>
-          handleChange(path, ev.currentTarget.value)
-        }
-        className={className}
-        id={id}
-        disabled={!enabled}
-        autoFocus={uischema.options && uischema.options.focus}
-      />
-    );
+  return (
+    <input
+      type='date'
+      value={data || ''}
+      onChange={(ev: SyntheticEvent<HTMLInputElement>) =>
+        handleChange(path, ev.currentTarget.value)
+      }
+      className={className}
+      id={id}
+      disabled={!enabled}
+      autoFocus={uischema.options && uischema.options.focus}
+    />
+  );
 };
 /**
  * Default tester for date controls.
@@ -59,7 +56,4 @@ export const DateCell = (props: CellProps & VanillaRendererProps) => {
  */
 export const dateCellTester: RankedTester = rankWith(2, isDateControl);
 
-export default connect(
-  addVanillaCellProps(mapStateToCellProps),
-  mapDispatchToCellProps
-)(DateCell);
+export default withJsonFormsCellProps(DateCell);

--- a/packages/vanilla/src/cells/DateTimeCell.tsx
+++ b/packages/vanilla/src/cells/DateTimeCell.tsx
@@ -23,45 +23,40 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { connect } from 'react-redux';
 import { SyntheticEvent } from 'react';
 import {
-    CellProps,
-    isDateTimeControl,
-    mapDispatchToCellProps,
-    mapStateToCellProps,
-    RankedTester,
-    rankWith,
+  CellProps,
+  isDateTimeControl,
+  RankedTester,
+  rankWith,
 } from '@jsonforms/core';
+import { withJsonFormsCellProps } from '@jsonforms/react';
 import { VanillaRendererProps } from '../index';
-import { addVanillaCellProps } from '../util';
 
 export const DateTimeCell = (props: CellProps & VanillaRendererProps) => {
-    const { data, className, id, enabled, uischema, path, handleChange } = props;
-    const toISOString = (inputDateTime: string) => {
-        return (inputDateTime === '' ? '' : inputDateTime + ':00.000Z');
-    };
+  const { data, className, id, enabled, uischema, path, handleChange } = props;
+  const toISOString = (inputDateTime: string) => {
+    return (inputDateTime === '' ? '' : inputDateTime + ':00.000Z');
+  };
 
-    return (
-      <input
-        type='datetime-local'
-        value={(data || '').substr(0, 16)}
-        onChange={(ev: SyntheticEvent<HTMLInputElement>) =>
-          handleChange(path, toISOString(ev.currentTarget.value))
-        }
-        className={className}
-        id={id}
-        disabled={!enabled}
-        autoFocus={uischema.options && uischema.options.focus}
-      />
-    );
+  return (
+    <input
+      type='datetime-local'
+      value={(data || '').substr(0, 16)}
+      onChange={(ev: SyntheticEvent<HTMLInputElement>) =>
+        handleChange(path, toISOString(ev.currentTarget.value))
+      }
+      className={className}
+      id={id}
+      disabled={!enabled}
+      autoFocus={uischema.options && uischema.options.focus}
+    />
+  );
 };
 /**
  * Default tester for datetime controls.
  * @type {RankedTester}
  */
 export const dateTimeCellTester: RankedTester = rankWith(2, isDateTimeControl);
-export default connect(
-  addVanillaCellProps(mapStateToCellProps),
-  mapDispatchToCellProps
-)(DateTimeCell);
+
+export default withJsonFormsCellProps(DateTimeCell);

--- a/packages/vanilla/src/cells/EnumCell.tsx
+++ b/packages/vanilla/src/cells/EnumCell.tsx
@@ -23,17 +23,15 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { connect } from 'react-redux';
 import {
-  defaultMapDispatchToControlProps,
-  defaultMapStateToEnumCellProps,
   EnumCellProps,
   isEnumControl,
   RankedTester,
   rankWith,
 } from '@jsonforms/core';
+import { withJsonFormsEnumCellProps } from '@jsonforms/react';
 import { SyntheticEvent } from 'react';
-import { addVanillaCellProps } from '../util';
+import { withVanillaControlProps } from '../util';
 import { WithClassname } from '../index';
 
 export const EnumCell = (props: EnumCellProps & WithClassname) => {
@@ -70,7 +68,4 @@ export const EnumCell = (props: EnumCellProps & WithClassname) => {
  */
 export const enumCellTester: RankedTester = rankWith(2, isEnumControl);
 
-export default connect(
-  addVanillaCellProps(defaultMapStateToEnumCellProps),
-  defaultMapDispatchToControlProps
-)(EnumCell);
+export default withVanillaControlProps(withJsonFormsEnumCellProps(EnumCell));

--- a/packages/vanilla/src/cells/IntegerCell.tsx
+++ b/packages/vanilla/src/cells/IntegerCell.tsx
@@ -24,18 +24,16 @@
 */
 import React from 'react';
 import { SyntheticEvent } from 'react';
-import { connect } from 'react-redux';
 import {
   CellProps,
   isIntegerControl,
-  mapDispatchToCellProps,
-  mapStateToCellProps,
   RankedTester,
   rankWith
 } from '@jsonforms/core';
+import { withJsonFormsCellProps } from '@jsonforms/react';
 import { VanillaRendererProps } from '../index';
 
-export const IntegerCell  = (props: CellProps & VanillaRendererProps) => {
+export const IntegerCell = (props: CellProps & VanillaRendererProps) => {
   const { data, className, id, enabled, uischema, path, handleChange } = props;
 
   return (
@@ -59,7 +57,4 @@ export const IntegerCell  = (props: CellProps & VanillaRendererProps) => {
  */
 export const integerCellTester: RankedTester = rankWith(2, isIntegerControl);
 
-export default connect(
-  mapStateToCellProps,
-  mapDispatchToCellProps
-)(IntegerCell);
+export default withJsonFormsCellProps(IntegerCell);

--- a/packages/vanilla/src/cells/NumberCell.tsx
+++ b/packages/vanilla/src/cells/NumberCell.tsx
@@ -24,15 +24,13 @@
 */
 import React from 'react';
 import { SyntheticEvent } from 'react';
-import { connect } from 'react-redux';
 import {
   CellProps,
   isNumberControl,
-  mapDispatchToCellProps,
-  mapStateToCellProps,
   RankedTester,
   rankWith,
 } from '@jsonforms/core';
+import { withJsonFormsCellProps } from '@jsonforms/react';
 import { VanillaRendererProps } from '../index';
 
 export const NumberCell = (props: CellProps & VanillaRendererProps) => {
@@ -60,7 +58,4 @@ export const NumberCell = (props: CellProps & VanillaRendererProps) => {
  */
 export const numberCellTester: RankedTester = rankWith(2, isNumberControl);
 
-export default connect(
-  mapStateToCellProps,
-  mapDispatchToCellProps
-)(NumberCell);
+export default withJsonFormsCellProps(NumberCell);

--- a/packages/vanilla/src/cells/NumberFormatCell.tsx
+++ b/packages/vanilla/src/cells/NumberFormatCell.tsx
@@ -23,16 +23,14 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { connect } from 'react-redux';
 import {
   CellProps,
   Formatted,
   isNumberFormatControl,
-  mapDispatchToCellProps,
-  mapStateToCellProps,
   RankedTester,
   rankWith,
 } from '@jsonforms/core';
+import { withJsonFormsCellProps } from '@jsonforms/react';
 import { VanillaRendererProps } from '../index';
 
 export const NumberFormatCell = (props: CellProps & VanillaRendererProps & Formatted<number>) => {
@@ -74,7 +72,4 @@ export const NumberFormatCell = (props: CellProps & VanillaRendererProps & Forma
  */
 export const numberFormatCellTester: RankedTester = rankWith(4, isNumberFormatControl);
 
-export default connect(
-  mapStateToCellProps,
-  mapDispatchToCellProps
-)(NumberFormatCell);
+export default withJsonFormsCellProps(NumberFormatCell);

--- a/packages/vanilla/src/cells/SliderCell.tsx
+++ b/packages/vanilla/src/cells/SliderCell.tsx
@@ -24,44 +24,39 @@
 */
 import React from 'react';
 import { SyntheticEvent } from 'react';
-import { connect } from 'react-redux';
 import {
-    CellProps,
-    isRangeControl,
-    mapDispatchToCellProps,
-    mapStateToCellProps,
-    RankedTester,
-    rankWith,
+  CellProps,
+  isRangeControl,
+  RankedTester,
+  rankWith,
 } from '@jsonforms/core';
+import { withJsonFormsCellProps } from '@jsonforms/react';
 import { VanillaRendererProps } from '../index';
 
 export const SliderCell = (props: CellProps & VanillaRendererProps) => {
   const { data, className, id, enabled, uischema, schema, path, handleChange } = props;
 
   return (
-  <div style={{display: 'flex'}}>
-    <input
-      type='range'
-      max={schema.maximum}
-      min={schema.minimum}
-      value={data || schema.default}
-      onChange={(ev: SyntheticEvent<HTMLInputElement>) =>
-        handleChange(path, Number(ev.currentTarget.value))
-      }
-      className={className}
-      id={id}
-      disabled={!enabled}
-      autoFocus={uischema.options && uischema.options.focus}
-      style={{flex: '1'}}
-    />
-    <label style={{marginLeft: '0.5em'}}>{data || schema.default}</label>
-  </div>
+    <div style={{ display: 'flex' }}>
+      <input
+        type='range'
+        max={schema.maximum}
+        min={schema.minimum}
+        value={data || schema.default}
+        onChange={(ev: SyntheticEvent<HTMLInputElement>) =>
+          handleChange(path, Number(ev.currentTarget.value))
+        }
+        className={className}
+        id={id}
+        disabled={!enabled}
+        autoFocus={uischema.options && uischema.options.focus}
+        style={{ flex: '1' }}
+      />
+      <label style={{ marginLeft: '0.5em' }}>{data || schema.default}</label>
+    </div>
   );
 };
 
 export const sliderCellTester: RankedTester = rankWith(4, isRangeControl);
 
-export default connect(
-  mapStateToCellProps,
-  mapDispatchToCellProps
-)(SliderCell);
+export default withJsonFormsCellProps(SliderCell);

--- a/packages/vanilla/src/cells/TextAreaCell.tsx
+++ b/packages/vanilla/src/cells/TextAreaCell.tsx
@@ -24,15 +24,13 @@
 */
 import React from 'react';
 import { SyntheticEvent } from 'react';
-import { connect } from 'react-redux';
 import {
   CellProps,
   isMultiLineControl,
-  mapDispatchToCellProps,
-  mapStateToCellProps,
   RankedTester,
   rankWith,
 } from '@jsonforms/core';
+import { withJsonFormsCellProps } from '@jsonforms/react';
 import { VanillaRendererProps } from '../index';
 
 export const TextAreaCell = (props: CellProps & VanillaRendererProps) => {
@@ -58,7 +56,4 @@ export const TextAreaCell = (props: CellProps & VanillaRendererProps) => {
  */
 export const textAreaCellTester: RankedTester = rankWith(2, isMultiLineControl);
 
-export default connect(
-  mapStateToCellProps,
-  mapDispatchToCellProps
-)(TextAreaCell);
+export default withJsonFormsCellProps(TextAreaCell);

--- a/packages/vanilla/src/cells/TextCell.tsx
+++ b/packages/vanilla/src/cells/TextCell.tsx
@@ -24,15 +24,13 @@
 */
 import React from 'react';
 import { SyntheticEvent } from 'react';
-import { connect } from 'react-redux';
 import {
   CellProps,
   isStringControl,
-  mapDispatchToCellProps,
-  mapStateToCellProps,
   RankedTester,
   rankWith
 } from '@jsonforms/core';
+import { withJsonFormsCellProps } from '@jsonforms/react';
 import { VanillaRendererProps } from '../index';
 import merge from 'lodash/merge';
 
@@ -73,7 +71,4 @@ export const TextCell = (props: CellProps & VanillaRendererProps) => {
  */
 export const textCellTester: RankedTester = rankWith(1, isStringControl);
 
-export default connect(
-  mapStateToCellProps,
-  mapDispatchToCellProps
-)(TextCell);
+export default withJsonFormsCellProps(TextCell);

--- a/packages/vanilla/src/cells/TimeCell.tsx
+++ b/packages/vanilla/src/cells/TimeCell.tsx
@@ -23,15 +23,13 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { connect } from 'react-redux';
 import {
   CellProps,
   isTimeControl,
-  mapDispatchToCellProps,
-  mapStateToCellProps,
   RankedTester,
   rankWith,
 } from '@jsonforms/core';
+import { withJsonFormsCellProps } from '@jsonforms/react';
 import { SyntheticEvent } from 'react';
 import { VanillaRendererProps } from '../index';
 
@@ -58,7 +56,4 @@ export const TimeCell = (props: CellProps & VanillaRendererProps) => {
  */
 export const timeCellTester: RankedTester = rankWith(2, isTimeControl);
 
-export default connect(
-  mapStateToCellProps,
-  mapDispatchToCellProps
-)(TimeCell);
+export default withJsonFormsCellProps(TimeCell);

--- a/packages/vanilla/src/complex/LabelRenderer.tsx
+++ b/packages/vanilla/src/complex/LabelRenderer.tsx
@@ -23,10 +23,10 @@
   THE SOFTWARE.
 */
 import React, { FunctionComponent } from 'react';
-import { LabelElement, mapStateToLayoutProps, RankedTester, rankWith, RendererProps, uiTypeIs } from '@jsonforms/core';
-import { addVanillaLayoutProps } from '../util';
-import { connect } from 'react-redux';
+import { LabelElement, RankedTester, rankWith, RendererProps, uiTypeIs } from '@jsonforms/core';
+import { withJsonFormsLayoutProps } from '@jsonforms/react';
 import { VanillaRendererProps } from '../index';
+import { withVanillaControlProps } from '../util';
 
 /**
  * Default tester for a label.
@@ -37,7 +37,7 @@ export const labelRendererTester: RankedTester = rankWith(1, uiTypeIs('Label'));
 /**
  * Default renderer for a label.
  */
-export const LabelRenderer:  FunctionComponent<RendererProps & VanillaRendererProps> =
+export const LabelRenderer: FunctionComponent<RendererProps & VanillaRendererProps> =
   ({ uischema, visible, getStyleAsClassName }) => {
     const labelElement: LabelElement = uischema as LabelElement;
     const classNames = getStyleAsClassName('label-control');
@@ -53,4 +53,4 @@ export const LabelRenderer:  FunctionComponent<RendererProps & VanillaRendererPr
     );
   };
 
-export default connect(addVanillaLayoutProps(mapStateToLayoutProps))(LabelRenderer);
+export default withVanillaControlProps(withJsonFormsLayoutProps(LabelRenderer));

--- a/packages/vanilla/src/complex/TableArrayControl.tsx
+++ b/packages/vanilla/src/complex/TableArrayControl.tsx
@@ -29,25 +29,21 @@ import fpflow from 'lodash/fp/flow';
 import filter from 'lodash/filter';
 import join from 'lodash/join';
 import fpkeys from 'lodash/fp/keys';
+import fpstartCase from 'lodash/fp/startCase';
 import {
   ArrayControlProps,
   ControlElement,
   createDefaultValue,
   Helpers,
   isPlainLabel,
-  mapDispatchToArrayControlProps,
-  mapStateToArrayControlProps,
   Paths,
   RankedTester,
   Resolve,
-  StatePropsOfControl,
   Test
 } from '@jsonforms/core';
-import { DispatchCell } from '@jsonforms/react';
-import { addVanillaControlProps } from '../util';
-import { connect } from 'react-redux';
+import { DispatchCell, withJsonFormsArrayControlProps } from '@jsonforms/react';
+import { withVanillaControlProps } from '../util';
 import { VanillaRendererProps } from '../index';
-import { startCase } from 'lodash';
 
 const { createLabelDescriptionFrom, convertToValidClassName } = Helpers;
 
@@ -124,7 +120,7 @@ class TableArrayControl extends React.Component<ArrayControlProps & VanillaRende
                 fpflow(
                   fpkeys,
                   fpfilter(prop => schema.properties[prop].type !== 'array'),
-                  fpmap(prop => <th key={prop}>{startCase(prop)}</th>)
+                  fpmap(prop => <th key={prop}>{fpstartCase(prop)}</th>)
                 )(schema.properties)
               ) : (
                   <th>Items</th>
@@ -224,7 +220,4 @@ class TableArrayControl extends React.Component<ArrayControlProps & VanillaRende
   }
 }
 
-export default connect(
-  addVanillaControlProps<StatePropsOfControl>(mapStateToArrayControlProps),
-  mapDispatchToArrayControlProps
-)(TableArrayControl);
+export default withVanillaControlProps(withJsonFormsArrayControlProps(TableArrayControl));

--- a/packages/vanilla/src/complex/array/ArrayControl.tsx
+++ b/packages/vanilla/src/complex/array/ArrayControl.tsx
@@ -25,7 +25,7 @@
 import range from 'lodash/range';
 import React from 'react';
 import { ArrayControlProps, composePaths, createDefaultValue, findUISchema } from '@jsonforms/core';
-import { ResolvedJsonForms } from '@jsonforms/react';
+import { JsonFormsDispatch } from '@jsonforms/react';
 import { VanillaRendererProps } from '../../index';
 
 export const ArrayControl = ({
@@ -36,7 +36,8 @@ export const ArrayControl = ({
   schema,
   addItem,
   uischema,
-  uischemas
+  uischemas,
+  renderers
 }: ArrayControlProps & VanillaRendererProps) => {
   return (
     <div className={classNames.wrapper}>
@@ -57,17 +58,18 @@ export const ArrayControl = ({
               const childPath = composePaths(path, `${index}`);
 
               return (
-                <ResolvedJsonForms
+                <JsonFormsDispatch
                   schema={schema}
                   uischema={foundUISchema || uischema}
                   path={childPath}
                   key={childPath}
+                  renderers={renderers}
                 />
               );
             })
           ) : (
-            <p>No data</p>
-          )}
+              <p>No data</p>
+            )}
         </div>
       </fieldset>
     </div>

--- a/packages/vanilla/src/complex/array/ArrayControlRenderer.tsx
+++ b/packages/vanilla/src/complex/array/ArrayControlRenderer.tsx
@@ -25,34 +25,32 @@
 import React from 'react';
 
 import {
-  ArrayControlProps,
-  ControlElement,
-  Helpers,
-  mapDispatchToArrayControlProps,
-  mapStateToArrayControlProps
+    ArrayControlProps,
+    ControlElement,
+    Helpers
 } from '@jsonforms/core';
+import { withJsonFormsArrayControlProps } from '@jsonforms/react';
 import { ArrayControl } from './ArrayControl';
-import { addVanillaControlProps } from '../../util';
-import { connect } from 'react-redux';
+import { withVanillaControlProps } from '../../util';
 import { VanillaRendererProps } from '../../index';
 
-const ArrayControlRenderer  =
+const ArrayControlRenderer =
     ({
-         schema,
-         uischema,
-         data,
-         path,
-         rootSchema,
-         uischemas,
-         addItem,
-         getStyle,
-         getStyleAsClassName,
-         removeItems,
-         id,
-         visible,
-         enabled,
-         errors
-     }: ArrayControlProps & VanillaRendererProps) => {
+        schema,
+        uischema,
+        data,
+        path,
+        rootSchema,
+        uischemas,
+        addItem,
+        getStyle,
+        getStyleAsClassName,
+        removeItems,
+        id,
+        visible,
+        enabled,
+        errors
+    }: ArrayControlProps & VanillaRendererProps) => {
 
         const controlElement = uischema as ControlElement;
         const labelDescription = Helpers.createLabelDescriptionFrom(controlElement, schema);
@@ -62,7 +60,7 @@ const ArrayControlRenderer  =
         const fieldSetClassName = getStyleAsClassName('array.layout');
         const buttonClassName = getStyleAsClassName('array.button');
         const childrenClassName = getStyleAsClassName('array.children');
-        const classNames: { [className: string]: string} = {
+        const classNames: { [className: string]: string } = {
             wrapper: controlClassName,
             fieldSet: fieldSetClassName,
             button: buttonClassName,
@@ -91,9 +89,4 @@ const ArrayControlRenderer  =
         );
     };
 
-const ConnectedArrayControlRenderer = connect(
-    addVanillaControlProps(mapStateToArrayControlProps),
-    mapDispatchToArrayControlProps
-)(ArrayControlRenderer);
-
-export default ConnectedArrayControlRenderer;
+export default withVanillaControlProps(withJsonFormsArrayControlProps(ArrayControlRenderer));

--- a/packages/vanilla/src/complex/categorization/CategorizationRenderer.tsx
+++ b/packages/vanilla/src/complex/categorization/CategorizationRenderer.tsx
@@ -26,15 +26,13 @@ import React from 'react';
 import {
   Categorization,
   Category,
-  mapStateToLayoutProps,
   RendererProps
 } from '@jsonforms/core';
-import { RendererComponent } from '@jsonforms/react';
+import { RendererComponent, withJsonFormsLayoutProps } from '@jsonforms/react';
 import { CategorizationList } from './CategorizationList';
 import { SingleCategory } from './SingleCategory';
 import { isCategorization } from './tester';
-import { addVanillaLayoutProps } from '../../util';
-import { connect } from 'react-redux';
+import { withVanillaControlProps } from '../../util';
 import { VanillaRendererProps } from '../../index';
 
 export interface CategorizationState {
@@ -105,6 +103,4 @@ class CategorizationRenderer extends RendererComponent<
   }
 }
 
-export default connect(addVanillaLayoutProps(mapStateToLayoutProps))(
-  CategorizationRenderer
-);
+export default withVanillaControlProps(withJsonFormsLayoutProps(CategorizationRenderer));

--- a/packages/vanilla/src/complex/categorization/SingleCategory.tsx
+++ b/packages/vanilla/src/complex/categorization/SingleCategory.tsx
@@ -24,7 +24,7 @@
 */
 import React from 'react';
 import { Category, JsonSchema } from '@jsonforms/core';
-import { ResolvedJsonForms } from '@jsonforms/react';
+import { JsonFormsDispatch } from '@jsonforms/react';
 
 export interface CategoryProps {
   category: Category;
@@ -38,7 +38,7 @@ export const SingleCategory = ({ category, schema, path }: CategoryProps) => (
     {
       (category.elements || []).map((child, index) =>
         (
-          <ResolvedJsonForms
+          <JsonFormsDispatch
             key={`${path}-${index}`}
             uischema={child}
             schema={schema}

--- a/packages/vanilla/src/controls/InputControl.tsx
+++ b/packages/vanilla/src/controls/InputControl.tsx
@@ -31,22 +31,20 @@ import {
   isControl,
   isDescriptionHidden,
   isPlainLabel,
-  mapDispatchToControlProps,
-  mapStateToControlProps,
   NOT_APPLICABLE,
   RankedTester,
   rankWith
 } from '@jsonforms/core';
-import { Control, DispatchCell } from '@jsonforms/react';
-import { addVanillaControlProps } from '../util';
+import { Control, DispatchCell, withJsonFormsControlProps } from '@jsonforms/react';
+import { withVanillaControlProps } from '../util';
 import { VanillaRendererProps } from '../index';
-import { connect } from 'react-redux';
 
 export class InputControl extends Control<
   ControlProps & VanillaRendererProps,
   ControlState
-> {
+  > {
   render() {
+
     const {
       classNames,
       description,
@@ -64,7 +62,7 @@ export class InputControl extends Control<
     const isValid = errors.length === 0;
     const divClassNames = `validation  ${
       isValid ? classNames.description : 'validation_error'
-    }`;
+      }`;
     const showDescription = !isDescriptionHidden(
       visible,
       description,
@@ -100,8 +98,8 @@ export class InputControl extends Control<
             {!isValid
               ? errors
               : showDescription
-              ? description
-              : null}
+                ? description
+                : null}
           </div>
         </div>
       );
@@ -111,9 +109,4 @@ export class InputControl extends Control<
 
 export const inputControlTester: RankedTester = rankWith(1, isControl);
 
-export const ConnectedInputControl = connect(
-  addVanillaControlProps(mapStateToControlProps),
-  mapDispatchToControlProps
-)(InputControl);
-
-export default ConnectedInputControl;
+export default withVanillaControlProps(withJsonFormsControlProps(InputControl));

--- a/packages/vanilla/src/controls/RadioGroupControl.tsx
+++ b/packages/vanilla/src/controls/RadioGroupControl.tsx
@@ -23,18 +23,15 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { connect } from 'react-redux';
 import {
-  computeLabel,
-  ControlProps,
-  ControlState,
-  isDescriptionHidden,
-  isPlainLabel,
-  mapDispatchToControlProps,
-  mapStateToControlProps
+    computeLabel,
+    ControlProps,
+    ControlState,
+    isDescriptionHidden,
+    isPlainLabel
 } from '@jsonforms/core';
-import { Control } from '@jsonforms/react';
-import { addVanillaControlProps } from '../util';
+import { Control, withJsonFormsControlProps } from '@jsonforms/react';
+import { withVanillaControlProps } from '../util';
 import { VanillaRendererProps } from '../index';
 
 export class RadioGroupControl extends Control<ControlProps & VanillaRendererProps, ControlState> {
@@ -104,6 +101,4 @@ export class RadioGroupControl extends Control<ControlProps & VanillaRendererPro
     }
 }
 
-export default connect(
-    addVanillaControlProps(mapStateToControlProps), mapDispatchToControlProps
-)(RadioGroupControl);
+export default withVanillaControlProps(withJsonFormsControlProps(RadioGroupControl));

--- a/packages/vanilla/src/layouts/GroupLayout.tsx
+++ b/packages/vanilla/src/layouts/GroupLayout.tsx
@@ -24,11 +24,11 @@
 */
 import isEmpty from 'lodash/isEmpty';
 import React, { FunctionComponent } from 'react';
-import { connect } from 'react-redux';
-import { GroupLayout, mapStateToLayoutProps, RankedTester, rankWith, RendererProps, uiTypeIs } from '@jsonforms/core';
-import { addVanillaLayoutProps } from '../util';
+import { GroupLayout, RankedTester, rankWith, RendererProps, uiTypeIs } from '@jsonforms/core';
+import { withJsonFormsLayoutProps } from '@jsonforms/react';
 import { renderChildren } from './util';
 import { VanillaRendererProps } from '../index';
+import { withVanillaControlProps } from '../util';
 
 /**
  * Default tester for a group layout.
@@ -69,8 +69,4 @@ export const GroupLayoutRenderer: FunctionComponent<RendererProps & VanillaRende
   );
 };
 
-const ConnectedGroupLayout =  connect(
-  addVanillaLayoutProps(mapStateToLayoutProps)
-)(GroupLayoutRenderer);
-
-export default ConnectedGroupLayout;
+export default withVanillaControlProps(withJsonFormsLayoutProps(GroupLayoutRenderer));

--- a/packages/vanilla/src/layouts/HorizontalLayout.tsx
+++ b/packages/vanilla/src/layouts/HorizontalLayout.tsx
@@ -23,16 +23,15 @@
   THE SOFTWARE.
 */
 import React, { FunctionComponent } from 'react';
-import { connect } from 'react-redux';
 import {
   HorizontalLayout,
-  mapStateToLayoutProps,
   RankedTester,
   rankWith,
   RendererProps,
   uiTypeIs
 } from '@jsonforms/core';
-import { addVanillaLayoutProps } from '../util';
+import { withJsonFormsLayoutProps } from '@jsonforms/react';
+import { withVanillaControlProps } from '../util';
 import { JsonFormsLayout } from './JsonFormsLayout';
 import { renderChildren } from './util';
 import { VanillaRendererProps } from '../index';
@@ -78,8 +77,4 @@ const HorizontalLayoutRenderer: FunctionComponent<RendererProps & VanillaRendere
   );
 };
 
-const ConnectedHorizontalLayout = connect(
-  addVanillaLayoutProps(mapStateToLayoutProps)
-)(HorizontalLayoutRenderer);
-
-export default ConnectedHorizontalLayout;
+export default withVanillaControlProps(withJsonFormsLayoutProps(HorizontalLayoutRenderer));

--- a/packages/vanilla/src/layouts/VerticalLayout.tsx
+++ b/packages/vanilla/src/layouts/VerticalLayout.tsx
@@ -24,15 +24,14 @@
 */
 import React, { FunctionComponent } from 'react';
 import {
-    mapStateToLayoutProps,
-    RankedTester,
-    rankWith,
-    RendererProps,
-    uiTypeIs,
+  RankedTester,
+  rankWith,
+  RendererProps,
+  uiTypeIs,
   VerticalLayout
 } from '@jsonforms/core';
-import { connect } from 'react-redux';
-import { addVanillaLayoutProps } from '../util';
+import { withJsonFormsLayoutProps } from '@jsonforms/react';
+import { withVanillaControlProps } from '../util';
 import { JsonFormsLayout } from './JsonFormsLayout';
 import { renderChildren } from './util';
 import { VanillaRendererProps } from '../index';
@@ -43,7 +42,7 @@ import { VanillaRendererProps } from '../index';
  */
 export const verticalLayoutTester: RankedTester = rankWith(1, uiTypeIs('VerticalLayout'));
 
-export const VerticalLayoutRenderer: FunctionComponent<RendererProps & VanillaRendererProps>  = (
+export const VerticalLayoutRenderer: FunctionComponent<RendererProps & VanillaRendererProps> = (
   {
     schema,
     uischema,
@@ -77,6 +76,4 @@ export const VerticalLayoutRenderer: FunctionComponent<RendererProps & VanillaRe
   );
 };
 
-export default connect(
-  addVanillaLayoutProps(mapStateToLayoutProps)
-)(VerticalLayoutRenderer);
+export default withVanillaControlProps(withJsonFormsLayoutProps(VerticalLayoutRenderer));

--- a/packages/vanilla/src/layouts/util.tsx
+++ b/packages/vanilla/src/layouts/util.tsx
@@ -25,7 +25,7 @@
 import isEmpty from 'lodash/isEmpty';
 import React from 'react';
 import { JsonSchema, Layout } from '@jsonforms/core';
-import { ResolvedJsonForms } from '@jsonforms/react';
+import { JsonFormsDispatch, useJsonForms } from '@jsonforms/react';
 export interface RenderChildrenProps {
   layout: Layout;
   schema: JsonSchema;
@@ -43,10 +43,13 @@ export const renderChildren = (
     return [];
   }
 
+  const { renderers } = useJsonForms();
+
   return layout.elements.map((child, index) => {
     return (
       <div className={className} key={`${path}-${index}`}>
-        <ResolvedJsonForms
+        <JsonFormsDispatch
+          renderers={renderers}
           uischema={child}
           schema={schema}
           path={path}

--- a/packages/vanilla/src/reducers/styling.ts
+++ b/packages/vanilla/src/reducers/styling.ts
@@ -49,7 +49,8 @@ export const findStyle = (styles: StyleDef[]) => (
 ): string[] => {
   const foundStyle = find(styles, s => s.name === style);
   if (!isEmpty(foundStyle) && typeof foundStyle.classNames === 'function') {
-    return foundStyle.classNames(...args);
+    const res = foundStyle.classNames(args);
+    return res;
   } else if (!isEmpty(foundStyle)) {
     return foundStyle.classNames as string[];
   }

--- a/packages/vanilla/test/renderers/ArrayControl.test.tsx
+++ b/packages/vanilla/test/renderers/ArrayControl.test.tsx
@@ -23,6 +23,7 @@
   THE SOFTWARE.
 */
 import '@jsonforms/test';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 import * as React from 'react';
 import test from 'ava';
 import { Provider } from 'react-redux';
@@ -78,10 +79,12 @@ test('render two children', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <ArrayControl
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-      />
+      <JsonFormsReduxContext>
+        <ArrayControl
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 

--- a/packages/vanilla/test/renderers/BooleanCell.test.tsx
+++ b/packages/vanilla/test/renderers/BooleanCell.test.tsx
@@ -33,6 +33,7 @@ import {
   JsonSchema,
   update
 } from '@jsonforms/core';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 import BooleanCell, { booleanCellTester } from '../../src/cells/BooleanCell';
 import HorizontalLayoutRenderer from '../../src/layouts/HorizontalLayout';
 import { Provider } from 'react-redux';
@@ -117,7 +118,9 @@ test('autofocus active', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanCell schema={t.context.schema} uischema={uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <BooleanCell schema={t.context.schema} uischema={uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -142,7 +145,9 @@ test('autofocus inactive', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanCell schema={t.context.schema} uischema={uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <BooleanCell schema={t.context.schema} uischema={uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -164,7 +169,9 @@ test('autofocus inactive by default', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanCell schema={t.context.schema} uischema={uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <BooleanCell schema={t.context.schema} uischema={uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -242,11 +249,9 @@ test('render', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <BooleanCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
 
@@ -266,11 +271,9 @@ test('update via input event', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <BooleanCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
 
@@ -292,11 +295,9 @@ test('update via action', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <BooleanCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -316,11 +317,9 @@ test.failing('update with undefined value', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <BooleanCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -339,11 +338,9 @@ test.failing('update with null value', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <BooleanCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -362,11 +359,9 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <BooleanCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -385,11 +380,9 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <BooleanCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -408,11 +401,9 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <BooleanCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   store.dispatch(update(undefined, () => false));
@@ -431,11 +422,9 @@ test('disable', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        enabled={false}
-      />
+      <JsonFormsReduxContext>
+        <BooleanCell schema={t.context.schema} uischema={t.context.uischema} enabled={false}/>
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -453,11 +442,9 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <BooleanCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <BooleanCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(

--- a/packages/vanilla/test/renderers/CategorizationRenderer.test.tsx
+++ b/packages/vanilla/test/renderers/CategorizationRenderer.test.tsx
@@ -32,12 +32,13 @@ import {
   JsonSchema,
   Layout
 } from '@jsonforms/core';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 import * as TestUtils from 'react-dom/test-utils';
 import CategorizationRenderer, { categorizationTester } from '../../src/complex/categorization';
 import { initJsonFormsVanillaStore } from '../vanillaStore';
 
 test.beforeEach(t => {
-  t.context.data = { };
+  t.context.data = {};
   t.context.schema = {
     type: 'object',
     properties: {
@@ -82,8 +83,8 @@ test.beforeEach(t => {
 test('tester', t => {
   t.is(categorizationTester(undefined, undefined), -1);
   t.is(categorizationTester(null, undefined), -1);
-  t.is(categorizationTester({type: 'Foo'}, undefined), -1);
-  t.is(categorizationTester({type: 'Categorization'}, undefined), -1);
+  t.is(categorizationTester({ type: 'Foo' }, undefined), -1);
+  t.is(categorizationTester({ type: 'Categorization' }, undefined), -1);
 });
 
 test('tester with null elements and no schema', t => {
@@ -92,11 +93,11 @@ test('tester with null elements and no schema', t => {
     elements: null
   };
   t.is(
-      categorizationTester(
-          uischema,
-          undefined
-      ),
-      -1
+    categorizationTester(
+      uischema,
+      undefined
+    ),
+    -1
   );
 });
 
@@ -106,11 +107,11 @@ test('tester with empty elements and no schema', t => {
     elements: []
   };
   t.is(
-      categorizationTester(
-          uischema,
-          undefined
-      ),
-      -1
+    categorizationTester(
+      uischema,
+      undefined
+    ),
+    -1
   );
 });
 
@@ -124,16 +125,16 @@ test('apply tester with single unknown element and no schema', t => {
     ]
   };
   t.is(
-      categorizationTester(
-          uischema,
-          undefined
-      ),
-      -1
+    categorizationTester(
+      uischema,
+      undefined
+    ),
+    -1
   );
 });
 
 test('tester with single category and no schema', t => {
-  const categorization =  {
+  const categorization = {
     type: 'Categorization',
     elements: [
       {
@@ -142,11 +143,11 @@ test('tester with single category and no schema', t => {
     ]
   };
   t.is(
-      categorizationTester(
-          categorization,
-          undefined
-      ),
-      1
+    categorizationTester(
+      categorization,
+      undefined
+    ),
+    1
   );
 });
 
@@ -164,10 +165,10 @@ test('tester with nested categorization and single category and no schema', t =>
     elements: [nestedCategorization]
   };
   t.is(
-      categorizationTester(
-          categorization,
-          undefined),
-      1
+    categorizationTester(
+      categorization,
+      undefined),
+    1
   );
 });
 
@@ -181,11 +182,11 @@ test('tester with nested categorizations, but no category and no schema', t => {
     ]
   };
   t.is(
-      categorizationTester(
-          categorization,
-          undefined
-      ),
-      -1
+    categorizationTester(
+      categorization,
+      undefined
+    ),
+    -1
   );
 });
 
@@ -201,11 +202,11 @@ test('tester with nested categorizations, null elements and no schema', t => {
     ]
   };
   t.is(
-      categorizationTester(
-          categorization,
-          undefined
-      ),
-      -1
+    categorizationTester(
+      categorization,
+      undefined
+    ),
+    -1
   );
 });
 
@@ -220,11 +221,11 @@ test('tester with nested categorizations, empty elements and no schema', t => {
     ]
   };
   t.is(
-      categorizationTester(
-          categorization,
-          undefined
-      ),
-      -1
+    categorizationTester(
+      categorization,
+      undefined
+    ),
+    -1
   );
 });
 
@@ -273,10 +274,12 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <CategorizationRenderer
-        schema={schema}
-        uischema={uischema}
-      />
+      <JsonFormsReduxContext>
+        <CategorizationRenderer
+          schema={schema}
+          uischema={uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -322,7 +325,7 @@ test('render', t => {
 });
 
 test('render on click', t => {
-  const data = {'name': 'Foo'};
+  const data = { 'name': 'Foo' };
   const nameControl: ControlElement = {
     type: 'Control',
     scope: '#/properties/name'
@@ -369,10 +372,12 @@ test('render on click', t => {
 
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <CategorizationRenderer
-        schema={t.context.schema}
-        uischema={uischema}
-      />
+      <JsonFormsReduxContext>
+        <CategorizationRenderer
+          schema={t.context.schema}
+          uischema={uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -431,11 +436,13 @@ test('hide', t => {
 
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <CategorizationRenderer
-        schema={t.context.schema}
-        uischema={uischema}
-        visible={false}
-      />
+      <JsonFormsReduxContext>
+        <CategorizationRenderer
+          schema={t.context.schema}
+          uischema={uischema}
+          visible={false}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -466,10 +473,12 @@ test('showed by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <CategorizationRenderer
-        schema={t.context.schema}
-        uischema={uischema}
-      />
+      <JsonFormsReduxContext>
+        <CategorizationRenderer
+          schema={t.context.schema}
+          uischema={uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 

--- a/packages/vanilla/test/renderers/DateCell.test.tsx
+++ b/packages/vanilla/test/renderers/DateCell.test.tsx
@@ -32,6 +32,7 @@ import {
   JsonSchema,
   update
 } from '@jsonforms/core';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 import HorizontalLayoutRenderer from '../../src/layouts/HorizontalLayout';
 import DateCell, { dateCellTester } from '../../src/cells/DateCell';
 import { Provider } from 'react-redux';
@@ -99,7 +100,9 @@ test.failing('autofocus on first element', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <HorizontalLayoutRenderer schema={schema} uischema={uischema}/>
+      <JsonFormsReduxContext>
+        <HorizontalLayoutRenderer schema={schema} uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const inputs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
@@ -123,7 +126,9 @@ test('autofocus active', t => {
 
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateCell schema={t.context.schema} uischema={uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <DateCell schema={t.context.schema} uischema={uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -145,7 +150,9 @@ test('autofocus inactive', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateCell schema={t.context.schema} uischema={uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <DateCell schema={t.context.schema} uischema={uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -164,7 +171,9 @@ test('autofocus inactive by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateCell schema={t.context.schema} uischema={uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <DateCell schema={t.context.schema} uischema={uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -238,7 +247,9 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -255,7 +266,9 @@ test.cb('update via event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -278,7 +291,9 @@ test.cb('update via action', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -300,7 +315,9 @@ test('update with null value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -316,7 +333,9 @@ test('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -332,7 +351,9 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -348,7 +369,9 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -364,7 +387,9 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -380,7 +405,9 @@ test('disable', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateCell schema={t.context.schema} uischema={t.context.uischema} enabled={false}/>
+      <JsonFormsReduxContext>
+        <DateCell schema={t.context.schema} uischema={t.context.uischema} enabled={false} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -395,7 +422,9 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <DateCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/vanilla/test/renderers/DateTimeCell.test.tsx
+++ b/packages/vanilla/test/renderers/DateTimeCell.test.tsx
@@ -32,6 +32,7 @@ import {
   JsonSchema,
   update
 } from '@jsonforms/core';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 import HorizontalLayoutRenderer from '../../src/layouts/HorizontalLayout';
 import DateTimeCell, { dateTimeCellTester } from '../../src/cells/DateTimeCell';
 import { Provider } from 'react-redux';
@@ -99,11 +100,13 @@ test.failing('autofocus on first element', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <HorizontalLayoutRenderer schema={schema} uischema={uischema}/>
+      <JsonFormsReduxContext>
+        <HorizontalLayoutRenderer schema={schema} uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const inputs: HTMLInputElement[] =
-      TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input') as HTMLInputElement[];
+    TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input') as HTMLInputElement[];
   t.not(document.activeElement, inputs[0]);
   t.is(document.activeElement, inputs[1]);
 });
@@ -124,11 +127,13 @@ test('autofocus active', t => {
 
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeCell
-        schema={t.context.schema}
-        uischema={uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <DateTimeCell
+          schema={t.context.schema}
+          uischema={uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -150,11 +155,13 @@ test('autofocus inactive', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeCell
-        schema={t.context.schema}
-        uischema={uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <DateTimeCell
+          schema={t.context.schema}
+          uischema={uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -173,11 +180,13 @@ test('autofocus inactive by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeCell
-        schema={t.context.schema}
-        uischema={uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <DateTimeCell
+          schema={t.context.schema}
+          uischema={uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -251,11 +260,13 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <DateTimeCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -272,11 +283,13 @@ test.cb('update via event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <DateTimeCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -299,11 +312,13 @@ test.cb('update via action', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <DateTimeCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -325,11 +340,13 @@ test('update with null value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <DateTimeCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -345,11 +362,13 @@ test('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <DateTimeCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -365,11 +384,13 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <DateTimeCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -385,11 +406,13 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <DateTimeCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -405,11 +428,13 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <DateTimeCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -425,12 +450,14 @@ test('disable', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-        enabled={false}
-      />
+      <JsonFormsReduxContext>
+        <DateTimeCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+          enabled={false}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -445,11 +472,13 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <DateTimeCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <DateTimeCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/vanilla/test/renderers/EnumCell.test.tsx
+++ b/packages/vanilla/test/renderers/EnumCell.test.tsx
@@ -26,6 +26,7 @@ import '@jsonforms/test';
 import * as React from 'react';
 import test from 'ava';
 import { getData, update } from '@jsonforms/core';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 import EnumCell, { enumCellTester } from '../../src/cells/EnumCell';
 import { Provider } from 'react-redux';
 import * as TestUtils from 'react-dom/test-utils';
@@ -33,8 +34,8 @@ import { initJsonFormsVanillaStore } from '../vanillaStore';
 
 test.beforeEach(t => {
   t.context.data = { 'foo': 'a' };
-  t.context.schema =  {
-        type: 'string',
+  t.context.schema = {
+    type: 'string',
     enum: ['a', 'b'],
   };
   t.context.uischema = {
@@ -56,15 +57,15 @@ test.beforeEach(t => {
 test('tester', t => {
   t.is(enumCellTester(undefined, undefined), -1);
   t.is(enumCellTester(null, undefined), -1);
-  t.is(enumCellTester({type: 'Foo'}, undefined), -1);
-  t.is(enumCellTester({type: 'Control'}, undefined), -1);
+  t.is(enumCellTester({ type: 'Foo' }, undefined), -1);
+  t.is(enumCellTester({ type: 'Control' }, undefined), -1);
 });
 
 test('tester with wrong prop type', t => {
   t.is(
     enumCellTester(
       t.context.uischema,
-      { type: 'object', properties: {foo: {type: 'string'}} }
+      { type: 'object', properties: { foo: { type: 'string' } } }
     ),
     -1
   );
@@ -72,59 +73,59 @@ test('tester with wrong prop type', t => {
 
 test('tester with wrong prop type, but sibling has correct one', t => {
   t.is(
-      enumCellTester(
-          t.context.uischema,
-          {
-            'type': 'object',
-            'properties': {
-              'foo': {
-                'type': 'string'
-              },
-              'bar': {
-                'type': 'string',
-                'enum': ['a', 'b']
-              }
-            }
+    enumCellTester(
+      t.context.uischema,
+      {
+        'type': 'object',
+        'properties': {
+          'foo': {
+            'type': 'string'
+          },
+          'bar': {
+            'type': 'string',
+            'enum': ['a', 'b']
           }
-      ),
-      -1
+        }
+      }
+    ),
+    -1
   );
 });
 
 test('tester with matching string type', t => {
   t.is(
-      enumCellTester(
-          t.context.uischema,
-          {
-            'type': 'object',
-            'properties': {
-              'foo': {
-                'type': 'string',
-                'enum': ['a', 'b']
-              }
-            }
+    enumCellTester(
+      t.context.uischema,
+      {
+        'type': 'object',
+        'properties': {
+          'foo': {
+            'type': 'string',
+            'enum': ['a', 'b']
           }
-      ),
-      2
+        }
+      }
+    ),
+    2
   );
 });
 
 test('tester with matching numeric type', t => {
   // TODO should this be true?
   t.is(
-      enumCellTester(
-          t.context.uischema,
-          {
-            'type': 'object',
-            'properties': {
-              'foo': {
-                'type': 'number',
-                'enum': [1, 2]
-              }
-            }
+    enumCellTester(
+      t.context.uischema,
+      {
+        'type': 'object',
+        'properties': {
+          'foo': {
+            'type': 'number',
+            'enum': [1, 2]
           }
-      ),
-      2
+        }
+      }
+    ),
+    2
   );
 });
 
@@ -136,7 +137,9 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -157,7 +160,9 @@ test('update via input event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -176,7 +181,9 @@ test('update via action', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const select = TestUtils.findRenderedDOMComponentWithTag(tree, 'select') as HTMLSelectElement;
@@ -193,7 +200,9 @@ test('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const select = TestUtils.findRenderedDOMComponentWithTag(tree, 'select') as HTMLSelectElement;
@@ -210,7 +219,9 @@ test('update with null value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const select = TestUtils.findRenderedDOMComponentWithTag(tree, 'select') as HTMLSelectElement;
@@ -227,7 +238,9 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const select = TestUtils.findRenderedDOMComponentWithTag(tree, 'select') as HTMLSelectElement;
@@ -244,7 +257,9 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const select = TestUtils.findRenderedDOMComponentWithTag(tree, 'select') as HTMLSelectElement;
@@ -261,7 +276,9 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const select = TestUtils.findRenderedDOMComponentWithTag(tree, 'select') as HTMLSelectElement;
@@ -278,7 +295,9 @@ test('disable', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumCell schema={t.context.schema} uischema={t.context.uischema} enabled={false}/>
+      <JsonFormsReduxContext>
+        <EnumCell schema={t.context.schema} uischema={t.context.uischema} enabled={false} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const select = TestUtils.findRenderedDOMComponentWithTag(tree, 'select') as HTMLSelectElement;
@@ -293,7 +312,9 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <EnumCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const select = TestUtils.findRenderedDOMComponentWithTag(tree, 'select') as HTMLSelectElement;

--- a/packages/vanilla/test/renderers/GroupLayout.test.tsx
+++ b/packages/vanilla/test/renderers/GroupLayout.test.tsx
@@ -26,6 +26,7 @@ import '@jsonforms/test';
 import * as React from 'react';
 import test from 'ava';
 import { GroupLayout } from '@jsonforms/core';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 import { Provider } from 'react-redux';
 import GroupLayoutRenderer, { groupTester } from '../../src/layouts/GroupLayout';
 import * as TestUtils from 'react-dom/test-utils';
@@ -34,7 +35,7 @@ import { initJsonFormsVanillaStore } from '../vanillaStore';
 test.beforeEach(t => {
   t.context.uischema = {
     type: 'GroupLayout',
-    elements: [{type: 'Control'}]
+    elements: [{ type: 'Control' }]
   };
   t.context.styles = [
     {
@@ -47,8 +48,8 @@ test.beforeEach(t => {
 test('tester', t => {
   t.is(groupTester(undefined, undefined), -1);
   t.is(groupTester(null, undefined), -1);
-  t.is(groupTester({type: 'Foo'}, undefined), -1);
-  t.is(groupTester({type: 'Group'}, undefined), 1);
+  t.is(groupTester({ type: 'Foo' }, undefined), -1);
+  t.is(groupTester({ type: 'Group' }, undefined), 1);
 });
 
 test('render with label', t => {
@@ -65,7 +66,9 @@ test('render with label', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <GroupLayoutRenderer uischema={uischema} />
+      <JsonFormsReduxContext>
+        <GroupLayoutRenderer uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const groupLayout = TestUtils.findRenderedDOMComponentWithClass(tree, 'group-layout');
@@ -90,7 +93,9 @@ test('render with null elements', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <GroupLayoutRenderer uischema={uischema} />
+      <JsonFormsReduxContext>
+        <GroupLayoutRenderer uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const groupLayout = TestUtils.findRenderedDOMComponentWithClass(tree, 'group-layout');
@@ -102,8 +107,8 @@ test('render with children', t => {
   const uischema: GroupLayout = {
     type: 'Group',
     elements: [
-      {type: 'Control'},
-      {type: 'Control'}
+      { type: 'Control' },
+      { type: 'Control' }
     ]
   };
   const store = initJsonFormsVanillaStore({
@@ -114,7 +119,9 @@ test('render with children', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <GroupLayoutRenderer uischema={uischema} />
+      <JsonFormsReduxContext>
+        <GroupLayoutRenderer uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const groupLayout = TestUtils.findRenderedDOMComponentWithClass(tree, 'group-layout');
@@ -131,10 +138,12 @@ test('hide', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <GroupLayoutRenderer
-        uischema={t.context.uischema}
-        visible={false}
-      />
+      <JsonFormsReduxContext>
+        <GroupLayoutRenderer
+          uischema={t.context.uischema}
+          visible={false}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const groupLayout = TestUtils.findRenderedDOMComponentWithClass(
@@ -153,7 +162,9 @@ test('show by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <GroupLayoutRenderer uischema={t.context.uischema} />
+      <JsonFormsReduxContext>
+        <GroupLayoutRenderer uischema={t.context.uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const groupLayout = TestUtils.findRenderedDOMComponentWithClass(

--- a/packages/vanilla/test/renderers/HorizontalLayout.test.tsx
+++ b/packages/vanilla/test/renderers/HorizontalLayout.test.tsx
@@ -35,11 +35,12 @@ import HorizontalLayoutRenderer, {
   horizontalLayoutTester
 } from '../../src/layouts/HorizontalLayout';
 import { initJsonFormsVanillaStore } from '../vanillaStore';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 
 test.beforeEach(t => {
   t.context.uischema = {
     type: 'HorizontalLayout',
-    elements: [{type: 'Control'}]
+    elements: [{ type: 'Control' }]
   };
   t.context.styles = [
     {
@@ -68,7 +69,9 @@ test('render with undefined elements', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <HorizontalLayoutRenderer uischema={uischema} />
+      <JsonFormsReduxContext>
+        <HorizontalLayoutRenderer uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -90,7 +93,9 @@ test('render with null elements', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <HorizontalLayoutRenderer uischema={uischema} />
+      <JsonFormsReduxContext>
+        <HorizontalLayoutRenderer uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const horizontalLayout = TestUtils.findRenderedDOMComponentWithClass(tree, 'horizontal-layout');
@@ -114,7 +119,9 @@ test('render with children', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <HorizontalLayoutRenderer uischema={uischema} />
+      <JsonFormsReduxContext>
+        <HorizontalLayoutRenderer uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const horizontalLayout = TestUtils.findRenderedDOMComponentWithClass(tree, 'horizontal-layout');
@@ -131,10 +138,12 @@ test('hide', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <HorizontalLayoutRenderer
-        uischema={t.context.uischema}
-        visible={false}
-      />
+      <JsonFormsReduxContext>
+        <HorizontalLayoutRenderer
+          uischema={t.context.uischema}
+          visible={false}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const horizontalLayout = TestUtils.findRenderedDOMComponentWithClass(
@@ -152,7 +161,9 @@ test('show by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <HorizontalLayoutRenderer uischema={t.context.uischema}/>
+      <JsonFormsReduxContext>
+        <HorizontalLayoutRenderer uischema={t.context.uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const horizontalLayout = TestUtils.findRenderedDOMComponentWithClass(

--- a/packages/vanilla/test/renderers/InputControl.test.tsx
+++ b/packages/vanilla/test/renderers/InputControl.test.tsx
@@ -31,7 +31,7 @@ import {
   HorizontalLayout,
   JsonSchema
 } from '@jsonforms/core';
-import { JsonForms } from '@jsonforms/react';
+import { JsonFormsDispatch, JsonFormsReduxContext } from '@jsonforms/react';
 import { Provider } from 'react-redux';
 import '../../src';
 import HorizontalLayoutRenderer, {
@@ -104,7 +104,9 @@ test('autofocus on first element', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <JsonForms />
+      <JsonFormsReduxContext>
+        <JsonFormsDispatch />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const inputs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
@@ -134,7 +136,9 @@ test('render', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <InputControl uischema={t.context.uischema} schema={t.context.schema} />
+      <JsonFormsReduxContext>
+        <InputControl uischema={t.context.uischema} schema={t.context.schema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
 
@@ -182,7 +186,9 @@ test('render without label', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <JsonForms />
+      <JsonFormsReduxContext>
+        <JsonFormsDispatch />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
 
@@ -226,12 +232,14 @@ test('hide', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <InputControl
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path={''}
-        visible={false}
-      />
+      <JsonFormsReduxContext>
+        <InputControl
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path={''}
+          visible={false}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const control = TestUtils.findRenderedDOMComponentWithClass(
@@ -251,7 +259,9 @@ test('show by default', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <InputControl schema={t.context.schema} uischema={t.context.uischema} />
+      <JsonFormsReduxContext>
+        <InputControl schema={t.context.schema} uischema={t.context.uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const control = TestUtils.findRenderedDOMComponentWithClass(
@@ -271,7 +281,9 @@ test('single error', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <InputControl schema={t.context.schema} uischema={t.context.uischema} />
+      <JsonFormsReduxContext>
+        <InputControl schema={t.context.schema} uischema={t.context.uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const validation = TestUtils.findRenderedDOMComponentWithClass(
@@ -292,7 +304,9 @@ test('multiple errors', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <InputControl schema={t.context.schema} uischema={t.context.uischema} />
+      <JsonFormsReduxContext>
+        <InputControl schema={t.context.schema} uischema={t.context.uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const validation = TestUtils.findRenderedDOMComponentWithClass(
@@ -313,7 +327,9 @@ test('empty errors by default', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <JsonForms />
+      <JsonFormsReduxContext>
+        <JsonFormsDispatch />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const validation = TestUtils.findRenderedDOMComponentWithClass(
@@ -333,7 +349,9 @@ test('reset validation message', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <JsonForms />
+      <JsonFormsReduxContext>
+        <JsonFormsDispatch />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const validation = TestUtils.findRenderedDOMComponentWithClass(
@@ -396,7 +414,9 @@ test('validation of nested schema', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <HorizontalLayoutRenderer schema={schema} uischema={uischema} />
+      <JsonFormsReduxContext>
+        <HorizontalLayoutRenderer schema={schema} uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const validation = TestUtils.scryRenderedDOMComponentsWithClass(
@@ -431,7 +451,9 @@ test('required cell is marked', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <InputControl schema={schema} uischema={uischema} />
+      <JsonFormsReduxContext>
+        <InputControl schema={schema} uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const label = TestUtils.findRenderedDOMComponentWithTag(tree, 'label');
@@ -461,7 +483,9 @@ test('not required', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <InputControl schema={schema} uischema={uischema} />
+      <JsonFormsReduxContext>
+        <InputControl schema={schema} uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const label = TestUtils.findRenderedDOMComponentWithTag(tree, 'label');
@@ -492,7 +516,9 @@ test('required cell is marked', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <InputControl schema={schema} uischema={uischema} />
+      <JsonFormsReduxContext>
+        <InputControl schema={schema} uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const label = TestUtils.findRenderedDOMComponentWithTag(tree, 'label');
@@ -523,7 +549,9 @@ test('not required', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <InputControl schema={schema} uischema={uischema} />
+      <JsonFormsReduxContext>
+        <InputControl schema={schema} uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const label = TestUtils.findRenderedDOMComponentWithTag(tree, 'label');
@@ -554,7 +582,9 @@ test('show description on focus', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <InputControl schema={schema} uischema={uischema} />
+      <JsonFormsReduxContext>
+        <InputControl schema={schema} uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const control = TestUtils.findRenderedDOMComponentWithClass(
@@ -593,7 +623,9 @@ test('hide description when input cell is not focused', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <InputControl schema={schema} uischema={uischema} />
+      <JsonFormsReduxContext>
+        <InputControl schema={schema} uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const description = TestUtils.findRenderedDOMComponentWithClass(
@@ -627,7 +659,9 @@ test('hide description on blur', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <JsonForms />
+      <JsonFormsReduxContext>
+        <JsonFormsDispatch />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const control = TestUtils.findRenderedDOMComponentWithClass(
@@ -671,7 +705,9 @@ test('description undefined', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <JsonForms />
+      <JsonFormsReduxContext>
+        <JsonFormsDispatch />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const description = TestUtils.findRenderedDOMComponentWithClass(
@@ -703,7 +739,9 @@ test('undefined input control', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <InputControl schema={schema} uischema={uischema} />
+      <JsonFormsReduxContext>
+        <InputControl schema={schema} uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const control = TestUtils.scryRenderedDOMComponentsWithClass(tree, 'control');

--- a/packages/vanilla/test/renderers/IntegerCell.test.tsx
+++ b/packages/vanilla/test/renderers/IntegerCell.test.tsx
@@ -37,9 +37,10 @@ import HorizontalLayoutRenderer from '../../src/layouts/HorizontalLayout';
 import { Provider } from 'react-redux';
 import * as TestUtils from 'react-dom/test-utils';
 import { initJsonFormsVanillaStore } from '../vanillaStore';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 
 test.beforeEach(t => {
-  t.context.data = {'foo': 42};
+  t.context.data = { 'foo': 42 };
   t.context.schema = {
     type: 'integer',
     minimum: 5
@@ -99,7 +100,7 @@ test.failing('autofocus on first element', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <HorizontalLayoutRenderer schema={schema} uischema={uischema}/>
+      <HorizontalLayoutRenderer schema={schema} uischema={uischema} />
     </Provider>
   ) as unknown as React.Component<any>;
   const inputs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
@@ -176,8 +177,8 @@ test('autofocus inactive by default', t => {
 test('tester', t => {
   t.is(integerCellTester(undefined, undefined), -1);
   t.is(integerCellTester(null, undefined), -1);
-  t.is(integerCellTester({type: 'Foo'}, undefined), -1);
-  t.is(integerCellTester({type: 'Control'}, undefined), -1);
+  t.is(integerCellTester({ type: 'Foo' }, undefined), -1);
+  t.is(integerCellTester({ type: 'Control' }, undefined), -1);
 
   const controlElement: ControlElement = {
     type: 'Control',
@@ -186,21 +187,21 @@ test('tester', t => {
   t.is(
     integerCellTester(
       controlElement,
-      {type: 'object', properties: {foo: {type: 'string'}}}
+      { type: 'object', properties: { foo: { type: 'string' } } }
     ),
     -1
   );
   t.is(
     integerCellTester(
       controlElement,
-      {type: 'object', properties: {foo: {type: 'string'}, bar: {type: 'integer'}}}
+      { type: 'object', properties: { foo: { type: 'string' }, bar: { type: 'integer' } } }
     ),
     -1
   );
   t.is(
     integerCellTester(
       controlElement,
-      {type: 'object', properties: {foo: {type: 'integer'}}}),
+      { type: 'object', properties: { foo: { type: 'integer' } } }),
     2
   );
 });
@@ -213,7 +214,9 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -231,7 +234,9 @@ test('update via input event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -251,7 +256,9 @@ test.cb('update via action', t => {
 
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -273,7 +280,9 @@ test('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -289,7 +298,9 @@ test('update with null value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -306,7 +317,9 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -322,7 +335,9 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -338,7 +353,9 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   store.dispatch(update(undefined, () => 13));
@@ -354,7 +371,9 @@ test('disable', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerCell schema={t.context.schema} uischema={t.context.uischema} enabled={false}/>
+      <JsonFormsReduxContext>
+        <IntegerCell schema={t.context.schema} uischema={t.context.uischema} enabled={false} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -369,7 +388,9 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <IntegerCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/vanilla/test/renderers/LabelControl.test.tsx
+++ b/packages/vanilla/test/renderers/LabelControl.test.tsx
@@ -26,6 +26,7 @@ import '@jsonforms/test';
 import * as React from 'react';
 import test from 'ava';
 import { LabelElement, UISchemaElement } from '@jsonforms/core';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 import { Provider } from 'react-redux';
 import LabelRenderer, {
   labelRendererTester
@@ -65,7 +66,12 @@ test('render with undefined text', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <LabelRenderer schema={t.context.schema} uischema={uischema} />
+      <JsonFormsReduxContext>
+        <LabelRenderer
+          schema={t.context.schema}
+          uischema={uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
 
@@ -91,7 +97,12 @@ test('render with null text', t => {
 
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <LabelRenderer schema={t.context.schema} uischema={uischema} />
+      <JsonFormsReduxContext>
+        <LabelRenderer
+          schema={t.context.schema}
+          uischema={uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const label = TestUtils.findRenderedDOMComponentWithTag(
@@ -111,7 +122,12 @@ test('render with text', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <LabelRenderer schema={t.context.schema} uischema={t.context.uischema} />
+      <JsonFormsReduxContext>
+        <LabelRenderer
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const label = TestUtils.findRenderedDOMComponentWithTag(
@@ -131,11 +147,13 @@ test('hide', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <LabelRenderer
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        visible={false}
-      />
+      <JsonFormsReduxContext>
+        <LabelRenderer
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          visible={false}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const label = TestUtils.findRenderedDOMComponentWithTag(
@@ -153,7 +171,12 @@ test('show by default', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <LabelRenderer schema={t.context.schema} uischema={t.context.uischema} />
+      <JsonFormsReduxContext>
+        <LabelRenderer
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const label = TestUtils.findRenderedDOMComponentWithTag(

--- a/packages/vanilla/test/renderers/NumberCell.test.tsx
+++ b/packages/vanilla/test/renderers/NumberCell.test.tsx
@@ -32,6 +32,7 @@ import {
   JsonSchema,
   update
 } from '@jsonforms/core';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 import NumberCell, { numberCellTester } from '../../src/cells/NumberCell';
 import HorizontalLayoutRenderer from '../../src/layouts/HorizontalLayout';
 import { Provider } from 'react-redux';
@@ -39,7 +40,7 @@ import * as TestUtils from 'react-dom/test-utils';
 import { initJsonFormsVanillaStore } from '../vanillaStore';
 
 test.beforeEach(t => {
-  t.context.data = {'foo': 3.14};
+  t.context.data = { 'foo': 3.14 };
   t.context.schema = {
     type: 'number',
     minimum: 5
@@ -99,9 +100,11 @@ test.failing('autofocus on first element', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <HorizontalLayoutRenderer schema={schema} uischema={uischema}/>
+      <JsonFormsReduxContext>
+        <HorizontalLayoutRenderer schema={schema} uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
-  ) as unknown as React.Component<any> ;
+  ) as unknown as React.Component<any>;
 
   const inputs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
   t.not(document.activeElement, inputs[0]);
@@ -123,9 +126,11 @@ test('autofocus active', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberCell schema={t.context.schema} uischema={uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <NumberCell schema={t.context.schema} uischema={uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
-  ) as unknown as React.Component<any> ;
+  ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
   t.is(document.activeElement, input);
 });
@@ -146,7 +151,9 @@ test('autofocus inactive', t => {
 
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberCell schema={t.context.schema} uischema={uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <NumberCell schema={t.context.schema} uischema={uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -165,7 +172,9 @@ test('autofocus inactive by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberCell schema={t.context.schema} uischema={uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <NumberCell schema={t.context.schema} uischema={uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -175,8 +184,8 @@ test('autofocus inactive by default', t => {
 test('tester', t => {
   t.is(numberCellTester(undefined, undefined), -1);
   t.is(numberCellTester(null, undefined), -1);
-  t.is(numberCellTester({type: 'Foo'}, undefined), -1);
-  t.is(numberCellTester({type: 'Control'}, undefined), -1);
+  t.is(numberCellTester({ type: 'Foo' }, undefined), -1);
+  t.is(numberCellTester({ type: 'Control' }, undefined), -1);
 });
 
 test('tester with wrong schema type', t => {
@@ -254,7 +263,9 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberCell schema={schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <NumberCell schema={schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -272,7 +283,9 @@ test('update via input event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <NumberCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -289,7 +302,9 @@ test('update via action', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <NumberCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -306,7 +321,9 @@ test('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <NumberCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -322,7 +339,9 @@ test('update with null value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <NumberCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -338,7 +357,9 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <NumberCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -354,7 +375,9 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <NumberCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -370,7 +393,9 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <NumberCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   store.dispatch(update(undefined, () => 13));
@@ -386,7 +411,9 @@ test('disable', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberCell schema={t.context.schema} uischema={t.context.uischema} enabled={false}/>
+      <JsonFormsReduxContext>
+        <NumberCell schema={t.context.schema} uischema={t.context.uischema} enabled={false} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -401,7 +428,9 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <NumberCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <NumberCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/vanilla/test/renderers/RadioGroupControl.test.tsx
+++ b/packages/vanilla/test/renderers/RadioGroupControl.test.tsx
@@ -29,12 +29,13 @@ import {
     rankWith,
     update
 } from '@jsonforms/core';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 import * as React from 'react';
+import * as TestUtils from 'react-dom/test-utils';
 import * as _ from 'lodash';
 import { Provider } from 'react-redux';
 import '../../src';
 import RadioGroupControl from '../../src/controls/RadioGroupControl';
-import * as TestUtils from 'react-dom/test-utils';
 import { initJsonFormsVanillaStore } from '../vanillaStore';
 
 test.beforeEach(t => {
@@ -63,7 +64,9 @@ test('render', t => {
     });
     const tree: React.Component<any> = TestUtils.renderIntoDocument(
         <Provider store={store}>
-            <RadioGroupControl schema={t.context.schema} uischema={t.context.uischema} />
+            <JsonFormsReduxContext>
+                <RadioGroupControl schema={t.context.schema} uischema={t.context.uischema} />
+            </JsonFormsReduxContext>
         </Provider>
     ) as unknown as React.Component<any>;
 
@@ -86,7 +89,9 @@ test('Radio group should have only one selected option', t => {
     });
     const tree: React.Component<any> = TestUtils.renderIntoDocument(
         <Provider store={store}>
-            <RadioGroupControl schema={t.context.schema} uischema={t.context.uischema} />
+            <JsonFormsReduxContext>
+                <RadioGroupControl schema={t.context.schema} uischema={t.context.uischema} />
+            </JsonFormsReduxContext>
         </Provider>
     ) as unknown as React.Component<any>;
 

--- a/packages/vanilla/test/renderers/SliderCell.test.tsx
+++ b/packages/vanilla/test/renderers/SliderCell.test.tsx
@@ -32,6 +32,7 @@ import {
   JsonSchema,
   update
 } from '@jsonforms/core';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 import SliderCell, { sliderCellTester } from '../../src/cells/SliderCell';
 import HorizontalLayoutRenderer from '../../src/layouts/HorizontalLayout';
 import { Provider } from 'react-redux';
@@ -39,7 +40,7 @@ import * as TestUtils from 'react-dom/test-utils';
 import { initJsonFormsVanillaStore } from '../vanillaStore';
 
 test.beforeEach(t => {
-  t.context.data = {'foo': 5};
+  t.context.data = { 'foo': 5 };
   t.context.schema = {
     type: 'number',
     maximum: 10,
@@ -102,7 +103,9 @@ test.failing('autofocus on first element', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <HorizontalLayoutRenderer schema={schema} uischema={uischema}/>
+      <JsonFormsReduxContext>
+        <HorizontalLayoutRenderer schema={schema} uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -114,7 +117,7 @@ test.failing('autofocus on first element', t => {
 test('autofocus active', t => {
   const uischema: ControlElement = {
     type: 'Control',
-    scope:   '#/properties/foo',
+    scope: '#/properties/foo',
     options: { focus: true }
   };
   const store = initJsonFormsVanillaStore({
@@ -124,11 +127,13 @@ test('autofocus active', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderCell
-        schema={t.context.schema}
-        uischema={uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <SliderCell
+          schema={t.context.schema}
+          uischema={uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -138,7 +143,7 @@ test('autofocus active', t => {
 test('autofocus inactive', t => {
   const uischema: ControlElement = {
     type: 'Control',
-    scope:   '#/properties/foo',
+    scope: '#/properties/foo',
     options: { focus: false }
   };
   const store = initJsonFormsVanillaStore({
@@ -148,11 +153,13 @@ test('autofocus inactive', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderCell
-        schema={t.context.schema}
-        uischema={uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <SliderCell
+          schema={t.context.schema}
+          uischema={uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -168,11 +175,13 @@ test('autofocus inactive by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderCell
-        schema={t.context.schema}
-        uischema={uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <SliderCell
+          schema={t.context.schema}
+          uischema={uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -182,8 +191,8 @@ test('autofocus inactive by default', t => {
 test('tester', t => {
   t.is(sliderCellTester(undefined, undefined), -1);
   t.is(sliderCellTester(null, undefined), -1);
-  t.is(sliderCellTester({type: 'Foo'}, undefined), -1);
-  t.is(sliderCellTester({type: 'Control'}, undefined), -1);
+  t.is(sliderCellTester({ type: 'Foo' }, undefined), -1);
+  t.is(sliderCellTester({ type: 'Control' }, undefined), -1);
 });
 
 test('tester with wrong schema type', t => {
@@ -376,11 +385,13 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderCell
-        schema={schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <SliderCell
+          schema={schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -396,11 +407,13 @@ test('update via input event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <SliderCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -411,17 +424,19 @@ test('update via input event', t => {
 
 test('update via action', t => {
   const store = initJsonFormsVanillaStore({
-    data: { 'foo': 3},
+    data: { 'foo': 3 },
     schema: t.context.schema,
     uischema: t.context.uischema
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <SliderCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -438,11 +453,13 @@ test.failing('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <SliderCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -458,11 +475,13 @@ test.failing('update with null value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <SliderCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -478,11 +497,13 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <SliderCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -498,11 +519,13 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <SliderCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -518,11 +541,13 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <SliderCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   store.dispatch(update(undefined, () => 13));
@@ -538,12 +563,14 @@ test('disable', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-        enabled={false}
-      />
+      <JsonFormsReduxContext>
+        <SliderCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+          enabled={false}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -558,11 +585,13 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <SliderCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='foo'
-      />
+      <JsonFormsReduxContext>
+        <SliderCell
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          path='foo'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/vanilla/test/renderers/TableArrayControl.test.tsx
+++ b/packages/vanilla/test/renderers/TableArrayControl.test.tsx
@@ -33,6 +33,7 @@ import {
   HorizontalLayout,
   update
 } from '@jsonforms/core';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 import TableArrayControl, { tableArrayControlTester, } from '../../src/complex/TableArrayControl';
 import HorizontalLayoutRenderer from '../../src/layouts/HorizontalLayout';
 import '../../src';
@@ -83,10 +84,12 @@ test('render two children', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-      />
+      <JsonFormsReduxContext>
+        <TableArrayControl
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -149,10 +152,12 @@ test('render empty data', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-      />
+      <JsonFormsReduxContext>
+        <TableArrayControl
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -206,10 +211,12 @@ test('render new child (empty init data)', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-      />
+      <JsonFormsReduxContext>
+        <TableArrayControl
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -229,10 +236,12 @@ test('render new child (undefined data)', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-      />
+      <JsonFormsReduxContext>
+        <TableArrayControl
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -252,10 +261,12 @@ test('render new child (null data)', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-      />
+      <JsonFormsReduxContext>
+        <TableArrayControl
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -275,10 +286,12 @@ test('render new child', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-      />
+      <JsonFormsReduxContext>
+        <TableArrayControl
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -311,10 +324,12 @@ test('render primitives ', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl
-        schema={schema}
-        uischema={uischema}
-      />
+      <JsonFormsReduxContext>
+        <TableArrayControl
+          schema={schema}
+          uischema={uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const rows = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'tr');
@@ -331,10 +346,12 @@ test('update via action', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-      />
+      <JsonFormsReduxContext>
+        <TableArrayControl
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -461,12 +478,13 @@ test('hide', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        visible={false}
-
-      />
+      <JsonFormsReduxContext>
+        <TableArrayControl
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+          visible={false}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const control = TestUtils.findRenderedDOMComponentWithClass(tree, 'control') as HTMLElement;
@@ -482,10 +500,12 @@ test('show by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-      />
+      <JsonFormsReduxContext>
+        <TableArrayControl
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const control = TestUtils.findRenderedDOMComponentWithClass(tree, 'control') as HTMLElement;
@@ -500,10 +520,12 @@ test('single error', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-      />
+      <JsonFormsReduxContext>
+        <TableArrayControl
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const validation = TestUtils.findRenderedDOMComponentWithClass(tree, 'validation');
@@ -519,10 +541,12 @@ test('multiple errors', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-      />
+      <JsonFormsReduxContext>
+        <TableArrayControl
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const validation = TestUtils.findRenderedDOMComponentWithClass(tree, 'validation');
@@ -538,10 +562,12 @@ test('empty errors by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-      />
+      <JsonFormsReduxContext>
+        <TableArrayControl
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const validation = TestUtils.findRenderedDOMComponentWithClass(tree, 'validation');
@@ -556,10 +582,12 @@ test('reset validation message', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TableArrayControl
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-      />
+      <JsonFormsReduxContext>
+        <TableArrayControl
+          schema={t.context.schema}
+          uischema={t.context.uischema}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const validation = TestUtils.findRenderedDOMComponentWithClass(tree, 'validation');

--- a/packages/vanilla/test/renderers/TextAreaCell.test.tsx
+++ b/packages/vanilla/test/renderers/TextAreaCell.test.tsx
@@ -32,6 +32,7 @@ import {
   JsonSchema,
   update
 } from '@jsonforms/core';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 import TextAreaCell, { textAreaCellTester, } from '../../src/cells/TextAreaCell';
 import HorizontalLayoutRenderer from '../../src/layouts/HorizontalLayout';
 import { Provider } from 'react-redux';
@@ -39,7 +40,7 @@ import * as TestUtils from 'react-dom/test-utils';
 import { initJsonFormsVanillaStore } from '../vanillaStore';
 
 test.beforeEach(t => {
-  t.context.data = {'name': 'Foo'};
+  t.context.data = { 'name': 'Foo' };
   t.context.schema = {
     type: 'string',
     minLength: 3
@@ -60,73 +61,73 @@ test.beforeEach(t => {
   ];
 });
 test.failing('autofocus on first element', t => {
-    const schema: JsonSchema = {
-        type: 'object',
-        properties: {
-            firstName: { type: 'string', minLength: 3 },
-            lastName: { type: 'string', minLength: 3 }
-        }
-    };
-    const firstControlElement: ControlElement = {
-        type: 'Control',
-        scope: '#/properties/firstName',
-        options: {
-            focus: true
-        }
-    };
-    const secondControlElement: ControlElement = {
-        type: 'Control',
-        scope: '#/properties/lastName',
-        options: {
-            focus: true
-        }
-    };
-    const uischema: HorizontalLayout = {
-        type: 'HorizontalLayout',
-        elements: [
-            firstControlElement,
-            secondControlElement
-        ]
-    };
-    const data = {
-        'firstName': 'Foo',
-        'lastName': 'Boo'
-    };
-    const store = initJsonFormsVanillaStore({
-      data,
-      schema,
-      uischema
-    });
-    const tree: React.Component<any> = TestUtils.renderIntoDocument(
-        <Provider store={store}>
-          <HorizontalLayoutRenderer schema={schema} uischema={uischema}/>
-        </Provider>
-    ) as unknown as React.Component<any>;
-    const inputs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
-    t.not(document.activeElement, inputs[0]);
-    t.is(document.activeElement, inputs[1]);
+  const schema: JsonSchema = {
+    type: 'object',
+    properties: {
+      firstName: { type: 'string', minLength: 3 },
+      lastName: { type: 'string', minLength: 3 }
+    }
+  };
+  const firstControlElement: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/firstName',
+    options: {
+      focus: true
+    }
+  };
+  const secondControlElement: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/lastName',
+    options: {
+      focus: true
+    }
+  };
+  const uischema: HorizontalLayout = {
+    type: 'HorizontalLayout',
+    elements: [
+      firstControlElement,
+      secondControlElement
+    ]
+  };
+  const data = {
+    'firstName': 'Foo',
+    'lastName': 'Boo'
+  };
+  const store = initJsonFormsVanillaStore({
+    data,
+    schema,
+    uischema
+  });
+  const tree: React.Component<any> = TestUtils.renderIntoDocument(
+    <Provider store={store}>
+      <HorizontalLayoutRenderer schema={schema} uischema={uischema} />
+    </Provider>
+  ) as unknown as React.Component<any>;
+  const inputs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
+  t.not(document.activeElement, inputs[0]);
+  t.is(document.activeElement, inputs[1]);
 });
 
 test('autofocus active', t => {
-    const uischema: ControlElement = {
-        type: 'Control',
-        scope: '#/properties/name',
-        options: {
-            focus: true
-        }
-    };
-    const store = initJsonFormsVanillaStore({
-      data: t.context.data,
-      schema: t.context.schema,
-      uischema
-    });
-    const tree: React.Component<any> = TestUtils.renderIntoDocument(
-        <Provider store={store}>
-          <TextAreaCell schema={t.context.schema} uischema={uischema} path='name' />
-        </Provider>
-    ) as unknown as React.Component<any>;
-    const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'textarea') as HTMLInputElement;
-    t.is(document.activeElement, input);
+  const uischema: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/name',
+    options: {
+      focus: true
+    }
+  };
+  const store = initJsonFormsVanillaStore({
+    data: t.context.data,
+    schema: t.context.schema,
+    uischema
+  });
+  const tree: React.Component<any> = TestUtils.renderIntoDocument(
+    <Provider store={store}>
+      <TextAreaCell schema={t.context.schema} uischema={uischema} path='name' />
+    </Provider>
+  ) as unknown as React.Component<any>;
+  const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'textarea') as HTMLInputElement;
+  t.is(document.activeElement, input);
 });
 
 test('autofocus inactive', t => {
@@ -173,9 +174,9 @@ test('autofocus inactive by default', t => {
 test('tester', t => {
   t.is(textAreaCellTester(undefined, undefined), -1);
   t.is(textAreaCellTester(null, undefined), -1);
-  t.is(textAreaCellTester({type: 'Foo'}, undefined), -1);
-  t.is(textAreaCellTester({type: 'Control'}, undefined), -1);
-  t.is(textAreaCellTester({type: 'Control', options: {multi: true}}, undefined), 2);
+  t.is(textAreaCellTester({ type: 'Foo' }, undefined), -1);
+  t.is(textAreaCellTester({ type: 'Control' }, undefined), -1);
+  t.is(textAreaCellTester({ type: 'Control', options: { multi: true } }, undefined), 2);
 });
 
 test('render', t => {
@@ -185,9 +186,11 @@ test('render', t => {
     uischema: t.context.uischema
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
-      <Provider store={store}>
-          <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
-      </Provider>
+    <Provider store={store}>
+      <JsonFormsReduxContext>
+        <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      </JsonFormsReduxContext>
+    </Provider>
   ) as unknown as React.Component<any>;
   const textarea = TestUtils.findRenderedDOMComponentWithTag(
     tree,
@@ -204,7 +207,9 @@ test('update via input event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      <JsonFormsReduxContext>
+        <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -225,7 +230,9 @@ test.cb('update via action', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      <JsonFormsReduxContext>
+        <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const textarea = TestUtils.findRenderedDOMComponentWithTag(
@@ -236,7 +243,7 @@ test.cb('update via action', t => {
   setTimeout(() => {
     t.is(textarea.value, 'Bar');
     t.end();
-  },         100);
+  }, 100);
 });
 
 test('update with undefined value', t => {
@@ -247,7 +254,9 @@ test('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      <JsonFormsReduxContext>
+        <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const textArea = TestUtils.findRenderedDOMComponentWithTag(
@@ -266,7 +275,9 @@ test('update with null value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      <JsonFormsReduxContext>
+        <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const textArea = TestUtils.findRenderedDOMComponentWithTag(
@@ -285,7 +296,9 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      <JsonFormsReduxContext>
+        <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const textArea = TestUtils.findRenderedDOMComponentWithTag(
@@ -304,7 +317,9 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      <JsonFormsReduxContext>
+        <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const textArea = TestUtils.findRenderedDOMComponentWithTag(
@@ -323,7 +338,9 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      <JsonFormsReduxContext>
+        <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const textArea = TestUtils.findRenderedDOMComponentWithTag(
@@ -342,7 +359,9 @@ test('disable', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} enabled={false}/>
+      <JsonFormsReduxContext>
+        <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} enabled={false} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const textArea = TestUtils.findRenderedDOMComponentWithTag(
@@ -360,7 +379,9 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      <JsonFormsReduxContext>
+        <TextAreaCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const textArea = TestUtils.findRenderedDOMComponentWithTag(

--- a/packages/vanilla/test/renderers/TextCell.test.tsx
+++ b/packages/vanilla/test/renderers/TextCell.test.tsx
@@ -37,6 +37,7 @@ import HorizontalLayoutRenderer from '../../src/layouts/HorizontalLayout';
 import { Provider } from 'react-redux';
 import * as TestUtils from 'react-dom/test-utils';
 import { initJsonFormsVanillaStore } from '../vanillaStore';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 
 const defaultMaxLength = 524288;
 const defaultSize = 20;
@@ -117,11 +118,13 @@ test('autofocus active', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell
-        schema={t.context.minLengthSchema}
-        uischema={uischema}
-        path='name'
-      />
+      <JsonFormsReduxContext>
+        <TextCell
+          schema={t.context.minLengthSchema}
+          uischema={uischema}
+          path='name'
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -144,11 +147,9 @@ test('autofocus inactive', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell
-        schema={t.context.minLengthSchema}
-        uischema={uischema}
-        path='name'
-      />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.minLengthSchema} uischema={uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -166,11 +167,9 @@ test('autofocus inactive by default', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell
-        schema={t.context.minLengthSchema}
-        uischema={t.context.uischema}
-        path='name'
-      />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -201,7 +200,9 @@ test('render', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell schema={schema} uischema={t.context.uischema} path='name' />
+      <JsonFormsReduxContext>
+        <TextCell schema={schema} uischema={t.context.uischema} path='name'/>
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -219,11 +220,9 @@ test('update via input event', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell
-        schema={t.context.minLengthSchema}
-        uischema={t.context.uischema}
-        path='name'
-      />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name'/>
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -243,11 +242,9 @@ test.cb('update via action', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell
-        schema={t.context.minLengthSchema}
-        uischema={t.context.uischema}
-        path='name'
-      />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -269,11 +266,9 @@ test('update with undefined value', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell
-        schema={t.context.minLengthSchema}
-        uischema={t.context.uischema}
-        path='name'
-      />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name'/>
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -292,11 +287,9 @@ test('update with null value', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell
-        schema={t.context.minLengthSchema}
-        uischema={t.context.uischema}
-        path='name'
-      />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name'/>
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -315,11 +308,9 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell
-        schema={t.context.minLengthSchema}
-        uischema={t.context.uischema}
-        path='name'
-      />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -338,11 +329,9 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell
-        schema={t.context.minLengthSchema}
-        uischema={t.context.uischema}
-        path='name'
-      />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -361,11 +350,9 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell
-        schema={t.context.minLengthSchema}
-        uischema={t.context.uischema}
-        path='name'
-      />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -384,12 +371,9 @@ test('disable', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell
-        schema={t.context.minLengthSchema}
-        uischema={t.context.uischema}
-        path='name'
-        enabled={false}
-      />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name' enabled={false} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -407,11 +391,9 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell
-        schema={t.context.minLengthSchema}
-        uischema={t.context.uischema}
-        path='name'
-      />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.minLengthSchema} uischema={t.context.uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -438,11 +420,9 @@ test('use maxLength for attributes size and maxlength', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell
-        schema={t.context.maxLengthSchema}
-        uischema={uischema}
-        path='name'
-      />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.maxLengthSchema} uischema={uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -470,11 +450,9 @@ test('use maxLength for attribute size only', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell
-        schema={t.context.maxLengthSchema}
-        uischema={uischema}
-        path='name'
-      />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.maxLengthSchema} uischema={uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -502,11 +480,9 @@ test('use maxLength for attribute max length only', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell
-        schema={t.context.maxLengthSchema}
-        uischema={uischema}
-        path='name'
-      />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.maxLengthSchema} uischema={uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -525,11 +501,9 @@ test('do not use maxLength by default', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell
-        schema={t.context.maxLengthSchema}
-        uischema={t.context.uischema}
-        path='name'
-      />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.maxLengthSchema} uischema={t.context.uischema} path='name'/>
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -557,7 +531,9 @@ test('maxLength not specified, attributes should have default values (trim && re
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell schema={t.context.schema} uischema={uischema} path='name' />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.schema} uischema={uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -585,7 +561,9 @@ test('maxLength not specified, attributes should have default values (trim)', t 
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell schema={t.context.schema} uischema={uischema} path='name' />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.schema} uischema={uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -613,7 +591,9 @@ test('maxLength not specified, attributes should have default values (restrict)'
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell schema={t.context.schema} uischema={uischema} path='name' />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.schema} uischema={uischema} path='name'/>
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(
@@ -632,11 +612,9 @@ test('maxLength not specified, attributes should have default values', t => {
   });
   const tree: React.Component<any> = (TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TextCell
-        schema={t.context.schema}
-        uischema={t.context.uischema}
-        path='name'
-      />
+      <JsonFormsReduxContext>
+        <TextCell schema={t.context.schema} uischema={t.context.uischema} path='name' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown) as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(

--- a/packages/vanilla/test/renderers/TimeCell.test.tsx
+++ b/packages/vanilla/test/renderers/TimeCell.test.tsx
@@ -37,6 +37,7 @@ import TimeCell, { timeCellTester } from '../../src/cells/TimeCell';
 import { Provider } from 'react-redux';
 import * as TestUtils from 'react-dom/test-utils';
 import { initJsonFormsVanillaStore } from '../vanillaStore';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 
 test.beforeEach(t => {
   t.context.data = { 'foo': '13:37' };
@@ -100,7 +101,7 @@ test.failing('autofocus on first element', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <HorizontalLayoutRenderer schema={schema} uischema={uischema}/>
+      <HorizontalLayoutRenderer schema={schema} uischema={uischema} />
     </Provider>
   ) as unknown as React.Component<any>;
   const inputs = TestUtils.scryRenderedDOMComponentsWithTag(tree, 'input');
@@ -123,7 +124,7 @@ test('autofocus active', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeCell schema={t.context.schema} uischema={uischema} path='foo'/>
+      <TimeCell schema={t.context.schema} uischema={uischema} path='foo' />
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -145,7 +146,7 @@ test('autofocus inactive', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeCell schema={t.context.schema} uischema={uischema} path='foo'/>
+      <TimeCell schema={t.context.schema} uischema={uischema} path='foo' />
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -164,7 +165,7 @@ test('autofocus inactive by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeCell schema={t.context.schema} uischema={uischema} path='foo'/>
+      <TimeCell schema={t.context.schema} uischema={uischema} path='foo' />
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -239,7 +240,9 @@ test('render', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -257,13 +260,15 @@ test.cb('update via event', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
   input.value = '20:15';
   TestUtils.Simulate.change(input);
-  setTimeout(() => {t.is(getData(store.getState()).foo, '20:15'); t.end(); }, 100);
+  setTimeout(() => { t.is(getData(store.getState()).foo, '20:15'); t.end(); }, 100);
 });
 
 test.cb('update via action', t => {
@@ -275,12 +280,14 @@ test.cb('update via action', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
   store.dispatch(update('foo', () => '20:15'));
-  setTimeout(() => {t.is(input.value, '20:15'); t.end(); }, 100);
+  setTimeout(() => { t.is(input.value, '20:15'); t.end(); }, 100);
 });
 
 test('update with null value', t => {
@@ -309,7 +316,9 @@ test('update with undefined value', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -326,7 +335,9 @@ test('update with wrong ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -343,7 +354,9 @@ test('update with null ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -360,7 +373,9 @@ test('update with undefined ref', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -377,7 +392,9 @@ test('disable', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' enabled={false}/>
+      <JsonFormsReduxContext>
+        <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' enabled={false} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;
@@ -393,7 +410,9 @@ test('enabled by default', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      <JsonFormsReduxContext>
+        <TimeCell schema={t.context.schema} uischema={t.context.uischema} path='foo' />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const input = TestUtils.findRenderedDOMComponentWithTag(tree, 'input') as HTMLInputElement;

--- a/packages/vanilla/test/renderers/VerticalLayout.test.tsx
+++ b/packages/vanilla/test/renderers/VerticalLayout.test.tsx
@@ -27,6 +27,7 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import test from 'ava';
 import { UISchemaElement, VerticalLayout } from '@jsonforms/core';
+import { JsonFormsReduxContext } from '@jsonforms/react';
 import VerticalLayoutRenderer, { verticalLayoutTester } from '../../src/layouts/VerticalLayout';
 import * as TestUtils from 'react-dom/test-utils';
 import { initJsonFormsVanillaStore } from '../vanillaStore';
@@ -41,8 +42,8 @@ const styles = [
 test('tester', t => {
   t.is(verticalLayoutTester(undefined, undefined), -1);
   t.is(verticalLayoutTester(null, undefined), -1);
-  t.is(verticalLayoutTester({type: 'Foo'}, undefined), -1);
-  t.is(verticalLayoutTester({type: 'VerticalLayout'}, undefined), 1);
+  t.is(verticalLayoutTester({ type: 'Foo' }, undefined), -1);
+  t.is(verticalLayoutTester({ type: 'VerticalLayout' }, undefined), 1);
 });
 
 test('render with undefined elements', t => {
@@ -56,7 +57,9 @@ test('render with undefined elements', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <VerticalLayoutRenderer uischema={uischema} />
+      <JsonFormsReduxContext>
+        <VerticalLayoutRenderer uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as unknown as React.Component<any>;
 
@@ -76,7 +79,9 @@ test('render with null elements', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <VerticalLayoutRenderer uischema={uischema} />
+      <JsonFormsReduxContext>
+        <VerticalLayoutRenderer uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
 
@@ -86,7 +91,7 @@ test('render with null elements', t => {
 test('render with children', t => {
   const uischema: VerticalLayout = {
     type: 'VerticalLayout',
-    elements: [ {type: 'Control'}, {type: 'Control'} ]
+    elements: [{ type: 'Control' }, { type: 'Control' }]
   };
   const store = initJsonFormsVanillaStore({
     data: {},
@@ -96,7 +101,9 @@ test('render with children', t => {
   });
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <VerticalLayoutRenderer uischema={uischema} />
+      <JsonFormsReduxContext>
+        <VerticalLayoutRenderer uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const verticalLayout = TestUtils.findRenderedDOMComponentWithClass(tree, 'vertical-layout');
@@ -119,10 +126,12 @@ test('hide', t => {
 
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <VerticalLayoutRenderer
-        uischema={uischema}
-        visible={false}
-      />
+      <JsonFormsReduxContext>
+        <VerticalLayoutRenderer
+          uischema={uischema}
+          visible={false}
+        />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const verticalLayout = TestUtils.findRenderedDOMComponentWithClass(
@@ -146,7 +155,9 @@ test('show by default', t => {
 
   const tree: React.Component<any> = TestUtils.renderIntoDocument(
     <Provider store={store}>
-      <VerticalLayoutRenderer uischema={uischema} />
+      <JsonFormsReduxContext>
+        <VerticalLayoutRenderer uischema={uischema} />
+      </JsonFormsReduxContext>
     </Provider>
   ) as unknown as React.Component<any>;
   const verticalLayout = TestUtils.findRenderedDOMComponentWithClass(

--- a/packages/webcomponent/src/JsonFormsElement.tsx
+++ b/packages/webcomponent/src/JsonFormsElement.tsx
@@ -38,7 +38,7 @@ import {
   JsonSchema,
   UISchemaElement
 } from '@jsonforms/core';
-import { ResolvedJsonForms } from '@jsonforms/react';
+import { JsonFormsReduxContext, JsonFormsDispatch } from '@jsonforms/react';
 import { Store } from 'redux';
 
 /**
@@ -72,7 +72,8 @@ const CustomElement = (config: CustomElementConfig) => (cls: any) => {
   selector: 'json-forms'
 })
 export class JsonFormsElement extends HTMLElement {
-  private InnerComponent: any = ResolvedJsonForms;
+
+  private InnerComponent: any = JsonFormsDispatch;
   private innerComponentParameters: any = {};
   private allowDynamicUpdate = false;
   private _store: JsonFormsStore;
@@ -152,9 +153,12 @@ export class JsonFormsElement extends HTMLElement {
 
     ReactDOM.render(
       <Provider store={this._store} key={`${storeId}-store`}>
-        <this.InnerComponent {...this.innerComponentParameters} />
+        <JsonFormsReduxContext>
+          <this.InnerComponent {...this.innerComponentParameters} />
+        </JsonFormsReduxContext>
       </Provider>,
       this
     );
   }
+
 }


### PR DESCRIPTION
Add context-based mapping functions to react package.
Disconnect material renderer set and provide redux based context.

This is a WIP, there's are still some things to do:
- dispatch currently only handles core actions
- typings (react dispatch vs. redux dispatch)