### PR TITLE
Add responsive support to angular horizontallayout

### DIFF
--- a/packages/angular-material/src/layouts/horizontal-layout.renderer.ts
+++ b/packages/angular-material/src/layouts/horizontal-layout.renderer.ts
@@ -36,7 +36,7 @@ import { JsonFormsAngularService } from '@jsonforms/angular';
   selector: 'HorizontalLayoutRenderer',
   template: `
     <div
-      fxLayout="row"
+      fxLayout="row wrap"
       fxLayoutGap="16px"
       [fxHide]="hidden"
       fxLayoutAlign="center start"


### PR DESCRIPTION
Add `wrap` flag to fxLayout so that the horizontal layout is
automatically wrapped when the forms is shrinking.