### PR TITLE
Introduce validation mode

### DIFF
--- a/packages/angular/src/jsonforms.service.ts
+++ b/packages/angular/src/jsonforms.service.ts
@@ -12,7 +12,9 @@ import {
   SetConfigAction,
   UISchemaActions,
   UISchemaElement,
-  uischemaRegistryReducer
+  uischemaRegistryReducer,
+  ValidationMode,
+  Actions
 } from '@jsonforms/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { JsonFormsBaseRenderer } from './base.renderer';
@@ -60,21 +62,27 @@ export class JsonFormsAngularService {
         this.updateSubject();
     }
 
-  updateLocale<T extends LocaleActions>(localeAction: T): T {
+    updateValidationMode(validationMode: ValidationMode): void {
+        const coreState = coreReducer(this._state.core, Actions.setValidationMode(validationMode));
+        this._state.core = coreState;
+        this.updateSubject();
+    }
+
+    updateLocale<T extends LocaleActions>(localeAction: T): T {
         const localeState = i18nReducer(this._state.i18n, localeAction);
         this._state.i18n = localeState;
         this.updateSubject();
         return localeAction;
     }
 
-  updateCore<T extends CoreActions>(coreAction: T): T {
+    updateCore<T extends CoreActions>(coreAction: T): T {
         const coreState = coreReducer(this._state.core, coreAction);
         this._state.core = coreState;
         this.updateSubject();
         return coreAction;
     }
 
-  updateUiSchema<T extends UISchemaActions>(uischemaAction: T): T {
+    updateUiSchema<T extends UISchemaActions>(uischemaAction: T): T {
         const uischemaState = uischemaRegistryReducer(this._state.uischemas, uischemaAction);
         this._state.uischemas = uischemaState;
         this.updateSubject();

--- a/packages/core/src/actions/index.ts
+++ b/packages/core/src/actions/index.ts
@@ -29,6 +29,7 @@ import { generateDefaultUISchema, generateJsonSchema } from '../generators';
 import { RankedTester } from '../testers';
 import RefParser from 'json-schema-ref-parser';
 import { UISchemaTester } from '../reducers/uischemas';
+import { ValidationMode } from '../reducers/core';
 
 export const INIT: 'jsonforms/INIT' = 'jsonforms/INIT';
 export const SET_AJV: 'jsonforms/SET_AJV' = 'jsonforms/SET_AJV';
@@ -46,6 +47,8 @@ export const ADD_UI_SCHEMA: 'jsonforms/ADD_UI_SCHEMA' = `jsonforms/ADD_UI_SCHEMA
 export const REMOVE_UI_SCHEMA: 'jsonforms/REMOVE_UI_SCHEMA' = `jsonforms/REMOVE_UI_SCHEMA`;
 export const SET_SCHEMA: 'jsonforms/SET_SCHEMA' = `jsonforms/SET_SCHEMA`;
 export const SET_UISCHEMA: 'jsonforms/SET_UISCHEMA' = `jsonforms/SET_UISCHEMA`;
+export const SET_VALIDATION_MODE: 'jsonforms/SET_VALIDATION_MODE' =
+  'jsonforms/SET_VALIDATION_MODE';
 
 export const SET_LOCALE: 'jsonforms/SET_LOCALE' = `jsonforms/SET_LOCALE`;
 export const SET_LOCALIZED_SCHEMAS: 'jsonforms/SET_LOCALIZED_SCHEMAS' =
@@ -62,7 +65,8 @@ export type CoreActions =
   | UpdateErrorsAction
   | SetAjvAction
   | SetSchemaAction
-  | SetUISchemaAction;
+  | SetUISchemaAction
+  | SetValidationModeAction;
 
 export interface UpdateAction {
   type: 'jsonforms/UPDATE';
@@ -86,6 +90,12 @@ export interface InitAction {
 export interface InitActionOptions {
   ajv?: AJV.Ajv;
   refParserOptions?: RefParser.Options;
+  validationMode?: ValidationMode;
+}
+
+export interface SetValidationModeAction {
+  type: 'jsonforms/SET_VALIDATION_MODE'
+  validationMode: ValidationMode
 }
 
 export const init = (
@@ -205,6 +215,11 @@ export const setConfig = (config: any): SetConfigAction => ({
   type: SET_CONFIG,
   config
 });
+
+export const setValidationMode = (validationMode: ValidationMode): SetValidationModeAction => ({
+  type: SET_VALIDATION_MODE,
+  validationMode
+})
 
 export type UISchemaActions = AddUISchemaAction | RemoveUISchemaAction;
 

--- a/packages/core/src/reducers/index.ts
+++ b/packages/core/src/reducers/index.ts
@@ -1,3 +1,27 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
 import { ControlElement, UISchemaElement } from '../models/uischema';
 import {
   JsonFormsCore,
@@ -8,7 +32,8 @@ import {
   extractRefParserOptions,
   extractSchema,
   extractUiSchema,
-  subErrorsAt
+  subErrorsAt,
+  ValidationMode
 } from './core';
 import {
   JsonFormsDefaultDataRegistryEntry,
@@ -34,30 +59,7 @@ import { Generate } from '../generators';
 import { JsonFormsCellRendererRegistryEntry } from './cells';
 import { JsonSchema } from '../models/jsonSchema';
 import RefParser from 'json-schema-ref-parser';
-/*
-  The MIT License
-  
-  Copyright (c) 2017-2019 EclipseSource Munich
-  https://github.com/eclipsesource/jsonforms
-  
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-  
-  The above copyright notice and this permission notice shall be included in
-  all copies or substantial portions of the Software.
-  
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-  THE SOFTWARE.
-*/
+
 import { cellReducer } from './cells';
 import { configReducer } from './config';
 import get from 'lodash/get';
@@ -72,7 +74,7 @@ export {
   uischemaRegistryReducer,
   findMatchingUISchema
 };
-export { JsonFormsCore };
+export { JsonFormsCore, ValidationMode };
 
 export const jsonformsReducer = (
   additionalReducers = {}

--- a/packages/core/test/util/renderer.test.ts
+++ b/packages/core/test/util/renderer.test.ts
@@ -53,6 +53,7 @@ import {
 import { jsonformsReducer } from '../../src/reducers';
 import { ErrorObject } from 'ajv';
 import { combineReducers, createStore, Store } from 'redux';
+import { setValidationMode } from '../../lib';
 
 const middlewares: Redux.Middleware[] = [];
 const mockStore = configureStore<JsonFormsState>(middlewares);
@@ -409,6 +410,44 @@ test('mapStateToControlProps - id', t => {
   };
   const props = mapStateToControlProps(createState(coreUISchema), ownProps);
   t.is(props.id, '#/properties/firstName');
+});
+
+test('mapStateToControlProps - hide errors in hide validation mode', t => {
+  const schema = {
+    type: 'object',
+    properties: {
+      animal: {
+        type: 'string'
+      }
+    }
+  };
+  const uischema: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/animal'
+  };
+  const initCoreState = coreReducer(undefined, init({ animal: 100 }, schema, uischema));
+  t.is(initCoreState.errors.length, 1);
+
+  const ownProps = {
+    uischema
+  };
+  const props = mapStateToControlProps(
+    { jsonforms: { core: initCoreState } },
+    ownProps
+  );
+  t.not(props.errors.length, 0);
+
+  const hideErrorsState = coreReducer(
+    initCoreState,
+    setValidationMode('ValidateAndHide')
+  );
+  t.is(hideErrorsState.errors.length, 1);
+
+  const hideErrorsProps = mapStateToControlProps(
+    { jsonforms: { core: hideErrorsState } },
+    ownProps
+  );
+  t.is(hideErrorsProps.errors, '');
 });
 
 test('mapDispatchToControlProps', t => {

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -41,7 +41,8 @@ import {
   JsonSchema,
   OwnPropsOfJsonFormsRenderer,
   removeId,
-  UISchemaElement
+  UISchemaElement,
+  ValidationMode
 } from '@jsonforms/core';
 import {
   ctxToJsonFormsDispatchProps,
@@ -220,6 +221,7 @@ export interface JsonFormsInitStateProps {
   refParserOptions?: RefParser.Options;
   config?: any;
   readOnly?: boolean;
+  validationMode?: ValidationMode;
 }
 
 export const JsonForms = (
@@ -236,6 +238,7 @@ export const JsonForms = (
     onChange,
     config,
     readOnly,
+    validationMode
   } = props;
   const schemaToUse = schema !== undefined ? schema : Generate.jsonSchema(data);
   const uischemaToUse =
@@ -248,7 +251,8 @@ export const JsonForms = (
           data,
           refParserOptions,
           schema: schemaToUse,
-          uischema: uischemaToUse
+          uischema: uischemaToUse,
+          validationMode: validationMode
         },
         config,
         renderers,

--- a/packages/react/src/JsonFormsContext.tsx
+++ b/packages/react/src/JsonFormsContext.tsx
@@ -113,20 +113,20 @@ const useEffectAfterFirstRender = (
 };
 
 export const JsonFormsStateProvider = ({ children, initState }: any) => {
-  const { data, schema, uischema, ajv, refParserOptions } = initState.core;
+  const { data, schema, uischema, ajv, refParserOptions , validationMode} = initState.core;
   // Initialize core immediatly
   const [core, coreDispatch] = useReducer(
     coreReducer,
     coreReducer(
       initState.core,
-      Actions.init(data, schema, uischema, { ajv, refParserOptions })
+      Actions.init(data, schema, uischema, { ajv, refParserOptions, validationMode })
     )
   );
   useEffectAfterFirstRender(() => {
     coreDispatch(
-      Actions.init(data, schema, uischema, { ajv, refParserOptions })
+      Actions.init(data, schema, uischema, { ajv, refParserOptions, validationMode })
     );
-  }, [data, schema, uischema, ajv, refParserOptions]);
+  }, [data, schema, uischema, ajv, refParserOptions, validationMode]);
 
   const [config, configDispatch] = useReducer(
     configReducer,


### PR DESCRIPTION
Adds validationMode to the core state supporting
 * Validation & showing the validation result (default)
 * Validation & hiding the validation result
 * No validation

'Validation & showing the validation result' is the default mode and
represents the previous mode. 'Validation & hiding the validation
result' will still keep the errors in the core state up to date, however
they are not given to the respective renderers by default. 'No
validation' will short-circuit the validation, resulting in an always
empty errors array in the core state.

The mode can be set as part of the init action and can later be updated
with the separate setValidationMode action. The action is exposed as a
separate prop in React and as a separate method in the Angular service.

The new modes can be used for various use cases, e.g.
 * save performance by never validating on client side
 * show validation errors separately from the form
 * only show validation errors on submit or after first edit

---

Showcase in React seed

![ValidationModes](https://user-images.githubusercontent.com/8998368/87547468-6ede6f80-c6ab-11ea-9e94-016c8cb21565.gif)