### PR TITLE
Update material-ui to version 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
 			"integrity": "sha512-0aWUktzTK88xDoDlGUDmDBnGW1ZB21W3H9dq0E52fuaN87cwtdca83ioi20/YT+M6EOecYPY7il9fSpy/Ewd1A=="
 		},
 		"@angular/animations": {
-			"version": "7.2.13",
-			"resolved": "https://registry.npmjs.org/@angular/animations/-/animations-7.2.13.tgz",
-			"integrity": "sha512-Z0g0DthJnxTZ0dUc5BlojMq/0XIikhWzTqq0ym8w3G6jqBJD0OJ0jRCIfV0Leqlgzq6Jzvdrx0/JngBiKi5+uA==",
+			"version": "7.2.15",
+			"resolved": "https://registry.npmjs.org/@angular/animations/-/animations-7.2.15.tgz",
+			"integrity": "sha512-8oBt3HLgd2+kyJHUgsd7OzKCCss67t2sch15XNoIWlOLfxclqU+EfFE6t/vCzpT8/+lpZS6LU9ZrTnb+UBj5jg==",
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -48,17 +48,17 @@
 			}
 		},
 		"@angular/common": {
-			"version": "7.2.13",
-			"resolved": "https://registry.npmjs.org/@angular/common/-/common-7.2.13.tgz",
-			"integrity": "sha512-NYlzUkFVgjLg9VB6/lkd8ZV0ZezSiv9vlg+26wOyw7x+gahRrm5WMAGF7eBLrXoZPEaoOO0uhKWKo7oiA0aufA==",
+			"version": "7.2.15",
+			"resolved": "https://registry.npmjs.org/@angular/common/-/common-7.2.15.tgz",
+			"integrity": "sha512-2b5JY2HWVHCf3D1GZjmde7jdAXSTXkYtmjLtA9tQkjOOTr80eHpNSujQqnzb97dk9VT9OjfjqTQd7K3pxZz8jw==",
 			"requires": {
 				"tslib": "^1.9.0"
 			}
 		},
 		"@angular/compiler": {
-			"version": "7.2.13",
-			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-7.2.13.tgz",
-			"integrity": "sha512-k0IvaozNIlrPKUNF3M/NXMb/jfHBCDO9uRYA6h+84FFY4Y9po40c7YXfsfUxGKwouTWyemaxy9iXlLEnd3ELSQ==",
+			"version": "7.2.15",
+			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-7.2.15.tgz",
+			"integrity": "sha512-5yb4NcLk8GuXkYf7Dcor4XkGueYp4dgihzDmMjYDUrV0NPhubKlr+SwGtLOtzgRBWJ1I2bO0S3zwa0q0OgIPOw==",
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -82,9 +82,9 @@
 			}
 		},
 		"@angular/core": {
-			"version": "7.2.13",
-			"resolved": "https://registry.npmjs.org/@angular/core/-/core-7.2.13.tgz",
-			"integrity": "sha512-vHD69xxDDSQaE8KfHeY2STJSd3xgfsz3/meBCAnT+Bpq9LqxL8DuPlrkC0kyBa2vyj/BwPR3CJNTaQrZcszJ/w==",
+			"version": "7.2.15",
+			"resolved": "https://registry.npmjs.org/@angular/core/-/core-7.2.15.tgz",
+			"integrity": "sha512-XsuYm0jEU/mOqwDOk2utThv8J9kESkAerfuCHClE9rB2TtHUOGCfekF7lJWqjjypu6/J9ygoPFo7hdAE058ZGg==",
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -98,9 +98,9 @@
 			}
 		},
 		"@angular/forms": {
-			"version": "7.2.13",
-			"resolved": "https://registry.npmjs.org/@angular/forms/-/forms-7.2.13.tgz",
-			"integrity": "sha512-dBz7kYa8XoCKxZ+3EvYt6CxHZhM9Qbn3uYkLMsPA+NC6GtIt/tmYn1kNn+YWgVWZtWLvYRaOtYiCuMUJaRNQQw==",
+			"version": "7.2.15",
+			"resolved": "https://registry.npmjs.org/@angular/forms/-/forms-7.2.15.tgz",
+			"integrity": "sha512-p0kcIQLtBBC1qeTA6M3nOuXf/k91E80FKquVM9zEsO2kDjI0oZJVfFYL2UMov5samlJOPN+t6lRHEIUa7ApPsw==",
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -114,25 +114,25 @@
 			}
 		},
 		"@angular/platform-browser": {
-			"version": "7.2.13",
-			"resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-7.2.13.tgz",
-			"integrity": "sha512-4n9De4sOwVoYHh6IGO2+UQIjABqGAXk4RdrEGpXqPBHCNO4sF43c2JsXbPTU4kjPVwTwposfLlKEOjTXfwxGow==",
+			"version": "7.2.15",
+			"resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-7.2.15.tgz",
+			"integrity": "sha512-aYgmPsbC9Tvp9vmKWD8voeAp4crwCay7/D6lM3ClEe2EeK934LuEXq3/uczMrFVbnIX7BBIo8fh03Tl7wbiGPw==",
 			"requires": {
 				"tslib": "^1.9.0"
 			}
 		},
 		"@angular/platform-browser-dynamic": {
-			"version": "7.2.13",
-			"resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-7.2.13.tgz",
-			"integrity": "sha512-3+/BzrNLQ/Tn1hoPal3fvIeB3S/P3e00gHcH3oK+hfACYgWxLE1oIHL+w4NE2eTIJbHfphKhuascMaOH5WNlkg==",
+			"version": "7.2.15",
+			"resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-7.2.15.tgz",
+			"integrity": "sha512-UL2PqhzXMD769NQ6Lh6pxlBDKvN9Qol3XLRFil80lwJ1GRW16ITeYbCamcafIH2GOyd88IhmYcbMfUQ/6q4MMQ==",
 			"requires": {
 				"tslib": "^1.9.0"
 			}
 		},
 		"@angular/router": {
-			"version": "7.2.13",
-			"resolved": "https://registry.npmjs.org/@angular/router/-/router-7.2.13.tgz",
-			"integrity": "sha512-pTdJT9TXk1A9YMa6C2zRRqLB4GPGMSik838P7n+yGrzhdybiudZU9T3egcxDRCWQMjsobVBRKLEUn405n3Hjgg==",
+			"version": "7.2.15",
+			"resolved": "https://registry.npmjs.org/@angular/router/-/router-7.2.15.tgz",
+			"integrity": "sha512-qAubRJRQanguUqJQ76J9GSZ4JFtoyhJKRmX5P23ANZJXpB6YLzF2fJmOGi+E6cV8F0tKBMEq1pjxFTisx0MXwQ==",
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -207,11 +207,11 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
-			"integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+			"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
 			"requires": {
-				"@babel/types": "^7.4.0",
+				"@babel/types": "^7.4.4",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.11",
 				"source-map": "^0.5.0",
@@ -249,11 +249,11 @@
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
-			"integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+			"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
 			"requires": {
-				"@babel/types": "^7.4.0"
+				"@babel/types": "^7.4.4"
 			}
 		},
 		"@babel/highlight": {
@@ -267,39 +267,39 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
-			"integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ=="
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+			"integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew=="
 		},
 		"@babel/runtime": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
-			"integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+			"integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"@babel/template": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
-			"integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+			"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.4.0",
-				"@babel/types": "^7.4.0"
+				"@babel/parser": "^7.4.4",
+				"@babel/types": "^7.4.4"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
-			"integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+			"integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/generator": "^7.4.0",
+				"@babel/generator": "^7.4.4",
 				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.4.0",
-				"@babel/parser": "^7.4.3",
-				"@babel/types": "^7.4.0",
+				"@babel/helper-split-export-declaration": "^7.4.4",
+				"@babel/parser": "^7.4.5",
+				"@babel/types": "^7.4.4",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.11"
@@ -314,9 +314,9 @@
 					}
 				},
 				"globals": {
-					"version": "11.11.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
-					"integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw=="
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
 				},
 				"ms": {
 					"version": "2.1.1",
@@ -326,9 +326,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-			"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+			"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.11",
@@ -351,9 +351,9 @@
 			}
 		},
 		"@date-io/core": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@date-io/core/-/core-1.1.0.tgz",
