### PR TITLE
Fix performance of rendering lots of fields

### DIFF
--- a/packages/material/src/additional/MaterialListWithDetailRenderer.tsx
+++ b/packages/material/src/additional/MaterialListWithDetailRenderer.tsx
@@ -36,7 +36,7 @@ import {
   uiTypeIs
 } from '@jsonforms/core';
 import {
-  JsonFormsDispatch,
+  ResolvedJsonFormsDispatch,
   withJsonFormsArrayLayoutProps
 } from '@jsonforms/react';
 import { Grid, Hidden, List, Typography } from '@material-ui/core';
@@ -128,7 +128,7 @@ export const MaterialListWithDetailRenderer = ({
         </Grid>
         <Grid item xs>
           {selectedIndex !== undefined ? (
-            <JsonFormsDispatch
+            <ResolvedJsonFormsDispatch
               renderers={renderers}
               cells={cells}
               visible={visible}

--- a/packages/material/src/complex/CombinatorProperties.tsx
+++ b/packages/material/src/complex/CombinatorProperties.tsx
@@ -25,7 +25,7 @@
 import React from 'react';
 import _ from 'lodash';
 import { Generate, JsonSchema, Layout, UISchemaElement } from '@jsonforms/core';
-import { JsonFormsDispatch } from '@jsonforms/react';
+import { ResolvedJsonFormsDispatch } from '@jsonforms/react';
 
 interface CombinatorPropertiesProps {
   schema: JsonSchema;
@@ -51,7 +51,7 @@ export class CombinatorProperties extends React.Component<CombinatorPropertiesPr
 
     if (isLayoutWithElements) {
       return (
-        <JsonFormsDispatch
+        <ResolvedJsonFormsDispatch
           schema={otherProps}
           path={path}
           uischema={foundUISchema}

--- a/packages/material/src/complex/MaterialAllOfRenderer.tsx
+++ b/packages/material/src/complex/MaterialAllOfRenderer.tsx
@@ -35,7 +35,7 @@ import {
   resolveSubSchemas,
   StatePropsOfCombinator
 } from '@jsonforms/core';
-import { JsonFormsDispatch, withJsonFormsAllOfProps } from '@jsonforms/react';
+import { ResolvedJsonFormsDispatch, withJsonFormsAllOfProps } from '@jsonforms/react';
 
 const MaterialAllOfRenderer = ({
   schema,
@@ -56,7 +56,7 @@ const MaterialAllOfRenderer = ({
   if (delegateUISchema) {
     return (
       <Hidden xsUp={!visible}>
-        <JsonFormsDispatch
+        <ResolvedJsonFormsDispatch
           schema={_schema}
           uischema={delegateUISchema}
           path={path}
@@ -78,7 +78,7 @@ const MaterialAllOfRenderer = ({
   return (
     <Hidden xsUp={!visible}>
       {allOfRenderInfos.map((allOfRenderInfo, allOfIndex) => (
-        <JsonFormsDispatch
+        <ResolvedJsonFormsDispatch
           key={allOfIndex}
           schema={allOfRenderInfo.schema}
           uischema={allOfRenderInfo.uischema}

--- a/packages/material/src/complex/MaterialAnyOfRenderer.tsx
+++ b/packages/material/src/complex/MaterialAnyOfRenderer.tsx
@@ -33,7 +33,7 @@ import {
   resolveSubSchemas,
   StatePropsOfCombinator
 } from '@jsonforms/core';
-import { JsonFormsDispatch, withJsonFormsAnyOfProps } from '@jsonforms/react';
+import { ResolvedJsonFormsDispatch, withJsonFormsAnyOfProps } from '@jsonforms/react';
 import { Hidden, Tab, Tabs } from '@material-ui/core';
 import CombinatorProperties from './CombinatorProperties';
 
@@ -79,7 +79,7 @@ const MaterialAnyOfRenderer = ({
       {anyOfRenderInfos.map(
         (anyOfRenderInfo, anyOfIndex) =>
           selectedAnyOf === anyOfIndex && (
-            <JsonFormsDispatch
+            <ResolvedJsonFormsDispatch
               key={anyOfIndex}
               schema={anyOfRenderInfo.schema}
               uischema={anyOfRenderInfo.uischema}

--- a/packages/material/src/complex/MaterialObjectRenderer.tsx
+++ b/packages/material/src/complex/MaterialObjectRenderer.tsx
@@ -33,7 +33,7 @@ import {
   rankWith,
   StatePropsOfControlWithDetail
 } from '@jsonforms/core';
-import { JsonFormsDispatch, withJsonFormsDetailProps } from '@jsonforms/react';
+import { ResolvedJsonFormsDispatch, withJsonFormsDetailProps } from '@jsonforms/react';
 import { Hidden } from '@material-ui/core';
 import React from 'react';
 
@@ -67,7 +67,7 @@ const MaterialObjectRenderer = ({
   }
   return (
     <Hidden xsUp={!visible}>
-      <JsonFormsDispatch
+      <ResolvedJsonFormsDispatch
         visible={visible}
         enabled={enabled}
         schema={schema}

--- a/packages/material/src/complex/MaterialOneOfRenderer.tsx
+++ b/packages/material/src/complex/MaterialOneOfRenderer.tsx
@@ -48,7 +48,7 @@ import {
   Tabs
 } from '@material-ui/core';
 import {
-  JsonFormsDispatch,
+  ResolvedJsonFormsDispatch,
   withJsonFormsOneOfProps
 } from '@jsonforms/react';
 import CombinatorProperties from './CombinatorProperties';
@@ -112,7 +112,7 @@ const MaterialOneOfRenderer =
         {
           oneOfRenderInfos.map((oneOfRenderInfo, oneOfIndex) => (
             selectedIndex === oneOfIndex && (
-              <JsonFormsDispatch
+              <ResolvedJsonFormsDispatch
                 key={oneOfIndex}
                 schema={oneOfRenderInfo.schema}
                 uischema={oneOfRenderInfo.uischema}

--- a/packages/material/src/layouts/ExpandPanelRenderer.tsx
+++ b/packages/material/src/layouts/ExpandPanelRenderer.tsx
@@ -4,7 +4,7 @@ import React, { Dispatch, Fragment, ReducerAction, useState } from 'react';
 import { ComponentType } from 'enzyme';
 import {
   areEqual,
-  JsonFormsDispatch,
+  ResolvedJsonFormsDispatch,
   JsonFormsStateContext,
   withJsonFormsContext
 } from '@jsonforms/react';
@@ -179,7 +179,7 @@ const ExpandPanelRenderer = (props: ExpandPanelProps) => {
         </Grid>
       </ExpansionPanelSummary>
       <ExpansionPanelDetails>
-        <JsonFormsDispatch
+        <ResolvedJsonFormsDispatch
           schema={schema}
           uischema={foundUISchema}
           path={childPath}

--- a/packages/material/src/util/layout.tsx
+++ b/packages/material/src/util/layout.tsx
@@ -31,7 +31,7 @@ import {
   UISchemaElement,
   JsonFormsCellRendererRegistryEntry
 } from '@jsonforms/core';
-import { areEqual, JsonFormsDispatch } from '@jsonforms/react';
+import { areEqual, ResolvedJsonFormsDispatch } from '@jsonforms/react';
 import { Grid, Hidden } from '@material-ui/core';
 
 export const renderLayoutElements = (
@@ -44,7 +44,7 @@ export const renderLayoutElements = (
 ) => {
   return elements.map((child, index) => (
     <Grid item key={`${path}-${index}`} xs>
-      <JsonFormsDispatch
+      <ResolvedJsonFormsDispatch
         uischema={child}
         schema={schema}
         path={path}

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -176,27 +176,37 @@ export class JsonFormsDispatchRenderer extends ResolvedJsonFormsDispatchRenderer
   }
 }
 
+function useJsonFormsDispatchRendererProps(props: OwnPropsOfJsonFormsRenderer & JsonFormsReactProps) {
+  const ctx = useJsonForms();
+  const { refResolver } = ctxToJsonFormsDispatchProps(ctx, props);
+  const { data, errors } = ctx.core;
+  useLayoutEffect(() => {
+    props.onChange && props.onChange({ data, errors });
+  }, [data, errors]);
+
+  return {
+    schema: props.schema || ctx.core.schema,
+    uischema: props.uischema || ctx.core.uischema,
+    path: props.path || '',
+    enabled: props.enabled,
+    rootSchema: ctx.core.schema,
+    renderers: props.renderers || ctx.renderers,
+    refResolver: refResolver,
+    cells: props.cells || ctx.cells,
+  };
+}
+
 export const JsonFormsDispatch = React.memo(
   (props: OwnPropsOfJsonFormsRenderer & JsonFormsReactProps) => {
-    const ctx = useJsonForms();
-    const { refResolver } = ctxToJsonFormsDispatchProps(ctx, props);
-    const { data, errors } = ctx.core;
-    useLayoutEffect(() => {
-      props.onChange && props.onChange({ data, errors });
-    }, [data, errors]);
+    const renderProps = useJsonFormsDispatchRendererProps(props);
+    return <JsonFormsDispatchRenderer {...renderProps} />
+  }
+);
 
-    return (
-      <JsonFormsDispatchRenderer
-        schema={props.schema || ctx.core.schema}
-        uischema={props.uischema || ctx.core.uischema}
-        path={props.path || ''}
-        enabled={props.enabled}
-        rootSchema={ctx.core.schema}
-        renderers={props.renderers || ctx.renderers}
-        refResolver={refResolver}
-        cells={props.cells || ctx.cells}
-      />
-    );
+export const ResolvedJsonFormsDispatch = React.memo(
+  (props: OwnPropsOfJsonFormsRenderer & JsonFormsReactProps) => {
+    const renderProps = useJsonFormsDispatchRendererProps(props);
+    return <ResolvedJsonFormsDispatchRenderer {...renderProps} />
   }
 );
 

--- a/packages/react/src/JsonFormsContext.tsx
+++ b/packages/react/src/JsonFormsContext.tsx
@@ -359,12 +359,14 @@ const withContextToEnumProps =
 type JsonFormsPropTypes = ControlProps | CombinatorProps | LayoutProps | CellProps | ArrayLayoutProps | StatePropsOfControlWithDetail | OwnPropsOfRenderer;
 
 export const areEqual = (prevProps: JsonFormsPropTypes, nextProps: JsonFormsPropTypes) => {
-  const prev = omit(prevProps, ['handleChange', 'renderers', 'cells', 'uischemas']);
-  const next = omit(nextProps, ['handleChange', 'renderers', 'cells', 'uischemas']);
+  const prev = omit(prevProps, ['schema', 'uischema', 'handleChange', 'renderers', 'cells', 'uischemas']);
+  const next = omit(nextProps, ['schema', 'uischema', 'handleChange', 'renderers', 'cells', 'uischemas']);
   return isEqual(prev, next)
     && get(prevProps, 'renderers.length') === get(nextProps, 'renderers.length')
     && get(prevProps, 'cells.length') === get(nextProps, 'cells.length')
-    && get(prevProps, 'uischemas.length') === get(nextProps, 'uischemas.length');
+    && get(prevProps, 'uischemas.length') === get(nextProps, 'uischemas.length')
+    && get(prevProps, 'schema') === get(nextProps, 'schema')
+    && get(prevProps, 'uischema') === get(nextProps, 'uischema');
 };
 
 // top level HOCs --

--- a/packages/vanilla/src/complex/array/ArrayControl.tsx
+++ b/packages/vanilla/src/complex/array/ArrayControl.tsx
@@ -25,7 +25,7 @@
 import range from 'lodash/range';
 import React from 'react';
 import { ArrayControlProps, composePaths, createDefaultValue, findUISchema } from '@jsonforms/core';
-import { JsonFormsDispatch } from '@jsonforms/react';
+import { ResolvedJsonFormsDispatch } from '@jsonforms/react';
 import { VanillaRendererProps } from '../../index';
 
 export const ArrayControl = ({
@@ -58,7 +58,7 @@ export const ArrayControl = ({
               const childPath = composePaths(path, `${index}`);
 
               return (
-                <JsonFormsDispatch
+                <ResolvedJsonFormsDispatch
                   schema={schema}
                   uischema={foundUISchema || uischema}
                   path={childPath}

--- a/packages/vanilla/src/complex/categorization/SingleCategory.tsx
+++ b/packages/vanilla/src/complex/categorization/SingleCategory.tsx
@@ -24,7 +24,7 @@
 */
 import React from 'react';
 import { Category, JsonSchema } from '@jsonforms/core';
-import { JsonFormsDispatch } from '@jsonforms/react';
+import { ResolvedJsonFormsDispatch } from '@jsonforms/react';
 
 export interface CategoryProps {
   category: Category;
@@ -38,7 +38,7 @@ export const SingleCategory = ({ category, schema, path }: CategoryProps) => (
     {
       (category.elements || []).map((child, index) =>
         (
-          <JsonFormsDispatch
+          <ResolvedJsonFormsDispatch
             key={`${path}-${index}`}
             uischema={child}
             schema={schema}

--- a/packages/vanilla/src/layouts/util.tsx
+++ b/packages/vanilla/src/layouts/util.tsx
@@ -25,7 +25,7 @@
 import isEmpty from 'lodash/isEmpty';
 import React from 'react';
 import { JsonSchema, Layout } from '@jsonforms/core';
-import { JsonFormsDispatch, useJsonForms } from '@jsonforms/react';
+import { ResolvedJsonFormsDispatch, useJsonForms } from '@jsonforms/react';
 export interface RenderChildrenProps {
   layout: Layout;
   schema: JsonSchema;
@@ -48,7 +48,7 @@ export const renderChildren = (
   return layout.elements.map((child, index) => {
     return (
       <div className={className} key={`${path}-${index}`}>
-        <JsonFormsDispatch
+        <ResolvedJsonFormsDispatch
           renderers={renderers}
           cells={cells}
           uischema={child}


### PR DESCRIPTION
I introduced a fix in https://github.com/eclipsesource/jsonforms/pull/1214 to fix performance of rendering lots of fields. Since that time the code has shifted and that fix has been lost. The new manifestation appears to stems from
`JsonFormsDispatchRenderer` calling `hasRefs` while `ResolvedJsonFormsDispatchRenderer` does not, as only the first JsonForm needs to handle processing resolving refs.

Right now we are doing a lot of wasted `object-hash` comparisons in the `hasRefs` memoized check due to using the wrong component in our `material` and `vanilla` components.