### PR TITLE
Fix Vanilla example app crash

### DIFF
--- a/packages/vanilla/example/index.ts
+++ b/packages/vanilla/example/index.ts
@@ -31,7 +31,7 @@ import {
 } from '../src';
 import { renderExample } from '../../example/src/index';
 
-renderExample(vanillaRenderers, vanillaCells, {
+renderExample(vanillaRenderers, vanillaCells, undefined, {
   name: 'styles',
   reducer: stylingReducer,
   state: vanillaStyles


### PR DESCRIPTION
The Vanilla example app wasn't adapted when the 'renderExample' API was
extended. This lead to a crash on app startup. This is now fixed.