### PR TITLE
Export unwrapped material controls

### DIFF
--- a/packages/material/src/controls/index.ts
+++ b/packages/material/src/controls/index.ts
@@ -80,7 +80,7 @@ export const Unwrapped = {
   MaterialNumberControl: MaterialNumberControlUnwrapped,
   MaterialTextControl: MaterialTextControlUnwrapped,
   MaterialAnyOfStringOrEnumControl: MaterialAnyOfStringOrEnumControlUnwrapped
-}
+};
 
 export {
   MaterialBooleanControl,

--- a/packages/material/src/controls/index.ts
+++ b/packages/material/src/controls/index.ts
@@ -68,38 +68,41 @@ import MaterialAnyOfStringOrEnumControl, {
   MaterialAnyOfStringOrEnumControl as MaterialAnyOfStringOrEnumControlUnwrapped
 } from './MaterialAnyOfStringOrEnumControl';
 
+export const Unwrapped = {
+  MaterialBooleanControl: MaterialBooleanControlUnwrapped,
+  MaterialEnumControl: MaterialEnumControlUnwrapped,
+  MaterialNativeControl: MaterialNativeControlUnwrapped,
+  MaterialDateControl: MaterialDateControlUnwrapped,
+  MaterialDateTimeControl: MaterialDateTimeControlUnwrapped,
+  MaterialSliderControl: MaterialSliderControlUnwrapped,
+  MaterialRadioGroupControl: MaterialRadioGroupControlUnwrapped,
+  MaterialIntegerControl: MaterialIntegerControlUnwrapped,
+  MaterialNumberControl: MaterialNumberControlUnwrapped,
+  MaterialTextControl: MaterialTextControlUnwrapped,
+  MaterialAnyOfStringOrEnumControl: MaterialAnyOfStringOrEnumControlUnwrapped
+}
+
 export {
   MaterialBooleanControl,
-  MaterialBooleanControlUnwrapped,
   materialBooleanControlTester,
   MaterialEnumControl,
-  MaterialEnumControlUnwrapped,
   materialEnumControlTester,
   MaterialNativeControl,
-  MaterialNativeControlUnwrapped,
   materialNativeControlTester,
   MaterialDateControl,
-  MaterialDateControlUnwrapped,
   materialDateControlTester,
   MaterialDateTimeControl,
-  MaterialDateTimeControlUnwrapped,
   materialDateTimeControlTester,
   MaterialSliderControl,
-  MaterialSliderControlUnwrapped,
   materialSliderControlTester,
   MaterialRadioGroupControl,
-  MaterialRadioGroupControlUnwrapped,
   materialRadioGroupControlTester,
   MaterialIntegerControl,
-  MaterialIntegerControlUnwrapped,
   materialIntegerControlTester,
   MaterialNumberControl,
-  MaterialNumberControlUnwrapped,
   materialNumberControlTester,
   MaterialTextControl,
-  MaterialTextControlUnwrapped,
   materialTextControlTester,
   MaterialAnyOfStringOrEnumControl,
-  MaterialAnyOfStringOrEnumControlUnwrapped,
   materialAnyOfStringOrEnumControlTester
 };

--- a/packages/material/src/controls/index.ts
+++ b/packages/material/src/controls/index.ts
@@ -23,61 +23,72 @@
   THE SOFTWARE.
 */
 import MaterialBooleanControl, {
-  materialBooleanControlTester
+  materialBooleanControlTester, MaterialBooleanControl as MaterialBooleanControlUnwrapped
 } from './MaterialBooleanControl';
 import MaterialEnumControl, {
-  materialEnumControlTester
+  materialEnumControlTester, MaterialEnumControl as MaterialEnumControlUnwrapped
 } from './MaterialEnumControl';
 import MaterialNativeControl, {
-  materialNativeControlTester
+  materialNativeControlTester, MaterialNativeControl as MaterialNativeControlUnwrapped
 } from './MaterialNativeControl';
 import MaterialDateControl, {
-  materialDateControlTester
+  materialDateControlTester, MaterialDateControl as MaterialDateControlUnwrapped
 } from './MaterialDateControl';
 import MaterialDateTimeControl, {
-  materialDateTimeControlTester
+  materialDateTimeControlTester, MaterialDateTimeControl as MaterialDateTimeControlUnwrapped
 } from './MaterialDateTimeControl';
 import MaterialSliderControl, {
-  materialSliderControlTester
+  materialSliderControlTester, MaterialSliderControl as MaterialSliderControlUnwrapped
 } from './MaterialSliderControl';
 import MaterialRadioGroupControl, {
-  materialRadioGroupControlTester
+  materialRadioGroupControlTester, MaterialRadioGroupControl as MaterialRadioGroupControlUnwrapped
 } from './MaterialRadioGroupControl';
 import MaterialIntegerControl, {
-  materialIntegerControlTester
+  materialIntegerControlTester, MaterialIntegerControl as MaterialIntegerControlUnwrapped
 } from './MaterialIntegerControl';
 import MaterialNumberControl, {
-  materialNumberControlTester
+  materialNumberControlTester, MaterialNumberControl as MaterialNumberControlUnwrapped
 } from './MaterialNumberControl';
 import MaterialTextControl, {
-  materialTextControlTester
+  materialTextControlTester, MaterialTextControl as MaterialTextControlUnwrapped
 } from './MaterialTextControl';
 
 import MaterialAnyOfStringOrEnumControl, {
-  materialAnyOfStringOrEnumControlTester
+  materialAnyOfStringOrEnumControlTester, MaterialAnyOfStringOrEnumControl as MaterialAnyOfStringOrEnumControlUnwrapped
 } from './MaterialAnyOfStringOrEnumControl';
 
 export {
   MaterialBooleanControl,
+  MaterialBooleanControlUnwrapped,
   materialBooleanControlTester,
   MaterialEnumControl,
+  MaterialEnumControlUnwrapped,
   materialEnumControlTester,
   MaterialNativeControl,
+  MaterialNativeControlUnwrapped,
   materialNativeControlTester,
   MaterialDateControl,
+  MaterialDateControlUnwrapped,
   materialDateControlTester,
   MaterialDateTimeControl,
+  MaterialDateTimeControlUnwrapped,
   materialDateTimeControlTester,
   MaterialSliderControl,
+  MaterialSliderControlUnwrapped,
   materialSliderControlTester,
   MaterialRadioGroupControl,
+  MaterialRadioGroupControlUnwrapped,
   materialRadioGroupControlTester,
   MaterialIntegerControl,
+  MaterialIntegerControlUnwrapped,
   materialIntegerControlTester,
   MaterialNumberControl,
+  MaterialNumberControlUnwrapped,
   materialNumberControlTester,
   MaterialTextControl,
+  MaterialTextControlUnwrapped,
   materialTextControlTester,
   MaterialAnyOfStringOrEnumControl,
+  MaterialAnyOfStringOrEnumControlUnwrapped,
   materialAnyOfStringOrEnumControlTester
 };

--- a/packages/material/src/controls/index.ts
+++ b/packages/material/src/controls/index.ts
@@ -23,38 +23,49 @@
   THE SOFTWARE.
 */
 import MaterialBooleanControl, {
-  materialBooleanControlTester, MaterialBooleanControl as MaterialBooleanControlUnwrapped
+  materialBooleanControlTester,
+  MaterialBooleanControl as MaterialBooleanControlUnwrapped
 } from './MaterialBooleanControl';
 import MaterialEnumControl, {
-  materialEnumControlTester, MaterialEnumControl as MaterialEnumControlUnwrapped
+  materialEnumControlTester,
+  MaterialEnumControl as MaterialEnumControlUnwrapped
 } from './MaterialEnumControl';
 import MaterialNativeControl, {
-  materialNativeControlTester, MaterialNativeControl as MaterialNativeControlUnwrapped
+  materialNativeControlTester,
+  MaterialNativeControl as MaterialNativeControlUnwrapped
 } from './MaterialNativeControl';
 import MaterialDateControl, {
-  materialDateControlTester, MaterialDateControl as MaterialDateControlUnwrapped
+  materialDateControlTester,
+  MaterialDateControl as MaterialDateControlUnwrapped
 } from './MaterialDateControl';
 import MaterialDateTimeControl, {
-  materialDateTimeControlTester, MaterialDateTimeControl as MaterialDateTimeControlUnwrapped
+  materialDateTimeControlTester,
+  MaterialDateTimeControl as MaterialDateTimeControlUnwrapped
 } from './MaterialDateTimeControl';
 import MaterialSliderControl, {
-  materialSliderControlTester, MaterialSliderControl as MaterialSliderControlUnwrapped
+  materialSliderControlTester,
+  MaterialSliderControl as MaterialSliderControlUnwrapped
 } from './MaterialSliderControl';
 import MaterialRadioGroupControl, {
-  materialRadioGroupControlTester, MaterialRadioGroupControl as MaterialRadioGroupControlUnwrapped
+  materialRadioGroupControlTester,
+  MaterialRadioGroupControl as MaterialRadioGroupControlUnwrapped
 } from './MaterialRadioGroupControl';
 import MaterialIntegerControl, {
-  materialIntegerControlTester, MaterialIntegerControl as MaterialIntegerControlUnwrapped
+  materialIntegerControlTester,
+  MaterialIntegerControl as MaterialIntegerControlUnwrapped
 } from './MaterialIntegerControl';
 import MaterialNumberControl, {
-  materialNumberControlTester, MaterialNumberControl as MaterialNumberControlUnwrapped
+  materialNumberControlTester,
+  MaterialNumberControl as MaterialNumberControlUnwrapped
 } from './MaterialNumberControl';
 import MaterialTextControl, {
-  materialTextControlTester, MaterialTextControl as MaterialTextControlUnwrapped
+  materialTextControlTester,
+  MaterialTextControl as MaterialTextControlUnwrapped
 } from './MaterialTextControl';
 
 import MaterialAnyOfStringOrEnumControl, {
-  materialAnyOfStringOrEnumControlTester, MaterialAnyOfStringOrEnumControl as MaterialAnyOfStringOrEnumControlUnwrapped
+  materialAnyOfStringOrEnumControlTester,
+  MaterialAnyOfStringOrEnumControl as MaterialAnyOfStringOrEnumControlUnwrapped
 } from './MaterialAnyOfStringOrEnumControl';
 
 export {


### PR DESCRIPTION
Last week was talking to @eneufeld about building a custom control which reuses the MaterialTextControl. 

https://github.com/eclipsesource/jsonforms/pull/1413#issuecomment-504598408

This is a PR to export the control components not wrapped with `withJsonFormsControlProps` so they can be used in custom renderers. 