### PR TITLE
Fix performance issues

### DIFF
--- a/packages/material/src/layouts/ExpandPanelRenderer.tsx
+++ b/packages/material/src/layouts/ExpandPanelRenderer.tsx
@@ -1,0 +1,272 @@
+import React, { Fragment, Dispatch, ReducerAction } from 'react';
+import { ComponentType } from 'enzyme';
+import {
+  JsonFormsDispatch,
+  JsonFormsStateContext,
+  withJsonFormsContext
+} from '@jsonforms/react';
+import {
+  composePaths,
+  ControlElement,
+  findUISchema,
+  JsonFormsRendererRegistryEntry,
+  JsonSchema,
+  moveDown,
+  moveUp,
+  Resolve,
+  UISchemaElement,
+  UISchemaTester,
+  update
+} from '@jsonforms/core';
+import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
+import IconButton from '@material-ui/core/IconButton';
+import ExpansionPanel from '@material-ui/core/ExpansionPanel';
+import find from 'lodash/find';
+import omit from 'lodash/omit';
+import isEqual from 'lodash/isEqual';
+import get from 'lodash/get';
+import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+import { Grid } from '@material-ui/core';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import Avatar from '@material-ui/core/Avatar';
+import DeleteIcon from '@material-ui/icons/Delete';
+import ArrowUpward from '@material-ui/icons/ArrowUpward';
+import ArrowDownward from '@material-ui/icons/ArrowDownward';
+
+const iconStyle: any = { float: 'right' };
+
+interface OwnPropsOfExpandPanel {
+  index: number;
+  path: string;
+  uischema: ControlElement;
+  schema: JsonSchema;
+  expanded: boolean;
+  renderers?: JsonFormsRendererRegistryEntry[];
+  rootSchema: JsonSchema;
+  enableMoveUp: boolean;
+  enableMoveDown: boolean;
+  handleExpansion(panel: string): (event: any, expanded: boolean) => void;
+}
+
+interface StatePropsOfExpandPanel extends OwnPropsOfExpandPanel {
+  childLabel: string;
+  childPath: string;
+  uischemas: { tester: UISchemaTester; uischema: UISchemaElement }[];
+  enableMoveUp: boolean;
+  enableMoveDown: boolean;
+}
+
+/**
+ * Dispatch props of a table control
+ */
+export interface DispatchPropsOfExpandPanel {
+  removeItems(path: string, toDelete: number[]): (event: any) => void;
+  moveUp(path: string, toMove: number): (event: any) => void;
+  moveDown(path: string, toMove: number): (event: any) => void;
+}
+
+export interface ExpandPanelProps
+  extends StatePropsOfExpandPanel,
+  DispatchPropsOfExpandPanel { }
+
+const ExpandPanelRenderer = (props: ExpandPanelProps) => {
+  const {
+    childLabel,
+    childPath,
+    index,
+    expanded,
+    moveDown,
+    moveUp,
+    enableMoveDown,
+    enableMoveUp,
+    handleExpansion,
+    removeItems,
+    path,
+    rootSchema,
+    schema,
+    uischema,
+    uischemas,
+    renderers
+  } = props;
+
+  const foundUISchema = findUISchema(
+    uischemas,
+    schema,
+    uischema.scope,
+    path,
+    undefined,
+    uischema,
+    rootSchema
+  );
+
+  return (
+    <ExpansionPanel expanded={expanded} onChange={handleExpansion(childPath)}>
+      <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+        <Grid container alignItems={'center'}>
+          <Grid item xs={10}>
+            <Grid container alignItems={'center'}>
+              <Grid item xs={1}>
+                <Avatar aria-label='Index'>{index + 1}</Avatar>
+              </Grid>
+              <Grid item xs={2}>
+                {childLabel}
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid item xs={2}>
+            <Grid container justify={'flex-end'}>
+              <Grid item>
+                <Grid
+                  container
+                  direction='row'
+                  justify='center'
+                  alignItems='center'
+                >
+                  {uischema.options && uischema.options.showSortButtons ? (
+                    <Fragment>
+                      <Grid item>
+                        <IconButton
+                          onClick={moveUp(path, index)}
+                          style={iconStyle}
+                          disabled={!enableMoveUp}
+                          aria-label={`Move up`}
+                        >
+                          <ArrowUpward />
+                        </IconButton>
+                      </Grid>
+                      <Grid item>
+                        <IconButton
+                          onClick={moveDown(path, index)}
+                          style={iconStyle}
+                          disabled={!enableMoveDown}
+                          aria-label={`Move down`}
+                        >
+                          <ArrowDownward />
+                        </IconButton>
+                      </Grid>
+                    </Fragment>
+                  ) : (
+                      ''
+                    )}
+                  <Grid item>
+                    <IconButton
+                      onClick={removeItems(path, [index])}
+                      style={iconStyle}
+                      aria-label={`Delete`}
+                    >
+                      <DeleteIcon />
+                    </IconButton>
+                  </Grid>
+                </Grid>
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+      </ExpansionPanelSummary>
+      <ExpansionPanelDetails>
+        <JsonFormsDispatch
+          schema={schema}
+          uischema={foundUISchema}
+          path={childPath}
+          key={childPath}
+          renderers={renderers}
+        />
+      </ExpansionPanelDetails>
+    </ExpansionPanel>
+  );
+};
+
+/**
+ * Maps state to dispatch properties of an expand pandel control.
+ *
+ * @param dispatch the store's dispatch method
+ * @returns {DispatchPropsOfArrayControl} dispatch props of an expand panel control
+ */
+export const ctxDispatchToExpandPanelProps: (
+  dispatch: Dispatch<ReducerAction<any>>
+) => DispatchPropsOfExpandPanel = dispatch => ({
+  removeItems: (path: string, toDelete: number[]) => (event: any): void => {
+    event.stopPropagation();
+    dispatch(
+      update(path, array => {
+        toDelete
+          .sort()
+          .reverse()
+          .forEach(s => array.splice(s, 1));
+        return array;
+      })
+    );
+  },
+  moveUp: (path: string, toMove: number) => (event: any): void => {
+    event.stopPropagation();
+    dispatch(
+      update(path, array => {
+        moveUp(array, toMove);
+        return array;
+      })
+    );
+  },
+  moveDown: (path: string, toMove: number) => (event: any): void => {
+    event.stopPropagation();
+    dispatch(
+      update(path, array => {
+        moveDown(array, toMove);
+        return array;
+      })
+    );
+  }
+});
+
+/**
+ * Map state to control props.
+ * @param state the JSON Forms state
+ * @param ownProps any own props
+ * @returns {StatePropsOfControl} state props for a control
+ */
+export const withContextToExpandPanelProps =
+  (Component: ComponentType<ExpandPanelProps>): ComponentType<OwnPropsOfExpandPanel> =>
+    ({ ctx, props }: JsonFormsStateContext & ExpandPanelProps) => {
+      const dispatchProps = ctxDispatchToExpandPanelProps(ctx.dispatch);
+      const { schema, path, index, uischemas } = props;
+      const firstPrimitiveProp = schema.properties
+        ? find(Object.keys(schema.properties), propName => {
+          const prop = schema.properties[propName];
+          return (
+            prop.type === 'string' ||
+            prop.type === 'number' ||
+            prop.type === 'integer'
+          );
+        })
+        : undefined;
+      const childPath = composePaths(path, `${index}`);
+      const childData = Resolve.data(ctx.core.data, childPath);
+      const childLabel = firstPrimitiveProp ? childData[firstPrimitiveProp] : '';
+
+      return (
+        <Component
+          {...props}
+          {...dispatchProps}
+          childLabel={childLabel}
+          childPath={childPath}
+          uischemas={uischemas}
+        />
+      );
+    };
+
+export const areEqual = (prevProps: ExpandPanelProps, nextProps: ExpandPanelProps) => {
+  const prev = omit(prevProps, ['handleChange', 'renderers', 'cells', 'uischemas']);
+  const next = omit(nextProps, ['handleChange', 'renderers', 'cells', 'uischemas']);
+  return isEqual(prev, next)
+    && get(prevProps, 'renderers.length') === get(nextProps, 'renderers.length')
+    && get(prevProps, 'cells.length') === get(nextProps, 'cells.length')
+    && get(prevProps, 'uischemas.length') === get(nextProps, 'uischemas.length');
+};
+
+export const withJsonFormsExpandPanelProps =
+  (Component: ComponentType<ExpandPanelProps>): ComponentType<OwnPropsOfExpandPanel> =>
+    withJsonFormsContext(withContextToExpandPanelProps(React.memo(
+      Component,
+      (prevProps: ExpandPanelProps, nextProps: ExpandPanelProps) => areEqual(prevProps, nextProps)
+    )));
+
+export default withJsonFormsExpandPanelProps(ExpandPanelRenderer);

