### PR TITLE
Add minItems to array layout props

### DIFF
--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -811,6 +811,7 @@ export const mapStateToOneOfProps = (
 
 export interface StatePropsOfArrayLayout extends StatePropsOfControlWithDetail {
   data: number;
+  minItems?: number;
 }
 /**
  * Map state to table props
@@ -845,7 +846,8 @@ export const mapStateToArrayLayoutProps = (
     uischema,
     schema: resolvedSchema,
     data: props.data ? props.data.length : 0,
-    errors: allErrors
+    errors: allErrors,
+    minItems: schema.minItems
   };
 };
 

--- a/packages/core/test/util/renderer.test.ts
+++ b/packages/core/test/util/renderer.test.ts
@@ -34,6 +34,7 @@ import {
   mapStateToControlProps,
   mapStateToJsonFormsRendererProps,
   mapStateToLayoutProps,
+  mapStateToArrayLayoutProps,
   mapStateToOneOfProps
 } from '../../src/util';
 import configureStore from 'redux-mock-store';
@@ -546,6 +547,45 @@ test('mapStateToLayoutProps - visible via state with path from ownProps ', t => 
   };
   const props = mapStateToLayoutProps(state, ownProps);
   t.true(props.visible);
+});
+
+test('mapStateToArrayLayoutProps - should include minItems in array layout props', t => {
+  const schema: JsonSchema = {
+    type: 'array',
+    minItems: 42,
+    items: {
+      type: 'object',
+      properties: {
+        message: {
+          type: 'string',
+          default: 'foo'
+        }
+      }
+    }
+  };
+
+  const uischema: ControlElement = {
+    type: 'Control',
+    scope: '#'
+  };
+
+  const state = {
+    jsonforms: {
+      core: {
+        schema,
+        data: {},
+        uischema,
+        errors: [] as ErrorObject[]
+      }
+    }
+  };
+
+  const ownProps = {
+    uischema
+  };
+
+  const props = mapStateToArrayLayoutProps(state, ownProps);
+  t.is(props.minItems, 42);
 });
 
 test('mapStateToLayoutProps should return renderers prop via ownProps', t => {

--- a/packages/examples/src/oneOf.ts
+++ b/packages/examples/src/oneOf.ts
@@ -101,31 +101,31 @@ const schema_1265_array = {
     colours: {
       title: 'Colours',
       type: 'array',
+      minItems: 1,
       items: {
         title: 'Type',
         type: 'string',
-        enum: ['Red', 'Green', 'Blue'],
-        minItems: 1
+        enum: ['Red', 'Green', 'Blue']
       }
     },
     numbers: {
       title: 'Numbers',
       type: 'array',
+      minItems: 1,
       items: {
         title: 'Type',
         type: 'string',
-        enum: ['One', 'Two', 'Three'],
-        minItems: 1
+        enum: ['One', 'Two', 'Three']
       }
     },
     shapes: {
       title: 'Shapes',
       type: 'array',
+      minItems: 1,
       items: {
         title: 'Type',
         type: 'string',
-        enum: ['Circle', 'Triangle', 'Square'],
-        minItems: 1
+        enum: ['Circle', 'Triangle', 'Square']
       }
     }
   }


### PR DESCRIPTION
Adds minItems to mapStateToArrayLayoutProps, this is something I'd like to use in a custom renderer. 

I'd like that when the + button is pressed if the new object has arrays as children, if these have minItems rather than an empty array, an array with length minItems is rendered.

I also can see some uses for this in the material array renderer, it could be that if an array is required and has minItems of more than 0 it hides the Delete button from the first item in the array.

The other update here is moving minItems in the example, looking at the documention minItems should be at the same level as type: "array" https://json-schema.org/understanding-json-schema/reference/array.html#length