### PR TITLE
Add onChange props to React forms

### DIFF
--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -24,7 +24,7 @@
 */
 import isEqual from 'lodash/isEqual';
 import maxBy from 'lodash/maxBy';
-import React from 'react';
+import React, { useEffect } from 'react';
 import AJV from 'ajv';
 import RefParser from 'json-schema-ref-parser';
 import { UnknownRenderer } from './UnknownRenderer';
@@ -40,12 +40,17 @@ import {
     UISchemaElement,
 } from '@jsonforms/core';
 import { ctxToJsonFormsDispatchProps, JsonFormsStateProvider, useJsonForms } from './JsonFormsContext';
+import { ErrorObject } from 'ajv';
 
 interface JsonFormsRendererState {
     id: string;
     schema: JsonSchema;
     resolving: boolean;
     resolvedSchema: JsonSchema;
+}
+
+interface JsonFormsReactProps {
+  onChange?(state: {data: any,   errors?: ErrorObject[]}): void;
 }
 
 const hasRefs = (schema: JsonSchema): boolean => {
@@ -156,9 +161,13 @@ export class JsonFormsDispatchRenderer extends ResolvedJsonFormsDispatchRenderer
     }
 }
 
-export const JsonFormsDispatch = (props: OwnPropsOfJsonFormsRenderer) => {
+export const JsonFormsDispatch = (props: OwnPropsOfJsonFormsRenderer & JsonFormsReactProps) => {
     const ctx = useJsonForms();
     const { refResolver } = ctxToJsonFormsDispatchProps(ctx, props);
+    useEffect(() => {
+      props.onChange && props.onChange({data: ctx.core.data, errors: ctx.core.errors})
+    }, [ctx.core.data, ctx.core.errors])
+
     return (
         <JsonFormsDispatchRenderer
             schema={props.schema || ctx.core.schema}
@@ -180,8 +189,8 @@ export interface JsonFormsInitStateProps {
     refParserOptions?: RefParser.Options;
 }
 
-export const JsonForms = (props: JsonFormsInitStateProps) => {
-    const { ajv, data, schema, uischema, renderers, refParserOptions } = props;
+export const JsonForms = (props: JsonFormsInitStateProps & JsonFormsReactProps) => {
+    const { ajv, data, schema, uischema, renderers, refParserOptions, onChange } = props;
     return (
         <JsonFormsStateProvider
             initState={{
@@ -196,7 +205,7 @@ export const JsonForms = (props: JsonFormsInitStateProps) => {
                 renderers
             }}
         >
-            <JsonFormsDispatch />
+            <JsonFormsDispatch onChange={onChange}/>
         </JsonFormsStateProvider>
     );
 };

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -38,9 +38,9 @@ import {
     OwnPropsOfJsonFormsRenderer,
     removeId,
     UISchemaElement,
+    JsonFormsCore
 } from '@jsonforms/core';
 import { ctxToJsonFormsDispatchProps, JsonFormsStateProvider, useJsonForms } from './JsonFormsContext';
-import { ErrorObject } from 'ajv';
 
 interface JsonFormsRendererState {
     id: string;
@@ -50,7 +50,7 @@ interface JsonFormsRendererState {
 }
 
 interface JsonFormsReactProps {
-  onChange?(state: {data: any,   errors?: ErrorObject[]}): void;
+  onChange?(state: Pick<JsonFormsCore, 'data' | 'errors'>): void;
 }
 
 const hasRefs = (schema: JsonSchema): boolean => {
@@ -164,9 +164,10 @@ export class JsonFormsDispatchRenderer extends ResolvedJsonFormsDispatchRenderer
 export const JsonFormsDispatch = (props: OwnPropsOfJsonFormsRenderer & JsonFormsReactProps) => {
     const ctx = useJsonForms();
     const { refResolver } = ctxToJsonFormsDispatchProps(ctx, props);
+    const {data, errors}  = ctx.core
     useEffect(() => {
-      props.onChange && props.onChange({data: ctx.core.data, errors: ctx.core.errors})
-    }, [ctx.core.data, ctx.core.errors])
+      props.onChange && props.onChange({ data, errors });
+    }, [data, errors]);
 
     return (
         <JsonFormsDispatchRenderer

--- a/packages/react/test/renderers/JsonForms.test.tsx
+++ b/packages/react/test/renderers/JsonForms.test.tsx
@@ -41,12 +41,15 @@ import {
 } from '@jsonforms/core';
 import Enzyme from 'enzyme';
 import { mount, shallow } from 'enzyme';
-import { act } from 'react-dom/test-utils';
 import RefParser from 'json-schema-ref-parser';
 import { StatelessRenderer } from '../../src/Renderer';
 
 import Adapter from 'enzyme-adapter-react-16';
-import { JsonFormsDispatchRenderer, JsonFormsDispatch, JsonForms } from '../../src/JsonForms';
+import {
+  JsonFormsDispatchRenderer,
+  JsonFormsDispatch,
+  JsonForms
+} from '../../src/JsonForms';
 import {
   JsonFormsReduxContext,
   useJsonForms,
@@ -244,7 +247,7 @@ test('ids should be unique within the same form', () => {
       <JsonFormsReduxContext>
         <JsonFormsDispatch uischema={uischema2} schema={fixture.schema} />
       </JsonFormsReduxContext>
-    </Provider>,
+    </Provider>
   );
 
   expect(ids.indexOf('#/properties/foo') > -1).toBeTruthy();
@@ -530,22 +533,16 @@ test('JsonForms should call onChange handler with new data', () => {
     />
   );
 
-  const event = {
+  wrapper.find('input').simulate('change', {
     target: {
       value: 'Test Value'
     }
-  } as React.ChangeEvent<HTMLInputElement>;
-  act(() => {
-    wrapper
-      .find('input')
-      .props()
-      .onChange(event);
-  })
+  });
 
-  const calls = onChangeHandler.mock.calls
-  const lastCallParameter = calls[calls.length - 1][0]
-  expect(lastCallParameter.data).toEqual({foo: 'Test Value'})
-  expect(lastCallParameter.errors).toEqual([])
+  const calls = onChangeHandler.mock.calls;
+  const lastCallParameter = calls[calls.length - 1][0];
+  expect(lastCallParameter.data).toEqual({ foo: 'Test Value' });
+  expect(lastCallParameter.errors).toEqual([]);
 });
 
 test('JsonForms should call onChange handler with errors', () => {
@@ -555,15 +552,15 @@ test('JsonForms should call onChange handler with errors', () => {
   ));
 
   const schema = {
-      type: 'object',
-      properties: {
-        foo: {
-          type: 'string',
-          minLength: 5
-        }
-      },
-      required: ["foo"],
-    }
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'string',
+        minLength: 5
+      }
+    },
+    required: ['foo']
+  };
 
   const renderers = [
     {
@@ -581,23 +578,15 @@ test('JsonForms should call onChange handler with errors', () => {
     />
   );
 
-  const event = {
+  wrapper.find('input').simulate('change', {
     target: {
-      value: "xyz"
+      value: 'xyz'
     }
-  } as React.ChangeEvent<HTMLInputElement>;
+  });
 
-  act(() => {
-    wrapper
-      .find('input')
-      .props()
-      .onChange(event);
-  })
-
-
-  const calls = onChangeHandler.mock.calls
-  const lastCallParameter = calls[calls.length - 1][0]
-  expect(lastCallParameter.data).toEqual({foo: "xyz"})
-  expect(lastCallParameter.errors.length).toEqual(1)
-  expect(lastCallParameter.errors[0].keyword).toEqual("minLength")
-})
+  const calls = onChangeHandler.mock.calls;
+  const lastCallParameter = calls[calls.length - 1][0];
+  expect(lastCallParameter.data).toEqual({ foo: 'xyz' });
+  expect(lastCallParameter.errors.length).toEqual(1);
+  expect(lastCallParameter.errors[0].keyword).toEqual('minLength');
+});


### PR DESCRIPTION
This is for issue #1271 and an alternative to #1446

Opening a new PR as I've removed any changes to core.

# Possible Examples
I intend to update the example for something which shows a use of this feature. 
## Updating Error
Changing the validation logic as discussed here
https://spectrum.chat/jsonforms/general/pristine-and-dirty-checking~2ece93ab-7783-41cb-8ba1-804414eb1da4

or localising the error as discussed
https://spectrum.chat/jsonforms/general/development-sharing-state-between-reducers~d8dfcc0b-7876-4c32-a230-baff42501cab

Both these cases require an additional action for updating errors