### PR TITLE
MaterialRadioGroupControl not used

### DIFF
--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -68,6 +68,7 @@ import * as huge from './huge';
 import * as defaultExample from './default';
 import * as onChange from './onChange';
 import * as enumExample from './enum';
+import * as radioGroupExample from './radioGroup';
 export * from './register';
 export * from './example';
 
@@ -120,5 +121,6 @@ export {
   huge,
   ifThenElse,
   onChange,
-  enumExample
+  enumExample,
+  radioGroupExample
 };

--- a/packages/examples/src/radioGroup.ts
+++ b/packages/examples/src/radioGroup.ts
@@ -1,0 +1,56 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import { registerExamples } from './register';
+
+const data = {
+};
+
+const schema = {
+    type: 'object',
+    properties: {
+      exampleRadioEnum: {
+        type: 'string',
+        enum: ['One', 'Two', 'Three']
+      }
+    }
+  };
+
+const uischema = {
+    type: 'Control',
+    scope: '#/properties/exampleRadioEnum',
+    options: {
+      format: 'radio'
+    }
+  };
+
+registerExamples([
+  {
+    name: 'radio-group',
+    label: 'Radio Group',
+    data,
+    schema,
+    uischema
+  }
+]);

--- a/packages/material/src/controls/MaterialRadioGroupControl.tsx
+++ b/packages/material/src/controls/MaterialRadioGroupControl.tsx
@@ -32,7 +32,7 @@ import {
   isPlainLabel,
   rankWith,
   RankedTester,
-  optionIs
+  optionIs, and, isEnumControl
 } from '@jsonforms/core';
 import { Control, withJsonFormsControlProps } from '@jsonforms/react';
 import Radio from '@material-ui/core/Radio';
@@ -118,7 +118,7 @@ export class MaterialRadioGroupControl extends Control<
 }
 
 export const materialRadioGroupControlTester: RankedTester = rankWith(
-  2,
-  optionIs('format', 'radio')
+  20,
+  and(isEnumControl, optionIs('format', 'radio'))
 );
 export default withJsonFormsControlProps(MaterialRadioGroupControl);

--- a/packages/material/test/renderers/MaterialRadioGroupControl.test.tsx
+++ b/packages/material/test/renderers/MaterialRadioGroupControl.test.tsx
@@ -27,15 +27,14 @@ import * as React from 'react';
 import {
   Actions,
   ControlElement,
-  isEnumControl,
   jsonformsReducer,
   JsonFormsState,
   JsonSchema,
-  rankWith,
+  NOT_APPLICABLE,
   UISchemaElement,
   update
 } from '@jsonforms/core';
-import MaterialRadioGroupControl from '../../src/controls/MaterialRadioGroupControl';
+import MaterialRadioGroupControl, { materialRadioGroupControlTester } from '../../src/controls/MaterialRadioGroupControl';
 import { Provider } from 'react-redux';
 import { materialRenderers } from '../../src';
 import { AnyAction, combineReducers, createStore, Reducer, Store } from 'redux';
@@ -56,7 +55,10 @@ const schema = {
 };
 const uischema: ControlElement = {
   type: 'Control',
-  scope: '#/properties/foo'
+  scope: '#/properties/foo',
+  options: {
+    format: 'radio'
+  }
 };
 
 const initJsonFormsStore = (
@@ -66,13 +68,7 @@ const initJsonFormsStore = (
 ): Store<JsonFormsState> => {
   const s: JsonFormsState = {
     jsonforms: {
-      renderers: [
-        ...materialRenderers,
-        {
-          tester: rankWith(10, isEnumControl),
-          renderer: MaterialRadioGroupControl
-        }
-      ]
+      renderers: materialRenderers
     }
   };
   const reducer: Reducer<JsonFormsState, AnyAction> = combineReducers({
@@ -82,6 +78,22 @@ const initJsonFormsStore = (
   store.dispatch(Actions.init(testData, testSchema, testUiSchema));
   return store;
 };
+
+describe('Material radio group tester', () => {
+  it('should return valid rank for enums with radio format', () => {
+    const rank = materialRadioGroupControlTester(uischema, schema);
+    expect(rank).not.toBe(NOT_APPLICABLE);
+  });
+
+  it('should return NOT_APPLICABLE for enums without radio format', () => {
+    const uiSchemaNoRadio = {
+      type: 'Control',
+      scope: '#/properties/foo'
+    };
+    const rank = materialRadioGroupControlTester(uiSchemaNoRadio, schema);
+    expect(rank).toBe(NOT_APPLICABLE);
+  });
+});
 
 describe('Material radio group control', () => {
   let wrapper: ReactWrapper;


### PR DESCRIPTION
- increase ranking of tester (above that of
MaterialAutocompleteEnumControl)
- use radio group only when the 'radio' format is present in the UI
schema
- add radio group example
- add tests

Fixes #1601