### PR TITLE
#1254 - Add support for JSONSchema constants

### DIFF
--- a/packages/core/src/testers/index.ts
+++ b/packages/core/src/testers/index.ts
@@ -299,8 +299,10 @@ export const isDateControl = and(uiTypeIs('Control'), formatIs('date'));
  */
 export const isEnumControl = and(
   uiTypeIs('Control'),
-  or(schemaMatches(schema => schema.hasOwnProperty('enum')),
-     schemaMatches(schema => schema.hasOwnProperty('const')))
+  or(
+    schemaMatches(schema => schema.hasOwnProperty('enum')),
+    schemaMatches(schema => schema.hasOwnProperty('const'))
+  )
 );
 
 /**

--- a/packages/core/src/testers/index.ts
+++ b/packages/core/src/testers/index.ts
@@ -299,7 +299,8 @@ export const isDateControl = and(uiTypeIs('Control'), formatIs('date'));
  */
 export const isEnumControl = and(
   uiTypeIs('Control'),
-  schemaMatches(schema => schema.hasOwnProperty('enum'))
+  or(schemaMatches(schema => schema.hasOwnProperty('enum')),
+     schemaMatches(schema => schema.hasOwnProperty('const')))
 );
 
 /**

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -1,19 +1,19 @@
 /*
   The MIT License
-  
+
   Copyright (c) 2017-2019 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
-  
+
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
-  
+
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
-  
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -415,7 +415,9 @@ export const mapStateToEnumControlProps = (
 ): StatePropsOfControl & OwnPropsOfEnum => {
   const props: StatePropsOfControl = mapStateToControlProps(state, ownProps);
   const options =
-    ownProps.options !== undefined ? ownProps.options : props.schema.enum || [props.schema.const];
+    ownProps.options !== undefined
+      ? ownProps.options
+      : props.schema.enum || [props.schema.const];
   return {
     ...props,
     options

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -415,7 +415,7 @@ export const mapStateToEnumControlProps = (
 ): StatePropsOfControl & OwnPropsOfEnum => {
   const props: StatePropsOfControl = mapStateToControlProps(state, ownProps);
   const options =
-    ownProps.options !== undefined ? ownProps.options : props.schema.enum;
+    ownProps.options !== undefined ? ownProps.options : props.schema.enum || [props.schema.const];
   return {
     ...props,
     options

--- a/packages/core/test/testers.test.ts
+++ b/packages/core/test/testers.test.ts
@@ -518,8 +518,7 @@ test('test isEnumControl', t => {
   t.true(
     isEnumControl(t.context.uischema, {
       type: 'object',
-      properties: { foo: { const: '1.0' } },
-      required: ['version']
+      properties: { foo: { const: '1.0' } }
     })
   );
 });

--- a/packages/core/test/testers.test.ts
+++ b/packages/core/test/testers.test.ts
@@ -518,8 +518,8 @@ test('test isEnumControl', t => {
   t.true(
     isEnumControl(t.context.uischema, {
       type: 'object',
-      properties:{ foo: { const:"1.0" } },
-      required:[ "version" ]
+      properties: { foo: { const: '1.0' } },
+      required: ['version']
     })
   );
 });

--- a/packages/core/test/testers.test.ts
+++ b/packages/core/test/testers.test.ts
@@ -515,6 +515,13 @@ test('test isEnumControl', t => {
       properties: { foo: { type: 'number', enum: [1, 2] } }
     })
   );
+  t.true(
+    isEnumControl(t.context.uischema, {
+      type: 'object',
+      properties:{ foo: { const:"1.0" } },
+      required:[ "version" ]
+    })
+  );
 });
 test('test isIntegerControl', t => {
   t.false(isIntegerControl(undefined, undefined));

--- a/packages/examples/src/1254.ts
+++ b/packages/examples/src/1254.ts
@@ -1,0 +1,67 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import { registerExamples } from './register';
+
+export const schema = {
+   type: 'object',
+   properties:{
+     name: {
+       type: 'string',
+       minLength: 1
+     },
+     version: {
+         const: '1.0'
+      }
+   },
+   required: [
+      'version'
+   ]
+};
+
+export const uischema = {
+  type: "HorizontalLayout",
+  elements: [{
+    type: 'Control',
+    label: 'Value',
+    scope: '#/properties/name'
+  }, {
+    type: 'Control',
+    label: 'Value',
+    scope: '#/properties/version'
+  }]
+
+};
+
+const data = {};
+
+registerExamples([
+  {
+    name: 'issue-1254',
+    label: 'issue 1254 (JSONSchema constants)',
+    data,
+    schema,
+    uischema
+  }
+]);

--- a/packages/examples/src/1254.ts
+++ b/packages/examples/src/1254.ts
@@ -25,33 +25,33 @@
 import { registerExamples } from './register';
 
 export const schema = {
-   type: 'object',
-   properties:{
-     name: {
-       type: 'string',
-       minLength: 1
-     },
-     version: {
-         const: '1.0'
-      }
-   },
-   required: [
-      'version'
-   ]
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+      minLength: 1
+    },
+    version: {
+      const: '1.0'
+    }
+  },
+  required: ['version']
 };
 
 export const uischema = {
-  type: "HorizontalLayout",
-  elements: [{
-    type: 'Control',
-    label: 'Value',
-    scope: '#/properties/name'
-  }, {
-    type: 'Control',
-    label: 'Value',
-    scope: '#/properties/version'
-  }]
-
+  type: 'HorizontalLayout',
+  elements: [
+    {
+      type: 'Control',
+      label: 'Value',
+      scope: '#/properties/name'
+    },
+    {
+      type: 'Control',
+      label: 'Value',
+      scope: '#/properties/version'
+    }
+  ]
 };
 
 const data = {};

--- a/packages/examples/src/1254.ts
+++ b/packages/examples/src/1254.ts
@@ -43,12 +43,12 @@ export const uischema = {
   elements: [
     {
       type: 'Control',
-      label: 'Value',
+      label: 'Name',
       scope: '#/properties/name'
     },
     {
       type: 'Control',
-      label: 'Value',
+      label: 'Version',
       scope: '#/properties/version'
     }
   ]

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -58,6 +58,7 @@ import * as i18n from './i18n';
 import * as issue_1169 from './1169';
 import * as issue_1220 from './1220';
 import * as issue_1253 from './1253';
+import * as issue_1254 from './1254';
 import * as oneOfRecursive from './oneOf-recursive';
 import * as huge from './huge';
 export * from './register';
@@ -100,6 +101,7 @@ export {
   issue_1169,
   issue_1220,
   issue_1253,
+  issue_1254,
   oneOfRecursive,
   huge
 };


### PR DESCRIPTION
The JSON reference for constant values in JSONSchema says
"It should be noted that const is merely syntactic sugar for an enum
with a single element"
https://json-schema.org/understanding-json-schema/reference/generic.html#constant-values

So this is the way I've implemented them.



