### PR TITLE
Fix peer dependencies versions of JSON Forms

### DIFF
--- a/packages/angular-material/package.json
+++ b/packages/angular-material/package.json
@@ -63,8 +63,8 @@
     "@angular/material": "^9.0.0",
     "@angular/platform-browser": "^9.0.0",
     "@angular/router": "^9.0.0",
-    "@jsonforms/angular": "^2.3.0",
-    "@jsonforms/core": "^2.3.0",
+    "@jsonforms/angular": "^2.4.0-beta.0",
+    "@jsonforms/core": "^2.4.0-beta.0",
     "core-js": "^2.5.3",
     "rxjs": "^6.4.0",
     "zone.js": "^0.10.2"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -63,7 +63,7 @@
   "peerDependencies": {
     "@angular/core": "^9.0.0",
     "@angular/forms": "^9.0.0",
-    "@jsonforms/core": "^2.3.0",
+    "@jsonforms/core": "^2.4.0-beta.0",
     "rxjs": "^6.4.0"
   },
   "devDependencies": {

--- a/packages/material/package.json
+++ b/packages/material/package.json
@@ -72,8 +72,8 @@
     "uuid": "^3.3.3"
   },
   "peerDependencies": {
-    "@jsonforms/core": "^2.3.1",
-    "@jsonforms/react": "^2.3.1",
+    "@jsonforms/core": "^2.4.0-beta.0",
+    "@jsonforms/react": "^2.4.0-beta.0",
     "@material-ui/core": "^4.7.0",
     "@material-ui/icons": "^4.5.1",
     "react-redux": "^7.1.3"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -79,7 +79,7 @@
     "object-hash": "^2.0.0"
   },
   "peerDependencies": {
-    "@jsonforms/core": "^2.3.1",
+    "@jsonforms/core": "^2.4.0-beta.0",
     "react": "^16.12.0",
     "react-redux": "^7.1.3"
   },

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -32,8 +32,8 @@
     "customization"
   ],
   "peerDependencies": {
-    "@jsonforms/core": "^2.3.1",
-    "@jsonforms/react": "^2.3.1"
+    "@jsonforms/core": "^2.4.0-beta.0",
+    "@jsonforms/react": "^2.4.0-beta.0"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "0.1.3",


### PR DESCRIPTION
The peer dependency versions were incorrectly set to an older version
leading to warnings when installing JSON Forms. They are now adjusted to
be the current version.