-			"integrity": "sha512-PyjhyR2fbp7Q8xpB5zoOyT3dqr8Bn4kXfREf1w6AnQalwdftNxChB2/p88fI1qsx8KNmHDJY12eCgLoZaPegTw=="
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/@date-io/core/-/core-1.3.6.tgz",
+			"integrity": "sha512-cihiu8YaTHh7IqrzekbZcA7dh+7uhViHgWyxcKAO2cg1DYGYC5J7z4/rnGGL7swrK5xFVLIeyoxJ+sacziIRKg=="
 		},
 		"@date-io/moment": {
 			"version": "1.1.0",
@@ -362,6 +362,11 @@
 			"requires": {
 				"@date-io/core": "^1.1.0"
 			}
+		},
+		"@emotion/hash": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.1.tgz",
+			"integrity": "sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA=="
 		},
 		"@ionic-native/core": {
 			"version": "4.7.0",
@@ -695,121 +700,114 @@
 			}
 		},
 		"@material-ui/core": {
-			"version": "3.9.3",
-			"resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.3.tgz",
-			"integrity": "sha512-REIj62+zEvTgI/C//YL4fZxrCVIySygmpZglsu/Nl5jPqy3CDjZv1F9ubBYorHqmRgeVPh64EghMMWqk4egmfg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.0.2.tgz",
+			"integrity": "sha512-k7o95UIupTp14lsO9hejmswuPZsmWUafOBNaptHN+Pv8CBp/vW+hD6peuThgUpeGesrCuL2/yTpHB/9JkO9rNg==",
 			"requires": {
 				"@babel/runtime": "^7.2.0",
-				"@material-ui/system": "^3.0.0-alpha.0",
-				"@material-ui/utils": "^3.0.0-alpha.2",
-				"@types/jss": "^9.5.6",
-				"@types/react-transition-group": "^2.0.8",
-				"brcast": "^3.0.1",
-				"classnames": "^2.2.5",
+				"@material-ui/styles": "^4.0.2",
+				"@material-ui/system": "^4.0.2",
+				"@material-ui/types": "^4.0.1",
+				"@material-ui/utils": "^4.0.1",
+				"@types/react-transition-group": "^2.0.16",
+				"clsx": "^1.0.2",
+				"convert-css-length": "^2.0.0",
 				"csstype": "^2.5.2",
 				"debounce": "^1.1.0",
 				"deepmerge": "^3.0.0",
-				"dom-helpers": "^3.2.1",
 				"hoist-non-react-statics": "^3.2.1",
-				"is-plain-object": "^2.0.4",
-				"jss": "^9.8.7",
-				"jss-camel-case": "^6.0.0",
-				"jss-default-unit": "^8.0.2",
-				"jss-global": "^3.0.0",
-				"jss-nested": "^6.0.1",
-				"jss-props-sort": "^6.0.0",
-				"jss-vendor-prefixer": "^7.0.0",
-				"normalize-scroll-left": "^0.1.2",
+				"is-plain-object": "^3.0.0",
+				"normalize-scroll-left": "^0.2.0",
 				"popper.js": "^1.14.1",
-				"prop-types": "^15.6.0",
-				"react-event-listener": "^0.6.2",
-				"react-transition-group": "^2.2.1",
-				"recompose": "0.28.0 - 0.30.0",
+				"prop-types": "^15.7.2",
+				"react-event-listener": "^0.6.6",
+				"react-transition-group": "^4.0.0",
 				"warning": "^4.0.1"
 			},
 			"dependencies": {
-				"recompose": {
-					"version": "0.30.0",
-					"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-					"integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
+				"is-plain-object": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+					"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
 					"requires": {
-						"@babel/runtime": "^7.0.0",
-						"change-emitter": "^0.1.2",
-						"fbjs": "^0.8.1",
-						"hoist-non-react-statics": "^2.3.1",
-						"react-lifecycles-compat": "^3.0.2",
-						"symbol-observable": "^1.0.4"
-					},
-					"dependencies": {
-						"hoist-non-react-statics": {
-							"version": "2.5.5",
-							"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-							"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-						}
+						"isobject": "^4.0.0"
 					}
+				},
+				"isobject": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
 				}
 			}
 		},
 		"@material-ui/icons": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-3.0.2.tgz",
-			"integrity": "sha512-QY/3gJnObZQ3O/e6WjH+0ah2M3MOgLOzCy8HTUoUx9B6dDrS18vP7Ycw3qrDEKlB6q1KNxy6CZHm5FCauWGy2g==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.0.1.tgz",
+			"integrity": "sha512-03zUfksGXXbaWX2piB1LCmC28eydlT8ah8MbYT4n4mgiX9BTL4HH50lkFn9JIJJSk2oO5kRy4FvpXRGRBI+oxw==",
 			"requires": {
-				"@babel/runtime": "^7.2.0",
-				"recompose": "0.28.0 - 0.30.0"
-			},
-			"dependencies": {
-				"hoist-non-react-statics": {
-					"version": "2.5.5",
-					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-					"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-				},
-				"recompose": {
-					"version": "0.30.0",
-					"resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-					"integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
-					"requires": {
-						"@babel/runtime": "^7.0.0",
-						"change-emitter": "^0.1.2",
-						"fbjs": "^0.8.1",
-						"hoist-non-react-statics": "^2.3.1",
-						"react-lifecycles-compat": "^3.0.2",
-						"symbol-observable": "^1.0.4"
-					}
-				}
+				"@babel/runtime": "^7.2.0"
 			}
 		},
 		"@material-ui/lab": {
-			"version": "3.0.0-alpha.30",
-			"resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-3.0.0-alpha.30.tgz",
-			"integrity": "sha512-d8IXbkQO92Ln7f/Tzy8Q5cLi/sMWH/Uz1xrOO5NKUgg42whwyCuoT9ErddDPFNQmPi9d1C7A5AG8ONjEAbAIyQ==",
+			"version": "4.0.0-alpha.15",
+			"resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.15.tgz",
+			"integrity": "sha512-ixO6YxO0fFro2mt9C0dwrcgbpaNQEVszaDxWgKXaTFHIkXZDV4cY+XM0otV2o7DZVVfjvB5aAvyNsb0+db1JPA==",
 			"requires": {
 				"@babel/runtime": "^7.2.0",
-				"@material-ui/utils": "^3.0.0-alpha.2",
-				"classnames": "^2.2.5",
+				"@material-ui/utils": "^4.0.1",
+				"clsx": "^1.0.2",
 				"keycode": "^2.1.9",
-				"prop-types": "^15.6.0"
+				"prop-types": "^15.7.2"
 			}
 		},
-		"@material-ui/system": {
-			"version": "3.0.0-alpha.2",
-			"resolved": "https://registry.npmjs.org/@material-ui/system/-/system-3.0.0-alpha.2.tgz",
-			"integrity": "sha512-odmxQ0peKpP7RQBQ8koly06YhsPzcoVib1vByVPBH4QhwqBXuYoqlCjt02846fYspAqkrWzjxnWUD311EBbxOA==",
+		"@material-ui/styles": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.0.2.tgz",
+			"integrity": "sha512-RUM+2G++2X4M6cbZ/K/PzAdxdSdqIU4zhZ82YYIcEz/OgCx72HC68+VrYxoy7nEjZ9E6R+9JmPPS7CO8O1oPmw==",
 			"requires": {
 				"@babel/runtime": "^7.2.0",
+				"@emotion/hash": "^0.7.1",
+				"@material-ui/types": "^4.0.1",
+				"@material-ui/utils": "^4.0.1",
+				"clsx": "^1.0.2",
 				"deepmerge": "^3.0.0",
-				"prop-types": "^15.6.0",
+				"hoist-non-react-statics": "^3.2.1",
+				"jss": "^10.0.0-alpha.16",
+				"jss-plugin-camel-case": "^10.0.0-alpha.16",
+				"jss-plugin-default-unit": "^10.0.0-alpha.16",
+				"jss-plugin-global": "^10.0.0-alpha.16",
+				"jss-plugin-nested": "^10.0.0-alpha.16",
+				"jss-plugin-props-sort": "^10.0.0-alpha.16",
+				"jss-plugin-rule-value-function": "^10.0.0-alpha.16",
+				"jss-plugin-vendor-prefixer": "^10.0.0-alpha.16",
+				"prop-types": "^15.7.2",
 				"warning": "^4.0.1"
 			}
 		},
-		"@material-ui/utils": {
-			"version": "3.0.0-alpha.3",
-			"resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-3.0.0-alpha.3.tgz",
-			"integrity": "sha512-rwMdMZptX0DivkqBuC+Jdq7BYTXwqKai5G5ejPpuEDKpWzi1Oxp+LygGw329FrKpuKeiqpcymlqJTjmy+quWng==",
+		"@material-ui/system": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.0.2.tgz",
+			"integrity": "sha512-gpLYcDycJjK8tvWI9ZKrVLdGjFQ/YJM74TvhIMkP5ML453ZtPuFzMLt6FVEKp8okWxFEgYXVBNNSB4IF3Yig8g==",
 			"requires": {
 				"@babel/runtime": "^7.2.0",
-				"prop-types": "^15.6.0",
-				"react-is": "^16.6.3"
+				"deepmerge": "^3.0.0",
+				"prop-types": "^15.7.2",
+				"warning": "^4.0.1"
+			}
+		},
+		"@material-ui/types": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@material-ui/types/-/types-4.0.1.tgz",
+			"integrity": "sha512-FGhogU9l4s+ycMcC3hhOAvu5hcWa5TVSCCGUf4NOUF904ythroWSAvcCHn92NjftXZ8WZqmtPjL1K/d90Pq/3Q=="
+		},
+		"@material-ui/utils": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.0.1.tgz",
+			"integrity": "sha512-mWRcMQIrqsXGze73tx3hNfB1NUu+BL/oIQI7TImyuhsia1EQXw3bPVBjgwTzqM6MqfXw6eh1fR45Di+WN5hASA==",
+			"requires": {
+				"@babel/runtime": "^7.2.0",
+				"prop-types": "^15.7.2",
+				"react-is": "^16.8.0"
 			}
 		},
 		"@ngtools/json-schema": {
@@ -826,9 +824,9 @@
 			}
 		},
 		"@types/enzyme": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.9.1.tgz",
-			"integrity": "sha512-CasnOP73BFE3/5JvGkod+oQtGOD1+CVWz9BV2iAqDFJ+sofL5gTiizSr8ZM3lpDY27ptC8yjAdrUCdv8diKKqw==",
+			"version": "3.9.3",
+			"resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.9.3.tgz",
+			"integrity": "sha512-jDKoZiiMA3lGO3skSO7dfqEHNvmiTLLV+PHD9EBQVlJANJvpY6qq1zzjRI24ZOtG7F+CS7BVWDXKewRmN8PjHQ==",
 			"requires": {
 				"@types/cheerio": "*",
 				"@types/react": "*"
@@ -902,15 +900,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
 			"integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A=="
 		},
