### PR TITLE
Add types to findRefs

### DIFF
--- a/packages/core/src/util/index.ts
+++ b/packages/core/src/util/index.ts
@@ -111,7 +111,13 @@ const Resolve: {
   schema: resolveSchema,
   data: resolveData
 };
-export { resolveData, resolveSchema, findRefs } from './resolvers';
+export {
+  resolveData,
+  resolveSchema,
+  findRefs,
+  SchemaRef,
+  SchemaRefs
+} from './resolvers';
 export { Resolve };
 
 // Paths --

--- a/packages/core/src/util/resolvers.ts
+++ b/packages/core/src/util/resolvers.ts
@@ -204,11 +204,6 @@ export interface SchemaRefs {
 export const findRefs = (obj: JsonSchema): SchemaRefs => {
   const refs: SchemaRefs = {};
 
-  // Validate the provided document
-  if (!isArray(obj) && !isObject(obj)) {
-    throw new TypeError('obj must be an Array or an Object');
-  }
-
   // Walk the document (or sub document) and find all JSON References
   walk([], obj, [], ({}, node: any, path: any) => {
     let processChildren = true;

--- a/packages/core/src/util/resolvers.ts
+++ b/packages/core/src/util/resolvers.ts
@@ -187,8 +187,22 @@ function retrieveResolvableSchema(
 
 // copied and adapted from JsonRefs
 
-export const findRefs = (obj: any) => {
-  const refs = {} as any;
+/**
+ * Interface for describing result of an extracted schema ref
+ */
+export interface SchemaRef {
+  uri: string;
+}
+
+/**
+ * Interface wraps SchemaRef
+ */
+export interface SchemaRefs {
+  [id: string]: SchemaRef;
+}
+
+export const findRefs = (obj: JsonSchema): SchemaRefs => {
+  const refs: SchemaRefs = {};
 
   // Validate the provided document
   if (!isArray(obj) && !isObject(obj)) {

--- a/packages/core/test/util/resolvers.test.ts
+++ b/packages/core/test/util/resolvers.test.ts
@@ -32,8 +32,11 @@ test('findRef - does not fail on empty input object ', t => {
 
 test('findRef - finds http ref on level 1', t => {
   const refObject = {
-    myitem: {
-      $ref: 'http://myref.com/ref'
+    type: 'object',
+    properties: {
+      myitem: {
+        $ref: 'http://myref.com/ref'
+      }
     }
   };
   t.true(Object.keys(findRefs(refObject)).length > 0);

--- a/packages/material-tree-renderer/src/services/property.util.ts
+++ b/packages/material-tree-renderer/src/services/property.util.ts
@@ -33,8 +33,13 @@ import omitBy from 'lodash/omitBy';
 import startsWith from 'lodash/startsWith';
 import values from 'lodash/values';
 import each from 'lodash/each';
-import { JsonSchema, JsonSchema7 } from '@jsonforms/core';
-import { findRefs, resolveSchema } from '@jsonforms/core';
+import {
+  findRefs,
+  JsonSchema,
+  JsonSchema7,
+  resolveSchema,
+  SchemaRefs
+} from '@jsonforms/core';
 
 const isObject = (schema: JsonSchema): boolean => {
   return schema.properties !== undefined;
@@ -58,20 +63,6 @@ export interface Property {
    * The schema is the JsonSchema this property describes.
    */
   schema: JsonSchema7;
-}
-
-/**
- * Interface for describing result of an extracted schema ref
- */
-interface SchemaRef {
-  uri: string;
-}
-
-/**
- * Interface wraps SchemaRef
- */
-interface SchemaRefs {
-  [id: string]: SchemaRef;
 }
 
 /**
@@ -133,8 +124,8 @@ export const makeSchemaSelfContained = (
   parentSchema: JsonSchema7,
   schema: JsonSchema7
 ): JsonSchema7 => {
-  const schemaRefs = findRefs(schema) as SchemaRefs;
-  const allRefs = findRefs(parentSchema) as SchemaRefs;
+  const schemaRefs = findRefs(schema);
+  const allRefs = findRefs(parentSchema);
   let extractedReferences;
   findReferences(parentSchema, allRefs, schemaRefs, (extractedReferences = {}));
   const refList = values(extractedReferences) as string[];


### PR DESCRIPTION
I noticed findRefs used any type and then made a runtime type assertion. I think this could be improved by using typescript types. 

Not sure what the correct type for this function would be, currently usage suggests

```
const findRefs = (obj: JsonSchema): SchemaRefs 
```

Could be an appropriate type?