--- a/packages/material/src/layouts/MaterialArrayLayout.tsx
+++ b/packages/material/src/layouts/MaterialArrayLayout.tsx
@@ -22,54 +22,28 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
-import find from 'lodash/find';
 import range from 'lodash/range';
-import React, { Dispatch, Fragment, ReducerAction } from 'react';
+import React from 'react';
 import {
   ArrayLayoutProps,
   composePaths,
   computeLabel,
-  ControlElement,
   createDefaultValue,
-  findUISchema,
-  isPlainLabel,
-  JsonFormsRendererRegistryEntry,
-  JsonSchema,
-  Resolve,
-  UISchemaElement,
-  UISchemaTester,
-  update,
-  moveUp,
-  moveDown
+  isPlainLabel
 } from '@jsonforms/core';
-import {
-  JsonFormsDispatch,
-  JsonFormsStateContext,
-  useJsonForms
-} from '@jsonforms/react';
-import IconButton from '@material-ui/core/IconButton';
-import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 import map from 'lodash/map';
-import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
-import { Grid } from '@material-ui/core';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import Avatar from '@material-ui/core/Avatar';
 import Paper from '@material-ui/core/Paper';
-import DeleteIcon from '@material-ui/icons/Delete';
-import ArrowUpward from '@material-ui/icons/ArrowUpward';
-import ArrowDownward from '@material-ui/icons/ArrowDownward';
 import { ArrayLayoutToolbar } from './ArrayToolbar';
