### PR TITLE
Fix crash in MaterialTableControl

### DIFF
--- a/packages/material/src/complex/MaterialTableControl.tsx
+++ b/packages/material/src/complex/MaterialTableControl.tsx
@@ -116,7 +116,7 @@ const generateCells = (
 };
 
 const getValidColumnProps = (scopedSchema: JsonSchema) => {
-  if (scopedSchema.type === 'object') {
+  if (scopedSchema.type === 'object' && typeof scopedSchema.properties === 'object') {
     return Object.keys(scopedSchema.properties).filter(
       prop => scopedSchema.properties[prop].type !== 'array'
     );

--- a/packages/material/test/renderers/MaterialArrayControl.test.tsx
+++ b/packages/material/test/renderers/MaterialArrayControl.test.tsx
@@ -167,6 +167,41 @@ describe('Material array control', () => {
     expect(headerColumns).toHaveLength(3);
   });
 
+  it('should render even without properties', () => {
+    const store = initJsonFormsStore();
+    // re-init
+    const data: any = { test: [] };
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        test: {
+          type: 'array',
+          items: { type: 'object' }
+        }
+      }
+    };
+    const uischema: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/test'
+    };
+    store.dispatch(Actions.init(data, schema, uischema));
+
+    wrapper = mount(
+      <Provider store={store}>
+        <JsonFormsReduxContext>
+          <MaterialArrayControlRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
+      </Provider>
+    );
+
+    const rows = wrapper.find('tr');
+    // two header rows + no data row
+    expect(rows.length).toBe(3);
+    const headerColumns = rows.at(1).children();
+    // 2 columns: content + buttons
+    expect(headerColumns).toHaveLength(2);
+  });
+
   it('should render empty primitives', () => {
     const store = initJsonFormsStore();
     // re-init


### PR DESCRIPTION
When the item object schema doesn't specify properties the control
crashed. We now check the type of the properties before (not)
accessing them.