### PR TITLE
Show unfocused description config

### DIFF
--- a/packages/core/src/configDefault.ts
+++ b/packages/core/src/configDefault.ts
@@ -38,5 +38,5 @@ export const configDefault = {
   /*
    * [text] if input descriptions should hide when not focused
    */
-   showUnfocusedDescription: false
+  showUnfocusedDescription: false
 };

--- a/packages/core/src/configDefault.ts
+++ b/packages/core/src/configDefault.ts
@@ -33,5 +33,10 @@ export const configDefault = {
    * [text] whether to resize the input's width to maxLength,
    * if specified in the JSON schema
    */
-  trim: false
+  trim: false,
+
+  /*
+   * [text] if input descriptions should hide when not focused
+   */
+   showUnfocusedDescription: false
 };

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -151,12 +151,13 @@ export const createDefaultValue = (schema: JsonSchema) => {
 export const isDescriptionHidden = (
   visible: boolean,
   description: string,
-  isFocused: boolean
+  isFocused: boolean,
+  showUnfocusedDescription: boolean
 ): boolean => {
   return (
     description === undefined ||
     (description !== undefined && !visible) ||
-    !isFocused
+    (!showUnfocusedDescription && !isFocused)
   );
 };
 

--- a/packages/examples/src/config.ts
+++ b/packages/examples/src/config.ts
@@ -29,7 +29,7 @@ export const schema = {
   properties: {
     postalCode: {
       type: 'string',
-      description: "A Postal Code",
+      description: 'A Postal Code',
       maxLength: 5
     }
   }

--- a/packages/examples/src/config.ts
+++ b/packages/examples/src/config.ts
@@ -29,6 +29,7 @@ export const schema = {
   properties: {
     postalCode: {
       type: 'string',
+      description: "A Postal Code",
       maxLength: 5
     }
   }
@@ -56,7 +57,8 @@ export const data = {
 
 const config = {
   restrict: true,
-  trim: true
+  trim: true,
+  showUnfocusedDescription: true
 };
 
 registerExamples([

--- a/packages/material/src/controls/MaterialDateControl.tsx
+++ b/packages/material/src/controls/MaterialDateControl.tsx
@@ -63,14 +63,15 @@ export class MaterialDateControl extends Control<StatePropsOfDateControl & Dispa
             path,
             handleChange,
             data,
-            momentLocale
+            momentLocale,
+            config
         } = this.props;
         const defaultLabel = label as string;
         const cancelLabel = '%cancel';
         const clearLabel = '%clear';
         const isValid = errors.length === 0;
         const trim = uischema.options && uischema.options.trim;
-        const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused);
+        const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused, config.showUnfocusedDescription);
         const inputProps = {};
         const localeDateTimeFormat =
             momentLocale ? `${momentLocale.localeData().longDateFormat('L')}`

--- a/packages/material/src/controls/MaterialInputControl.tsx
+++ b/packages/material/src/controls/MaterialInputControl.tsx
@@ -67,7 +67,8 @@ export abstract class MaterialInputControl extends Control<ControlProps & WithIn
     const showDescription = !isDescriptionHidden(
       visible,
       description,
-      this.state.isFocused
+      this.state.isFocused,
+      config.showUnfocusedDescription
     );
     const InnerComponent = input;
     return (

--- a/packages/material/src/controls/MaterialInputControl.tsx
+++ b/packages/material/src/controls/MaterialInputControl.tsx
@@ -68,7 +68,7 @@ export abstract class MaterialInputControl extends Control<ControlProps & WithIn
       visible,
       description,
       this.state.isFocused,
-      config.showUnfocusedDescription
+      mergedConfig.showUnfocusedDescription
     );
     const InnerComponent = input;
     return (

--- a/packages/material/src/controls/MaterialNativeControl.tsx
+++ b/packages/material/src/controls/MaterialNativeControl.tsx
@@ -60,7 +60,7 @@ export class MaterialNativeControl extends Control<ControlProps, ControlState> {
     const trim = mergedConfig.trim;
     const onChange = (ev: any) => handleChange(path, ev.target.value);
     const fieldType = schema.format;
-    const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused);
+    const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused, config.showUnfocusedDescription);
 
     return (
       <Hidden xsUp={!visible}>

--- a/packages/material/src/controls/MaterialNativeControl.tsx
+++ b/packages/material/src/controls/MaterialNativeControl.tsx
@@ -60,7 +60,7 @@ export class MaterialNativeControl extends Control<ControlProps, ControlState> {
     const trim = mergedConfig.trim;
     const onChange = (ev: any) => handleChange(path, ev.target.value);
     const fieldType = schema.format;
-    const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused, config.showUnfocusedDescription);
+    const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused, mergedConfig.showUnfocusedDescription);
 
     return (
       <Hidden xsUp={!visible}>

--- a/packages/material/src/controls/MaterialRadioGroupControl.tsx
+++ b/packages/material/src/controls/MaterialRadioGroupControl.tsx
@@ -55,7 +55,7 @@ export class MaterialRadioGroupControl extends Control<ControlProps, ControlStat
     const isValid = errors.length === 0;
     const mergedConfig = merge({}, config, this.props.uischema.options);
     const trim = mergedConfig.trim;
-    const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused, config.showUnfocusedDescription);
+    const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused, mergedConfig.showUnfocusedDescription);
 
     const options = schema.enum;
 

--- a/packages/material/src/controls/MaterialRadioGroupControl.tsx
+++ b/packages/material/src/controls/MaterialRadioGroupControl.tsx
@@ -55,7 +55,7 @@ export class MaterialRadioGroupControl extends Control<ControlProps, ControlStat
     const isValid = errors.length === 0;
     const mergedConfig = merge({}, config, this.props.uischema.options);
     const trim = mergedConfig.trim;
-    const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused);
+    const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused, config.showUnfocusedDescription);
 
     const options = schema.enum;
 

