### PR TITLE
Memoize hasRefs

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -56,9 +56,11 @@
     ]
   },
   "dependencies": {
+    "@types/object-hash": "^1.3.0",
     "@types/react": "^16.4.14",
     "@types/react-redux": "^7.0.6",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "object-hash": "^1.3.1"
   },
   "peerDependencies": {
     "@jsonforms/core": "^2.3.0",

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -59,12 +59,15 @@ export interface JsonFormsReactProps {
   onChange?(state: Pick<JsonFormsCore, 'data' | 'errors'>): void;
 }
 
-const hasRefs = memoize((schema: JsonSchema): boolean => {
-  if (schema !== undefined) {
-    return Object.keys(findRefs(schema)).length > 0;
-  }
-  return false;
-}, hash);
+const hasRefs = memoize(
+  (schema: JsonSchema): boolean => {
+    if (schema !== undefined) {
+      return Object.keys(findRefs(schema)).length > 0;
+    }
+    return false;
+  },
+  (schema: JsonSchema) => (schema ? hash(schema) : false)
+);
 
 export class ResolvedJsonFormsDispatchRenderer extends React.Component<
   JsonFormsProps,

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -24,6 +24,7 @@
 */
 import isEqual from 'lodash/isEqual';
 import maxBy from 'lodash/maxBy';
+import memoize from 'lodash/memoize';
 import React, { useLayoutEffect } from 'react';
 import AJV from 'ajv';
 import RefParser from 'json-schema-ref-parser';
@@ -57,12 +58,12 @@ export interface JsonFormsReactProps {
   onChange?(state: Pick<JsonFormsCore, 'data' | 'errors'>): void;
 }
 
-const hasRefs = (schema: JsonSchema): boolean => {
+const hasRefs = memoize((schema: JsonSchema): boolean => {
   if (schema !== undefined) {
     return Object.keys(findRefs(schema)).length > 0;
   }
   return false;
-};
+});
 
 export class ResolvedJsonFormsDispatchRenderer extends React.Component<
   JsonFormsProps,

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -46,6 +46,7 @@ import {
   JsonFormsStateProvider,
   useJsonForms
 } from './JsonFormsContext';
+import hash from 'object-hash';
 
 interface JsonFormsRendererState {
   id: string;
@@ -63,7 +64,7 @@ const hasRefs = memoize((schema: JsonSchema): boolean => {
     return Object.keys(findRefs(schema)).length > 0;
   }
   return false;
-});
+}, hash);
 
 export class ResolvedJsonFormsDispatchRenderer extends React.Component<
   JsonFormsProps,


### PR DESCRIPTION
This is a performance optimisation for large schemas. 

I found with a large schema with a combination of 
- `MaterialArrayLayout`
- `MaterialOneOfRenderer`, 
- `MaterializedGroupLayoutRenderer` etc. 

There can be many instances of`JsonFormsDispatch`, but many will have identical schemas.

hasRefs is an expensive operation for a large schema so I found repeated calls were causing a slow down. 

I noticed a significant improvement using memoize