+import ExpandPanelRenderer from './ExpandPanelRenderer';
 
 const paperStyle = { padding: 10 };
-const iconStyle: any = { float: 'right' };
 interface MaterialArrayLayoutState {
   expanded: string | boolean;
 }
 export class MaterialArrayLayout extends React.Component<
   ArrayLayoutProps,
   MaterialArrayLayoutState
-> {
+  > {
   state: MaterialArrayLayoutState = {
     expanded: null
   };
@@ -127,219 +101,10 @@ export class MaterialArrayLayout extends React.Component<
               );
             })
           ) : (
-            <p>No data</p>
-          )}
+              <p>No data</p>
+            )}
         </div>
       </Paper>
     );
   }
 }
-
-const ExpandPanelRenderer = (props: OwnPropsOfExpandPanel) => {
-  const { renderers, uischemas, dispatch, ...ctx } = useJsonForms();
-  const {
-    index,
-    expanded,
-    childLabel,
-    schema,
-    childPath,
-    path,
-    handleExpansion,
-    uischema,
-    rootSchema,
-    enableMoveUp,
-    enableMoveDown
-  } = ctxStateToExpandPanelProps(ctx, props);
-  const { removeItems, moveDown, moveUp } = ctxDispatchToExpandPanelProps(
-    dispatch
-  );
-
-  const foundUISchema = findUISchema(
-    uischemas,
-    schema,
-    uischema.scope,
-    path,
-    undefined,
-    uischema,
-    rootSchema
-  );
-
-  return (
-    <ExpansionPanel expanded={expanded} onChange={handleExpansion(childPath)}>
-      <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-        <Grid container alignItems={'center'}>
-          <Grid item xs={10}>
-            <Grid container alignItems={'center'}>
-              <Grid item xs={1}>
-                <Avatar aria-label='Index'>{index + 1}</Avatar>
-              </Grid>
-              <Grid item xs={2}>
-                {childLabel}
-              </Grid>
-            </Grid>
-          </Grid>
-          <Grid item xs={2}>
-            <Grid container justify={'flex-end'}>
-              <Grid item>
-                <Grid
-                  container
-                  direction='row'
-                  justify='center'
-                  alignItems='center'
-                >
-                  {uischema.options && uischema.options.showSortButtons ? (
-                    <Fragment>
-                      <Grid item>
-                        <IconButton
-                          onClick={moveUp(path, index)}
-                          style={iconStyle}
-                          disabled={!enableMoveUp}
-                          aria-label={`Move up`}
-                        >
-                          <ArrowUpward />
-                        </IconButton>
-                      </Grid>
-                      <Grid item>
-                        <IconButton
-                          onClick={moveDown(path, index)}
-                          style={iconStyle}
-                          disabled={!enableMoveDown}
-                          aria-label={`Move down`}
-                        >
-                          <ArrowDownward />
-                        </IconButton>
-                      </Grid>
-                    </Fragment>
-                  ) : (
-                    ''
-                  )}
-                  <Grid item>
-                    <IconButton
-                      onClick={removeItems(path, [index])}
-                      style={iconStyle}
-                      aria-label={`Delete`}
-                    >
-                      <DeleteIcon />
-                    </IconButton>
-                  </Grid>
-                </Grid>
-              </Grid>
-            </Grid>
-          </Grid>
-        </Grid>
-      </ExpansionPanelSummary>
-      <ExpansionPanelDetails>
-        <JsonFormsDispatch
-          schema={schema}
-          uischema={foundUISchema}
-          path={childPath}
-          key={childPath}
-          renderers={renderers}
-        />
-      </ExpansionPanelDetails>
-    </ExpansionPanel>
-  );
-};
-
-interface OwnPropsOfExpandPanel {
-  index: number;
-  path: string;
-  uischema: ControlElement;
-  schema: JsonSchema;
-  expanded: boolean;
-  renderers?: JsonFormsRendererRegistryEntry[];
-  rootSchema: JsonSchema;
-  enableMoveUp: boolean;
-  enableMoveDown: boolean;
-  handleExpansion(panel: string): (event: any, expanded: boolean) => void;
-}
-interface StatePropsOfExpandPanel extends OwnPropsOfExpandPanel {
-  childLabel: string;
-  childPath: string;
-  uischemas: { tester: UISchemaTester; uischema: UISchemaElement }[];
-}
-/**
- * Map state to control props.
- * @param state the JSON Forms state
- * @param ownProps any own props
- * @returns {StatePropsOfControl} state props for a control
- */
-export const ctxStateToExpandPanelProps = (
-  state: JsonFormsStateContext,
-  ownProps: OwnPropsOfExpandPanel
-): StatePropsOfExpandPanel => {
-  const { schema, path, index } = ownProps;
-  const firstPrimitiveProp = schema.properties
-    ? find(Object.keys(schema.properties), propName => {
-        const prop = schema.properties[propName];
-        return (
-          prop.type === 'string' ||
-          prop.type === 'number' ||
-          prop.type === 'integer'
-        );
-      })
-    : undefined;
-  const childPath = composePaths(path, `${index}`);
-  const childData = Resolve.data(state.core.data, childPath);
-  const childLabel = firstPrimitiveProp ? childData[firstPrimitiveProp] : '';
-
-  return {
-    ...ownProps,
-    childLabel,
-    childPath,
-    uischemas: state.uischemas
-  };
-};
-
-/**
- * Dispatch props of a table control
- */
-export interface DispatchPropsOfExpandPanel {
-  removeItems(path: string, toDelete: number[]): (event: any) => void;
-  moveUp(path: string, toMove: number): (event: any) => void;
-  moveDown(path: string, toMove: number): (event: any) => void;
-}
-
-/**
- * Maps state to dispatch properties of an expand pandel control.
- *
- * @param dispatch the store's dispatch method
- * @returns {DispatchPropsOfArrayControl} dispatch props of an expand panel control
- */
-export const ctxDispatchToExpandPanelProps: (
-  dispatch: Dispatch<ReducerAction<any>>
-) => DispatchPropsOfExpandPanel = dispatch => ({
-  removeItems: (path: string, toDelete: number[]) => (event: any): void => {
-    event.stopPropagation();
-    dispatch(
-      update(path, array => {
-        toDelete
-          .sort()
-          .reverse()
-          .forEach(s => array.splice(s, 1));
-        return array;
-      })
-    );
-  },
-  moveUp: (path: string, toMove: number) => (event: any): void => {
-    event.stopPropagation();
-    dispatch(
-      update(path, array => {
-        moveUp(array, toMove);
-        return array;
-      })
-    );
-  },
-  moveDown: (path: string, toMove: number) => (event: any): void => {
-    event.stopPropagation();
-    dispatch(
-      update(path, array => {
-        moveDown(array, toMove);
-        return array;
-      })
-    );
-  }
-});
-export interface ExpandPanelProps
-  extends StatePropsOfExpandPanel,
-    DispatchPropsOfExpandPanel {}

