### PR TITLE
Add ajv-i18n

### DIFF
--- a/packages/core/src/actions/index.ts
+++ b/packages/core/src/actions/index.ts
@@ -22,7 +22,7 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import AJV from 'ajv';
+import AJV, { ErrorObject } from 'ajv';
 import RefParser from 'json-schema-ref-parser';
 import { RankedTester } from '../testers';
 import { JsonSchema, UISchemaElement } from '../';
@@ -33,6 +33,8 @@ import { AnyAction, Dispatch } from 'redux';
 export const INIT: 'jsonforms/INIT' = 'jsonforms/INIT';
 export const SET_AJV: 'jsonforms/SET_AJV' = 'jsonforms/SET_AJV';
 export const UPDATE_DATA: 'jsonforms/UPDATE' = 'jsonforms/UPDATE';
+export const UPDATE_ERRORS: 'jsonforms/UPDATE_ERRORS' =
+  'jsonforms/UPDATE_ERRORS';
 export const VALIDATE: 'jsonforms/VALIDATE' = 'jsonforms/VALIDATE';
 export const ADD_RENDERER: 'jsonforms/ADD_RENDERER' = 'jsonforms/ADD_RENDERER';
 export const REMOVE_RENDERER: 'jsonforms/REMOVE_RENDERER' =
@@ -58,6 +60,11 @@ export interface UpdateAction {
   type: 'jsonforms/UPDATE';
   path: string;
   updater(existingData?: any): any;
+}
+
+export interface UpdateErrorsAction {
+  type: 'jsonforms/UPDATE_ERRORS';
+  errors: ErrorObject[];
 }
 
 export interface InitAction {
@@ -125,6 +132,11 @@ export const update = (
   type: UPDATE_DATA,
   path,
   updater
+});
+
+export const updateErrors = (errors: ErrorObject[]): UpdateErrorsAction => ({
+  type: UPDATE_ERRORS,
+  errors
 });
 
 export interface AddRendererAction {

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -41,7 +41,9 @@ import {
   SetSchemaAction,
   SetUISchemaAction,
   UPDATE_DATA,
-  UpdateAction
+  UpdateAction,
+  UPDATE_ERRORS,
+  UpdateErrorsAction
 } from '../actions';
 import { createAjv } from '../util/validator';
 import { JsonSchema, UISchemaElement } from '..';
@@ -87,6 +89,7 @@ const initState: JsonFormsCore = {
 type ValidCoreActions =
   | InitAction
   | UpdateAction
+  | UpdateErrorsAction
   | SetAjvAction
   | SetSchemaAction
   | SetUISchemaAction;
@@ -221,6 +224,12 @@ export const coreReducer = (
           errors
         };
       }
+    }
+    case UPDATE_ERRORS: {
+      return {
+        ...state,
+        errors: action.errors
+      };
     }
     default:
       return state;

--- a/packages/core/test/reducers/core.test.ts
+++ b/packages/core/test/reducers/core.test.ts
@@ -26,7 +26,7 @@ import test from 'ava';
 import AJV from 'ajv';
 import RefParser from 'json-schema-ref-parser';
 import { coreReducer } from '../../src/reducers';
