### PR TITLE
Add onChange prop to JsonForms react component

### DIFF
--- a/packages/core/src/actions/index.ts
+++ b/packages/core/src/actions/index.ts
@@ -25,7 +25,7 @@
 import AJV from 'ajv';
 import RefParser from 'json-schema-ref-parser';
 import { RankedTester } from '../testers';
-import { JsonSchema, UISchemaElement } from '../';
+import { JsonSchema, UISchemaElement, JsonFormsCore } from '../';
 import { generateDefaultUISchema, generateJsonSchema } from '../generators';
 import { UISchemaTester } from '../reducers/uischemas';
 import { AnyAction, Dispatch } from 'redux';
@@ -71,6 +71,7 @@ export interface InitAction {
 export interface InitActionOptions {
   ajv?: AJV.Ajv;
   refParserOptions?: RefParser.Options;
+  onChange?(state: JsonFormsCore): void;
 }
 
 export const init = (

--- a/packages/example/src/reduxUtil.ts
+++ b/packages/example/src/reduxUtil.ts
@@ -61,7 +61,7 @@ const mapStateToProps = (state: any) => {
 const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => ({
   changeExampleData: (example: ReactExampleDescription) => {
     dispatch(changeExample(example));
-    dispatch(Actions.init(example.data, example.schema, example.uischema));
+    dispatch(Actions.init(example.data, example.schema, example.uischema, { onChange: example.onChange } ));
     Actions.setConfig(example.config)(dispatch);
   },
   getComponent: (example: ReactExampleDescription) =>

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -62,6 +62,7 @@ import * as issue_1254 from './1254';
 import * as oneOfRecursive from './oneOf-recursive';
 import * as huge from './huge';
 import * as defaultExample from './default';
+import * as onChange from './onChange';
 export * from './register';
 export * from './example';
 
@@ -108,5 +109,6 @@ export {
   issue_1254,
   oneOfRecursive,
   huge,
-  ifThenElse
+  ifThenElse,
+  onChange
 };

--- a/packages/examples/src/onChange.ts
+++ b/packages/examples/src/onChange.ts
@@ -1,19 +1,19 @@
 /*
   The MIT License
-  
+
   Copyright (c) 2017-2019 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
-  
+
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
-  
+
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
-  
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,26 +22,41 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import { JsonSchema, UISchemaElement, JsonFormsCore } from '@jsonforms/core';
+import { registerExamples } from './register';
+import { UISchemaElement } from '@jsonforms/core';
 
-export interface ExampleDescription {
-  name: string;
-  label: string;
-  data: any;
-  schema: JsonSchema;
-  uischema: UISchemaElement;
-  config?: any;
-  onChange?(state: JsonFormsCore): void;
-}
-export const CHANGE_EXAMPLE: 'jsonforms-example/CHANGE' =
-  'jsonforms-example/CHANGE';
-export interface ChangeExampleAction {
-  type: 'jsonforms-example/CHANGE';
-  example: ExampleDescription;
-}
-export const changeExample = (
-  example: ExampleDescription
-): ChangeExampleAction => ({
-  type: CHANGE_EXAMPLE,
-  example: example
-});
+export const schema = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+      minLength: 1
+    },
+    description: {
+      type: 'string'
+    },
+    done: {
+      type: 'boolean'
+    }
+  },
+  required: ['name']
+};
+
+export const uischema: UISchemaElement = undefined;
+
+export const data = {
+  name: 'Send email to Adrian',
+  description: 'Confirm if you have passed the subject\nHereby ...',
+  done: true
+};
+
+registerExamples([
+  {
+    name: 'onChange',
+    label: 'On Change',
+    data,
+    schema,
+    uischema,
+    onChange: (state) => console.log(state)
+  }
+]);

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -38,6 +38,7 @@ import {
     OwnPropsOfJsonFormsRenderer,
     removeId,
     UISchemaElement,
+    JsonFormsCore
 } from '@jsonforms/core';
 import { ctxToJsonFormsDispatchProps, JsonFormsStateProvider, useJsonForms } from './JsonFormsContext';
 
@@ -178,10 +179,11 @@ export interface JsonFormsInitStateProps {
     renderers: JsonFormsRendererRegistryEntry[];
     ajv?: AJV.Ajv;
     refParserOptions?: RefParser.Options;
+    onChange?(state: JsonFormsCore): void;
 }
 
 export const JsonForms = (props: JsonFormsInitStateProps) => {
-    const { ajv, data, schema, uischema, renderers, refParserOptions } = props;
+    const { ajv, data, schema, uischema, renderers, refParserOptions, onChange } = props;
     return (
         <JsonFormsStateProvider
             initState={{
@@ -191,7 +193,8 @@ export const JsonForms = (props: JsonFormsInitStateProps) => {
                     refParserOptions,
                     schema,
                     uischema,
-                    errors: [] // TODO
+                    errors: [], // TODO
+                    onChange
                 },
                 renderers
             }}


### PR DESCRIPTION
This is for #1271

# Possible Examples
I intend to update the example for something which shows a use of this feature. 
## Updating Error
Changing the validation logic as discussed here
https://spectrum.chat/jsonforms/general/pristine-and-dirty-checking~2ece93ab-7783-41cb-8ba1-804414eb1da4

or localising the error as discussed
https://spectrum.chat/jsonforms/general/development-sharing-state-between-reducers~d8dfcc0b-7876-4c32-a230-baff42501cab

Both these cases require an additional action for updating errors


TODO:
- [ ] Consider API, should onChange parameter be JsonFormsCore? I think perhaps there's only use cases for errors and data.
- [ ] Fix issue where swapping between examples doesn't remove the onChange handler
- [ ] Refactor to avoid repeating `state.onChange && state.onChange(state)`
- [ ] Refactor to allow any InitActionOptions to be provided by example
- [ ] Update example to be sensible use case
- [ ] Testing


And because this is the longest Pull Request description I've written, here is a gif related to this feature
![The more things change, the more they stay the same](https://media.giphy.com/media/RIjdINUcrxkt3ibfyZ/giphy.gif)

