### PR TITLE
Update rule example

### DIFF
--- a/packages/examples/src/rule.ts
+++ b/packages/examples/src/rule.ts
@@ -62,7 +62,7 @@ export const uischema = {
         condition: {
           scope: '#/properties/alive',
           schema: {
-            const: false
+            const: true
           }
         }
       }


### PR DESCRIPTION
- if the person is alive, the type of dead combo should be disabled