### PR TITLE
Add enum to structuralKeywords

### DIFF
--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -743,7 +743,7 @@ const mapStateToCombinatorRendererProps = (
   const ajv = state.jsonforms.core.ajv;
   const schema = resolvedSchema || rootSchema;
   const _schema = resolveSubSchemas(schema, rootSchema, keyword);
-  const structuralKeywords = ['required', 'additionalProperties', 'type'];
+  const structuralKeywords = ['required', 'additionalProperties', 'type', 'enum'];
   const dataIsValid = (errors: ErrorObject[]): boolean => {
     return (
       !errors ||

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -743,7 +743,12 @@ const mapStateToCombinatorRendererProps = (
   const ajv = state.jsonforms.core.ajv;
   const schema = resolvedSchema || rootSchema;
   const _schema = resolveSubSchemas(schema, rootSchema, keyword);
-  const structuralKeywords = ['required', 'additionalProperties', 'type', 'enum'];
+  const structuralKeywords = [
+    'required',
+    'additionalProperties',
+    'type',
+    'enum'
+  ];
   const dataIsValid = (errors: ErrorObject[]): boolean => {
     return (
       !errors ||

--- a/packages/core/test/util/renderer.test.ts
+++ b/packages/core/test/util/renderer.test.ts
@@ -33,7 +33,8 @@ import {
   mapDispatchToControlProps,
   mapStateToControlProps,
   mapStateToJsonFormsRendererProps,
-  mapStateToLayoutProps
+  mapStateToLayoutProps,
+  mapStateToOneOfProps
 } from '../../src/util';
 import configureStore from 'redux-mock-store';
 import test from 'ava';
@@ -613,6 +614,69 @@ test('mapStateToLayoutProps - hidden via state with path from ownProps ', t => {
   };
   const props = mapStateToLayoutProps(state, ownProps);
   t.false(props.visible);
+});
+
+test("mapStateToOneOfProps - indexOfFittingSchema should not select schema if enum doesn't match", t => {
+  const uischema: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/method'
+  };
+
+  const ownProps = {
+    uischema
+  };
+
+  const state = {
+    jsonforms: {
+      core: {
+        ajv: createAjv(),
+        schema: {
+          type: 'object',
+          properties: {
+            method: {
+              oneOf: [
+                {
+                  title: 'Injection',
+                  type: 'object',
+                  properties: {
+                    method: {
+                      title: 'Method',
+                      type: 'string',
+                      enum: ['Injection'],
+                      default: 'Injection'
+                    }
+                  },
+                  required: ['method']
+                },
+                {
+                  title: 'Infusion',
+                  type: 'object',
+                  properties: {
+                    method: {
+                      title: 'Method',
+                      type: 'string',
+                      enum: ['Infusion'],
+                      default: 'Infusion'
+                    }
+                  },
+                  required: ['method']
+                }
+              ]
+            }
+          }
+        },
+        data: {
+          method: {
+            method: 'Infusion'
+          }
+        },
+        uischema
+      }
+    }
+  };
+
+  const oneOfProps = mapStateToOneOfProps(state, ownProps);
+  t.is(oneOfProps.indexOfFittingSchema, 1);
 });
 
 test('should assign defaults to enum', t => {


### PR DESCRIPTION
There are cases where AJV error will be keyword enum.

Here is a such a case:
Schema:
```
{
  "title": "Injection",
  "type": "object",
  "properties": {
    "method": {
      "title": "Method",
      "type": "string",
      "enum": [
        "Injection"
      ],
      "default": "Injection"
    }
  },
  "required": [
    "method"
  ]
}
```

Data
```
{
  "method": "Infusion"
}
```

(We're using these enums to force the oneOf to select a specific tab when it could otherwise be ambigious) 

The error is 
```
  {
    keyword: 'enum',
    dataPath: '.method',
    schemaPath: '#/properties/method/enum',
    params: { allowedValues: [Array] },
    message: 'should be equal to one of the allowed values'
  }
```

