### PR TITLE
[Angular] Add hint to show description on controls

### DIFF
--- a/packages/angular-material/src/controls/autocomplete.renderer.ts
+++ b/packages/angular-material/src/controls/autocomplete.renderer.ts
@@ -70,7 +70,6 @@ import { startWith } from 'rxjs/operators';
         matInput
         type="text"
         (change)="onChange($event)"
-        placeholder="{{ description }}"
         [id]="id"
         [formControl]="form"
         [matAutocomplete]="auto"
@@ -88,6 +87,7 @@ import { startWith } from 'rxjs/operators';
           {{ option }}
         </mat-option>
       </mat-autocomplete>
+      <mat-hint>{{ description }}</mat-hint>
       <mat-error>{{ error }}</mat-error>
     </mat-form-field>
   `

--- a/packages/angular-material/src/controls/boolean.renderer.ts
+++ b/packages/angular-material/src/controls/boolean.renderer.ts
@@ -43,6 +43,7 @@ import { isBooleanControl, RankedTester, rankWith } from '@jsonforms/core';
       >
         {{ label }}
       </mat-checkbox>
+      <mat-hint class="mat-caption">{{ description }}</mat-hint>
       <mat-error class="mat-caption">{{ error }}</mat-error>
     </div>
   `

--- a/packages/angular-material/src/controls/date.renderer.ts
+++ b/packages/angular-material/src/controls/date.renderer.ts
@@ -40,7 +40,6 @@ import { DateAdapter, NativeDateAdapter } from '@angular/material/core';
       <input
         matInput
         (dateChange)="onChange($event)"
-        placeholder="{{ description }}"
         [id]="id"
         [formControl]="form"
         [matDatepicker]="datepicker"
@@ -50,7 +49,7 @@ import { DateAdapter, NativeDateAdapter } from '@angular/material/core';
         [for]="datepicker"
       ></mat-datepicker-toggle>
       <mat-datepicker #datepicker></mat-datepicker>
-
+      <mat-hint>{{ description }}</mat-hint>
       <mat-error>{{ error }}</mat-error>
     </mat-form-field>
   `

--- a/packages/angular-material/src/controls/number.renderer.ts
+++ b/packages/angular-material/src/controls/number.renderer.ts
@@ -41,7 +41,6 @@ import {
       <input
         matInput
         (input)="onChange($event)"
-        placeholder="{{ description }}"
         [value]="getValue()"
         [id]="id"
         [formControl]="form"
@@ -49,6 +48,7 @@ import {
         [max]="max"
         [step]="multipleOf"
       />
+      <mat-hint>{{ description }}</mat-hint>
       <mat-error>{{ error }}</mat-error>
     </mat-form-field>
   `

--- a/packages/angular-material/src/controls/range.renderer.ts
+++ b/packages/angular-material/src/controls/range.renderer.ts
@@ -44,6 +44,7 @@ import { isRangeControl, RankedTester, rankWith } from '@jsonforms/core';
         tickInterval="auto"
         [id]="id"
       ></mat-slider>
+      <mat-hint class="mat-caption">{{ description }}</mat-hint>
       <mat-error class="mat-caption">{{ error }}</mat-error>
     </div>
   `

--- a/packages/angular-material/src/controls/text.renderer.ts
+++ b/packages/angular-material/src/controls/text.renderer.ts
@@ -35,10 +35,10 @@ import { isStringControl, RankedTester, rankWith } from '@jsonforms/core';
         matInput
         [type]="getType()"
         (input)="onChange($event)"
-        placeholder="{{ description }}"
         [id]="id"
         [formControl]="form"
       />
+      <mat-hint>{{ description }}</mat-hint>
       <mat-error>{{ error }}</mat-error>
     </mat-form-field>
   `

--- a/packages/angular-material/src/controls/textarea.renderer.ts
+++ b/packages/angular-material/src/controls/textarea.renderer.ts
@@ -34,10 +34,10 @@ import { isMultiLineControl, RankedTester, rankWith } from '@jsonforms/core';
       <textarea
         matInput
         (input)="onChange($event)"
-        placeholder="{{ description }}"
         [id]="id"
         [formControl]="form"
       ></textarea>
+      <mat-hint>{{ description }}</mat-hint>
       <mat-error>{{ error }}</mat-error>
     </mat-form-field>
   `

--- a/packages/angular-material/src/controls/toggle.renderer.ts
+++ b/packages/angular-material/src/controls/toggle.renderer.ts
@@ -44,6 +44,7 @@ import {
       >
         {{ label }}
       </mat-slide-toggle>
+      <mat-hint class="mat-caption">{{ description }}</mat-hint>
       <mat-error class="mat-caption">{{ error }}</mat-error>
     </div>
   `


### PR DESCRIPTION
Add hint to angular controls. This way the hint is always visible.

Signed-off-by: Eugen Neufeld <eneufeld@eclipsesource.com>