### PR TITLE
Ajv i18n example

### DIFF
--- a/packages/example/src/reduxUtil.ts
+++ b/packages/example/src/reduxUtil.ts
@@ -35,7 +35,7 @@ import { AnyAction, Dispatch, Reducer } from 'redux';
 
 export const UPDATE_EXAMPLE_EXTENSION_STATE: 'jsonforms-example/UPDATE_EXAMPLE_EXTENSION_STATE' =
   'jsonforms-example/UPDATE_EXAMPLE_EXTENSION_STATE';
-  
+
 export interface UpdateExampleExtensionStateAction {
   type: 'jsonforms-example/UPDATE_EXAMPLE_EXTENSION_STATE';
   extensionState: any;
@@ -72,7 +72,7 @@ export interface AppProps extends ExampleStateProps {
 const mapStateToProps = (state: any) => {
   const examples = state.examples.data;
   const selectedExample = state.examples.selectedExample || examples[0];
-  const extensionState = state.examples.extensionState
+  const extensionState = state.examples.extensionState;
   return {
     dataAsString: JSON.stringify(getData(state), null, 2),
     examples,
@@ -117,7 +117,6 @@ const mergeProps = (
   });
 };
 
-
 interface ExamplesState {
   data: ReactExampleDescription[];
   selectedExample: ReactExampleDescription;
@@ -140,7 +139,7 @@ export const exampleReducer = (
     case UPDATE_EXAMPLE_EXTENSION_STATE:
       return Object.assign({}, state, {
         extensionState: action.extensionState
-      })
+      });
     default:
       return state;
   }

--- a/packages/example/src/reduxUtil.ts
+++ b/packages/example/src/reduxUtil.ts
@@ -33,10 +33,26 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { AnyAction, Dispatch, Reducer } from 'redux';
 
+export const UPDATE_EXAMPLE_EXTENSION_STATE: 'jsonforms-example/UPDATE_EXAMPLE_EXTENSION_STATE' =
+  'jsonforms-example/UPDATE_EXAMPLE_EXTENSION_STATE';
+  
+export interface UpdateExampleExtensionStateAction {
+  type: 'jsonforms-example/UPDATE_EXAMPLE_EXTENSION_STATE';
+  extensionState: any;
+}
+
+export const updateExampleExtensionState = (
+  extensionState: any
+): UpdateExampleExtensionStateAction => ({
+  type: UPDATE_EXAMPLE_EXTENSION_STATE,
+  extensionState
+});
+
 export interface ExampleStateProps {
   examples: ReactExampleDescription[];
   dataAsString: string;
   selectedExample: ReactExampleDescription;
+  extensionState: any;
 }
 
 export interface ExampleDispatchProps {
@@ -56,10 +72,12 @@ export interface AppProps extends ExampleStateProps {
 const mapStateToProps = (state: any) => {
   const examples = state.examples.data;
   const selectedExample = state.examples.selectedExample || examples[0];
+  const extensionState = state.examples.extensionState
   return {
     dataAsString: JSON.stringify(getData(state), null, 2),
     examples,
-    selectedExample
+    selectedExample,
+    extensionState
   };
 };
 const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => ({
@@ -90,9 +108,15 @@ const mergeProps = (
       ),
     getExtensionComponent: () =>
       dispatchProps.getComponent(stateProps.selectedExample),
-    onChange: dispatchProps.onChange(stateProps.selectedExample)
+    onChange:
+      dispatchProps.onChange &&
+      dispatchProps.onChange(stateProps.selectedExample) &&
+      dispatchProps.onChange(stateProps.selectedExample)(
+        stateProps.extensionState
+      )
   });
 };
+
 
 interface ExamplesState {
   data: ReactExampleDescription[];
@@ -113,6 +137,10 @@ export const exampleReducer = (
       return Object.assign({}, state, {
         selectedExample: action.example
       });
+    case UPDATE_EXAMPLE_EXTENSION_STATE:
+      return Object.assign({}, state, {
+        extensionState: action.extensionState
+      })
     default:
       return state;
   }

--- a/packages/example/src/util.tsx
+++ b/packages/example/src/util.tsx
@@ -28,7 +28,8 @@ import {
   ExampleDescription,
   issue_1220 as Issue1220Example,
   nestedArray as NestedArrayExample,
-  onChange as OnChangeExample
+  onChange as OnChangeExample,
+  i18n
 } from '@jsonforms/examples';
 import ConnectedRatingControl, { ratingControlTester } from './RatingControl';
 import {
@@ -41,10 +42,13 @@ import {
   JsonFormsCore
 } from '@jsonforms/core';
 import { AnyAction, Dispatch } from 'redux';
+import { updateExampleExtensionState } from './reduxUtil';
+import { withJsonFormsContext, JsonFormsStateContext } from '@jsonforms/react';
+import { ErrorObject } from 'ajv'
 
 export interface ReactExampleDescription extends ExampleDescription {
   customReactExtension?(dispatch: Dispatch<AnyAction>): React.Component;
-  onChange?:(dispatch: Dispatch<AnyAction>) => (state: Pick<JsonFormsCore, 'data' | 'errors'>) => AnyAction;
+  onChange?:(dispatch: Dispatch<AnyAction>) => (extensionState: any) => (state: Pick<JsonFormsCore, 'data' | 'errors'>) => AnyAction;
 }
 const registerRatingControl = (dispatch: Dispatch<AnyAction>) => {
   dispatch(Actions.registerCell(ratingControlTester, ConnectedRatingControl));
@@ -55,13 +59,19 @@ const unregisterRatingControl = (dispatch: Dispatch<AnyAction>) => {
   );
 };
 
-export interface I18nExampleProps {
+export interface I18nExampleProps extends OwnPropsOfI18nExample {
+  data: any;
+  errors: ErrorObject[];
+}
+
+export interface OwnPropsOfI18nExample {
   schema: JsonSchema;
   uischema: UISchemaElement;
   dispatch: Dispatch<AnyAction>;
+  onChange: (dispatch: Dispatch<AnyAction>) => (extensionState: any) => (state: Pick<JsonFormsCore, 'data' | 'errors'>) => void;
 }
 
-class I18nExample extends React.Component<
+class I18nExampleRenderer extends React.Component<
   I18nExampleProps,
   {
     localizedSchemas: Map<string, JsonSchema>;
@@ -85,6 +95,8 @@ class I18nExample extends React.Component<
     _.set(deUISchema, 'elements.2.elements.1.label', 'Vegetarier');
     localizedUISchemas.set('de-DE', deUISchema);
     localizedUISchemas.set('en-US', uischema);
+    
+    props.dispatch(updateExampleExtensionState({locale: "en-US"}));
 
     this.state = {
       localizedSchemas,
@@ -93,11 +105,13 @@ class I18nExample extends React.Component<
   }
 
   changeLocale = (locale: string) => {
-    const { dispatch } = this.props;
+    const { dispatch, onChange, data, errors } = this.props;
     const { localizedSchemas, localizedUISchemas } = this.state;
     dispatch(setLocale(locale));
     dispatch(setSchema(localizedSchemas.get(locale)));
     dispatch(setUISchema(localizedUISchemas.get(locale)));
+    dispatch(updateExampleExtensionState({ locale }));
+    onChange(dispatch)({ locale })({data, errors});
   };
 
   render() {
@@ -109,6 +123,18 @@ class I18nExample extends React.Component<
     );
   }
 }
+
+const withContextToI18nProps =
+  (Component: React.ComponentType<I18nExampleProps>): React.ComponentType<OwnPropsOfI18nExample> =>
+    ({ ctx, props }: JsonFormsStateContext & I18nExampleProps) => {
+      const {data, errors} = ctx.core
+      return <Component {...props} data={data} errors={errors}/>
+
+    };
+
+const withI18nProps = (Component: React.ComponentType<I18nExampleProps>): React.ComponentType<OwnPropsOfI18nExample> => withJsonFormsContext(withContextToI18nProps(Component))
+
+const I18nExample = withI18nProps(I18nExampleRenderer)
 
 export const enhanceExample: (
   examples: ExampleDescription[]
@@ -173,8 +199,10 @@ export const enhanceExample: (
               schema={e.schema}
               uischema={e.uischema}
               dispatch={dispatch}
+              onChange={i18n.onChange}
             />
-          )
+          ),
+          onChange: i18n.onChange
         });
       case '1220':
         const issue_1220 = Object.assign({}, e, {

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@jsonforms/core": "^2.3.0",
+    "ajv-i18n": "^3.4.0",
     "redux": "^4.0.1"
   }
 }

--- a/packages/examples/src/i18n.ts
+++ b/packages/examples/src/i18n.ts
@@ -28,14 +28,16 @@ import { JsonFormsCore, updateErrors } from '@jsonforms/core';
 import { AnyAction, Dispatch } from 'redux';
 const localize = require('ajv-i18n');
 
-export const onChange = (dispatch: Dispatch<AnyAction>) => (extensionState: any) => ({errors}: Pick<JsonFormsCore, 'data' | 'errors'>) => {
-  if(!extensionState) {
-    return
+export const onChange = (dispatch: Dispatch<AnyAction>) => (
+  extensionState: any
+) => ({ errors }: Pick<JsonFormsCore, 'data' | 'errors'>) => {
+  if (!extensionState) {
+    return;
   }
-  const localiseFunc = localize[extensionState.locale.split("-")[0]]
-  localiseFunc(errors)
-  dispatch(updateErrors(errors))
-}
+  const localiseFunc = localize[extensionState.locale.split('-')[0]];
+  localiseFunc(errors);
+  dispatch(updateErrors(errors));
+};
 
 export const uischema = {
   type: 'VerticalLayout',

--- a/packages/examples/src/i18n.ts
+++ b/packages/examples/src/i18n.ts
@@ -24,6 +24,18 @@
 */
 import { registerExamples } from './register';
 import { personCoreSchema } from './person';
+import { JsonFormsCore, updateErrors } from '@jsonforms/core';
+import { AnyAction, Dispatch } from 'redux';
+const localize = require('ajv-i18n');
+
+export const onChange = (dispatch: Dispatch<AnyAction>) => (extensionState: any) => ({errors}: Pick<JsonFormsCore, 'data' | 'errors'>) => {
+  if(!extensionState) {
+    return
+  }
+  const localiseFunc = localize[extensionState.locale.split("-")[0]]
+  localiseFunc(errors)
+  dispatch(updateErrors(errors))
+}
 
 export const uischema = {
   type: 'VerticalLayout',

--- a/packages/examples/src/onChange.ts
+++ b/packages/examples/src/onChange.ts
@@ -31,7 +31,7 @@ let touchedProperties: any = {
   description: false
 };
 
-export const onChange = (dispatch: Dispatch<AnyAction>) => ({
+export const onChange = (dispatch: Dispatch<AnyAction>) => (_: any) => ({
   data,
   errors
 }: Pick<JsonFormsCore, 'data' | 'errors'>) => {


### PR DESCRIPTION
This PR is to add an example of using the onChange handler and error update action (PR #1450) to show how a user of the library can add localisation of the errors with i18n.

4c5a9fe5ce5e8f8263f874f914e796ce1cd696f5 is the new commit, others will be rebased away when #1450 is complete. 

## ajv-i18n in core
I had initally been adding ajv-i18n to the core package, however this became complex when trying to combine navigator languages, selected locale from i18n reducer, and languages supported by ajv-i18n. 
There are a few cases to consider
- Schemas are provided in languages which are not supported by ajv-i18n
- Schemas are not provided for a language in the users navigator.language but which is supported by ajv-i18n

I think it is better for the user of JsonForms to implement this logic so they can implement i18n logic consistantly rather than enforcing a specific method on the user.

It may be possible for the user to provide their own language selection logic to JSONForms but I decided to try to keep it simple for now.