-		"@types/jss": {
-			"version": "9.5.8",
-			"resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.5.8.tgz",
-			"integrity": "sha512-bBbHvjhm42UKki+wZpR89j73ykSXg99/bhuKuYYePtpma3ZAnmeGnl0WxXiZhPGsIfzKwCUkpPC0jlrVMBfRxA==",
-			"requires": {
-				"csstype": "^2.0.0",
-				"indefinite-observable": "^1.0.1"
-			}
-		},
 		"@types/lodash": {
 			"version": "4.14.123",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
@@ -942,9 +931,9 @@
 			"integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU="
 		},
 		"@types/react": {
-			"version": "16.8.13",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.13.tgz",
-			"integrity": "sha512-otJ4ntMuHGrvm67CdDJMAls4WqotmAmW0g3HmWi9LCjSWXrxoXY/nHXrtmMfvPEEmGFNm6NdgMsJmnfH820Qaw==",
+			"version": "16.8.19",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.19.tgz",
+			"integrity": "sha512-QzEzjrd1zFzY9cDlbIiFvdr+YUmefuuRYrPxmkwG0UQv5XF35gFIi7a95m1bNVcFU0VimxSZ5QVGSiBmlggQXQ==",
 			"requires": {
 				"@types/prop-types": "*",
 				"csstype": "^2.2.0"
@@ -959,27 +948,28 @@
 			}
 		},
 		"@types/react-redux": {
-			"version": "7.0.7",
-			"resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.0.7.tgz",
-			"integrity": "sha512-IrGTb1UZEP2EdOudTsfLEihL/C/U7nHxvSsMwJmPF9zRGJuCMo28ELVnlhtRtkxYmZT+4IE2Nm1IhTN4z64T4Q==",
+			"version": "7.0.9",
+			"resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.0.9.tgz",
+			"integrity": "sha512-fMVX9SneWWw68d/JoeNUh6hj42kx2G30YhPdCYJTOv3xqbJ1xzIz6tEM/xzi7nBvpNbwZkSa9TMsV06kWOFIIg==",
 			"requires": {
 				"@types/hoist-non-react-statics": "^3.3.0",
 				"@types/react": "*",
+				"hoist-non-react-statics": "^3.3.0",
 				"redux": "^4.0.0"
 			}
 		},
 		"@types/react-text-mask": {
-			"version": "5.4.4",
-			"resolved": "https://registry.npmjs.org/@types/react-text-mask/-/react-text-mask-5.4.4.tgz",
-			"integrity": "sha512-mnwyDgUwFtJVAZ8f+tzPGmYjpH7TLXxHSGty338abca6aAjdjRLCOC4h+CxlvB8xrVAIU5pkNllpHhfJCA3hXQ==",
+			"version": "5.4.5",
+			"resolved": "https://registry.npmjs.org/@types/react-text-mask/-/react-text-mask-5.4.5.tgz",
+			"integrity": "sha512-rylpW2nfi3iARbrNAT+yOGmhnzL8iz7gmr+ZDT2kB1B3q66a27rSLPnkl8tVUWM9MVrbrheSvdU8BJbiKW40xQ==",
 			"requires": {
 				"@types/react": "*"
 			}
 		},
 		"@types/react-transition-group": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.9.0.tgz",
-			"integrity": "sha512-hP7vUaZMVSWKxo133P8U51U6UZ7+pbY+eAQb8+p6SZ2rB1rj3mOTDgTzhhi+R2SCB4S+sWekAAGoxdiZPG0ReQ==",
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.9.1.tgz",
+			"integrity": "sha512-1usq4DRUVBFnxc9KGJAlJO9EpQrLZGDDEC8wDOn2+2ODSyudYo8FiIzPDRaX/hfQjHqGeeoNaNdA2bj0l35hZQ==",
 			"requires": {
 				"@types/react": "*"
 			}
@@ -1014,9 +1004,9 @@
 			}
 		},
 		"@types/redux-mock-store": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/redux-mock-store/-/redux-mock-store-1.0.0.tgz",
-			"integrity": "sha512-7+H3+O8VX4Mx2HNdDLP1MSNoWp+FXfq3HDGc08kY5vxyuml7OAudO4CAQFsKsDvbU5spApJMZ6buEi/c3hKjtQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/redux-mock-store/-/redux-mock-store-1.0.1.tgz",
+			"integrity": "sha512-1egEnh2/+sRRKImnCo5EMVm0Uxu4fBHeLHk/inhSp/VpE93It8lk3gYeNfehUgXd6OzqP5LLA9kzO9x7o3WfwA==",
 			"requires": {
 				"redux": "^4.0.0"
 			}
@@ -1228,12 +1218,27 @@
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
 		},
 		"accepts": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
 			"requires": {
-				"mime-types": "~2.1.18",
-				"negotiator": "0.6.1"
+				"mime-types": "~2.1.24",
+				"negotiator": "0.6.2"
+			},
+			"dependencies": {
+				"mime-db": {
+					"version": "1.40.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+					"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+				},
+				"mime-types": {
+					"version": "2.1.24",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+					"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+					"requires": {
+						"mime-db": "1.40.0"
+					}
+				}
 			}
 		},
 		"acorn": {
@@ -1257,9 +1262,9 @@
 			}
 		},
 		"acorn-globals": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.1.tgz",
-			"integrity": "sha512-gJSiKY8dBIjV/0jagZIFBdVMtfQyA5QHCvAT48H2q8REQoW8Fs5AOjqBql1LgSXgrMWdevcE+8cdZ33NtVbIBA==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
+			"integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
 			"requires": {
 				"acorn": "^6.0.1",
 				"acorn-walk": "^6.0.1"
@@ -1364,9 +1369,9 @@
 			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
 		},
 		"angular-l10n": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/angular-l10n/-/angular-l10n-7.1.0.tgz",
-			"integrity": "sha512-IIC0tPRbcAZ105kklmlf8whqnzC4HxzzNkX3i6vYGH8Z8D8FnZUSaH3uczPDL4yEmAK52FdjhUW0CI2uoh1Azg==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/angular-l10n/-/angular-l10n-7.2.0.tgz",
+			"integrity": "sha512-KyPvuhPKLGi11RVtBSCaKwvqAuhGrwSAAmUf3rAag8PQYsfq6zRufdt9Ba0mUP4AVqrzBAr+SW/Z6TNMj12A0A==",
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -1561,12 +1566,12 @@
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 		},
 		"array.prototype.find": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
-			"integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
+			"integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.7.0"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.13.0"
 			}
 		},
 		"array.prototype.flat": {
@@ -2670,20 +2675,35 @@
 			}
 		},
 		"body-parser": {
-			"version": "1.18.3",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-			"integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+			"integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
 			"requires": {
-				"bytes": "3.0.0",
+				"bytes": "3.1.0",
 				"content-type": "~1.0.4",
 				"debug": "2.6.9",
 				"depd": "~1.1.2",
-				"http-errors": "~1.6.3",
-				"iconv-lite": "0.4.23",
+				"http-errors": "1.7.2",
+				"iconv-lite": "0.4.24",
 				"on-finished": "~2.3.0",
-				"qs": "6.5.2",
-				"raw-body": "2.3.3",
-				"type-is": "~1.6.16"
+				"qs": "6.7.0",
+				"raw-body": "2.4.0",
+				"type-is": "~1.6.17"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.4.24",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
+				"qs": {
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+				}
 			}
 		},
 		"bonjour": {
@@ -2768,11 +2788,6 @@
 					}
 				}
 			}
-		},
-		"brcast": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
-			"integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg=="
 		},
 		"brorand": {
 			"version": "1.1.0",
@@ -2962,9 +2977,9 @@
 			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
 		},
 		"bytes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
 		},
 		"cacache": {
 			"version": "10.0.4",
@@ -3101,9 +3116,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000960",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000960.tgz",
-			"integrity": "sha512-7nK5qs17icQaX6V3/RYrJkOsZyRNnroA4+ZwxaKJzIKy+crIy0Mz5CBlLySd2SNV+4nbUZeqeNfiaEieUBu3aA=="
+			"version": "1.0.30000973",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000973.tgz",
+			"integrity": "sha512-/F3t/Yo8LEdRSEPCmI15fLu5vepVh9UCg/9inJXF5AAfW7xRRJkbaM2ut52iRMQMnGCLQouLbFdbOA+VEFOIsg=="
 		},
 		"canonical-path": {
 			"version": "1.0.0",
@@ -3251,11 +3266,6 @@
 					}
 				}
 			}
-		},
-		"classnames": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
 		},
 		"clean-css": {
 			"version": "4.2.1",
@@ -3521,11 +3531,18 @@
 			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
 		},
 		"compressible": {
-			"version": "2.0.16",
-			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.16.tgz",
-			"integrity": "sha512-JQfEOdnI7dASwCuSPWIeVYwc/zMsu/+tRhoUvEfXz2gxOA2DNjmG5vhtFdBlhWPPGo+RdT9S3tgc/uH5qgDiiA==",
+			"version": "2.0.17",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
+			"integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
 			"requires": {
-				"mime-db": ">= 1.38.0 < 2"
+				"mime-db": ">= 1.40.0 < 2"
+			},
+			"dependencies": {
+				"mime-db": {
+					"version": "1.40.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+					"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+				}
 			}
 		},
 		"compression": {
@@ -3540,6 +3557,13 @@
 				"on-headers": "~1.0.2",
 				"safe-buffer": "5.1.2",
 				"vary": "~1.1.2"
+			},
+			"dependencies": {
+				"bytes": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+					"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+				}
 			}
 		},
 		"concat-map": {
@@ -3600,35 +3624,14 @@
 			}
 		},
 		"connect": {
-			"version": "3.6.6",
-			"resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
-			"integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+			"integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
 			"requires": {
 				"debug": "2.6.9",
-				"finalhandler": "1.1.0",
-				"parseurl": "~1.3.2",
+				"finalhandler": "1.1.2",
+				"parseurl": "~1.3.3",
 				"utils-merge": "1.0.1"
-			},
-			"dependencies": {
-				"finalhandler": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
-					"integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
-					"requires": {
-						"debug": "2.6.9",
-						"encodeurl": "~1.0.1",
-						"escape-html": "~1.0.3",
-						"on-finished": "~2.3.0",
-						"parseurl": "~1.3.2",
-						"statuses": "~1.3.1",
-						"unpipe": "~1.0.0"
-					}
-				},
-				"statuses": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-					"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
-				}
 			}
 		},
 		"connect-history-api-fallback": {
@@ -3649,15 +3652,23 @@
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
+		"console-polyfill": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/console-polyfill/-/console-polyfill-0.1.2.tgz",
+			"integrity": "sha1-ls/tUcr3gYn2mVcubxgnHcN8DjA="
+		},
 		"constants-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
 			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
 		},
 		"content-disposition": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+			"requires": {
+				"safe-buffer": "5.1.2"
+			}
 		},
 		"content-type": {
 			"version": "1.0.4",
@@ -4301,6 +4312,15 @@
 				"object-assign": "^4.0.1"
 			}
 		},
