### PR TITLE
Add global readonly flag to react and core

### DIFF
--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -70,6 +70,10 @@ export interface JsonFormsSubStates {
    *
    */
   uischemas?: { tester: UISchemaTester; uischema: UISchemaElement }[];
+  /**
+   * If true, sets all controls to read-only.
+   */
+  readOnly?: boolean;
   // allow additional state
   [additionalState: string]: any;
 }

--- a/packages/core/src/util/cell.ts
+++ b/packages/core/src/util/cell.ts
@@ -103,10 +103,11 @@ export const mapStateToCellProps = (
     ownProps.visible !== undefined
       ? ownProps.visible
       : isVisible(uischema, rootData);
+  const readOnly = state.jsonforms.readOnly;
   const enabled =
-    ownProps.enabled !== undefined
+    !readOnly && (ownProps.enabled !== undefined
       ? ownProps.enabled
-      : isEnabled(uischema, rootData);
+      : isEnabled(uischema, rootData));
   const errors = formatErrorMessage(
     union(getErrorAt(path, schema)(state).map(error => error.message))
   );

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -387,10 +387,11 @@ export const mapStateToControlProps = (
     ownProps.visible === undefined || hasShowRule(uischema)
       ? isVisible(uischema, rootData, ownProps.path)
       : ownProps.visible;
+  const readOnly = state.jsonforms.readOnly;
   const enabled: boolean =
-    ownProps.enabled === undefined || hasEnableRule(uischema)
+    !readOnly && (ownProps.enabled === undefined || hasEnableRule(uischema)
       ? isEnabled(uischema, rootData, ownProps.path)
-      : ownProps.enabled;
+      : ownProps.enabled);
   const controlElement = uischema as ControlElement;
   const id = ownProps.id;
   const rootSchema = getSchema(state);
@@ -673,10 +674,11 @@ export const mapStateToLayoutProps = (
     ownProps.visible === undefined || hasShowRule(uischema)
       ? isVisible(ownProps.uischema, rootData, ownProps.path)
       : ownProps.visible;
+  const readOnly = state.jsonforms.readOnly;
   const enabled: boolean =
-    ownProps.enabled === undefined || hasEnableRule(uischema)
+    !readOnly && (ownProps.enabled === undefined || hasEnableRule(uischema)
       ? isEnabled(ownProps.uischema, rootData, ownProps.path)
-      : ownProps.enabled;
+      : ownProps.enabled);
 
   const data = Resolve.data(rootData, ownProps.path);
 

--- a/packages/core/test/util/cell.test.ts
+++ b/packages/core/test/util/cell.test.ts
@@ -62,6 +62,15 @@ const disableRule = {
   }
 };
 
+const enableRule = {
+  effect: RuleEffect.ENABLE,
+  condition: {
+    type: 'LEAF',
+    scope: '#/properties/firstName',
+    expectedValue: 'Homer'
+  }
+};
+
 const coreUISchema: ControlElement = {
   type: 'Control',
   scope: '#/properties/firstName'
@@ -192,6 +201,44 @@ test('mapStateToCellProps - enabled via state ', t => {
   clonedState.jsonforms.core.data.firstName = 'Lisa';
   const props = mapStateToCellProps(clonedState, ownProps);
   t.true(props.enabled);
+});
+
+test('mapStateToCellProps - disabled via global readOnly', t => {
+  const ownProps = {
+    uischema: coreUISchema
+  };
+  const state: JsonFormsState = createState(coreUISchema);
+  state.jsonforms.readOnly = true;
+
+  const props = mapStateToCellProps(state, ownProps);
+  t.false(props.enabled);
+});
+
+test('mapStateToCellProps - disabled via global readOnly beats enabled via ownProps', t => {
+  const ownProps = {
+    uischema: coreUISchema,
+    enabled: true
+  };
+  const state: JsonFormsState = createState(coreUISchema);
+  state.jsonforms.readOnly = true;
+
+  const props = mapStateToCellProps(state, ownProps);
+  t.false(props.enabled);
+});
+
+test('mapStateToCellProps - disabled via global readOnly beats enabled via rule', t => {
+  const uischema = {
+    ...coreUISchema,
+    rule: enableRule
+  };
+  const ownProps = {
+    uischema
+  };
+  const state: JsonFormsState = createState(uischema);
+  state.jsonforms.readOnly = true;
+
+  const props = mapStateToCellProps(state, ownProps);
+  t.false(props.enabled);
 });
 
 test('mapStateToCellProps - path', t => {

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -219,6 +219,7 @@ export interface JsonFormsInitStateProps {
   ajv?: AJV.Ajv;
   refParserOptions?: RefParser.Options;
   config?: any;
+  readOnly?: boolean;
 }
 
 export const JsonForms = (
@@ -234,6 +235,7 @@ export const JsonForms = (
     refParserOptions,
     onChange,
     config,
+    readOnly,
   } = props;
   const schemaToUse = schema !== undefined ? schema : Generate.jsonSchema(data);
   const uischemaToUse =
@@ -250,7 +252,8 @@ export const JsonForms = (
         },
         config,
         renderers,
-        cells
+        cells,
+        readOnly,
       }}
     >
       <JsonFormsDispatch onChange={onChange} />

--- a/packages/react/src/JsonFormsContext.tsx
+++ b/packages/react/src/JsonFormsContext.tsx
@@ -141,6 +141,7 @@ export const JsonFormsStateProvider = ({ children, initState }: any) => {
         renderers: initState.renderers,
         cells: initState.cells,
         config: config,
+        readOnly: initState.readOnly,
         // only core dispatch available
         dispatch: coreDispatch,
       }}


### PR DESCRIPTION
Core:
* Extend jsonforms state with optional `readOnly` property
* Apply `readOnly` state property to mapStateToXYZProps: If readOnly is set to true, the enabled prop is always set to false. If readOnly is false or non-existant, existing rules apply as before.
* Add tests for mapStateToCellProps, mapStateToControlProps, mapStateToLayoutProps

React:
Extend react component and context with `readOnly` property