--- a/packages/material/src/controls/MaterialSliderControl.tsx
+++ b/packages/material/src/controls/MaterialSliderControl.tsx
@@ -74,7 +74,7 @@ export class MaterialSliderControl extends Control<ControlProps, ControlState> {
       marginTop: '7px'
     };
 
-    const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused,  config.showUnfocusedDescription);
+    const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused, mergedConfig.showUnfocusedDescription);
     return (
       <Hidden xsUp={!visible}>
         <FormControl

--- a/packages/material/src/controls/MaterialSliderControl.tsx
+++ b/packages/material/src/controls/MaterialSliderControl.tsx
@@ -74,7 +74,7 @@ export class MaterialSliderControl extends Control<ControlProps, ControlState> {
       marginTop: '7px'
     };
 
-    const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused);
+    const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused,  config.showUnfocusedDescription);
     return (
       <Hidden xsUp={!visible}>
         <FormControl

--- a/packages/vanilla/src/controls/InputControl.tsx
+++ b/packages/vanilla/src/controls/InputControl.tsx
@@ -38,6 +38,7 @@ import {
 import { Control, DispatchCell, withJsonFormsControlProps } from '@jsonforms/react';
 import { withVanillaControlProps } from '../util';
 import { VanillaRendererProps } from '../index';
+import merge from 'lodash/merge';
 
 export class InputControl extends Control<
   ControlProps & VanillaRendererProps,
@@ -64,11 +65,13 @@ export class InputControl extends Control<
     const divClassNames = `validation  ${
       isValid ? classNames.description : 'validation_error'
       }`;
+
+    const mergedConfig = merge({}, config, uischema.options);
     const showDescription = !isDescriptionHidden(
       visible,
       description,
       this.state.isFocused,
-      config.showUnfocusedDescription
+      mergedConfig.showUnfocusedDescription
     );
     const labelText = isPlainLabel(label) ? label : label.default;
     const cell = maxBy(cells, r => r.tester(uischema, schema));

--- a/packages/vanilla/src/controls/InputControl.tsx
+++ b/packages/vanilla/src/controls/InputControl.tsx
@@ -56,7 +56,8 @@ export class InputControl extends Control<
       visible,
       required,
       path,
-      cells
+      cells,
+      config
     } = this.props;
 
     const isValid = errors.length === 0;
@@ -66,7 +67,8 @@ export class InputControl extends Control<
     const showDescription = !isDescriptionHidden(
       visible,
       description,
-      this.state.isFocused
+      this.state.isFocused,
+      config.showUnfocusedDescription
     );
     const labelText = isPlainLabel(label) ? label : label.default;
     const cell = maxBy(cells, r => r.tester(uischema, schema));

--- a/packages/vanilla/src/controls/RadioGroupControl.tsx
+++ b/packages/vanilla/src/controls/RadioGroupControl.tsx
@@ -33,6 +33,7 @@ import {
 import { Control, withJsonFormsControlProps } from '@jsonforms/react';
 import { withVanillaControlProps } from '../util';
 import { VanillaRendererProps } from '../index';
+import merge from 'lodash/merge';
 
 export class RadioGroupControl extends Control<ControlProps & VanillaRendererProps, ControlState> {
 
@@ -56,7 +57,9 @@ export class RadioGroupControl extends Control<ControlProps & VanillaRendererPro
             display: 'flex',
             flexDirection: 'row'
         };
-        const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused, config.showUnfocusedDescription);
+
+        const mergedConfig = merge({}, config, uischema.options);
+        const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused, mergedConfig.showUnfocusedDescription);
 
         const options = schema.enum;
 

--- a/packages/vanilla/src/controls/RadioGroupControl.tsx
+++ b/packages/vanilla/src/controls/RadioGroupControl.tsx
@@ -47,6 +47,7 @@ export class RadioGroupControl extends Control<ControlProps & VanillaRendererPro
             data,
             schema,
             visible,
+            config
         } = this.props;
         const isValid = errors.length === 0;
         const divClassNames =
@@ -55,7 +56,7 @@ export class RadioGroupControl extends Control<ControlProps & VanillaRendererPro
             display: 'flex',
             flexDirection: 'row'
         };
-        const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused);
+        const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused, config.showUnfocusedDescription);
 
         const options = schema.enum;
 

--- a/packages/vanilla/src/controls/RadioGroupControl.tsx
+++ b/packages/vanilla/src/controls/RadioGroupControl.tsx
@@ -47,6 +47,7 @@ export class RadioGroupControl extends Control<ControlProps & VanillaRendererPro
             errors,
             data,
             schema,
+            uischema,
             visible,
             config
         } = this.props;


### PR DESCRIPTION
I was doing user testing yesterday and found the user didn't know what unit one of the inputs required, this was it the description but this only showed when they focused the field.

I'd like the option to show unfocused helper text.
![Screenshot 2019-06-21 at 15 38 16](https://user-images.githubusercontent.com/1368025/59930347-a8a65d80-943a-11e9-9895-a207187f600b.png)