+		"convert-css-length": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-css-length/-/convert-css-length-2.0.0.tgz",
+			"integrity": "sha512-ygBgHNzImHJ/kjgqdzC0oaY2+EMID3s88/CZD2C9O1stM3PwsOwXzzlFTTkZy/bPZe0wjyt1UoYjilfunQGjlw==",
+			"requires": {
+				"console-polyfill": "^0.1.2",
+				"parse-unit": "^1.0.1"
+			}
+		},
 		"convert-source-map": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
@@ -4315,9 +4335,9 @@
 			"integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU="
 		},
 		"cookie": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
 		},
 		"cookie-signature": {
 			"version": "1.0.6",
@@ -4553,10 +4573,11 @@
 			}
 		},
 		"css-vendor": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-0.3.8.tgz",
-			"integrity": "sha1-ZCHP0wNM5mT+dnOXL9ARn8KJQfo=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.2.tgz",
+			"integrity": "sha512-Xn5ZAlI00d8HaQ8/oQ8d+iBzSF//NCc77LPzsucM32X/R/yTqmXy6otVsAM0XleXk6HjPuXoVZwXsayky/fsFQ==",
 			"requires": {
+				"@babel/runtime": "^7.3.1",
 				"is-in-browser": "^1.0.2"
 			}
 		},
@@ -4584,9 +4605,9 @@
 			}
 		},
 		"csstype": {
-			"version": "2.6.4",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.4.tgz",
-			"integrity": "sha512-lAJUJP3M6HxFXbqtGRc0iZrdyeN+WzOWeY0q/VnFzI+kqVrYIzC7bWlKqCW7oCIdzoPkvfp82EVvrTlQ8zsWQg=="
+			"version": "2.6.5",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.5.tgz",
+			"integrity": "sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA=="
 		},
 		"cuint": {
 			"version": "0.2.2",
@@ -5173,9 +5194,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.124",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.124.tgz",
-			"integrity": "sha512-glecGr/kFdfeXUHOHAWvGcXrxNU+1wSO/t5B23tT1dtlvYB26GY8aHzZSWD7HqhqC800Lr+w/hQul6C5AF542w=="
+			"version": "1.3.146",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.146.tgz",
+			"integrity": "sha512-BrUq08sx7eR4PCwLbjFxXmjcbDro6DSoc1pN8VCxq76U+o9JQzJlWH/NVtcpAqcktwpE5CVvMyqHqTQfCETNoQ=="
 		},
 		"elliptic": {
 			"version": "6.4.1",
@@ -5239,6 +5260,11 @@
 				"ws": "~3.3.1"
 			},
 			"dependencies": {
+				"cookie": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+					"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -5316,9 +5342,9 @@
 			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
 		},
 		"enzyme": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.9.0.tgz",
-			"integrity": "sha512-JqxI2BRFHbmiP7/UFqvsjxTirWoM1HfeaJrmVSZ9a1EADKkZgdPcAuISPMpoUiHlac9J4dYt81MC5BBIrbJGMg==",
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.10.0.tgz",
+			"integrity": "sha512-p2yy9Y7t/PFbPoTvrWde7JIYB2ZyGC+NgTNbVEGvZ5/EyoYSr9aG/2rSbVvyNvMHEhw9/dmGUJHWtfQIEiX9pg==",
 			"requires": {
 				"array.prototype.flat": "^1.2.1",
 				"cheerio": "^1.0.0-rc.2",
@@ -5344,25 +5370,26 @@
 			}
 		},
 		"enzyme-adapter-react-16": {
-			"version": "1.12.1",
-			"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.12.1.tgz",
-			"integrity": "sha512-GB61gvY97XvrA6qljExGY+lgI6BBwz+ASLaRKct9VQ3ozu0EraqcNn3CcrUckSGIqFGa1+CxO5gj5is5t3lwrw==",
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.14.0.tgz",
+			"integrity": "sha512-7PcOF7pb4hJUvjY7oAuPGpq3BmlCig3kxXGi2kFx0YzJHppqX1K8IIV9skT1IirxXlu8W7bneKi+oQ10QRnhcA==",
 			"requires": {
-				"enzyme-adapter-utils": "^1.11.0",
+				"enzyme-adapter-utils": "^1.12.0",
+				"has": "^1.0.3",
 				"object.assign": "^4.1.0",
 				"object.values": "^1.1.0",
 				"prop-types": "^15.7.2",
 				"react-is": "^16.8.6",
 				"react-test-renderer": "^16.0.0-0",
-				"semver": "^5.6.0"
+				"semver": "^5.7.0"
 			}
 		},
 		"enzyme-adapter-utils": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.11.0.tgz",
-			"integrity": "sha512-0VZeoE9MNx+QjTfsjmO1Mo+lMfunucYB4wt5ficU85WB/LoetTJrbuujmHP3PJx6pSoaAuLA+Mq877x4LoxdNg==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.12.0.tgz",
+			"integrity": "sha512-wkZvE0VxcFx/8ZsBw0iAbk3gR1d9hK447ebnSYBf95+r32ezBq+XDSAvRErkc4LZosgH8J7et7H7/7CtUuQfBA==",
 			"requires": {
-				"airbnb-prop-types": "^2.12.0",
+				"airbnb-prop-types": "^2.13.2",
 				"function.prototype.name": "^1.1.0",
 				"object.assign": "^4.1.0",
 				"object.fromentries": "^2.0.0",
@@ -5424,9 +5451,9 @@
 			}
 		},
 		"es5-ext": {
-			"version": "0.10.49",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.49.tgz",
-			"integrity": "sha512-3NMEhi57E31qdzmYp2jwRArIUsj1HI/RxbQ4bgnSB+AIKIxsAmTiK83bYMifIcpWvEc3P1X30DhUKOqEtF/kvg==",
+			"version": "0.10.50",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+			"integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
 			"requires": {
 				"es6-iterator": "~2.0.3",
 				"es6-symbol": "~3.1.1",
@@ -5638,9 +5665,9 @@
 			}
 		},
 		"eventemitter3": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-			"integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+			"integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
 		},
 		"events": {
 			"version": "3.0.0",
@@ -5835,40 +5862,47 @@
 			}
 		},
 		"express": {
-			"version": "4.16.4",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-			"integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+			"version": "4.17.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+			"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
 			"requires": {
-				"accepts": "~1.3.5",
+				"accepts": "~1.3.7",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.18.3",
-				"content-disposition": "0.5.2",
+				"body-parser": "1.19.0",
+				"content-disposition": "0.5.3",
 				"content-type": "~1.0.4",
-				"cookie": "0.3.1",
+				"cookie": "0.4.0",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "~1.1.2",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
-				"finalhandler": "1.1.1",
+				"finalhandler": "~1.1.2",
 				"fresh": "0.5.2",
 				"merge-descriptors": "1.0.1",
 				"methods": "~1.1.2",
 				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
+				"parseurl": "~1.3.3",
 				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.4",
-				"qs": "6.5.2",
-				"range-parser": "~1.2.0",
+				"proxy-addr": "~2.0.5",
+				"qs": "6.7.0",
+				"range-parser": "~1.2.1",
 				"safe-buffer": "5.1.2",
-				"send": "0.16.2",
-				"serve-static": "1.13.2",
-				"setprototypeof": "1.1.0",
-				"statuses": "~1.4.0",
-				"type-is": "~1.6.16",
+				"send": "0.17.1",
+				"serve-static": "1.14.1",
+				"setprototypeof": "1.1.1",
+				"statuses": "~1.5.0",
+				"type-is": "~1.6.18",
 				"utils-merge": "1.0.1",
 				"vary": "~1.1.2"
+			},
+			"dependencies": {
+				"qs": {
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+				}
 			}
 		},
 		"extend": {
@@ -6080,16 +6114,16 @@
 			}
 		},
 		"finalhandler": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
 			"requires": {
 				"debug": "2.6.9",
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
 				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
-				"statuses": "~1.4.0",
+				"parseurl": "~1.3.3",
+				"statuses": "~1.5.0",
 				"unpipe": "~1.0.0"
 			}
 		},
@@ -6295,7 +6329,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -6313,11 +6348,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -6330,15 +6367,18 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -6441,7 +6481,8 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -6451,6 +6492,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -6463,17 +6505,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -6490,6 +6535,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -6562,7 +6608,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -6572,6 +6619,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -6647,7 +6695,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -6677,6 +6726,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -6694,6 +6744,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -6732,18 +6783,20 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				}
 			}
 		},
 		"fstream": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"inherits": "~2.0.0",