--- a/packages/material/src/layouts/MaterialCategorizationLayout.tsx
+++ b/packages/material/src/layouts/MaterialCategorizationLayout.tsx
@@ -29,7 +29,6 @@ import {
   and,
   Categorization,
   isVisible,
-  JsonFormsSubStates,
   RankedTester,
   rankWith,
   StatePropsOfLayout,
@@ -37,7 +36,7 @@ import {
   UISchemaElement,
   uiTypeIs,
 } from '@jsonforms/core';
-import { ctxToLayoutProps, JsonFormsContext, RendererComponent } from '@jsonforms/react';
+import { RendererComponent, withJsonFormsLayoutProps } from '@jsonforms/react';
 import { MaterialLayoutRenderer, MaterialLayoutRendererProps } from '../util/layout';
 
 export const isSingleLevelCategorization: Tester = and(
@@ -69,45 +68,29 @@ export class MaterialCategorizationLayoutRenderer
   };
 
   render() {
+    const { data, path, renderers, schema, uischema, visible, selected } = this.props;
+    const categorization = uischema as Categorization;
+    const value = this.hasOwnState() ? this.state.activeCategory : selected;
+    const childProps: MaterialLayoutRendererProps = {
+      elements: categorization.elements[value].elements,
+      schema,
+      path,
+      direction: 'column',
+      visible,
+      renderers
+    };
+    const categories = categorization.elements.filter(category => isVisible(category, data));
     return (
-      <JsonFormsContext.Consumer>
-        {
-          (ctx: JsonFormsSubStates) => {
-            const {
-              uischema,
-              schema,
-              path,
-              visible,
-              renderers
-            } = ctxToLayoutProps(ctx, this.props);
-            const data = ctx.core.data;
-            const categorization = uischema as Categorization;
-            const value = this.hasOwnState() ? this.state.activeCategory : this.props.selected;
-            const childProps: MaterialLayoutRendererProps = {
-              elements: categorization.elements[value].elements,
-              schema,
-              path,
-              direction: 'column',
-              visible,
-              renderers
-            };
-            const categories = categorization.elements.filter(category => isVisible(category, data));
-
-            return (
-              <Hidden xsUp={!visible}>
-                <AppBar position='static'>
-                  <Tabs value={value} onChange={this.handleChange} variant='scrollable'>
-                    {categories.map((e, idx) => <Tab key={idx} label={e.label} />)}
-                  </Tabs>
-                </AppBar>
-                <div style={{ marginTop: '0.5em' }}>
-                  <MaterialLayoutRenderer {...childProps} />
-                </div>
-              </Hidden>
-            )
-          }
-        }
-      </JsonFormsContext.Consumer>
+      <Hidden xsUp={!visible}>
+        <AppBar position='static'>
+          <Tabs value={value} onChange={this.handleChange} variant='scrollable'>
+            {categories.map((e, idx) => <Tab key={idx} label={e.label} />)}
+          </Tabs>
+        </AppBar>
+        <div style={{ marginTop: '0.5em' }}>
+          <MaterialLayoutRenderer {...childProps} />
+        </div>
+      </Hidden>
     );
   }
 
@@ -126,4 +109,4 @@ export class MaterialCategorizationLayoutRenderer
   };
 }
 
