### PR TITLE
Add allowing additional inputProps

### DIFF
--- a/packages/material/src/mui-controls/MuiInputText.tsx
+++ b/packages/material/src/mui-controls/MuiInputText.tsx
@@ -36,19 +36,7 @@ interface MuiInputTextStatus {
 }
 
 interface MuiTextInputProps {
-  inputProps?: {
-    autocomplete?: string;
-    maxLength?: number;
-    minLength?: number;
-    pattern?: string | object;
-    placeholder?: string;
-    readonly?: boolean;
-    required?: boolean;
-    size?: number;
-    spellcheck?: boolean;
-    autocorrect?: 'on' | 'off';
-    mozactionhint?: 'go' | 'done' | 'next' | 'search' | 'send';
-  };
+  muiInputProps? : React.HTMLAttributes<HTMLInputElement>
 }
 
 export class MuiInputText extends React.Component<
@@ -68,21 +56,21 @@ export class MuiInputText extends React.Component<
       path,
       handleChange,
       schema,
-      inputProps
+      muiInputProps
     } = this.props;
     const maxLength = schema.maxLength;
     const mergedConfig = merge({}, config, uischema.options);
-    let innerInputProps: any;
+    let inputProps: any;
     if (mergedConfig.restrict) {
-      innerInputProps = { maxLength: maxLength };
+      inputProps = { maxLength: maxLength };
     } else {
-      innerInputProps = {};
+      inputProps = {};
     }
 
-    innerInputProps = merge(innerInputProps, inputProps);
+    inputProps = merge(inputProps, muiInputProps);
 
     if (mergedConfig.trim && maxLength !== undefined) {
-      innerInputProps.size = maxLength;
+      inputProps.size = maxLength;
     }
     const onChange = (ev: any) => handleChange(path, ev.target.value);
 
@@ -101,7 +89,7 @@ export class MuiInputText extends React.Component<
         autoFocus={uischema.options && uischema.options.focus}
         multiline={uischema.options && uischema.options.multi}
         fullWidth={!mergedConfig.trim || maxLength === undefined}
-        inputProps={innerInputProps}
+        inputProps={inputProps}
         error={!isValid}
         onPointerEnter={() => this.setState({ showAdornment: true })}
         onPointerLeave={() => this.setState({ showAdornment: false })}

--- a/packages/material/src/mui-controls/MuiInputText.tsx
+++ b/packages/material/src/mui-controls/MuiInputText.tsx
@@ -35,8 +35,24 @@ interface MuiInputTextStatus {
   showAdornment: boolean;
 }
 
+interface MuiTextInputProps {
+  inputProps?: {
+    autocomplete?: string;
+    maxLength?: number;
+    minLength?: number;
+    pattern?: string | object;
+    placeholder?: string;
+    readonly?: boolean;
+    required?: boolean;
+    size?: number;
+    spellcheck?: boolean;
+    autocorrect?: 'on' | 'off';
+    mozactionhint?: 'go' | 'done' | 'next' | 'search' | 'send';
+  };
+}
+
 export class MuiInputText extends React.Component<
-  CellProps & WithClassname,
+  CellProps & WithClassname & MuiTextInputProps,
   MuiInputTextStatus
 > {
   state: MuiInputTextStatus = { showAdornment: false };
@@ -51,18 +67,22 @@ export class MuiInputText extends React.Component<
       isValid,
       path,
       handleChange,
-      schema
+      schema,
+      inputProps
     } = this.props;
     const maxLength = schema.maxLength;
     const mergedConfig = merge({}, config, uischema.options);
-    let inputProps: any;
+    let innerInputProps: any;
     if (mergedConfig.restrict) {
-      inputProps = { maxLength: maxLength };
+      innerInputProps = { maxLength: maxLength };
     } else {
-      inputProps = {};
+      innerInputProps = {};
     }