@@ -7795,9 +7848,9 @@
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-					"integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -7812,14 +7865,15 @@
 			"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
 		},
 		"http-errors": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+			"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
 			"requires": {
 				"depd": "~1.1.2",
 				"inherits": "2.0.3",
-				"setprototypeof": "1.1.0",
-				"statuses": ">= 1.4.0 < 2"
+				"setprototypeof": "1.1.1",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.0"
 			}
 		},
 		"http-parser-js": {
@@ -8001,14 +8055,6 @@
 			"resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
 			"integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
 		},
-		"indefinite-observable": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-1.0.2.tgz",
-			"integrity": "sha512-Mps0898zEduHyPhb7UCgNmfzlqNZknVmaFz5qzr0mm04YQ5FGLhAyK/dJ+NaRxGyR6juQXIxh5Ev0xx+qq0nYA==",
-			"requires": {
-				"symbol-observable": "1.2.0"
-			}
-		},
 		"indent-string": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
@@ -8110,9 +8156,9 @@
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 		},
 		"ionic-selectable": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/ionic-selectable/-/ionic-selectable-4.4.0.tgz",
-			"integrity": "sha512-1ET0wbw6t2Vap1YoPS6BIrnt5oJrGMU4dSVnyzxJWZCiqmoOPlXr+RN8vpq4ULSA6kyh2ZWZpMt5eTLczkun0g=="
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/ionic-selectable/-/ionic-selectable-4.4.1.tgz",
+			"integrity": "sha512-6Pai6Pqw4ofCNFSpbcN7SiOeH419wjczehrxWbMVNy3KOmSw1mfY0/wazEKlqk+iwgsOuYrhkAaEC8srtHdsBQ=="
 		},
 		"ionicons": {
 			"version": "3.0.0",
@@ -8315,9 +8361,9 @@
 			"integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
 		},
 		"is-my-json-valid": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
-			"integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
+			"version": "2.20.0",
+			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.0.tgz",
+			"integrity": "sha512-XTHBZSIIxNsIsZXg7XB5l8z/OBFosl1Wao4tXLpeC7eKU4Vm/kdop2azkPqULwnfGQjmeDIyey9g7afMMtdWAA==",
 			"requires": {
 				"generate-function": "^2.0.0",
 				"generate-object-property": "^1.1.0",
@@ -9704,9 +9750,9 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json3": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
+			"integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA=="
 		},
 		"json5": {
 			"version": "1.0.1",
@@ -9746,72 +9792,79 @@
 			}
 		},
 		"jss": {
-			"version": "9.8.7",
-			"resolved": "https://registry.npmjs.org/jss/-/jss-9.8.7.tgz",
-			"integrity": "sha512-awj3XRZYxbrmmrx9LUSj5pXSUfm12m8xzi/VKeqI1ZwWBtQ0kVPTs3vYs32t4rFw83CgFDukA8wKzOE9sMQnoQ==",
+			"version": "10.0.0-alpha.16",
+			"resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.16.tgz",
+			"integrity": "sha512-HmKNNnr82TR5jkWjBcbrx/uim2ief588pWp7zsf4GQpL125zRkEaWYL1SXv5bR6bBvAoTtvJsTAOxDIlLxUNZg==",
 			"requires": {
+				"@babel/runtime": "^7.3.1",
 				"is-in-browser": "^1.1.3",
-				"symbol-observable": "^1.1.0",
-				"warning": "^3.0.0"
-			},
-			"dependencies": {
-				"warning": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-					"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-					"requires": {
-						"loose-envify": "^1.0.0"
-					}
-				}
+				"tiny-warning": "^1.0.2"
 			}
 		},
-		"jss-camel-case": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jss-camel-case/-/jss-camel-case-6.1.0.tgz",
-			"integrity": "sha512-HPF2Q7wmNW1t79mCqSeU2vdd/vFFGpkazwvfHMOhPlMgXrJDzdj9viA2SaHk9ZbD5pfL63a8ylp4++irYbbzMQ==",
+		"jss-plugin-camel-case": {
+			"version": "10.0.0-alpha.16",
+			"resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0-alpha.16.tgz",
+			"integrity": "sha512-nki+smHEsFyoZ0OlOYtaxVqcQA0ZHVJCE1slRnk+1TklbmxbBiO4TwITMTEaNIDv0U0Uyb0Z8wVgFgRwCCIFog==",
 			"requires": {
-				"hyphenate-style-name": "^1.0.2"
+				"@babel/runtime": "^7.3.1",
+				"hyphenate-style-name": "^1.0.3",
+				"jss": "10.0.0-alpha.16"
 			}
 		},
-		"jss-default-unit": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
-			"integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg=="
-		},
-		"jss-global": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
-			"integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q=="
-		},
-		"jss-nested": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/jss-nested/-/jss-nested-6.0.1.tgz",
-			"integrity": "sha512-rn964TralHOZxoyEgeq3hXY8hyuCElnvQoVrQwKHVmu55VRDd6IqExAx9be5HgK0yN/+hQdgAXQl/GUrBbbSTA==",
+		"jss-plugin-default-unit": {
+			"version": "10.0.0-alpha.16",
+			"resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.0-alpha.16.tgz",
+			"integrity": "sha512-jjGW4F/r9yKvoyUk22M8nWhdMfvoWzJw/oFO2cDRXCk2onnWFiRALfqeUsEDyocwdZbyVF9WhZbSHn4GL03kSw==",
 			"requires": {
-				"warning": "^3.0.0"
-			},
-			"dependencies": {
-				"warning": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-					"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-					"requires": {
-						"loose-envify": "^1.0.0"
-					}
-				}
+				"@babel/runtime": "^7.3.1",
+				"jss": "10.0.0-alpha.16"
 			}
 		},
-		"jss-props-sort": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
-			"integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g=="
-		},
-		"jss-vendor-prefixer": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz",
-			"integrity": "sha512-Agd+FKmvsI0HLcYXkvy8GYOw3AAASBUpsmIRvVQheps+JWaN892uFOInTr0DRydwaD91vSSUCU4NssschvF7MA==",
+		"jss-plugin-global": {
+			"version": "10.0.0-alpha.16",
+			"resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.0.0-alpha.16.tgz",
+			"integrity": "sha512-B1mm2ZF9OEsWPmzkG5ZUXqV88smDqpc4unILLXhWVuj0U5JeT0DNitH+QbXFrSueDJzkWVfvqyckvWDR/0qeDg==",
 			"requires": {
-				"css-vendor": "^0.3.8"
+				"@babel/runtime": "^7.3.1",
+				"jss": "10.0.0-alpha.16"
+			}
+		},
+		"jss-plugin-nested": {
+			"version": "10.0.0-alpha.16",
+			"resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.0.0-alpha.16.tgz",
+			"integrity": "sha512-3l/MB6COnIpq4GOXQFae6UydoaIPa81UxhuBTEQuiAojgTeUla9L7nB3h18Q4zAhQQpjxaEsyppAKuEzIP7kPQ==",
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"jss": "10.0.0-alpha.16",
+				"tiny-warning": "^1.0.2"
+			}
+		},
+		"jss-plugin-props-sort": {
+			"version": "10.0.0-alpha.16",
+			"resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.0-alpha.16.tgz",
+			"integrity": "sha512-+Yn9nugHAH58nf/d43H2uxMvlCFPDgLKRSmKO4Q4m1IGYjMbHsWt1Rk2HfC9IiCanqcqpc8hstwtzf+HG7PWFQ==",
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"jss": "10.0.0-alpha.16"
+			}
+		},
+		"jss-plugin-rule-value-function": {
+			"version": "10.0.0-alpha.16",
+			"resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.0-alpha.16.tgz",
+			"integrity": "sha512-MQap9ne6ZGZH0NlpSQTMSm6QalBTF0hYpd2uaGQwam+GlT7IKeO+sTjd46I1WgO3kyOmwb0pIY6CnuLQGXKtSA==",
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"jss": "10.0.0-alpha.16"
+			}
+		},
+		"jss-plugin-vendor-prefixer": {
+			"version": "10.0.0-alpha.16",
+			"resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.0-alpha.16.tgz",
+			"integrity": "sha512-70yJ6QE5dN8VlPUGKld5jK2SKyrteheEL/ismexpybIufunMs6iJgkhDndbOfv8ia13yZgUVqeakMdhRKYwK1A==",
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"css-vendor": "^2.0.1",
+				"jss": "10.0.0-alpha.16"
 			}
 		},
 		"jszip": {
@@ -9861,9 +9914,9 @@
 			},
 			"dependencies": {
 				"mime": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
-					"integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg=="
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
+					"integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw=="
 				}
 			}
 		},
@@ -9910,80 +9963,80 @@
 					}
 				},
 				"istanbul-api": {
-					"version": "2.1.5",
-					"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.5.tgz",
-					"integrity": "sha512-meYk1BwDp59Pfse1TvPrkKYgVqAufbdBLEVoqvu/hLLKSaQ054ZTksbNepyc223tMnWdm6AdK2URIJJRqdP87g==",
+					"version": "2.1.6",
+					"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.6.tgz",
+					"integrity": "sha512-x0Eicp6KsShG1k1rMgBAi/1GgY7kFGEBwQpw3PXGEmu+rBcBNhqU8g2DgY9mlepAsLPzrzrbqSgCGANnki4POA==",
 					"requires": {
-						"async": "^2.6.1",
-						"compare-versions": "^3.2.1",
+						"async": "^2.6.2",
+						"compare-versions": "^3.4.0",
 						"fileset": "^2.0.3",
-						"istanbul-lib-coverage": "^2.0.4",
-						"istanbul-lib-hook": "^2.0.6",
-						"istanbul-lib-instrument": "^3.2.0",
-						"istanbul-lib-report": "^2.0.7",
-						"istanbul-lib-source-maps": "^3.0.5",
-						"istanbul-reports": "^2.2.3",
-						"js-yaml": "^3.13.0",
+						"istanbul-lib-coverage": "^2.0.5",
+						"istanbul-lib-hook": "^2.0.7",
+						"istanbul-lib-instrument": "^3.3.0",
+						"istanbul-lib-report": "^2.0.8",
+						"istanbul-lib-source-maps": "^3.0.6",
+						"istanbul-reports": "^2.2.4",
+						"js-yaml": "^3.13.1",
 						"make-dir": "^2.1.0",
 						"minimatch": "^3.0.4",
 						"once": "^1.4.0"
 					}
 				},
 				"istanbul-lib-coverage": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
