### PR TITLE
Fix #1543: Fix styling support for vanilla cells

### DIFF
--- a/packages/react/src/JsonFormsContext.tsx
+++ b/packages/react/src/JsonFormsContext.tsx
@@ -338,7 +338,7 @@ const withContextToDispatchCellProps = (
 
 const withContextToEnumCellProps =
   (Component: ComponentType<EnumCellProps>): ComponentType<OwnPropsOfEnumCell> =>
-    ({ ctx, props }: JsonFormsStateContext & OwnPropsOfEnumCell) => {
+    ({ ctx, props }: JsonFormsStateContext & EnumCellProps) => {
       const cellProps = ctxToCellProps(ctx, props);
       const dispatchProps = ctxDispatchToControlProps(ctx.dispatch);
       const options =

--- a/packages/vanilla/Styles.md
+++ b/packages/vanilla/Styles.md
@@ -50,7 +50,13 @@
 - control &rightarrow; id for the whole control
 - control.label &rightarrow; id for the label of control
 - input.description &rightarrow; id for the description of control
+
 ## Example of styling id contributions
+You can either contribute all styles yourself or adapt an existing style definition.
+
+### Define all styles from scratch
+If you want to define all styles yourself, you can hand them into JsonForms's store.
+
 ```typescript
 import { vanillaStyles } from '../src/util';
 import { stylingReducer } from '../src/reducers';
@@ -79,3 +85,35 @@ export const vanillaStyles = [
 ```
 So you can either provide a simple `name` to `classNames` mapping using strings where `classNames` must be an array of strings.
 Or you can provide a function for `classNames` which returns an array of strings. The second method allows you to provide classes as needed for some layouts like bootstrap.
+
+### Adapt an existing style definition
+You can also adapt an existing style definition by adding new styles or removing existing ones.
+For this, you can use the JsonForms _styling reducer_ and its corresponding actions.
+
+```typescript
+import { registerStyles, stylingReducer, vanillaStyles } from '@jsonforms/vanilla-renderers';
+
+// Setup adapted styles by creating a register styles action and applying it
+// to the vanilla styles by invoking the stylingReducer with the action.
+const registerStylesAction = registerStyles([
+  {
+    name: 'control.input',
+    classNames: ['custom-input']
+  },
+  {
+    name: 'array.button',
+    classNames: ['custom-array-button']
+  }
+]);
+const adaptedStyles = stylingReducer(vanillaStyles, registerStylesAction);
+
+const store: Store<JsonFormsState> = createStore(
+    combineReducers({ jsonforms: jsonformsReducer({ styles: stylingReducer }) }),
+    {
+      jsonforms: {
+        styles: adaptedStyles,
+        ...other
+      }
+    }
+  );
+```

--- a/packages/vanilla/src/cells/BooleanCell.tsx
+++ b/packages/vanilla/src/cells/BooleanCell.tsx
@@ -32,6 +32,7 @@ import {
 import { withJsonFormsCellProps } from '@jsonforms/react';
 import { StatelessComponent } from 'react';
 import { VanillaRendererProps } from '../index';
+import { withVanillaCellProps } from '../util/index';
 
 export const BooleanCell: StatelessComponent<CellProps> =
   (props: CellProps & VanillaRendererProps) => {
@@ -58,4 +59,4 @@ export const BooleanCell: StatelessComponent<CellProps> =
  */
 export const booleanCellTester: RankedTester = rankWith(2, isBooleanControl);
 
-export default withJsonFormsCellProps(BooleanCell);
+export default withJsonFormsCellProps(withVanillaCellProps(BooleanCell));

--- a/packages/vanilla/src/cells/DateCell.tsx
+++ b/packages/vanilla/src/cells/DateCell.tsx
@@ -31,6 +31,7 @@ import {
 } from '@jsonforms/core';
 import { withJsonFormsCellProps } from '@jsonforms/react';
 import { VanillaRendererProps } from '../index';
+import { withVanillaCellProps } from '../util/index';
 
 export const DateCell = (props: CellProps & VanillaRendererProps) => {
   const { data, className, id, enabled, uischema, path, handleChange } = props;
@@ -53,4 +54,4 @@ export const DateCell = (props: CellProps & VanillaRendererProps) => {
  */
 export const dateCellTester: RankedTester = rankWith(2, isDateControl);
 
-export default withJsonFormsCellProps(DateCell);
+export default withJsonFormsCellProps(withVanillaCellProps(DateCell));

--- a/packages/vanilla/src/cells/DateTimeCell.tsx
+++ b/packages/vanilla/src/cells/DateTimeCell.tsx
@@ -31,6 +31,7 @@ import {
 } from '@jsonforms/core';
 import { withJsonFormsCellProps } from '@jsonforms/react';
 import { VanillaRendererProps } from '../index';
+import { withVanillaCellProps } from '../util/index';
 
 export const DateTimeCell = (props: CellProps & VanillaRendererProps) => {
   const { data, className, id, enabled, uischema, path, handleChange } = props;
@@ -56,4 +57,4 @@ export const DateTimeCell = (props: CellProps & VanillaRendererProps) => {
  */
 export const dateTimeCellTester: RankedTester = rankWith(2, isDateTimeControl);
 
-export default withJsonFormsCellProps(DateTimeCell);
+export default withJsonFormsCellProps(withVanillaCellProps(DateTimeCell));

--- a/packages/vanilla/src/cells/EnumCell.tsx
+++ b/packages/vanilla/src/cells/EnumCell.tsx
@@ -30,10 +30,10 @@ import {
   rankWith,
 } from '@jsonforms/core';
 import { withJsonFormsEnumCellProps } from '@jsonforms/react';
-import { withVanillaControlProps, withVanillaEnumCellProps } from '../util';
-import { WithClassname } from '../index';
+import { withVanillaEnumCellProps } from '../util';
+import { VanillaRendererProps } from '../index';
 
-export const EnumCell = (props: EnumCellProps & WithClassname) => {
+export const EnumCell = (props: EnumCellProps & VanillaRendererProps) => {
   const { data, className, id, enabled, uischema, path, handleChange, options } = props;
 
   return (
@@ -65,4 +65,4 @@ export const EnumCell = (props: EnumCellProps & WithClassname) => {
  */
 export const enumCellTester: RankedTester = rankWith(2, isEnumControl);
 
-export default withVanillaControlProps(withJsonFormsEnumCellProps(withVanillaEnumCellProps(EnumCell)));
+export default withJsonFormsEnumCellProps(withVanillaEnumCellProps(EnumCell));

--- a/packages/vanilla/src/cells/EnumCell.tsx
+++ b/packages/vanilla/src/cells/EnumCell.tsx
@@ -30,7 +30,7 @@ import {
   rankWith,
 } from '@jsonforms/core';
 import { withJsonFormsEnumCellProps } from '@jsonforms/react';
-import { withVanillaControlProps } from '../util';
+import { withVanillaControlProps, withVanillaEnumCellProps } from '../util';
 import { WithClassname } from '../index';
 
 export const EnumCell = (props: EnumCellProps & WithClassname) => {
@@ -65,4 +65,4 @@ export const EnumCell = (props: EnumCellProps & WithClassname) => {
  */
 export const enumCellTester: RankedTester = rankWith(2, isEnumControl);
 
-export default withVanillaControlProps(withJsonFormsEnumCellProps(EnumCell));
+export default withVanillaControlProps(withJsonFormsEnumCellProps(withVanillaEnumCellProps(EnumCell)));

--- a/packages/vanilla/src/cells/IntegerCell.tsx
+++ b/packages/vanilla/src/cells/IntegerCell.tsx
@@ -31,6 +31,7 @@ import {
 } from '@jsonforms/core';
 import { withJsonFormsCellProps } from '@jsonforms/react';
 import { VanillaRendererProps } from '../index';
+import { withVanillaCellProps } from '../util/index';
 
 export const IntegerCell = (props: CellProps & VanillaRendererProps) => {
   const { data, className, id, enabled, uischema, path, handleChange } = props;
@@ -54,4 +55,4 @@ export const IntegerCell = (props: CellProps & VanillaRendererProps) => {
  */
 export const integerCellTester: RankedTester = rankWith(2, isIntegerControl);
 
-export default withJsonFormsCellProps(IntegerCell);
+export default withJsonFormsCellProps(withVanillaCellProps(IntegerCell));

--- a/packages/vanilla/src/cells/NumberCell.tsx
+++ b/packages/vanilla/src/cells/NumberCell.tsx
@@ -31,6 +31,7 @@ import {
 } from '@jsonforms/core';
 import { withJsonFormsCellProps } from '@jsonforms/react';
 import { VanillaRendererProps } from '../index';
+import { withVanillaCellProps } from '../util/index';
 
 export const NumberCell = (props: CellProps & VanillaRendererProps) => {
   const { data, className, id, enabled, uischema, path, handleChange } = props;
@@ -55,4 +56,4 @@ export const NumberCell = (props: CellProps & VanillaRendererProps) => {
  */
 export const numberCellTester: RankedTester = rankWith(2, isNumberControl);
 
-export default withJsonFormsCellProps(NumberCell);
+export default withJsonFormsCellProps(withVanillaCellProps(NumberCell));

--- a/packages/vanilla/src/cells/NumberFormatCell.tsx
+++ b/packages/vanilla/src/cells/NumberFormatCell.tsx
@@ -32,6 +32,7 @@ import {
 } from '@jsonforms/core';
 import { withJsonFormsCellProps } from '@jsonforms/react';
 import { VanillaRendererProps } from '../index';
+import { withVanillaCellProps } from '../util/index';
 
 export const NumberFormatCell = (props: CellProps & VanillaRendererProps & Formatted<number>) => {
   const {
@@ -72,4 +73,4 @@ export const NumberFormatCell = (props: CellProps & VanillaRendererProps & Forma
  */
 export const numberFormatCellTester: RankedTester = rankWith(4, isNumberFormatControl);
 
-export default withJsonFormsCellProps(NumberFormatCell);
+export default withJsonFormsCellProps(withVanillaCellProps(NumberFormatCell));

--- a/packages/vanilla/src/cells/SliderCell.tsx
+++ b/packages/vanilla/src/cells/SliderCell.tsx
@@ -31,6 +31,7 @@ import {
 } from '@jsonforms/core';
 import { withJsonFormsCellProps } from '@jsonforms/react';
 import { VanillaRendererProps } from '../index';
+import { withVanillaCellProps } from '../util/index';
 
 export const SliderCell = (props: CellProps & VanillaRendererProps) => {
   const { data, className, id, enabled, uischema, schema, path, handleChange } = props;
@@ -56,4 +57,4 @@ export const SliderCell = (props: CellProps & VanillaRendererProps) => {
 
 export const sliderCellTester: RankedTester = rankWith(4, isRangeControl);
 
-export default withJsonFormsCellProps(SliderCell);
+export default withJsonFormsCellProps(withVanillaCellProps(SliderCell));

--- a/packages/vanilla/src/cells/TextAreaCell.tsx
+++ b/packages/vanilla/src/cells/TextAreaCell.tsx
@@ -31,6 +31,7 @@ import {
 } from '@jsonforms/core';
 import { withJsonFormsCellProps } from '@jsonforms/react';
 import { VanillaRendererProps } from '../index';
+import { withVanillaCellProps } from '../util/index';
 
 export const TextAreaCell = (props: CellProps & VanillaRendererProps) => {
   const { data, className, id, enabled, uischema, path, handleChange } = props;
@@ -53,4 +54,4 @@ export const TextAreaCell = (props: CellProps & VanillaRendererProps) => {
  */
 export const textAreaCellTester: RankedTester = rankWith(2, isMultiLineControl);
 
-export default withJsonFormsCellProps(TextAreaCell);
+export default withJsonFormsCellProps(withVanillaCellProps(TextAreaCell));

--- a/packages/vanilla/src/cells/TextCell.tsx
+++ b/packages/vanilla/src/cells/TextCell.tsx
@@ -31,6 +31,7 @@ import {
 } from '@jsonforms/core';
 import { withJsonFormsCellProps } from '@jsonforms/react';
 import { VanillaRendererProps } from '../index';
+import { withVanillaCellProps } from '../util/index';
 import merge from 'lodash/merge';
 
 export const TextCell = (props: CellProps & VanillaRendererProps) => {
@@ -68,4 +69,4 @@ export const TextCell = (props: CellProps & VanillaRendererProps) => {
  */
 export const textCellTester: RankedTester = rankWith(1, isStringControl);
 
-export default withJsonFormsCellProps(TextCell);
+export default withJsonFormsCellProps(withVanillaCellProps(TextCell));

--- a/packages/vanilla/src/cells/TimeCell.tsx
+++ b/packages/vanilla/src/cells/TimeCell.tsx
@@ -31,6 +31,7 @@ import {
 } from '@jsonforms/core';
 import { withJsonFormsCellProps } from '@jsonforms/react';
 import { VanillaRendererProps } from '../index';
+import { withVanillaCellProps } from '../util/index';
 
 export const TimeCell = (props: CellProps & VanillaRendererProps) => {
   const { data, className, id, enabled, uischema, path, handleChange } = props;
@@ -53,4 +54,4 @@ export const TimeCell = (props: CellProps & VanillaRendererProps) => {
  */
 export const timeCellTester: RankedTester = rankWith(2, isTimeControl);
 
-export default withJsonFormsCellProps(TimeCell);
+export default withJsonFormsCellProps(withVanillaCellProps(TimeCell));

--- a/packages/vanilla/src/index.ts
+++ b/packages/vanilla/src/index.ts
@@ -99,6 +99,7 @@ export interface WithChildren {
   children: any;
 }
 
+export * from './actions';
 export * from './controls';
 export * from './complex';
 export * from './cells';

--- a/packages/vanilla/src/util/index.tsx
+++ b/packages/vanilla/src/util/index.tsx
@@ -168,11 +168,14 @@ export const addVanillaCellProps = (
     };
   };
 
-export const withVanillaCellProps = (Component: ComponentType<any>) => (props: any) => {
+const withVanillaCellPropsForType = (type: string) => (
+  Component: ComponentType<any>
+) => (props: any) => {
   const ctx = useJsonForms();
   const inputClassName = ['validate'].concat(
-    props.isValid ? 'valid' : 'invalid');
-  const definedStyle = findStyleAsClassName(ctx.styles)('control.input');
+    props.isValid ? 'valid' : 'invalid'
+  );
+  const definedStyle = findStyleAsClassName(ctx.styles)(type);
   if (definedStyle) {
     inputClassName.push(definedStyle);
   }
@@ -187,18 +190,13 @@ export const withVanillaCellProps = (Component: ComponentType<any>) => (props: a
   );
 };
 
-export const withVanillaEnumCellProps = (Component: ComponentType<any>) => (props: any) => {
-  const ctx = useJsonForms();
+export const withVanillaCellProps = withVanillaCellPropsForType(
+  'control.input'
+);
 
-  return (
-    <Component
-      {...props}
-      getStyleAsClassName={findStyleAsClassName(ctx.styles)}
-      getStyle={findStyle(ctx.styles)}
-      className={findStyleAsClassName(ctx.styles)('control.select')}
-    />
-  );
-};
+export const withVanillaEnumCellProps = withVanillaCellPropsForType(
+  'control.select'
+);
 
 /**
  * Pre-defined vanilla styles.

--- a/packages/vanilla/src/util/index.tsx
+++ b/packages/vanilla/src/util/index.tsx
@@ -171,8 +171,11 @@ export const addVanillaCellProps = (
 export const withVanillaCellProps = (Component: ComponentType<any>) => (props: any) => {
   const ctx = useJsonForms();
   const inputClassName = ['validate'].concat(
-    props.isValid ? 'valid' : 'invalid'
-  );
+    props.isValid ? 'valid' : 'invalid');
+  const definedStyle = findStyleAsClassName(ctx.styles)('control.input');
+  if (definedStyle) {
+    inputClassName.push(definedStyle);
+  }
 
   return (
     <Component
@@ -181,7 +184,20 @@ export const withVanillaCellProps = (Component: ComponentType<any>) => (props: a
       getStyle={findStyle(ctx.styles)}
       className={inputClassName.join(' ')}
     />
-  )
+  );
+};
+
+export const withVanillaEnumCellProps = (Component: ComponentType<any>) => (props: any) => {
+  const ctx = useJsonForms();
+
+  return (
+    <Component
+      {...props}
+      getStyleAsClassName={findStyleAsClassName(ctx.styles)}
+      getStyle={findStyle(ctx.styles)}
+      className={findStyleAsClassName(ctx.styles)('control.select')}
+    />
+  );
 };
 
 /**
@@ -201,6 +217,10 @@ export const vanillaStyles = [
   {
     name: 'control.input',
     classNames: ['input']
+  },
+  {
+    name: 'control.select',
+    classNames: ['select']
   },
   {
     name: 'control.validation',

--- a/packages/vanilla/test/renderers/BooleanCell.test.tsx
+++ b/packages/vanilla/test/renderers/BooleanCell.test.tsx
@@ -266,6 +266,25 @@ describe('Boolean cell', () => {
     expect(input.checked).toBe(true);
   });
 
+  test('has classes set', () => {
+    const store = initJsonFormsVanillaStore({
+      data: fixture.data,
+      schema: fixture.schema,
+      uischema: fixture.uischema
+    });
+    wrapper = mount(
+      <Provider store={store}>
+        <JsonFormsReduxContext>
+          <BooleanCell schema={fixture.schema} uischema={fixture.uischema} path='foo' />
+        </JsonFormsReduxContext>
+      </Provider>
+    );
+    const input = wrapper.find('input');
+    expect(input.hasClass('input')).toBe(true);
+    expect(input.hasClass('validate')).toBe(true);
+    expect(input.hasClass('valid')).toBe(true);
+  });
+
   test('update via input event', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,

--- a/packages/vanilla/test/renderers/DateCell.test.tsx
+++ b/packages/vanilla/test/renderers/DateCell.test.tsx
@@ -267,6 +267,25 @@ describe('Date cell', () => {
     expect(input.props().value).toBe('1980-04-04');
   });
 
+  test('has classes set', () => {
+    const store = initJsonFormsVanillaStore({
+      data: fixture.data,
+      schema: fixture.schema,
+      uischema: fixture.uischema
+    });
+    wrapper = mount(
+      <Provider store={store}>
+        <JsonFormsReduxContext>
+          <DateCell schema={fixture.schema} uischema={fixture.uischema} path='foo' />
+        </JsonFormsReduxContext>
+      </Provider>
+    );
+    const input = wrapper.find('input');
+    expect(input.hasClass('input')).toBe(true);
+    expect(input.hasClass('validate')).toBe(true);
+    expect(input.hasClass('valid')).toBe(true);
+  });
+
   test('update via event', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,

--- a/packages/vanilla/test/renderers/DateTimeCell.test.tsx
+++ b/packages/vanilla/test/renderers/DateTimeCell.test.tsx
@@ -283,6 +283,30 @@ describe('date time cell', () => {
     expect(input.props().value).toBe('1980-04-04T13:37');
   });
 
+  test('has classes set', () => {
+    const store = initJsonFormsVanillaStore({
+      data: fixture.data,
+      schema: fixture.schema,
+      uischema: fixture.uischema
+    });
+    wrapper = mount(
+      <Provider store={store}>
+        <JsonFormsReduxContext>
+          <DateTimeCell
+            schema={fixture.schema}
+            uischema={fixture.uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
+      </Provider>
+    );
+
+    const input = wrapper.find('input');
+    expect(input.hasClass('input')).toBe(true);
+    expect(input.hasClass('validate')).toBe(true);
+    expect(input.hasClass('valid')).toBe(true);
+  });
+
   test('update via event', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,

--- a/packages/vanilla/test/renderers/EnumCell.test.tsx
+++ b/packages/vanilla/test/renderers/EnumCell.test.tsx
@@ -23,7 +23,7 @@
   THE SOFTWARE.
 */
 import * as React from 'react';
-import { getData, update } from '@jsonforms/core';
+import { ControlElement, getData, update } from '@jsonforms/core';
 import { JsonFormsReduxContext } from '@jsonforms/react';
 import Adapter from 'enzyme-adapter-react-16';
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
@@ -33,16 +33,18 @@ import { initJsonFormsVanillaStore } from '../vanillaStore';
 
 Enzyme.configure({ adapter: new Adapter() });
 
+const control: ControlElement = {
+  type: 'Control',
+  scope: '#/properties/foo',
+};
+
 const fixture = {
   data: { 'foo': 'a' },
   schema: {
     type: 'string',
     enum: ['a', 'b'],
   },
-  uischema: {
-    type: 'Control',
-    scope: '#/properties/foo',
-  },
+  uischema: control,
   styles: [
     {
       name: 'control',

--- a/packages/vanilla/test/renderers/EnumCell.test.tsx
+++ b/packages/vanilla/test/renderers/EnumCell.test.tsx
@@ -157,6 +157,26 @@ describe('Enum cell', () => {
     expect(select.options.item(2).value).toBe('b');
   });
 
+  test('has classes set', () => {
+    const store = initJsonFormsVanillaStore({
+      data: fixture.data,
+      schema: fixture.schema,
+      uischema: fixture.uischema
+    });
+    wrapper = mount(
+      <Provider store={store}>
+        <JsonFormsReduxContext>
+          <EnumCell schema={fixture.schema} uischema={fixture.uischema} path='foo' />
+        </JsonFormsReduxContext>
+      </Provider>
+    );
+
+    const input = wrapper.find('select');
+    expect(input.hasClass('select')).toBe(true);
+    expect(input.hasClass('validate')).toBe(true);
+    expect(input.hasClass('valid')).toBe(true);
+  });
+
   test('update via input event', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,

--- a/packages/vanilla/test/renderers/IntegerCell.test.tsx
+++ b/packages/vanilla/test/renderers/IntegerCell.test.tsx
@@ -235,6 +235,26 @@ describe('Integer cell', () => {
     expect(input.value).toBe('42');
   });
 
+  test('has classes set', () => {
+    const store = initJsonFormsVanillaStore({
+      data: fixture.data,
+      schema: fixture.schema,
+      uischema: fixture.uischema
+    });
+    wrapper = mount(
+      <Provider store={store}>
+        <JsonFormsReduxContext>
+          <IntegerCell schema={fixture.schema} uischema={fixture.uischema} path='foo' />
+        </JsonFormsReduxContext>
+      </Provider>
+    );
+
+    const input = wrapper.find('input');
+    expect(input.hasClass('input')).toBe(true);
+    expect(input.hasClass('validate')).toBe(true);
+    expect(input.hasClass('valid')).toBe(true);
+  });
+
   test('update via input event', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,

--- a/packages/vanilla/test/renderers/NumberCell.test.tsx
+++ b/packages/vanilla/test/renderers/NumberCell.test.tsx
@@ -284,6 +284,26 @@ describe('Number cell', () => {
     expect(input.value).toBe('3.14');
   });
 
+  test('has classes set', () => {
+    const store = initJsonFormsVanillaStore({
+      data: fixture.data,
+      schema: fixture.schema,
+      uischema: fixture.uischema
+    });
+    wrapper = mount(
+      <Provider store={store}>
+        <JsonFormsReduxContext>
+          <NumberCell schema={fixture.schema} uischema={fixture.uischema} path='foo' />
+        </JsonFormsReduxContext>
+      </Provider>
+    );
+
+    const input = wrapper.find('input');
+    expect(input.hasClass('input')).toBe(true);
+    expect(input.hasClass('validate')).toBe(true);
+    expect(input.hasClass('valid')).toBe(true);
+  });
+
   test('update via input event', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,

--- a/packages/vanilla/test/renderers/SliderCell.test.tsx
+++ b/packages/vanilla/test/renderers/SliderCell.test.tsx
@@ -398,6 +398,30 @@ describe('Slider cell', () => {
     expect(input.value).toBe('5');
   });
 
+  test('has classes set', () => {
+    const store = initJsonFormsVanillaStore({
+      data: fixture.data,
+      schema: fixture.schema,
+      uischema: fixture.uischema
+    });
+    wrapper = mount(
+      <Provider store={store}>
+        <JsonFormsReduxContext>
+          <SliderCell
+            schema={fixture.schema}
+            uischema={fixture.uischema}
+            path='foo'
+          />
+        </JsonFormsReduxContext>
+      </Provider>
+    );
+
+    const input = wrapper.find('input');
+    expect(input.hasClass('input')).toBe(true);
+    expect(input.hasClass('validate')).toBe(true);
+    expect(input.hasClass('valid')).toBe(true);
+  });
+
   test('update via input event', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,

--- a/packages/vanilla/test/renderers/TextAreaCell.test.tsx
+++ b/packages/vanilla/test/renderers/TextAreaCell.test.tsx
@@ -198,6 +198,26 @@ describe('Text area cell', () => {
     expect(textarea.value).toBe('Foo');
   });
 
+  test('has classes set', () => {
+    const store = initJsonFormsVanillaStore({
+      data: fixture.data,
+      schema: fixture.schema,
+      uischema: fixture.uischema
+    });
+    wrapper = mount(
+      <Provider store={store}>
+        <JsonFormsReduxContext>
+          <TextAreaCell schema={fixture.schema} uischema={fixture.uischema} path='name' />
+        </JsonFormsReduxContext>
+      </Provider>
+    );
+
+    const input = wrapper.find('textarea');
+    expect(input.hasClass('input')).toBe(true);
+    expect(input.hasClass('validate')).toBe(true);
+    expect(input.hasClass('valid')).toBe(true);
+  });
+
   test('update via input event', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,

--- a/packages/vanilla/test/renderers/TextCell.test.tsx
+++ b/packages/vanilla/test/renderers/TextCell.test.tsx
@@ -210,6 +210,26 @@ describe('Text cell', () => {
     expect(input.value).toBe('Foo');
   });
 
+  test('has classes set', () => {
+    const store = initJsonFormsVanillaStore({
+      data: fixture.data,
+      schema: fixture.schema,
+      uischema: fixture.uischema
+    });
+    wrapper = mount(
+      <Provider store={store}>
+        <JsonFormsReduxContext>
+          <TextCell schema={fixture.schema} uischema={fixture.uischema} path='name' />
+        </JsonFormsReduxContext>
+      </Provider>
+    );
+
+    const input = wrapper.find('input');
+    expect(input.hasClass('input')).toBe(true);
+    expect(input.hasClass('validate')).toBe(true);
+    expect(input.hasClass('valid')).toBe(true);
+  });
+
   test('update via input event', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,

--- a/packages/vanilla/test/renderers/TimeCell.test.tsx
+++ b/packages/vanilla/test/renderers/TimeCell.test.tsx
@@ -239,6 +239,7 @@ describe('Time cell', () => {
     const input = wrapper.find('input').getDOMNode() as HTMLInputElement;
     expect(input.autofocus).toBe(false);
   });
+
   test('render', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
@@ -257,6 +258,26 @@ describe('Time cell', () => {
     const input = wrapper.find('input').getDOMNode() as HTMLInputElement;
     expect(input.type).toBe('time');
     expect(input.value).toBe('13:37');
+  });
+
+  test('has classes set', () => {
+    const store = initJsonFormsVanillaStore({
+      data: fixture.data,
+      schema: fixture.schema,
+      uischema: fixture.uischema
+    });
+    wrapper = mount(
+      <Provider store={store}>
+        <JsonFormsReduxContext>
+          <TimeCell schema={fixture.schema} uischema={fixture.uischema} path='foo' />
+        </JsonFormsReduxContext>
+      </Provider>
+    );
+
+    const input = wrapper.find('input');
+    expect(input.hasClass('input')).toBe(true);
+    expect(input.hasClass('validate')).toBe(true);
+    expect(input.hasClass('valid')).toBe(true);
   });
 
   test('update via event', () => {


### PR DESCRIPTION
* Use `withVanillaCellProps` to apply styling to `<input>` based cells (currently all but enum) and fix application of validation style classes
* Add `withVanillaEnumCellProps` wrapper to add style props to enum cells
* Add style name `control.select` with default style class `select`
* Apply style `control.select` to enum cells' `<select>` element
* Export actions to allow editing styles with the `stylingReducer`: So far the vanilla package only exported the reducer but not the actions. I think this was an oversight.
* Extend styles documention with using the style reducer and actions