### PR TITLE
Fix moving table array fields

### DIFF
--- a/packages/material/src/mui-controls/MuiInputText.tsx
+++ b/packages/material/src/mui-controls/MuiInputText.tsx
@@ -29,7 +29,6 @@ import merge from 'lodash/merge';
 import IconButton from '@material-ui/core/IconButton';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import Close from '@material-ui/icons/Close';
-import { Hidden } from '@material-ui/core';
 
 interface MuiInputTextStatus {
   showAdornment: boolean;
@@ -42,7 +41,7 @@ interface MuiTextInputProps {
 export class MuiInputText extends React.PureComponent<
   CellProps & WithClassname & MuiTextInputProps,
   MuiInputTextStatus
-  > {
+> {
   state: MuiInputTextStatus = { showAdornment: false };
   render() {
     const {
@@ -92,15 +91,20 @@ export class MuiInputText extends React.PureComponent<
         onPointerEnter={() => this.setState({ showAdornment: true })}
         onPointerLeave={() => this.setState({ showAdornment: false })}
         endAdornment={
-          <InputAdornment position='end'>
-            <Hidden xsUp={!this.state.showAdornment || !enabled}>
-              <IconButton
-                aria-label='Clear input field'
-                onClick={() => handleChange(path, undefined)}
-              >
-                <Close />
-              </IconButton>
-            </Hidden>
+          // Use visibility instead of 'Hidden' so the layout doesn't change when the icon is shown
+          <InputAdornment
+            position='end'
+            style={{
+              visibility:
+                !this.state.showAdornment || !enabled ? 'hidden' : 'visible'
+            }}
+          >
+            <IconButton
+              aria-label='Clear input field'
+              onClick={() => handleChange(path, undefined)}
+            >
+              <Close />
+            </IconButton>
           </InputAdornment>
         }
       />

--- a/packages/material/test/renderers/MaterialArrayControl.test.tsx
+++ b/packages/material/test/renderers/MaterialArrayControl.test.tsx
@@ -247,17 +247,19 @@ describe('Material array control', () => {
     );
 
     const buttons = wrapper.find('button');
-    // 5 buttons
+    // 7 buttons
     // add row
+    // clear string
     // delete row
+    // clear string
     // delete row
     // two dialog buttons (no + yes)
     const nrOfRowsBeforeDelete = wrapper.find('tr').length;
 
-    const deleteButton = buttons.at(1);
+    const deleteButton = buttons.at(2);
     deleteButton.simulate('click');
 
-    const confirmButton = buttons.at(4);
+    const confirmButton = buttons.at(6);
     confirmButton.simulate('click');
 
     const nrOfRowsAfterDelete = wrapper.find('tr').length;


### PR DESCRIPTION
The width of table columns is determined by its content. By using
'Hidden' for adornments the width of the contained butiton was
not considered initially, but only when shown on hover. This lead to a
width increase for the control and therefore the whole column. We now use
'visibility: hidden' instead as this doesn't change the layout.