-					"integrity": "sha512-LXTBICkMARVgo579kWDm8SqfB6nvSDKNqIOBEjmJRnL04JvoMHCYGWaMddQnseJYtkEuEvO/sIcOxPLk9gERug=="
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+					"integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA=="
 				},
 				"istanbul-lib-hook": {
-					"version": "2.0.6",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.6.tgz",
-					"integrity": "sha512-829DKONApZ7UCiPXcOYWSgkFXa4+vNYoNOt3F+4uDJLKL1OotAoVwvThoEj1i8jmOj7odbYcR3rnaHu+QroaXg==",
+					"version": "2.0.7",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+					"integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
 					"requires": {
 						"append-transform": "^1.0.0"
 					}
 				},
 				"istanbul-lib-instrument": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.2.0.tgz",
-					"integrity": "sha512-06IM3xShbNW4NgZv5AP4QH0oHqf1/ivFo8eFys0ZjPXHGldHJQWb3riYOKXqmOqfxXBfxu4B+g/iuhOPZH0RJg==",
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+					"integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
 					"requires": {
-						"@babel/generator": "^7.0.0",
-						"@babel/parser": "^7.0.0",
-						"@babel/template": "^7.0.0",
-						"@babel/traverse": "^7.0.0",
-						"@babel/types": "^7.0.0",
-						"istanbul-lib-coverage": "^2.0.4",
+						"@babel/generator": "^7.4.0",
+						"@babel/parser": "^7.4.3",
+						"@babel/template": "^7.4.0",
+						"@babel/traverse": "^7.4.3",
+						"@babel/types": "^7.4.0",
+						"istanbul-lib-coverage": "^2.0.5",
 						"semver": "^6.0.0"
 					}
 				},
 				"istanbul-lib-report": {
-					"version": "2.0.7",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.7.tgz",
-					"integrity": "sha512-wLH6beJBFbRBLiTlMOBxmb85cnVM1Vyl36N48e4e/aTKSM3WbOx7zbVIH1SQ537fhhsPbX0/C5JB4qsmyRXXyA==",
+					"version": "2.0.8",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+					"integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
 					"requires": {
-						"istanbul-lib-coverage": "^2.0.4",
+						"istanbul-lib-coverage": "^2.0.5",
 						"make-dir": "^2.1.0",
-						"supports-color": "^6.0.0"
+						"supports-color": "^6.1.0"
 					}
 				},
 				"istanbul-lib-source-maps": {
-					"version": "3.0.5",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.5.tgz",
-					"integrity": "sha512-eDhZ7r6r1d1zQPVZehLc3D0K14vRba/eBYkz3rw16DLOrrTzve9RmnkcwrrkWVgO1FL3EK5knujVe5S8QHE9xw==",
+					"version": "3.0.6",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+					"integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
 					"requires": {
 						"debug": "^4.1.1",
-						"istanbul-lib-coverage": "^2.0.4",
+						"istanbul-lib-coverage": "^2.0.5",
 						"make-dir": "^2.1.0",
-						"rimraf": "^2.6.2",
+						"rimraf": "^2.6.3",
 						"source-map": "^0.6.1"
 					}
 				},
 				"istanbul-reports": {
-					"version": "2.2.3",
-					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.3.tgz",
-					"integrity": "sha512-T6EbPuc8Cb620LWAYyZ4D8SSn06dY9i1+IgUX2lTH8gbwflMc9Obd33zHTyNX653ybjpamAHS9toKS3E6cGhTw==",
+					"version": "2.2.6",
+					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+					"integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
 					"requires": {
-						"handlebars": "^4.1.0"
+						"handlebars": "^4.1.2"
 					}
 				},
 				"make-dir": {
@@ -10013,9 +10066,9 @@
 					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
 				},
 				"semver": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-					"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ=="
 				},
 				"supports-color": {
 					"version": "6.1.0",
@@ -10036,9 +10089,9 @@
 			}
 		},
 		"karma-jasmine-html-reporter": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-1.4.0.tgz",
-			"integrity": "sha512-0wxhwA8PLPpICZ4o2GRnPi67hf3JhfQm5WCB8nElh4qsE6wRNOTtrqooyBPNqI087Xr2SBhxLg5fU+BJ/qxRrw=="
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-1.4.2.tgz",
+			"integrity": "sha512-7g0gPj8+9JepCNJR9WjDyQ2RkZ375jpdurYQyAYv8PorUCadepl8vrD6LmMqOGcM17cnrynBawQYZHaumgDjBw=="
 		},
 		"karma-sourcemap-loader": {
 			"version": "0.3.7",
@@ -10517,9 +10570,9 @@
 			}
 		},
 		"loglevel": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
-			"integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.2.tgz",
+			"integrity": "sha512-Jt2MHrCNdtIe1W6co3tF5KXGRkzF+TYffiQstfXa04mrss9IKXzAAXYWak8LbZseAQY03sH2GzMCMU0ZOUc9bg=="
 		},
 		"loglevelnext": {
 			"version": "1.0.5",
@@ -10667,6 +10720,19 @@
 				"react-text-mask": "^5.4.3",
 				"react-transition-group": "^2.5.3",
 				"tslib": "^1.9.3"
+			},
+			"dependencies": {
+				"react-transition-group": {
+					"version": "2.9.0",
+					"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+					"integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+					"requires": {
+						"dom-helpers": "^3.4.0",
+						"loose-envify": "^1.4.0",
+						"prop-types": "^15.6.2",
+						"react-lifecycles-compat": "^3.0.4"
+					}
+				}
 			}
 		},
 		"math-random": {
@@ -10857,9 +10923,9 @@
 			}
 		},
 		"mime": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
 		},
 		"mime-db": {
 			"version": "1.39.0",
@@ -11071,9 +11137,9 @@
 			}
 		},
 		"negotiator": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
 		},
 		"neo-async": {
 			"version": "2.6.0",
@@ -11140,9 +11206,9 @@
 					}
 				},
 				"estree-walker": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.0.tgz",
-					"integrity": "sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw=="
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+					"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
 				},
 				"fs-extra": {
 					"version": "6.0.1",
@@ -11227,9 +11293,9 @@
 					}
 				},
 				"uglify-js": {
-					"version": "3.5.4",
-					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.4.tgz",
-					"integrity": "sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+					"integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
 					"requires": {
 						"commander": "~2.20.0",
 						"source-map": "~0.6.1"
@@ -11542,9 +11608,9 @@
 			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
 		},
 		"normalize-scroll-left": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz",
-			"integrity": "sha512-F9YMRls0zCF6BFIE2YnXDRpHPpfd91nOIaNdDgrx5YMoPLo8Wqj+6jNXHQsYBavJeXP4ww8HCt0xQAKc5qk2Fg=="
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.2.0.tgz",
+			"integrity": "sha512-t5oCENZJl8TGusJKoCJm7+asaSsPuNmK6+iEjrZ5TyBj2f02brCRsd4c83hwtu+e5d4LCSBZ0uoDlMjBo+A8yA=="
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
@@ -11594,9 +11660,9 @@
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"nwsapi": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.3.tgz",
-			"integrity": "sha512-RowAaJGEgYXEZfQ7tvvdtAQUKPyTR6T6wNu0fwlNsGQYr/h3yQc6oI8WnVZh3Y/Sylwc+dtAlvPqfFZjhTyk3A=="
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
+			"integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw=="
 		},
 		"nyc": {
 			"version": "11.9.0",
@@ -11635,6 +11701,7 @@
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"kind-of": "^3.0.2",
 						"longest": "^1.0.1",
@@ -12666,7 +12733,8 @@
 				},
 				"longest": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"loose-envify": {
 					"version": "1.3.1",
@@ -14362,6 +14430,11 @@
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
 			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
 		},
+		"parse-unit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
+			"integrity": "sha1-fhu21b7zh0wo45JSaiVBFwKR7s8="
+		},
 		"parse5": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
@@ -14818,9 +14891,9 @@
 					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				},
 				"webdriver-manager": {
-					"version": "12.1.1",
-					"resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.1.tgz",
-					"integrity": "sha512-L9TEQmZs6JbMMRQI1w60mfps265/NCr0toYJl7p/R2OAk6oXAfwI6jqYP7EWae+d7Ad2S2Aj4+rzxoSjqk3ZuA==",
+					"version": "12.1.5",
+					"resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.5.tgz",
+					"integrity": "sha512-f1apDjMpZ8SHlXtXGzqBxOjV+WQcDRz5PN7pWScgjXS7vhUIFcM3V89Shetf4A04n8DDR2MxiVQq6JproFcRZw==",
 					"requires": {
 						"adm-zip": "^0.4.9",
 						"chalk": "^1.1.1",
@@ -14995,19 +15068,29 @@
 			}
 		},
 		"range-parser": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
 		},
 		"raw-body": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-			"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+			"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
 			"requires": {
-				"bytes": "3.0.0",
-				"http-errors": "1.6.3",
-				"iconv-lite": "0.4.23",
+				"bytes": "3.1.0",
+				"http-errors": "1.7.2",
+				"iconv-lite": "0.4.24",
 				"unpipe": "1.0.0"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.4.24",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				}
 			}
 		},
 		"rc": {
@@ -15115,14 +15198,13 @@
 			}
 		},
 		"react-transition-group": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-			"integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.1.0.tgz",
