### PR TITLE
Use createStyles in ValidationIcon.tsx

### DIFF
--- a/packages/material/src/complex/ValidationIcon.tsx
+++ b/packages/material/src/complex/ValidationIcon.tsx
@@ -29,18 +29,19 @@ import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
 import Tooltip from '@material-ui/core/Tooltip';
 import {
   StyledComponentProps,
-  StyleRulesCallback,
   withStyles,
-  WithStyles
+  WithStyles,
+  createStyles,
+  Theme
 } from '@material-ui/core/styles';
 import { compose } from 'redux';
 
 export { StyledComponentProps };
-const styles: StyleRulesCallback<'badge'> = ({ palette }) => ({
+const styles = createStyles(({ palette }: Theme) => ({
   badge: {
     color: palette.error.main
   }
-});
+}));
 
 export interface ValidationProps {
   errorMessages: string;


### PR DESCRIPTION
Not sure if this is to do with my version of typescript but I was getting this error

```
src/complex/ValidationIcon.tsx:40:15 - error TS2707: Generic type 'StyleRulesCallback' requires between 2 and 3 type arguments.

40 const styles: StyleRulesCallback<'badge'> = ({ palette }: Theme) => ({
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

and also 

```
src/complex/ValidationIcon.tsx:38:19 - error TS7031: Binding element 'palette' implicitly has an 'any' type.

38 const styles = ({ palette }) => ({
```

so I used the `createStyles` method