### PR TITLE
Remove label cutoff

### DIFF
--- a/packages/material/src/controls/MaterialInputControl.tsx
+++ b/packages/material/src/controls/MaterialInputControl.tsx
@@ -32,13 +32,27 @@ import {
 } from '@jsonforms/core';
 import { Control } from '@jsonforms/react';
 
-import { Hidden, InputLabel } from '@material-ui/core';
+import { Hidden, InputLabel, withStyles } from '@material-ui/core';
 import { FormControl, FormHelperText } from '@material-ui/core';
 import merge from 'lodash/merge';
 
 interface WithInput {
   input: any;
 }
+
+const TrimmableInputLabel = withStyles({
+  root: {
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    right: '50px', // adjust for remove adornment
+    bottom: '0px' // avoid horizontal cutoff for characters like `qypgj`
+  },
+  shrink: {
+    width: '125%' // shrinked labels are scaled by 75%, therefore set width to 125% to make it the same width as the input
+  }
+})(InputLabel);
+
 export abstract class MaterialInputControl extends Control<
   ControlProps & WithInput,
   ControlState
@@ -57,13 +71,6 @@ export abstract class MaterialInputControl extends Control<
     } = this.props;
     const isValid = errors.length === 0;
     const appliedUiSchemaOptions = merge({}, config, uischema.options);
-    const inputLabelStyle: { [x: string]: any } = {
-      whiteSpace: 'nowrap',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      // magic width as the label is transformed to 75% of its size
-      width: '125%'
-    };
 
     const showDescription = !isDescriptionHidden(
       visible,
@@ -78,8 +85,8 @@ export abstract class MaterialInputControl extends Control<
       ? errors
       : null;
     const secondFormHelperText = showDescription && !isValid ? errors : null;
-
     const InnerComponent = input;
+
     return (
       <Hidden xsUp={!visible}>
         <FormControl
@@ -88,17 +95,16 @@ export abstract class MaterialInputControl extends Control<
           onBlur={this.onBlur}
           id={id}
         >
-          <InputLabel
+          <TrimmableInputLabel
             htmlFor={id + '-input'}
             error={!isValid}
-            style={inputLabelStyle}
           >
             {computeLabel(
               isPlainLabel(label) ? label : label.default,
               required,
               appliedUiSchemaOptions.hideRequiredAsterisk
             )}
-          </InputLabel>
+          </TrimmableInputLabel>
           <InnerComponent
             {...this.props}
             id={id + '-input'}

--- a/packages/material/src/mui-controls/MuiInputText.tsx
+++ b/packages/material/src/mui-controls/MuiInputText.tsx
@@ -96,7 +96,7 @@ export class MuiInputText extends React.PureComponent<
             position='end'
             style={{
               visibility:
-                !this.state.showAdornment || !enabled ? 'hidden' : 'visible'
+                !this.state.showAdornment || !enabled || data === undefined ? 'hidden' : 'visible'
             }}
           >
             <IconButton

--- a/packages/material/test/renderers/MaterialTextControl.test.tsx
+++ b/packages/material/test/renderers/MaterialTextControl.test.tsx
@@ -30,6 +30,7 @@ import { MaterialInputControl } from '../../src/controls/MaterialInputControl';
 import { MuiInputText } from '../../src/mui-controls/MuiInputText';
 import Adapter from 'enzyme-adapter-react-16';
 import { ControlElement, ControlProps } from '@jsonforms/core';
+import { Input, InputAdornment } from '@material-ui/core';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -91,5 +92,20 @@ describe('Material text control', () => {
     };
     wrapper = mount(createMaterialTextControl(props));
     expect(wrapper.find('input').props().spellCheck).toEqual(false);
+  });
+
+  it('shows clear button when data exists', () => {
+    const props = defaultControlProps();
+    wrapper = mount(createMaterialTextControl(props));
+    wrapper.find(Input).simulate('pointerenter');
+    expect(wrapper.find(InputAdornment).props().style).toHaveProperty('visibility', 'visible');
+  });
+
+  it('hides clear button when data is undefined', () => {
+    const props = defaultControlProps();
+    delete props.data;
+    wrapper = mount(createMaterialTextControl(props));
+    wrapper.find(Input).simulate('pointerenter');
+    expect(wrapper.find(InputAdornment).props().style).toHaveProperty('visibility', 'hidden');
   });
 });


### PR DESCRIPTION
## Don't cut off labels in MaterialInputControl 
Adjust the custom classes for MaterialInputControl's InputLabel to not
cut off characters.

We use a special style to increase the InputLabel's length when
shrinked as well as to avoid line breaks by rendering ellipses instead.
With an update of material ui the custom styles collided with the
default ones and lead to characters like 'ypq' etc. to be
cut off. This cutoff is now avoided. Also the width of the InputLabel is
adjusted to respect the input adornment when not shrinked.

## Hide 'clear' adornment when data is undefined 
Adds a check in MuiInputText to hide the clear button when its data
is already undefined.