+			"integrity": "sha512-/OITbogb3emGN49WaP7468QGSde7er5w6eIHldIDCSQBq/9QTSCzs8OgpgmOnaUXCXzBUcK1zoZ6DqRlM8CJtA==",
 			"requires": {
 				"dom-helpers": "^3.4.0",
 				"loose-envify": "^1.4.0",
-				"prop-types": "^15.6.2",
-				"react-lifecycles-compat": "^3.0.4"
+				"prop-types": "^15.6.2"
 			}
 		},
 		"read-cmd-shim": {
@@ -15509,9 +15591,9 @@
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
 		"rfdc": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.2.tgz",
-			"integrity": "sha512-92ktAgvZhBzYTIK0Mja9uen5q5J3NRVMoDkJL2VMwq6SXjVCgqvQeVP2XAaUY6HT+XpQYeLSjb3UoitBryKmdA=="
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
+			"integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug=="
 		},
 		"right-align": {
 			"version": "0.1.3",
@@ -15586,18 +15668,17 @@
 			}
 		},
 		"rollup-pluginutils": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.6.0.tgz",
-			"integrity": "sha512-aGQwspEF8oPKvg37u3p7h0cYNwmJR1sCBMZGZ5b9qy8HGtETknqjzcxrDRrcAnJNXN18lBH4Q9vZYth/p4n8jQ==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
+			"integrity": "sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==",
 			"requires": {
-				"estree-walker": "^0.6.0",
-				"micromatch": "^3.1.10"
+				"estree-walker": "^0.6.1"
 			},
 			"dependencies": {
 				"estree-walker": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.0.tgz",
-					"integrity": "sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw=="
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+					"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
 				}
 			}
 		},
@@ -15645,9 +15726,9 @@
 			}
 		},
 		"rxjs": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-			"integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+			"integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -15946,9 +16027,9 @@
 			}
 		},
 		"send": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+			"version": "0.17.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
 			"requires": {
 				"debug": "2.6.9",
 				"depd": "~1.1.2",
@@ -15957,12 +16038,19 @@
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
 				"fresh": "0.5.2",
-				"http-errors": "~1.6.2",
-				"mime": "1.4.1",
-				"ms": "2.0.0",
+				"http-errors": "~1.7.2",
+				"mime": "1.6.0",
+				"ms": "2.1.1",
 				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.0",
-				"statuses": "~1.4.0"
+				"range-parser": "~1.2.1",
+				"statuses": "~1.5.0"
+			},
+			"dependencies": {
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+				}
 			}
 		},
 		"serialize-error": {
@@ -15987,17 +16075,35 @@
 				"http-errors": "~1.6.2",
 				"mime-types": "~2.1.17",
 				"parseurl": "~1.3.2"
+			},
+			"dependencies": {
+				"http-errors": {
+					"version": "1.6.3",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+					"requires": {
+						"depd": "~1.1.2",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.1.0",
+						"statuses": ">= 1.4.0 < 2"
+					}
+				},
+				"setprototypeof": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+				}
 			}
 		},
 		"serve-static": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+			"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
 			"requires": {
 				"encodeurl": "~1.0.2",
 				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.2",
-				"send": "0.16.2"
+				"parseurl": "~1.3.3",
+				"send": "0.17.1"
 			}
 		},
 		"serviceworker-cache-polyfill": {
@@ -16042,9 +16148,9 @@
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"setprototypeof": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
 		},
 		"sha.js": {
 			"version": "2.4.11",
@@ -16512,9 +16618,9 @@
 					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				},
 				"readable-stream": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-					"integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -16601,9 +16707,9 @@
 			}
 		},
 		"statuses": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
 		},
 		"stdout-stream": {
 			"version": "1.4.1",
@@ -16983,12 +17089,12 @@
 			"integrity": "sha512-2wsvQ+4GwBvLPLWsNfLCDYGsW6xb7aeC6utq2Qh0PFwgEy7K7dsma9Jsmb2zSQj7GvYAyUGSntLtsv++GmgL1A=="
 		},
 		"tar": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+			"integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
 			"requires": {
 				"block-stream": "*",
-				"fstream": "^1.0.2",
+				"fstream": "^1.0.12",
 				"inherits": "2"
 			}
 		},
@@ -17483,6 +17589,11 @@
 				}
 			}
 		},
+		"tiny-warning": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.2.tgz",
+			"integrity": "sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q=="
+		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -17566,6 +17677,11 @@
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
 			}
+		},
+		"toidentifier": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
 		},
 		"tough-cookie": {
 			"version": "2.4.3",
@@ -17789,12 +17905,27 @@
 			}
 		},
 		"type-is": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
 			"requires": {
 				"media-typer": "0.3.0",
-				"mime-types": "~2.1.18"
+				"mime-types": "~2.1.24"
+			},
+			"dependencies": {
+				"mime-db": {
+					"version": "1.40.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+					"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+				},
+				"mime-types": {
+					"version": "2.1.24",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+					"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+					"requires": {
+						"mime-db": "1.40.0"
+					}
+				}
 			}
 		},
 		"typedarray": {
@@ -18142,11 +18273,11 @@
 			"integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg="
 		},
 		"url-parse": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.6.tgz",
-			"integrity": "sha512-/B8AD9iQ01seoXmXf9z/MjLZQIdOoYl/+gvsQF6+mpnxaTfG9P7srYaiqaDMyKkR36XMXfhqSHss5MyFAO8lew==",
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+			"integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
 			"requires": {
-				"querystringify": "^2.0.0",
+				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
 			}
 		},
@@ -18205,9 +18336,9 @@
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
 		"v8-compile-cache": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz",
-			"integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw=="
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
+			"integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w=="
 		},
 		"vali-date": {
 			"version": "1.0.0",
@@ -18475,9 +18606,9 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.0.tgz",
-			"integrity": "sha512-t1M7G4z5FhHKJ92WRKwZ1rtvi7rHc0NZoZRbSkol0YKl4HvcC8+DsmGDmK7MmZxHSAetHagiOsjOB6MmzC2TUw==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.2.tgz",
+			"integrity": "sha512-FLkobnaJJ+03j5eplxlI0TUxhGCOdfewspIGuvDVtpOlrAuKMFC57K42Ukxqs1tn8947/PM6tP95gQc0DCzRYA==",
 			"requires": {
 				"chalk": "^2.4.1",
 				"cross-spawn": "^6.0.5",
@@ -18716,37 +18847,37 @@
 			},
 			"dependencies": {
 				"mime": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
-					"integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg=="
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
+					"integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw=="
 				}
 			}
 		},
 		"webpack-dev-server": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.3.1.tgz",
-			"integrity": "sha512-jY09LikOyGZrxVTXK0mgIq9y2IhCoJ05848dKZqX1gAGLU1YDqgpOT71+W53JH/wI4v6ky4hm+KvSyW14JEs5A==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.6.0.tgz",
+			"integrity": "sha512-49CWhocbMzjNW2Dzo3ETnxtzifcKGx4Pa3Hx+sl0hBU5/t7zJTkOvMP1sCnu9/qGNDYW1PKCuszYQn5r2g5Sww==",
 			"requires": {
 				"ansi-html": "0.0.7",
 				"bonjour": "^3.5.0",
-				"chokidar": "^2.1.5",
+				"chokidar": "^2.1.6",
 				"compression": "^1.7.4",
 				"connect-history-api-fallback": "^1.6.0",
 				"debug": "^4.1.1",
-				"del": "^4.1.0",
-				"express": "^4.16.4",
+				"del": "^4.1.1",
+				"express": "^4.17.1",
 				"html-entities": "^1.2.1",
 				"http-proxy-middleware": "^0.19.1",
 				"import-local": "^2.0.0",
-				"internal-ip": "^4.2.0",
+				"internal-ip": "^4.3.0",
 				"ip": "^1.1.5",
 				"killable": "^1.0.1",
-				"loglevel": "^1.6.1",
+				"loglevel": "^1.6.2",
 				"opn": "^5.5.0",
 				"portfinder": "^1.0.20",
 				"schema-utils": "^1.0.0",
 				"selfsigned": "^1.10.4",
-				"semver": "^6.0.0",
+				"semver": "^6.1.1",
 				"serve-index": "^1.9.1",
 				"sockjs": "0.3.19",
 				"sockjs-client": "1.3.0",
@@ -18754,7 +18885,7 @@
 				"strip-ansi": "^3.0.1",
 				"supports-color": "^6.1.0",
 				"url": "^0.11.0",
-				"webpack-dev-middleware": "^3.6.2",
+				"webpack-dev-middleware": "^3.7.0",
 				"webpack-log": "^2.0.0",
 				"yargs": "12.0.5"
 			},
@@ -18773,6 +18904,25 @@
 					"version": "5.3.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+				},
+				"chokidar": {
+					"version": "2.1.6",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+					"integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+					"requires": {
+						"anymatch": "^2.0.0",
+						"async-each": "^1.0.1",
+						"braces": "^2.3.2",
+						"fsevents": "^1.2.7",
+						"glob-parent": "^3.1.0",
+						"inherits": "^2.0.3",
+						"is-binary-path": "^1.0.0",
+						"is-glob": "^4.0.0",
+						"normalize-path": "^3.0.0",
+						"path-is-absolute": "^1.0.0",
+						"readdirp": "^2.2.1",
+						"upath": "^1.1.1"
+					}
 				},
 				"cliui": {
 					"version": "4.1.0",
@@ -18822,10 +18972,11 @@
 					}
 				},
 				"del": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/del/-/del-4.1.0.tgz",
