### PR TITLE
Export JsonFormsReactProps interface

### DIFF
--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -53,7 +53,7 @@ interface JsonFormsRendererState {
   resolvedSchema: JsonSchema;
 }
 
-interface JsonFormsReactProps {
+export interface JsonFormsReactProps {
   onChange?(state: Pick<JsonFormsCore, 'data' | 'errors'>): void;
 }
 


### PR DESCRIPTION
I'd like to create a function in my code like
```
const initalJsonFormsProps = (): JsonFormsInitStateProps & JsonFormsReactProps => {
// Some logic for creating inital props
}
```

but I noticed JsonFormsReactProps is not currently exported.