### PR TITLE
Use setupMockStore to create mockSubStore in angular material tests

### DIFF
--- a/packages/angular-material/test/autocomplete-control.spec.ts
+++ b/packages/angular-material/test/autocomplete-control.spec.ts
@@ -43,7 +43,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MockNgRedux } from '@angular-redux/store/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { ErrorTestExpectation } from '@jsonforms/angular-test';
+import { ErrorTestExpectation, setupMockStore } from '@jsonforms/angular-test';
 import { ControlElement, JsonSchema } from '@jsonforms/core';
 import { MockNgZone } from './mock-ng-zone';
 import { AutocompleteControlRenderer } from '../src';
@@ -99,17 +99,7 @@ describe('Autocomplete control Base Tests', () => {
   });
 
   it('should render', fakeAsync(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-    component.schema = schema;
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     mockSubStore.complete();
     fixture.detectChanges();
     component.ngOnInit();
@@ -120,18 +110,7 @@ describe('Autocomplete control Base Tests', () => {
   }));
 
   it('should support updating the state', fakeAsync(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-    component.schema = schema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     fixture.detectChanges();
     component.ngOnInit();
     tick();
@@ -151,18 +130,7 @@ describe('Autocomplete control Base Tests', () => {
   }));
 
   it('should update with undefined value', () => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-    component.schema = schema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     fixture.detectChanges();
     component.ngOnInit();
 
@@ -180,18 +148,7 @@ describe('Autocomplete control Base Tests', () => {
     expect(inputElement.value).toBe('');
   });
   it('should update with null value', () => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-    component.schema = schema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     fixture.detectChanges();
     component.ngOnInit();
 
@@ -209,18 +166,7 @@ describe('Autocomplete control Base Tests', () => {
     expect(inputElement.value).toBe('');
   });
   it('should not update with wrong ref', fakeAsync(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-    component.schema = schema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     fixture.detectChanges();
     component.ngOnInit();
     tick();
@@ -240,38 +186,16 @@ describe('Autocomplete control Base Tests', () => {
   }));
   // store needed as we evaluate the calculated enabled value to disable/enable the control
   it('can be disabled', () => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-    component.schema = schema;
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     component.disabled = true;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
     mockSubStore.complete();
     fixture.detectChanges();
     component.ngOnInit();
     expect(inputElement.disabled).toBe(true);
   });
   it('id should be present in output', () => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-    component.schema = schema;
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     component.id = 'myId';
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
     mockSubStore.complete();
 
     fixture.detectChanges();
@@ -319,18 +243,7 @@ describe('AutoComplete control Input Event Tests', () => {
     }
   ));
   it('should update via input event', fakeAsync(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-    component.schema = schema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     mockSubStore.complete();
     fixture.detectChanges();
     component.ngOnInit();
@@ -355,19 +268,8 @@ describe('AutoComplete control Input Event Tests', () => {
     expect(event.option.value).toBe('B');
   }));
   it('options should prefer own props', fakeAsync(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-    component.schema = schema;
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     component.options = ['X', 'Y', 'Z'];
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
     mockSubStore.complete();
     fixture.detectChanges();
     component.ngOnInit();
@@ -409,23 +311,17 @@ describe('AutoComplete control Error Tests', () => {
     component = fixture.componentInstance;
   });
   it('should display errors', () => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-    component.schema = schema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema,
-          errors: [
-            {
-              dataPath: 'foo',
-              message: 'Hi, this is me, test error!'
-            }
-          ]
-        }
+    const errors = [
+      {
+        dataPath: 'foo',
+        message: 'Hi, this is me, test error!'
       }
+    ];
+    const mockSubStore = setupMockStore(fixture, {
+      uischema,
+      schema,
+      data,
+      errors
     });
     mockSubStore.complete();
     fixture.detectChanges();

--- a/packages/angular-material/test/categorization-tab-layout.spec.ts
+++ b/packages/angular-material/test/categorization-tab-layout.spec.ts
@@ -38,6 +38,7 @@ import { JsonFormsOutlet, UnknownRenderer } from '@jsonforms/angular';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 import { CategorizationTabLayoutRenderer } from '../src';
 import { FlexLayoutModule } from '@angular/flex-layout';
+import { setupMockStore } from '@jsonforms/angular-test';
 
 describe('Categorization tab layout', () => {
   let fixture: ComponentFixture<any>;
@@ -79,8 +80,7 @@ describe('Categorization tab layout', () => {
   });
 
   it('render categories initially', async(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = {
+    const uischema = {
       type: 'Categorization',
       elements: [
         {
@@ -110,14 +110,7 @@ describe('Categorization tab layout', () => {
       ]
     };
 
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data,
-          schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     mockSubStore.complete();
     fixture.detectChanges();
     fixture.whenRenderingDone().then(() => {
@@ -152,8 +145,7 @@ describe('Categorization tab layout', () => {
   }));
 
   it('add category', async(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = {
+    const uischema = {
       type: 'Categorization',
       elements: [
         {
@@ -182,15 +174,7 @@ describe('Categorization tab layout', () => {
         }
       ]
     };
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data,
-          schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     fixture.detectChanges();
     fixture.whenRenderingDone().then(() => {
       fixture.detectChanges();
@@ -291,17 +275,8 @@ describe('Categorization tab layout', () => {
         }
       ]
     };
-    component.uischema = uischema;
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     component.visible = false;
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data,
-          schema
-        }
-      }
-    });
     mockSubStore.complete();
     fixture.detectChanges();
     fixture.whenRenderingDone().then(() => {

--- a/packages/angular-material/test/date-control.spec.ts
+++ b/packages/angular-material/test/date-control.spec.ts
@@ -42,7 +42,7 @@ import {
 } from '@angular/material';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { ErrorTestExpectation } from '@jsonforms/angular-test';
+import { ErrorTestExpectation, setupMockStore } from '@jsonforms/angular-test';
 import { ControlElement, JsonSchema } from '@jsonforms/core';
 import { DateControlRenderer, DateControlRendererTester } from '../src';
 import { FlexLayoutModule } from '@angular/flex-layout';
@@ -105,17 +105,7 @@ describe('Date control Base Tests', () => {
   });
 
   it('should render', () => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     mockSubStore.complete();
     fixture.detectChanges();
     component.ngOnInit();
@@ -128,17 +118,7 @@ describe('Date control Base Tests', () => {
   });
 
   it('should support updating the state', () => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     fixture.detectChanges();
     component.ngOnInit();
 
@@ -156,17 +136,7 @@ describe('Date control Base Tests', () => {
     expect(inputElement.value).toBe('3/3/2018');
   });
   it('should update with undefined value', () => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     fixture.detectChanges();
     component.ngOnInit();
 
@@ -184,17 +154,7 @@ describe('Date control Base Tests', () => {
     expect(inputElement.value).toBe('');
   });
   it('should update with null value', () => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     fixture.detectChanges();
     component.ngOnInit();
 
@@ -212,17 +172,7 @@ describe('Date control Base Tests', () => {
     expect(inputElement.value).toBe('');
   });
   it('should not update with wrong ref', () => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     fixture.detectChanges();
     component.ngOnInit();
 
@@ -241,18 +191,9 @@ describe('Date control Base Tests', () => {
   });
   // store needed as we evaluate the calculated enabled value to disable/enable the control
   it('can be disabled', () => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     component.disabled = true;
 
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
     mockSubStore.complete();
     fixture.detectChanges();
     component.ngOnInit();
@@ -260,18 +201,9 @@ describe('Date control Base Tests', () => {
   });
   // store needed as we evaluate the calculated enabled value to disable/enable the control
   it('can be disabled', () => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     component.visible = false;
 
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
     mockSubStore.complete();
     fixture.detectChanges();
     component.ngOnInit();
@@ -307,17 +239,7 @@ describe('Date control Input Event Tests', () => {
     inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
   });
   it('should update via input event', fakeAsync(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     mockSubStore.complete();
     fixture.detectChanges();
     component.ngOnInit();
@@ -360,23 +282,18 @@ describe('Date control Error Tests', () => {
     component = fixture.componentInstance;
   });
   it('should display errors', () => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema,
-          errors: [
-            {
-              dataPath: 'foo',
-              message: 'Hi, this is me, test error!'
-            }
-          ]
+    const mockSubStore = setupMockStore(fixture, {
+      uischema,
+      schema,
+      data,
+      errors: [
+        {
+          dataPath: 'foo',
+          message: 'Hi, this is me, test error!'
         }
-      }
+      ]
     });
+
     mockSubStore.complete();
     fixture.detectChanges();
     component.ngOnInit();

--- a/packages/angular-material/test/label-renderer.spec.ts
+++ b/packages/angular-material/test/label-renderer.spec.ts
@@ -29,6 +29,7 @@ import { By } from '@angular/platform-browser';
 import { JsonSchema, LabelElement } from '@jsonforms/core';
 
 import { LabelRenderer, LabelRendererTester } from '../src/other';
+import { setupMockStore } from '@jsonforms/angular-test';
 
 const data = {};
 const schema: JsonSchema = {
@@ -72,17 +73,7 @@ describe('Label Renderer Base Tests', () => {
   });
 
   it('should render', () => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: data,
-          schema: schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     mockSubStore.complete();
     fixture.detectChanges();
     component.ngOnInit();

--- a/packages/angular-material/test/master-detail.spec.ts
+++ b/packages/angular-material/test/master-detail.spec.ts
@@ -40,6 +40,7 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 import { DebugElement } from '@angular/core';
 import { MasterListComponent } from '../src/other/master-detail/master';
 import { JsonFormsDetailComponent } from '../src/other/master-detail/detail';
+import { setupMockStore } from '@jsonforms/angular-test';
 
 describe('Master detail', () => {
   let fixture: ComponentFixture<MasterListComponent>;
@@ -130,17 +131,7 @@ describe('Master detail', () => {
   });
 
   it('should render', async(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data,
-          schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     component.ngOnInit();
     mockSubStore.complete();
 
@@ -157,17 +148,7 @@ describe('Master detail', () => {
   }));
 
   it('add a master item', async(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data,
-          schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     component.ngOnInit();
     mockSubStore.complete();
     fixture.detectChanges();
@@ -189,17 +170,7 @@ describe('Master detail', () => {
   }));
 
   it('remove an item', async(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data,
-          schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     component.ngOnInit();
     mockSubStore.complete();
     fixture.detectChanges();
@@ -236,16 +207,11 @@ describe('Master detail', () => {
         }
       ]
     };
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
 
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: moreData,
-          schema
-        }
-      }
+    const mockSubStore = setupMockStore(fixture, {
+      uischema,
+      schema,
+      data: moreData
     });
     component.ngOnInit();
     fixture.detectChanges();
@@ -297,16 +263,10 @@ describe('Master detail', () => {
         }
       ]
     };
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: moreData,
-          schema
-        }
-      }
+    const mockSubStore = setupMockStore(fixture, {
+      uischema,
+      schema,
+      data: moreData
     });
     component.ngOnInit();
     fixture.detectChanges();
@@ -352,16 +312,10 @@ describe('Master detail', () => {
         }
       ]
     };
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: moreData,
-          schema
-        }
-      }
+    const mockSubStore = setupMockStore(fixture, {
+      uischema,
+      schema,
+      data: moreData
     });
     component.ngOnInit();
     fixture.detectChanges();
@@ -397,16 +351,10 @@ describe('Master detail', () => {
         }
       ]
     };
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data: moreData,
-          schema
-        }
-      }
+    const mockSubStore = setupMockStore(fixture, {
+      uischema,
+      schema,
+      data: moreData
     });
     component.ngOnInit();
     fixture.detectChanges();
@@ -434,17 +382,7 @@ describe('Master detail', () => {
   });
 
   it('setting detail on click', async(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema;
-
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data,
-          schema
-        }
-      }
-    });
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     component.ngOnInit();
     mockSubStore.complete();
 
@@ -487,17 +425,8 @@ describe('Master detail', () => {
   }));
 
   it('can be hidden', async(() => {
-    component.uischema = uischema;
+    const mockSubStore = setupMockStore(fixture, { uischema, schema, data });
     component.visible = false;
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    mockSubStore.next({
-      jsonforms: {
-        core: {
-          data,
-          schema
-        }
-      }
-    });
     mockSubStore.complete();
     component.ngOnInit();
     fixture.detectChanges();

--- a/packages/angular-material/test/table-control.spec.ts
+++ b/packages/angular-material/test/table-control.spec.ts
@@ -43,6 +43,7 @@ import {
   TableRendererTester
 } from '../src/other/table.renderer';
 import { FlexLayoutModule } from '@angular/flex-layout';
+import { setupMockStore } from '@jsonforms/angular-test';
 
 const uischema1: ControlElement = { type: 'Control', scope: '#' };
 const uischema2: ControlElement = {
@@ -138,21 +139,11 @@ describe('Table', () => {
   }));
 
   it('renders object array on root', async(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema1;
-    component.schema = schema_object1;
-
-    mockSubStore.next({
-      jsonforms: {
-        renderers: renderers,
-        core: {
-          data: [
-            { foo: 'foo_1', bar: 'bar_1' },
-            { foo: 'foo_2', bar: 'bar_2' }
-          ],
-          schema: schema_object1
-        }
-      }
+    const mockSubStore = setupMockStore(fixture, {
+      uischema: uischema1,
+      schema: schema_object1,
+      data: [{ foo: 'foo_1', bar: 'bar_1' }, { foo: 'foo_2', bar: 'bar_2' }],
+      renderers
     });
     mockSubStore.complete();
     fixture.detectChanges();
@@ -167,21 +158,15 @@ describe('Table', () => {
     });
   }));
   it('renders object array on path', async(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema2;
-    component.schema = schema_object2;
-
-    mockSubStore.next({
-      jsonforms: {
-        renderers: renderers,
-        core: {
-          data: {
-            my: [{ foo: 'foo_1', bar: 'bar_1' }, { foo: 'foo_2', bar: 'bar_2' }]
-          },
-          schema: schema_object2
-        }
-      }
+    const mockSubStore = setupMockStore(fixture, {
+      uischema: uischema2,
+      schema: schema_object2,
+      data: {
+        my: [{ foo: 'foo_1', bar: 'bar_1' }, { foo: 'foo_2', bar: 'bar_2' }]
+      },
+      renderers
     });
+
     mockSubStore.complete();
     fixture.detectChanges();
     component.ngOnInit();
@@ -196,18 +181,11 @@ describe('Table', () => {
   }));
 
   it('renders simple array on root', async(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema1;
-    component.schema = schema_simple1;
-
-    mockSubStore.next({
-      jsonforms: {
-        renderers: renderers,
-        core: {
-          data: ['foo', 'bar'],
-          schema: schema_simple1
-        }
-      }
+    const mockSubStore = setupMockStore(fixture, {
+      uischema: uischema1,
+      schema: schema_simple1,
+      data: ['foo', 'bar'],
+      renderers
     });
     mockSubStore.complete();
     fixture.detectChanges();
@@ -222,18 +200,11 @@ describe('Table', () => {
     });
   }));
   it('renders simple array on path', async(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema2;
-    component.schema = schema_simple2;
-
-    mockSubStore.next({
-      jsonforms: {
-        renderers: renderers,
-        core: {
-          data: { my: ['foo', 'bar'] },
-          schema: schema_simple2
-        }
-      }
+    const mockSubStore = setupMockStore(fixture, {
+      uischema: uischema2,
+      schema: schema_simple2,
+      data: { my: ['foo', 'bar'] },
+      renderers
     });
     mockSubStore.complete();
     fixture.detectChanges();
@@ -249,20 +220,13 @@ describe('Table', () => {
   }));
 
   it('can be disabled', async(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema1;
-    component.schema = schema_object1;
-    component.disabled = true;
-
-    mockSubStore.next({
-      jsonforms: {
-        renderers: renderers,
-        core: {
-          data: [{ foo: 'foo_1', bar: 'bar_1' }],
-          schema: schema_object1
-        }
-      }
+    const mockSubStore = setupMockStore(fixture, {
+      uischema: uischema1,
+      schema: schema_object1,
+      data: [{ foo: 'foo_1', bar: 'bar_1' }],
+      renderers
     });
+    component.disabled = true;
     mockSubStore.complete();
     fixture.detectChanges();
     component.ngOnInit();
@@ -277,18 +241,11 @@ describe('Table', () => {
     });
   }));
   it('should be enabled by default', async(() => {
-    const mockSubStore = MockNgRedux.getSelectorStub();
-    component.uischema = uischema1;
-    component.schema = schema_object1;
-
-    mockSubStore.next({
-      jsonforms: {
-        renderers: renderers,
-        core: {
-          data: [{ foo: 'foo_1', bar: 'bar_1' }],
-          schema: schema_object1
-        }
-      }
+    const mockSubStore = setupMockStore(fixture, {
+      uischema: uischema1,
+      schema: schema_object1,
+      data: [{ foo: 'foo_1', bar: 'bar_1' }],
+      renderers
     });
     mockSubStore.complete();
     fixture.detectChanges();

--- a/packages/angular-test/src/util.ts
+++ b/packages/angular-test/src/util.ts
@@ -26,7 +26,12 @@ import { Type } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockNgRedux } from '@angular-redux/store/testing';
 import { JsonFormsControl } from '@jsonforms/angular';
-import { ControlElement, JsonSchema, UISchemaElement } from '@jsonforms/core';
+import {
+  ControlElement,
+  JsonSchema,
+  UISchemaElement,
+  JsonFormsRendererRegistryEntry
+} from '@jsonforms/core';
 import { Subject } from 'rxjs';
 
 export interface ErrorTestExpectation {
@@ -58,6 +63,8 @@ export interface TestData<T extends UISchemaElement> {
   data: any;
   schema: JsonSchema;
   uischema: T;
+  errors?: { dataPath: string; message: string }[];
+  renderers?: JsonFormsRendererRegistryEntry[];
 }
 
 export const setupMockStore = (
@@ -71,9 +78,11 @@ export const setupMockStore = (
 
   mockSubStore.next({
     jsonforms: {
+      renderers: testData.renderers,
       core: {
         data: testData.data,
-        schema: testData.schema
+        schema: testData.schema,
+        errors: testData.errors
       }
     }
   });


### PR DESCRIPTION
This is a refactor of some angular-material tests to use setupMockStore.
This is to make it easier to add additional properties (e.g. configuration) to the mock stores. 