-					"integrity": "sha512-C4kvKNlYrwXhKxz97BuohF8YoGgQ23Xm9lvoHmgT7JaPGprSEjk3+XFled74Yt/x0ZABUHg2D67covzAPUKx5Q==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+					"integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
 					"requires": {
+						"@types/glob": "^7.1.1",
 						"globby": "^6.1.0",
 						"is-path-cwd": "^2.0.0",
 						"is-path-in-cwd": "^2.0.0",
@@ -18898,16 +19049,24 @@
 					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
 				},
 				"is-path-cwd": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.0.0.tgz",
-					"integrity": "sha512-m5dHHzpOXEiv18JEORttBO64UgTEypx99vCxQLjbBvGhOJxnTNglYoFXxwo6AbsQb79sqqycQEHv2hWkHZAijA=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.1.0.tgz",
+					"integrity": "sha512-Sc5j3/YnM8tDeyCsVeKlm/0p95075DyLmDEIkSgQ7mXkrOX+uTCtmQFm0CYzVyJwcCCmO3k8qfJt17SxQwB5Zw=="
 				},
 				"is-path-in-cwd": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.0.0.tgz",
-					"integrity": "sha512-6Vz5Gc9s/sDA3JBVu0FzWufm8xaBsqy1zn8Q6gmvGP6nSDMw78aS4poBNeatWjaRpTpxxLn1WOndAiOlk+qY8A==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+					"integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
 					"requires": {
-						"is-path-inside": "^1.0.0"
+						"is-path-inside": "^2.1.0"
+					}
+				},
+				"is-path-inside": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+					"integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+					"requires": {
+						"path-is-inside": "^1.0.2"
 					}
 				},
 				"lcid": {
@@ -18938,9 +19097,9 @@
 					}
 				},
 				"mime": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
-					"integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg=="
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
+					"integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw=="
 				},
 				"mimic-fn": {
 					"version": "2.1.0",
@@ -19016,9 +19175,9 @@
 					}
 				},
 				"semver": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-					"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ=="
 				},
 				"supports-color": {
 					"version": "6.1.0",
@@ -19029,13 +19188,13 @@
 					}
 				},
 				"webpack-dev-middleware": {
-					"version": "3.6.2",
-					"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.6.2.tgz",
-					"integrity": "sha512-A47I5SX60IkHrMmZUlB0ZKSWi29TZTcPz7cha1Z75yYOsgWh/1AcPmQEbC8ZIbU3A1ytSv1PMU0PyPz2Lmz2jg==",
+					"version": "3.7.0",
+					"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.0.tgz",
+					"integrity": "sha512-qvDesR1QZRIAZHOE3iQ4CXLZZSQ1lAUsSpnQmlB1PBfoN/xdRjmge3Dok0W4IdaVLJOGJy3sGI4sZHwjRU0PCA==",
 					"requires": {
 						"memory-fs": "^0.4.1",
-						"mime": "^2.3.1",
-						"range-parser": "^1.0.3",
+						"mime": "^2.4.2",
+						"range-parser": "^1.2.1",
 						"webpack-log": "^2.0.0"
 					}
 				},

--- a/packages/material/package.json
+++ b/packages/material/package.json
@@ -56,9 +56,9 @@
   },
   "dependencies": {
     "@date-io/moment": "1.1.0",
-    "@material-ui/core": "^3.3.1",
-    "@material-ui/icons": "^3.0.1",
-    "@material-ui/lab": "^3.0.0-alpha.21",
+    "@material-ui/core": "^4.0.1",
+    "@material-ui/icons": "^4.0.1",
+    "@material-ui/lab": "^4.0.0-alpha.15",
     "material-ui-pickers": "^2.2.4",
     "moment": "^2.20.1"
   },

--- a/packages/material/src/additional/MaterialListWithDetailRenderer.tsx
+++ b/packages/material/src/additional/MaterialListWithDetailRenderer.tsx
@@ -79,7 +79,7 @@ export const MaterialListWithDetailRenderer =
           addItem={addItem}
           createDefault={handleCreateDefaultValue}
         />
-        <Grid container direction='row' spacing={16}>
+        <Grid container direction='row' spacing={10}>
           <Grid item xs={3}>
             <List>
               {data > 0 ?

--- a/packages/material/src/additional/MaterialListWithDetailRenderer.tsx
+++ b/packages/material/src/additional/MaterialListWithDetailRenderer.tsx
@@ -79,7 +79,7 @@ export const MaterialListWithDetailRenderer =
           addItem={addItem}
           createDefault={handleCreateDefaultValue}
         />
-        <Grid container direction='row' spacing={10}>
+        <Grid container direction='row' spacing={2}>
           <Grid item xs={3}>
             <List>
               {data > 0 ?

--- a/packages/material/src/complex/TableToolbar.tsx
+++ b/packages/material/src/complex/TableToolbar.tsx
@@ -52,7 +52,7 @@ const TableToolbar = React.memo((
                 container
                 justify={'flex-start'}
                 alignItems={'center'}
-                spacing={10}
+                spacing={2}
             >
                 <Grid item>
                   <Typography variant={'h6'}>{label}</Typography>

--- a/packages/material/src/complex/TableToolbar.tsx
+++ b/packages/material/src/complex/TableToolbar.tsx
@@ -52,7 +52,7 @@ const TableToolbar = React.memo((
                 container
                 justify={'flex-start'}
                 alignItems={'center'}
-                spacing={16}
+                spacing={10}
             >
                 <Grid item>
                   <Typography variant={'h6'}>{label}</Typography>

--- a/packages/material/src/controls/MaterialSliderControl.tsx
+++ b/packages/material/src/controls/MaterialSliderControl.tsx
@@ -99,7 +99,7 @@ export class MaterialSliderControl extends Control<ControlProps, ControlState> {
             min={schema.minimum}
             max={schema.maximum}
             value={Number(data || schema.default)}
-            onChange={(_ev, value) => {
+            onChange={(_ev: any, value: any) => {
               handleChange(path, Number(value));
             }
             }

--- a/packages/material/src/util/layout.tsx
+++ b/packages/material/src/util/layout.tsx
@@ -72,7 +72,7 @@ export const MaterialLayoutRenderer = ({
         <Grid
           container
           direction={direction}
-          spacing={direction === 'row' ? 16 : 0}
+          spacing={direction === 'row' ? 10 : 0}
         >
           {renderLayoutElements(elements, schema, path, renderers)}
         </Grid>

--- a/packages/material/src/util/layout.tsx
+++ b/packages/material/src/util/layout.tsx
@@ -72,7 +72,7 @@ export const MaterialLayoutRenderer = ({
         <Grid
           container
           direction={direction}
-          spacing={direction === 'row' ? 10 : 0}
+          spacing={direction === 'row' ? 2 : 0}
         >
           {renderLayoutElements(elements, schema, path, renderers)}
         </Grid>

--- a/packages/material/test/renderers/MaterialArrayLayout.test.tsx
+++ b/packages/material/test/renderers/MaterialArrayLayout.test.tsx
@@ -320,7 +320,7 @@ describe('Material array layout', () => {
     // up button
     expect(
       wrapper
-        .find('ExpansionPanelSummary')
+        .find('ExpandPanelRenderer')
         .at(0)
         .find('button')
         .find({ 'aria-label': 'Move up' }).length
@@ -328,7 +328,7 @@ describe('Material array layout', () => {
     // down button
     expect(
       wrapper
-        .find('ExpansionPanelSummary')
+        .find('ExpandPanelRenderer')
         .at(0)
         .find('button')
         .find({ 'aria-label': 'Move down' }).length
@@ -349,7 +349,7 @@ describe('Material array layout', () => {
     );
     // getting up button of second item in expension panel;
     const upButton = wrapper
-      .find('ExpansionPanelSummary')
+      .find('ExpandPanelRenderer')
       .at(1)
       .find('button')
       .find({ 'aria-label': 'Move up' });
@@ -379,7 +379,7 @@ describe('Material array layout', () => {
     );
     // getting up button of second item in expension panel;
     const upButton = wrapper
-      .find('ExpansionPanelSummary')
+      .find('ExpandPanelRenderer')
       .at(0)
       .find('button')
       .find({ 'aria-label': 'Move down' });
@@ -409,7 +409,7 @@ describe('Material array layout', () => {
     );
     // getting up button of second item in expension panel;
     const upButton = wrapper
-      .find('ExpansionPanelSummary')
+      .find('ExpandPanelRenderer')
       .at(0)
       .find('button')
       .find({ 'aria-label': 'Move up' });
@@ -430,7 +430,7 @@ describe('Material array layout', () => {
     );
     // getting up button of second item in expension panel;
     const downButton = wrapper
-      .find('ExpansionPanelSummary')
+      .find('ExpandPanelRenderer')
       .at(1)
       .find('button')
       .find({ 'aria-label': 'Move down' });


### PR DESCRIPTION
I'd like to use material-ui version 4 so I can use the new version of ThemeProvider and [ServerStyleSheets with next](https://github.com/mui-org/material-ui/blob/master/examples/nextjs/pages/_document.js)

The type of GridSpacing has been updated
https://github.com/mui-org/material-ui/blob/89687f38cae750650555772ba4d821c9084d8dfc/packages/material-ui/src/Grid/Grid.d.ts

and ExpansionPanelSummary is now wrapped in a higher order styling component so I updated the test to find an the ancestor ExpandPanelRenderer
