### PR TITLE
Make sure resolveData throws no exception

### DIFF
--- a/packages/core/src/util/resolvers.ts
+++ b/packages/core/src/util/resolvers.ts
@@ -58,7 +58,7 @@ export const resolveData = (instance: any, dataPath: string): any => {
     .map(segment => decodeURIComponent(segment))
     .reduce((curInstance, decodedSegment) => {
       if (
-        curInstance === undefined ||
+        !curInstance ||
         !curInstance.hasOwnProperty(decodedSegment)
       ) {
         return undefined;


### PR DESCRIPTION
Previosuly the resolver only made sure that data is not 'undefined'
before checking its properties, however this fails for 'null' values. We
now also check for them.