-export default MaterialCategorizationLayoutRenderer;
+export default withJsonFormsLayoutProps(MaterialCategorizationLayoutRenderer);

--- a/packages/material/test/renderers/MaterialCategorizationLayout.test.tsx
+++ b/packages/material/test/renderers/MaterialCategorizationLayout.test.tsx
@@ -40,11 +40,10 @@ import Enzyme, { mount } from 'enzyme';
 
 import { AnyAction, combineReducers, createStore, Reducer, Store } from 'redux';
 import MaterialCategorizationLayoutRenderer, {
-  MaterialCategorizationLayoutRenderer as CategorizationLayoutRenderer,
   materialCategorizationTester
 } from '../../src/layouts/MaterialCategorizationLayout';
 import { MaterialLayoutRenderer, materialRenderers } from '../../src';
-import { Tab } from '@material-ui/core';
+import { Tab, Tabs } from '@material-ui/core';
 import Adapter from 'enzyme-adapter-react-16';
 import { Provider } from 'react-redux';
 
@@ -191,7 +190,7 @@ describe('Material categorization layout tester', () => {
   });
 });
 
-describe('Material categorization stepper layout', () => {
+describe('Material categorization layout', () => {
 
   it('should render', () => {
     const nameControl = {
@@ -293,9 +292,10 @@ describe('Material categorization stepper layout', () => {
         </JsonFormsReduxContext>
       </Provider>
     );
-    const beforeClick = wrapper.find(CategorizationLayoutRenderer).state().activeCategory;
+
+    const beforeClick = wrapper.find(Tabs).props().value;
     wrapper.find(Tab).at(1).simulate('click');
-    const afterClick = wrapper.find(CategorizationLayoutRenderer).state().activeCategory;
+    const afterClick = wrapper.find(Tabs).props().value;
 
     expect(beforeClick).toBe(0);
     expect(afterClick).toBe(1);

--- a/packages/react/src/JsonFormsContext.tsx
+++ b/packages/react/src/JsonFormsContext.tsx
@@ -188,7 +188,7 @@ export const ctxToOneOfProps = (
   ownProps: OwnPropsOfControl
 ): CombinatorProps => {
   const props = mapStateToOneOfProps({ jsonforms: { ...ctx } }, ownProps);
-  const { handleChange } = ctxDispatchToControlProps(ctx.dispatch)
+  const { handleChange } = ctxDispatchToControlProps(ctx.dispatch);
   return {
     ...props,
     handleChange
@@ -223,7 +223,7 @@ interface WithContext {
   ctx: JsonFormsStateContext;
 }
 
-const withJsonFormsContext =
+export const withJsonFormsContext =
   (Component: ComponentType<WithContext & any>): ComponentType<any> => (props: any) => {
     const ctx = useJsonForms();
     return <Component ctx={ctx} props={props} />;
@@ -334,7 +334,7 @@ const withContextToEnumProps =
 
 type JsonFormsPropTypes = ControlProps | CombinatorProps | LayoutProps | CellProps | ArrayLayoutProps | StatePropsOfControlWithDetail;
 
-const areEqual = (prevProps: JsonFormsPropTypes, nextProps: JsonFormsPropTypes) => {
+export const areEqual = (prevProps: JsonFormsPropTypes, nextProps: JsonFormsPropTypes) => {
   const prev = omit(prevProps, ['handleChange', 'renderers', 'cells', 'uischemas']);
   const next = omit(nextProps, ['handleChange', 'renderers', 'cells', 'uischemas']);
   return isEqual(prev, next)


### PR DESCRIPTION
Fixes the problems identified in #1433 

Extracted `ExpandPanelRenderer` into its own file and replace usage of context within renderer. Instead provide HOC that extract the props accordingly. 
Remove usage of context consumer in categorization layout renderer and replace with usage of HOC as well. Adapted tests.