### PR TITLE
attempt at adding value and label support for select control

### DIFF
--- a/packages/material/src/mui-controls/MuiSelect.tsx
+++ b/packages/material/src/mui-controls/MuiSelect.tsx
@@ -30,6 +30,12 @@ import { MenuItem } from '@material-ui/core';
 import { areEqual } from '@jsonforms/react';
 import merge from 'lodash/merge';
 
+interface Option {
+  key: string;
+  value: string;
+  label: string;
+}
+
 export const MuiSelect = React.memo((props: EnumCellProps & WithClassname) => {
   const {
     data,
@@ -43,6 +49,17 @@ export const MuiSelect = React.memo((props: EnumCellProps & WithClassname) => {
     config
   } = props;
   const appliedUiSchemaOptions = merge({}, config, uischema.options);
+  const delimiter: string = appliedUiSchemaOptions.keyValueDelimiter;
+  const keyValueLabels: Option[] = (delimiter === undefined) ?
+  options.map(option => {
+    return { key: option, value: option, label: option };
+  }) :
+  options.map(option => {
+    return option.split(delimiter, 2).map((parts: void[]) => {
+      return { key: parts[0], value: option, label: parts[1] };
+    }
+    );
+  });
 
   return (
     <Select
@@ -55,9 +72,9 @@ export const MuiSelect = React.memo((props: EnumCellProps & WithClassname) => {
       fullWidth={true}
     >
       {[<MenuItem value='' key={'empty'} />].concat(
-        options.map(optionValue => (
-          <MenuItem value={optionValue} key={optionValue}>
-            {optionValue}
+        keyValueLabels.map(option => (
+          <MenuItem value={option.value} key={option.key}>
+            {option.label}
           </MenuItem>
         ))
       )}


### PR DESCRIPTION
As per the discussion in the following thread, trying to add support for having different key and label for select options (MaterialEnumControl).

https://spectrum.chat/jsonforms/general/for-enums-i-need-to-be-able-to-put-labels-for-the-enum-values~5b8b5153-033f-43a9-8f5e-bc27c37a2781

I am still working on adding the test for this. MaterialEnumControl doesn't seem to have existing tests (please correct me if I am wrong). So, I am writing tests for the base control and also the modification I am proposing.