### PR TITLE
Export MaterialInputControl

### DIFF
--- a/packages/material/src/controls/index.ts
+++ b/packages/material/src/controls/index.ts
@@ -53,6 +53,8 @@ import MaterialTextControl, {
   materialTextControlTester
 } from './MaterialTextControl';
 
+import { MaterialInputControl } from './MaterialInputControl';
+
 import MaterialAnyOfStringOrEnumControl, {
   materialAnyOfStringOrEnumControlTester
 } from './MaterialAnyOfStringOrEnumControl';
@@ -78,6 +80,7 @@ export {
   materialNumberControlTester,
   MaterialTextControl,
   materialTextControlTester,
+  MaterialInputControl,
   MaterialAnyOfStringOrEnumControl,
   materialAnyOfStringOrEnumControlTester
 };


### PR DESCRIPTION
I'd like to make a custom renderer that uses MaterialInputControl. This is so I can override the onChange so I can create a TextField which automatically converts the input to Sentence Case.

I haven't tested this yet but I imagine something like
```jsx
import * as React from "react";
import { Control } from "@jsonforms/react";
import { connect } from "react-redux";
import {
  MuiInputText,
  MaterialInputControl
} from "@jsonforms/material-renderers";

export class SentenceCaseRender extends Control {
  render() {
    const { path, handleChange } = this.props;
    return (
      <MaterialInputControl
        input={MuiInputText}
        {...this.props}
        onChange={e => handleChange(path, sentenceCase(ev.target.value))}
      />
    );
  }
}

export default SentenceCaseRender;
```