-import { init } from '../../src/actions';
+import { init, updateErrors } from '../../src/actions';
 import { JsonSchema } from '../../src/models/jsonSchema';
 import {
   errorAt,
@@ -386,6 +386,51 @@ test('core reducer - previous state - init with empty options should not overwri
   );
   t.deepEqual(after.ajv, myAjv);
   t.deepEqual(after.refParserOptions, myOptions);
+});
+
+test('core reducer - updateErrors - should update errors with empty list', t => {
+  const before: JsonFormsCore = {
+    data: {},
+    schema: {},
+    uischema: undefined
+  };
+
+  const after = coreReducer(before, updateErrors([]));
+  t.deepEqual(after, { ...before, errors: [] });
+});
+
+test('core reducer - updateErrors - should update errors with error', t => {
+  const before: JsonFormsCore = {
+    data: {},
+    schema: {},
+    uischema: undefined,
+    errors: []
+  };
+
+  const error = {
+    dataPath: 'color',
+    keyword: 'enum',
+    message: 'should be equal to one of the allowed values',
+    params: {
+      allowedValues: ['Blue', 'Green']
+    },
+    schemaPath: '#/properties/color/enum'
+  };
+
+  const after = coreReducer(before, updateErrors([error]));
+  t.deepEqual(after, { ...before, errors: [error] });
+});
+
+test('core reducer - updateErrors - should update errors with undefined', t => {
+  const before: JsonFormsCore = {
+    data: {},
+    schema: {},
+    uischema: undefined,
+    errors: []
+  };
+
+  const after = coreReducer(before, updateErrors(undefined));
+  t.deepEqual(after, { ...before, errors: undefined });
 });
 
 test('errorAt filters enum', t => {

--- a/packages/example/src/App.tsx
+++ b/packages/example/src/App.tsx
@@ -68,7 +68,7 @@ class App extends Component<AppProps> {
           </div>
           <div className='demoform'>
             {this.props.getExtensionComponent()}
-            <JsonFormsDispatch />
+            <JsonFormsDispatch onChange={this.props.onChange} />
           </div>
         </div>
       </JsonFormsReduxContext>

--- a/packages/example/src/reduxUtil.ts
+++ b/packages/example/src/reduxUtil.ts
@@ -32,6 +32,7 @@ import { ReactExampleDescription } from './util';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { AnyAction, Dispatch, Reducer } from 'redux';
+import { ErrorObject } from 'ajv';
 
 export interface ExampleStateProps {
   examples: ReactExampleDescription[];
@@ -42,11 +43,15 @@ export interface ExampleStateProps {
 export interface ExampleDispatchProps {
   changeExampleData(example: ReactExampleDescription): void;
   getComponent(example: ReactExampleDescription): React.Component;
+  onChange?(
+    example: ReactExampleDescription
+  ): (state: { data: any; errors?: ErrorObject[] }) => void;
 }
 
 export interface AppProps extends ExampleStateProps {
   changeExample(exampleName: string): void;
   getExtensionComponent(): React.Component;
+  onChange?(state: { data: any; errors?: ErrorObject[] }): AnyAction;
 }
 
 const mapStateToProps = (state: any) => {
@@ -65,7 +70,11 @@ const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => ({
     Actions.setConfig(example.config)(dispatch);
   },
   getComponent: (example: ReactExampleDescription) =>
-    example.customReactExtension ? example.customReactExtension(dispatch) : null
+    example.customReactExtension
+      ? example.customReactExtension(dispatch)
+      : null,
+  onChange: (example: ReactExampleDescription) =>
+    example.onChange ? example.onChange(dispatch) : undefined
 });
 const mergeProps = (
   stateProps: ExampleStateProps,
@@ -81,7 +90,8 @@ const mergeProps = (
         )
       ),
     getExtensionComponent: () =>
-      dispatchProps.getComponent(stateProps.selectedExample)
+      dispatchProps.getComponent(stateProps.selectedExample),
+    onChange: dispatchProps.onChange(stateProps.selectedExample)
   });
 };
 

--- a/packages/example/src/reduxUtil.ts
+++ b/packages/example/src/reduxUtil.ts
@@ -22,7 +22,7 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import { Actions, getData } from '@jsonforms/core';
+import { Actions, getData, JsonFormsCore } from '@jsonforms/core';
 import {
   CHANGE_EXAMPLE,
   changeExample,
@@ -32,7 +32,6 @@ import { ReactExampleDescription } from './util';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { AnyAction, Dispatch, Reducer } from 'redux';
-import { ErrorObject } from 'ajv';
 
 export interface ExampleStateProps {
   examples: ReactExampleDescription[];
@@ -45,13 +44,13 @@ export interface ExampleDispatchProps {
   getComponent(example: ReactExampleDescription): React.Component;
   onChange?(
     example: ReactExampleDescription
-  ): (state: { data: any; errors?: ErrorObject[] }) => void;
+  ): (state: Pick<JsonFormsCore, 'data' | 'errors'>) => void;
 }
 
 export interface AppProps extends ExampleStateProps {
   changeExample(exampleName: string): void;
   getExtensionComponent(): React.Component;
-  onChange?(state: { data: any; errors?: ErrorObject[] }): AnyAction;
+  onChange?(state: Pick<JsonFormsCore, 'data' | 'errors'>): AnyAction;
 }
 
 const mapStateToProps = (state: any) => {

--- a/packages/example/src/util.tsx
+++ b/packages/example/src/util.tsx
@@ -37,14 +37,14 @@ import {
   setLocale,
   setSchema,
   setUISchema,
-  UISchemaElement
+  UISchemaElement,
+  JsonFormsCore
 } from '@jsonforms/core';
 import { AnyAction, Dispatch } from 'redux';
-import { ErrorObject } from 'ajv';
 
 export interface ReactExampleDescription extends ExampleDescription {
   customReactExtension?(dispatch: Dispatch<AnyAction>): React.Component;
-  onChange?:(dispatch: Dispatch<AnyAction>) => (state: {data: any,   errors?: ErrorObject[]}) => AnyAction;
+  onChange?:(dispatch: Dispatch<AnyAction>) => (state: Pick<JsonFormsCore, 'data' | 'errors'>) => AnyAction;
 }
 const registerRatingControl = (dispatch: Dispatch<AnyAction>) => {
   dispatch(Actions.registerCell(ratingControlTester, ConnectedRatingControl));

--- a/packages/example/src/util.tsx
+++ b/packages/example/src/util.tsx
@@ -27,7 +27,8 @@ import * as _ from 'lodash';
 import {
   ExampleDescription,
   issue_1220 as Issue1220Example,
-  nestedArray as NestedArrayExample
+  nestedArray as NestedArrayExample,
+  onChange as OnChangeExample
 } from '@jsonforms/examples';
 import ConnectedRatingControl, { ratingControlTester } from './RatingControl';
 import {
@@ -39,9 +40,11 @@ import {
   UISchemaElement
 } from '@jsonforms/core';
 import { AnyAction, Dispatch } from 'redux';
+import { ErrorObject } from 'ajv';
 
 export interface ReactExampleDescription extends ExampleDescription {
   customReactExtension?(dispatch: Dispatch<AnyAction>): React.Component;
+  onChange?:(dispatch: Dispatch<AnyAction>) => (state: {data: any,   errors?: ErrorObject[]}) => AnyAction;
 }
 const registerRatingControl = (dispatch: Dispatch<AnyAction>) => {
   dispatch(Actions.registerCell(ratingControlTester, ConnectedRatingControl));
@@ -195,6 +198,11 @@ export const enhanceExample: (
           )
         });
         return issue_1220;
+        case 'onChange':
+         return {
+           ...e,
+           onChange: OnChangeExample.onChange
+         }
       default:
         return e;
     }

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -62,6 +62,7 @@ import * as issue_1254 from './1254';
 import * as oneOfRecursive from './oneOf-recursive';
 import * as huge from './huge';
 import * as defaultExample from './default';
+import * as onChange from './onChange';
 export * from './register';
 export * from './example';
 
@@ -108,5 +109,6 @@ export {
   issue_1254,
   oneOfRecursive,
   huge,
-  ifThenElse
+  ifThenElse,
+  onChange
 };

--- a/packages/examples/src/onChange.ts
+++ b/packages/examples/src/onChange.ts
@@ -23,8 +23,7 @@
   THE SOFTWARE.
 */
 import { registerExamples } from './register';
-import { UISchemaElement, updateErrors } from '@jsonforms/core';
-import { ErrorObject } from 'ajv';
+import { UISchemaElement, updateErrors, JsonFormsCore } from '@jsonforms/core';
 import { AnyAction, Dispatch } from 'redux';
 
 let touchedProperties: any = {
@@ -35,10 +34,7 @@ let touchedProperties: any = {
 export const onChange = (dispatch: Dispatch<AnyAction>) => ({
   data,
   errors
-}: {
-  data: any;
-  errors: ErrorObject[];
-}) => {
+}: Pick<JsonFormsCore, 'data' | 'errors'>) => {
   Object.keys(data).forEach(key => (touchedProperties[key] = true));
 
   const newErrors = errors.filter(error => {

--- a/packages/examples/src/onChange.ts
+++ b/packages/examples/src/onChange.ts
@@ -1,0 +1,80 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import { registerExamples } from './register';
+import { UISchemaElement, updateErrors } from '@jsonforms/core';
+import { ErrorObject } from 'ajv';
+import { AnyAction, Dispatch } from 'redux';
+
+let touchedProperties: any = {
+  name: false,
+  description: false
+};
+
+export const onChange = (dispatch: Dispatch<AnyAction>) => ({
+  data,
+  errors
+}: {
+  data: any;
+  errors: ErrorObject[];
+}) => {
+  Object.keys(data).forEach(key => (touchedProperties[key] = true));
+
+  const newErrors = errors.filter(error => {
+    return touchedProperties[error.dataPath];
+  });
+
+  if (newErrors.length < errors.length) {
+    return dispatch(updateErrors(newErrors));
+  }
+};
+
+export const schema = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+      minLength: 1
+    },
+    description: {
+      type: 'string',
+      minLength: 1
+    }
+  },
+  required: ['name', 'description']
+};
+
+export const uischema: UISchemaElement = undefined;
+
+export const data = {};
+
+registerExamples([
+  {
+    name: 'onChange',
+    label: 'On Change',
+    data,
+    schema,
+    uischema
+  }
+]);

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -24,7 +24,7 @@
 */
 import isEqual from 'lodash/isEqual';
 import maxBy from 'lodash/maxBy';
-import React, { useEffect } from 'react';
+import React, { useLayoutEffect } from 'react';
 import AJV from 'ajv';
 import RefParser from 'json-schema-ref-parser';
 import { UnknownRenderer } from './UnknownRenderer';
@@ -165,7 +165,7 @@ export const JsonFormsDispatch = (props: OwnPropsOfJsonFormsRenderer & JsonForms
     const ctx = useJsonForms();
     const { refResolver } = ctxToJsonFormsDispatchProps(ctx, props);
     const {data, errors}  = ctx.core
-    useEffect(() => {
+    useLayoutEffect(() => {
       props.onChange && props.onChange({ data, errors });
     }, [data, errors]);
 


### PR DESCRIPTION
I would like to be able to localize the error messages from ajv.

I've added the ajv-i18n package and localize based on navigator.languages. 

I've asked a question on spectrum about how best to get state from other reducers as I'd like to take the list of languages from the i18n reducer.  
https://spectrum.chat/jsonforms/general/development-sharing-state-between-reducers~d8dfcc0b-7876-4c32-a230-baff42501cab