+
+    innerInputProps = merge(innerInputProps, inputProps);
+
     if (mergedConfig.trim && maxLength !== undefined) {
-      inputProps.size = maxLength;
+      innerInputProps.size = maxLength;
     }
     const onChange = (ev: any) => handleChange(path, ev.target.value);
 
@@ -81,7 +101,7 @@ export class MuiInputText extends React.Component<
         autoFocus={uischema.options && uischema.options.focus}
         multiline={uischema.options && uischema.options.multi}
         fullWidth={!mergedConfig.trim || maxLength === undefined}
-        inputProps={inputProps}
+        inputProps={innerInputProps}
         error={!isValid}
         onPointerEnter={() => this.setState({ showAdornment: true })}
         onPointerLeave={() => this.setState({ showAdornment: false })}

--- a/packages/material/test/renderers/MaterialTextControl.test.tsx
+++ b/packages/material/test/renderers/MaterialTextControl.test.tsx
@@ -1,0 +1,83 @@
+/*
+  The MIT License
+
+  Copyright (c) 2018-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import React from 'react';
+import Enzyme, { mount, ReactWrapper } from 'enzyme';
+import { MaterialTextControl } from '../../src/controls/MaterialTextControl';
+import { MaterialInputControl } from '../../src/controls/MaterialInputControl';
+import { MuiInputText } from '../../src/mui-controls/MuiInputText';
+import Adapter from 'enzyme-adapter-react-16';
+import { ControlElement, ControlProps } from '@jsonforms/core';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+const schema = {
+  type: 'object',
+  properties: {
+    foo: {
+      type: 'string'
+    }
+  }
+};
+const uischema: ControlElement = {
+  type: 'Control',
+  scope: '#/properties/foo'
+};
+
+const createMaterialTextControl = (props: ControlProps) => {
+  return <MaterialTextControl {...props} />;
+};
+
+const defaultControlProps = (): ControlProps => {
+  return {
+    handleChange: () => {},
+    enabled: true,
+    visible: true,
+    path: 'path',
+    rootSchema: schema,
+    schema: schema.properties.foo,
+    uischema: uischema,
+    label: 'Foo',
+    id: 'foo-id',
+    errors: '',
+    data: ''
+  };
+};
+
+describe('Material text control', () => {
+  let wrapper: ReactWrapper;
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('render', () => {
+    const props = defaultControlProps();
+    wrapper = mount(createMaterialTextControl(props));
+    expect(wrapper.find(MaterialInputControl).props()).toEqual({
+      ...props,
+      input: MuiInputText
+    });
+  });
+});

--- a/packages/material/test/renderers/MaterialTextControl.test.tsx
+++ b/packages/material/test/renderers/MaterialTextControl.test.tsx
@@ -79,5 +79,16 @@ describe('Material text control', () => {
       ...props,
       input: MuiInputText
     });
+    
+    expect(wrapper.find("input").props().id).toEqual(`${props.id}-input`);
+  });
+
+  it('allows adding of mui input props', () => {
+    const props = {
+      ...defaultControlProps(),
+      muiInputProps: { spellCheck: false }
+    };
+    wrapper = mount(createMaterialTextControl(props));
+    expect(wrapper.find('input').props().spellCheck).toEqual(false)
   });
 });


### PR DESCRIPTION
I would like to turn off spellcheck for a TextControl. I have my custom renderer 

```
import * as React from "react";
import { withJsonFormsControlProps } from "@jsonforms/react";

import { Unwrapped } from "@jsonforms/material-renderers";

export const SentenceCaseRender = props => {
  const sentenceCaseString = s => {
    return s.length > 0 ? s[0].toUpperCase() + s.slice(1).toLowerCase() : s;
  };

  const { handleChange } = props;
  return (
    <Unwrapped.MaterialTextControl
      {...props}
      inputProps={{ spellcheck: "false" }}
      handleChange={(path, targetValue) => {
        handleChange(path, sentenceCaseString(targetValue));
      }}
    />
  );
};

export default withJsonFormsControlProps(SentenceCaseRender);
```

This PR allows adding inputProps which get passed down to the MuiInputText