### PR TITLE
Seperate FormHelperText into description and errors

### DIFF
--- a/packages/material/src/controls/MaterialInputControl.tsx
+++ b/packages/material/src/controls/MaterialInputControl.tsx
@@ -69,6 +69,14 @@ export abstract class MaterialInputControl extends Control<ControlProps & WithIn
       description,
       this.state.isFocused
     );
+
+    const firstFormHelperText = showDescription
+      ? description
+      : !isValid
+      ? errors
+      : null;
+    const secondFormHelperText = showDescription && !isValid ? errors : null;
+
     const InnerComponent = input;
     return (
       <Hidden xsUp={!visible}>
@@ -91,13 +99,11 @@ export abstract class MaterialInputControl extends Control<ControlProps & WithIn
             isValid={isValid}
             visible={visible}
           />
-          {description !== undefined ? (
-            <FormHelperText>
-              {showDescription || !isValid ? description : null}
-            </FormHelperText>
-          ) : null}
+          <FormHelperText error={!isValid && !showDescription}>
+            {firstFormHelperText}
+          </FormHelperText>
           <FormHelperText error={!isValid}>
-            {!isValid ? errors : null}
+            {secondFormHelperText}
           </FormHelperText>
         </FormControl>
       </Hidden>

--- a/packages/material/src/controls/MaterialInputControl.tsx
+++ b/packages/material/src/controls/MaterialInputControl.tsx
@@ -91,12 +91,13 @@ export abstract class MaterialInputControl extends Control<ControlProps & WithIn
             isValid={isValid}
             visible={visible}
           />
+          {description !== undefined ? (
+            <FormHelperText>
+              {showDescription || !isValid ? description : null}
+            </FormHelperText>
+          ) : null}
           <FormHelperText error={!isValid}>
-            {!isValid
-              ? errors
-              : showDescription
-              ? description
-              : null}
+            {!isValid ? errors : null}
           </FormHelperText>
         </FormControl>
       </Hidden>

--- a/packages/material/test/renderers/MaterialInputControl.test.tsx
+++ b/packages/material/test/renderers/MaterialInputControl.test.tsx
@@ -112,7 +112,7 @@ describe('Material input control', () => {
     );
 
     const control = wrapper.find('div').first();
-    expect(control.children()).toHaveLength(3);
+    expect(control.children()).toHaveLength(4);
 
     const label = wrapper.find('label');
     expect(label.text()).toBe('Foo');
@@ -141,7 +141,7 @@ describe('Material input control', () => {
     );
 
     const div = wrapper.find('div').first();
-    expect(div.children()).toHaveLength(3);
+    expect(div.children()).toHaveLength(4);
 
     const label = wrapper.find('label');
     expect(label.text()).toBe('');
@@ -294,10 +294,10 @@ describe('Material input control', () => {
       </Provider>
     );
     const validation = wrapper.find('p');
-    expect(validation).toHaveLength(3);
+    expect(validation).toHaveLength(6);
     expect(validation.at(0).text()).toBe('');
-    expect(validation.at(1).text()).toBe('is a required property');
     expect(validation.at(2).text()).toBe('is a required property');
+    expect(validation.at(4).text()).toBe('is a required property');
   });
 
   it('should display a marker for a required prop', () => {


### PR DESCRIPTION
I'd like to be able to see the description even when there are validation errors. I've seperated them into two seperate FormHelperText.

https://giphy.com/gifs/UQD8EYWLpnqMxiRp0f/fullscreen