### PR TITLE
Add hideRequiredAsterisk option

### DIFF
--- a/packages/angular/src/abstract-control.ts
+++ b/packages/angular/src/abstract-control.ts
@@ -100,11 +100,13 @@ export abstract class JsonFormsAbstractControl<
           schema,
           rootSchema,
           visible,
-          path
+          path,
+          config
         } = props;
         this.label = computeLabel(
           isPlainLabel(label) ? label : label.default,
-          required
+          required,
+          config ? config.hideRequiredAsterisk : false
         );
         this.data = data;
         this.error = errors;

--- a/packages/core/src/configDefault.ts
+++ b/packages/core/src/configDefault.ts
@@ -38,5 +38,10 @@ export const configDefault = {
   /*
    * [text] if input descriptions should hide when not focused
    */
-  showUnfocusedDescription: false
+  showUnfocusedDescription: false,
+
+  /*
+   * [text] if asterisks in labels for required fields should be hidden
+   */
+  hideRequiredAsterisk: false
 };

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -105,8 +105,12 @@ const isRequired = (
  * @param {boolean} required whether the label belongs to a control which is required
  * @returns {string} the label string
  */
-export const computeLabel = (label: string, required: boolean): string => {
-  return required ? label + '*' : label;
+export const computeLabel = (
+  label: string,
+  required: boolean,
+  hideRequiredAsterisk: boolean
+): string => {
+  return required && !hideRequiredAsterisk ? label + '*' : label;
 };
 
 /**

--- a/packages/core/test/util/renderer.test.ts
+++ b/packages/core/test/util/renderer.test.ts
@@ -35,7 +35,8 @@ import {
   mapStateToJsonFormsRendererProps,
   mapStateToLayoutProps,
   mapStateToArrayLayoutProps,
-  mapStateToOneOfProps
+  mapStateToOneOfProps,
+  computeLabel
 } from '../../src/util';
 import configureStore from 'redux-mock-store';
 import test from 'ava';
@@ -843,4 +844,24 @@ test('should assign defaults to newly added item within nested object of an arra
 
   t.is(store.getState().jsonforms.core.data.length, 2);
   t.deepEqual(store.getState().jsonforms.core.data[0], { message: 'foo' });
+});
+
+test('computeLabel - should not edit label if not required and hideRequiredAsterisk is false', t => {
+  const computedLabel = computeLabel('Test Label', false, false);
+  t.is(computedLabel, 'Test Label');
+});
+
+test('computeLabel - should not edit label if not required and hideRequiredAsterisk is true', t => {
+  const computedLabel = computeLabel('Test Label', false, true);
+  t.is(computedLabel, 'Test Label');
+});
+
+test('computeLabel - should not edit label if required but hideRequiredAsterisk is true', t => {
+  const computedLabel = computeLabel('Test Label', true, true);
+  t.is(computedLabel, 'Test Label');
+});
+
+test('computeLabel - should add asterisk if required but hideRequiredAsterisk is false', t => {
+  const computedLabel = computeLabel('Test Label', true, false);
+  t.is(computedLabel, 'Test Label*');
 });

--- a/packages/examples/src/config.ts
+++ b/packages/examples/src/config.ts
@@ -36,7 +36,8 @@ export const schema = {
       type: 'integer',
       description: 'A recurrence interval'
     }
-  }
+  },
+  required: ['postalCode']
 };
 
 export const uischema = {
@@ -67,7 +68,8 @@ export const data = {
 const config = {
   restrict: true,
   trim: true,
-  showUnfocusedDescription: true
+  showUnfocusedDescription: true,
+  hideRequiredAsterisk: true
 };
 
 registerExamples([

--- a/packages/material/src/additional/MaterialListWithDetailRenderer.tsx
+++ b/packages/material/src/additional/MaterialListWithDetailRenderer.tsx
@@ -47,9 +47,10 @@ import range from 'lodash/range';
 import React, { useCallback, useState } from 'react';
 import { ArrayLayoutToolbar } from '../layouts/ArrayToolbar';
 import ListWithDetailMasterItem from './ListWithDetailMasterItem';
+import merge from 'lodash/merge';
 
 export const MaterialListWithDetailRenderer =
-  ({ uischemas, schema, uischema, path, errors, visible, label, required, removeItems, addItem, data, renderers }: ArrayLayoutProps) => {
+  ({ uischemas, schema, uischema, path, errors, visible, label, required, removeItems, addItem, data, renderers, config }: ArrayLayoutProps) => {
     const [selectedIndex, setSelectedIndex] = useState(undefined);
     const handleRemoveItem = useCallback((p: string, value: any) => () => {
       removeItems(p, [value])();
@@ -69,11 +70,12 @@ export const MaterialListWithDetailRenderer =
       undefined,
       uischema
     );
+    const mergedConfig = merge({}, config, uischema.options);
 
     return (
       <Hidden xsUp={!visible}>
         <ArrayLayoutToolbar
-          label={computeLabel(isPlainLabel(label) ? label : label.default, required)}
+          label={computeLabel(isPlainLabel(label) ? label : label.default, required, mergedConfig.hideRequiredAsterisk)}
           errors={errors}
           path={path}
           addItem={addItem}

--- a/packages/material/src/controls/MaterialDateControl.tsx
+++ b/packages/material/src/controls/MaterialDateControl.tsx
@@ -44,6 +44,7 @@ import moment from 'moment';
 import { Moment } from 'moment';
 import { DatePicker, MuiPickersUtilsProvider } from 'material-ui-pickers';
 import MomentUtils from '@date-io/moment';
+import merge from 'lodash/merge';
 
 export interface DateControl {
     momentLocale?: Moment;
@@ -71,7 +72,8 @@ export class MaterialDateControl extends Control<StatePropsOfDateControl & Dispa
         const clearLabel = '%clear';
         const isValid = errors.length === 0;
         const trim = uischema.options && uischema.options.trim;
-        const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused, config.showUnfocusedDescription);
+        const mergedConfig = merge({}, config, uischema.options);
+        const showDescription = !isDescriptionHidden(visible, description, this.state.isFocused, mergedConfig.showUnfocusedDescription);
         const inputProps = {};
         const localeDateTimeFormat =
             momentLocale ? `${momentLocale.localeData().longDateFormat('L')}`
@@ -100,7 +102,7 @@ export class MaterialDateControl extends Control<StatePropsOfDateControl & Dispa
                     <DatePicker
                         keyboard
                         id={id + '-input'}
-                        label={computeLabel(labelText, required)}
+                        label={computeLabel(labelText, required, mergedConfig.hideRequiredAsterisk)}
                         error={!isValid}
                         fullWidth={!trim}
                         helperText={!isValid ? errors : showDescription ? description : ' '}

--- a/packages/material/src/controls/MaterialDateTimeControl.tsx
+++ b/packages/material/src/controls/MaterialDateTimeControl.tsx
@@ -74,7 +74,7 @@ export class MaterialDateTimeControl extends Control<ControlProps, ControlState>
           <DateTimePicker
             keyboard
             id={id + '-input'}
-            label={computeLabel(isPlainLabel(label) ? label : label.default, required)}
+            label={computeLabel(isPlainLabel(label) ? label : label.default, required, mergedConfig.hideRequiredAsterisk)}
             error={!isValid}
             fullWidth={!trim}
             onFocus={this.onFocus}

--- a/packages/material/src/controls/MaterialInputControl.tsx
+++ b/packages/material/src/controls/MaterialInputControl.tsx
@@ -92,7 +92,7 @@ export abstract class MaterialInputControl extends Control<ControlProps & WithIn
             error={!isValid}
             style={inputLabelStyle}
           >
-            {computeLabel(isPlainLabel(label) ? label : label.default, required)}
+            {computeLabel(isPlainLabel(label) ? label : label.default, required, mergedConfig.hideRequiredAsterisk)}
           </InputLabel>
           <InnerComponent
             {...this.props}

--- a/packages/material/src/controls/MaterialNativeControl.tsx
+++ b/packages/material/src/controls/MaterialNativeControl.tsx
@@ -66,7 +66,7 @@ export class MaterialNativeControl extends Control<ControlProps, ControlState> {
       <Hidden xsUp={!visible}>
         <TextField
           id={id + '-input'}
-          label={computeLabel(isPlainLabel(label) ? label : label.default, required)}
+          label={computeLabel(isPlainLabel(label) ? label : label.default, required, mergedConfig.hideRequiredAsterisk)}
           type={fieldType}
           error={!isValid}
           fullWidth={!trim}

--- a/packages/material/src/controls/MaterialRadioGroupControl.tsx
+++ b/packages/material/src/controls/MaterialRadioGroupControl.tsx
@@ -72,7 +72,8 @@ export class MaterialRadioGroupControl extends Control<ControlProps, ControlStat
           >
             {computeLabel(
               isPlainLabel(label) ? label : label.default,
-              required
+              required,
+              mergedConfig.hideRequiredAsterisk
             )}
           </FormLabel>
 

--- a/packages/material/src/controls/MaterialSliderControl.tsx
+++ b/packages/material/src/controls/MaterialSliderControl.tsx
@@ -84,7 +84,7 @@ export class MaterialSliderControl extends Control<ControlProps, ControlState> {
           id={id}
         >
           <Typography id={id + '-typo'} style={labelStyle} variant='caption'>
-            {computeLabel(isPlainLabel(label) ? label : label.default, required)}
+            {computeLabel(isPlainLabel(label) ? label : label.default, required, mergedConfig.hideRequiredAsterisk)}
           </Typography>
           <div style={rangeContainerStyle}>
             <Typography style={rangeItemStyle} variant='caption' align='left'>

--- a/packages/material/src/layouts/MaterialArrayLayout.tsx
+++ b/packages/material/src/layouts/MaterialArrayLayout.tsx
@@ -35,6 +35,7 @@ import map from 'lodash/map';
 import Paper from '@material-ui/core/Paper';
 import { ArrayLayoutToolbar } from './ArrayToolbar';
 import ExpandPanelRenderer from './ExpandPanelRenderer';
+import merge from 'lodash/merge';
 
 const paperStyle = { padding: 10 };
 interface MaterialArrayLayoutState {
@@ -66,15 +67,18 @@ export class MaterialArrayLayout extends React.PureComponent<
       renderers,
       label,
       required,
-      rootSchema
+      rootSchema,
+      config
     } = this.props;
+    const mergedConfig = merge({}, config, this.props.uischema.options);
 
     return (
       <Paper style={paperStyle}>
         <ArrayLayoutToolbar
           label={computeLabel(
             isPlainLabel(label) ? label : label.default,
-            required
+            required,
+            mergedConfig.hideRequiredAsterisk
           )}
           errors={errors}
           path={path}

--- a/packages/vanilla/src/controls/InputControl.tsx
+++ b/packages/vanilla/src/controls/InputControl.tsx
@@ -91,7 +91,7 @@ export class InputControl extends Control<
           id={id}
         >
           <label htmlFor={id + '-input'} className={classNames.label}>
-            {computeLabel(labelText, required)}
+            {computeLabel(labelText, required, mergedConfig.hideRequiredAsterisk)}
           </label>
           <DispatchCell
             uischema={uischema}

--- a/packages/vanilla/src/controls/RadioGroupControl.tsx
+++ b/packages/vanilla/src/controls/RadioGroupControl.tsx
@@ -72,7 +72,7 @@ export class RadioGroupControl extends Control<ControlProps & VanillaRendererPro
                 onBlur={this.onBlur}
             >
                 <label htmlFor={id} className={classNames.label} >
-                    {computeLabel(isPlainLabel(label) ? label : label.default, required)}
+                    {computeLabel(isPlainLabel(label) ? label : label.default, required, mergedConfig.hideRequiredAsterisk)}
                 </label>
 
                 <div


### PR DESCRIPTION
I'd like the option to not have asterisk in labels of required properties. 

This can be useful if
- all properties are required so asterisk is not necessary
- If you want to build custom renderers using Unwrapped Controls which have some other way to show the required state

For me as almost all properties are required the asterisk is adding visual noise.