### PR TITLE
Fix adornment placement with display instead of visibility

### DIFF
--- a/packages/material/src/mui-controls/MuiInputText.tsx
+++ b/packages/material/src/mui-controls/MuiInputText.tsx
@@ -30,20 +30,11 @@ import merge from 'lodash/merge';
 import IconButton from '@material-ui/core/IconButton';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import Close from '@material-ui/icons/Close';
-import { Theme, useTheme } from '@material-ui/core/styles';
+import { useTheme } from '@material-ui/core/styles';
+import { JsonFormsTheme } from '../util';
 
 interface MuiTextInputProps {
   muiInputProps?: React.HTMLAttributes<HTMLInputElement>;
-}
-
-interface JsonFormsTheme extends Theme {
-  jsonforms?: {
-    input: {
-      delete: {
-        background: string;
-      }
-    }
-  };
 }
 
 export const MuiInputText = React.memo((props: CellProps & WithClassname & MuiTextInputProps) => {
@@ -78,7 +69,7 @@ export const MuiInputText = React.memo((props: CellProps & WithClassname & MuiTe
   const onChange = (ev: any) => handleChange(path, ev.target.value);
 
   const theme: JsonFormsTheme = useTheme();
-  const iconBackgroundColor = theme.jsonforms?.input?.delete?.background || theme.palette.background.default;
+  const inputDeleteBackgroundColor = theme.jsonforms?.input?.delete?.background || theme.palette.background.default;
 
   return (
     <Input
@@ -111,7 +102,7 @@ export const MuiInputText = React.memo((props: CellProps & WithClassname & MuiTe
             aria-label='Clear input field'
             onClick={() => handleChange(path, undefined)}   
           >
-            <Close style={{background: iconBackgroundColor, borderRadius: '50%'}}/>
+            <Close style={{background: inputDeleteBackgroundColor, borderRadius: '50%'}}/>
           </IconButton>
         </InputAdornment>
       }

--- a/packages/material/src/mui-controls/MuiInputText.tsx
+++ b/packages/material/src/mui-controls/MuiInputText.tsx
@@ -67,7 +67,7 @@ export const MuiInputText = React.memo((props: CellProps & WithClassname & MuiTe
   }
   const onChange = (ev: any) => handleChange(path, ev.target.value);
 
-  const hoverColor = useTheme().palette.action.hover;
+  const iconBackgroundColor = useTheme().palette.background.default;
 
   return (
     <Input
@@ -98,10 +98,9 @@ export const MuiInputText = React.memo((props: CellProps & WithClassname & MuiTe
         >
           <IconButton
             aria-label='Clear input field'
-            onClick={() => handleChange(path, undefined)}
-            style={{background: hoverColor}}
+            onClick={() => handleChange(path, undefined)}   
           >
-            <Close />
+            <Close style={{background: iconBackgroundColor, borderRadius: '50%'}}/>
           </IconButton>
         </InputAdornment>
       }

--- a/packages/material/src/mui-controls/MuiInputText.tsx
+++ b/packages/material/src/mui-controls/MuiInputText.tsx
@@ -30,10 +30,20 @@ import merge from 'lodash/merge';
 import IconButton from '@material-ui/core/IconButton';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import Close from '@material-ui/icons/Close';
-import { useTheme } from '@material-ui/core/styles';
+import { Theme, useTheme } from '@material-ui/core/styles';
 
 interface MuiTextInputProps {
   muiInputProps?: React.HTMLAttributes<HTMLInputElement>;
+}
+
+interface JsonFormsTheme extends Theme {
+  jsonforms?: {
+    input: {
+      delete: {
+        background: string;
+      }
+    }
+  };
 }
 
 export const MuiInputText = React.memo((props: CellProps & WithClassname & MuiTextInputProps) => {
@@ -67,7 +77,8 @@ export const MuiInputText = React.memo((props: CellProps & WithClassname & MuiTe
   }
   const onChange = (ev: any) => handleChange(path, ev.target.value);
 
-  const iconBackgroundColor = useTheme().palette.background.default;
+  const theme: JsonFormsTheme = useTheme();
+  const iconBackgroundColor = theme.jsonforms?.input?.delete?.background || theme.palette.background.default;
 
   return (
     <Input

--- a/packages/material/src/mui-controls/MuiInputText.tsx
+++ b/packages/material/src/mui-controls/MuiInputText.tsx
@@ -22,92 +22,89 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import React from 'react';
+import React, { useState } from 'react';
 import { CellProps, WithClassname } from '@jsonforms/core';
+import { areEqual } from '@jsonforms/react';
 import Input from '@material-ui/core/Input';
 import merge from 'lodash/merge';
 import IconButton from '@material-ui/core/IconButton';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import Close from '@material-ui/icons/Close';
-
-interface MuiInputTextStatus {
-  showAdornment: boolean;
-}
+import { useTheme } from '@material-ui/core/styles';
 
 interface MuiTextInputProps {
   muiInputProps?: React.HTMLAttributes<HTMLInputElement>;
 }
 
-export class MuiInputText extends React.PureComponent<
-  CellProps & WithClassname & MuiTextInputProps,
-  MuiInputTextStatus
-> {
-  state: MuiInputTextStatus = { showAdornment: false };
-  render() {
-    const {
-      data,
-      config,
-      className,
-      id,
-      enabled,
-      uischema,
-      isValid,
-      path,
-      handleChange,
-      schema,
-      muiInputProps
-    } = this.props;
-    const maxLength = schema.maxLength;
-    const appliedUiSchemaOptions = merge({}, config, uischema.options);
-    let inputProps: any;
-    if (appliedUiSchemaOptions.restrict) {
-      inputProps = { maxLength: maxLength };
-    } else {
-      inputProps = {};
-    }
-
-    inputProps = merge(inputProps, muiInputProps);
-
-    if (appliedUiSchemaOptions.trim && maxLength !== undefined) {
-      inputProps.size = maxLength;
-    }
-    const onChange = (ev: any) => handleChange(path, ev.target.value);
-
-    return (
-      <Input
-        type={
-          appliedUiSchemaOptions.format === 'password' ? 'password' : 'text'
-        }
-        value={data || ''}
-        onChange={onChange}
-        className={className}
-        id={id}
-        disabled={!enabled}
-        autoFocus={appliedUiSchemaOptions.focus}
-        multiline={appliedUiSchemaOptions.multi}
-        fullWidth={!appliedUiSchemaOptions.trim || maxLength === undefined}
-        inputProps={inputProps}
-        error={!isValid}
-        onPointerEnter={() => this.setState({ showAdornment: true })}
-        onPointerLeave={() => this.setState({ showAdornment: false })}
-        endAdornment={
-          // Use visibility instead of 'Hidden' so the layout doesn't change when the icon is shown
-          <InputAdornment
-            position='end'
-            style={{
-              visibility:
-                !this.state.showAdornment || !enabled || data === undefined ? 'hidden' : 'visible'
-            }}
-          >
-            <IconButton
-              aria-label='Clear input field'
-              onClick={() => handleChange(path, undefined)}
-            >
-              <Close />
-            </IconButton>
-          </InputAdornment>
-        }
-      />
-    );
+export const MuiInputText = React.memo((props: CellProps & WithClassname & MuiTextInputProps) => {
+  const [showAdornment, setShowAdornment] = useState(false);
+  const {
+    data,
+    config,
+    className,
+    id,
+    enabled,
+    uischema,
+    isValid,
+    path,
+    handleChange,
+    schema,
+    muiInputProps
+  } = props;
+  const maxLength = schema.maxLength;
+  const appliedUiSchemaOptions = merge({}, config, uischema.options);
+  let inputProps: any;
+  if (appliedUiSchemaOptions.restrict) {
+    inputProps = { maxLength: maxLength };
+  } else {
+    inputProps = {};
   }
-}
+
+  inputProps = merge(inputProps, muiInputProps);
+
+  if (appliedUiSchemaOptions.trim && maxLength !== undefined) {
+    inputProps.size = maxLength;
+  }
+  const onChange = (ev: any) => handleChange(path, ev.target.value);
+
+  const hoverColor = useTheme().palette.action.hover;
+
+  return (
+    <Input
+      type={
+        appliedUiSchemaOptions.format === 'password' ? 'password' : 'text'
+      }
+      value={data || ''}
+      onChange={onChange}
+      className={className}
+      id={id}
+      disabled={!enabled}
+      autoFocus={appliedUiSchemaOptions.focus}
+      multiline={appliedUiSchemaOptions.multi}
+      fullWidth={!appliedUiSchemaOptions.trim || maxLength === undefined}
+      inputProps={inputProps}
+      error={!isValid}
+      onPointerEnter={() => setShowAdornment(true) }
+      onPointerLeave={() => setShowAdornment(false) }
+      endAdornment={
+        <InputAdornment
+          position='end'
+          style={{
+            display:
+              !showAdornment || !enabled || data === undefined ? 'none' : 'flex',
+            position: 'absolute',
+            right: 0
+          }}
+        >
+          <IconButton
+            aria-label='Clear input field'
+            onClick={() => handleChange(path, undefined)}
+            style={{background: hoverColor}}
+          >
+            <Close />
+          </IconButton>
+        </InputAdornment>
+      }
+    />
+  );
+}, areEqual);

--- a/packages/material/src/util/theme.ts
+++ b/packages/material/src/util/theme.ts
@@ -22,5 +22,14 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-export * from './layout';
-export * from './theme';
+import { Theme } from '@material-ui/core/styles';
+
+export interface JsonFormsTheme extends Theme {
+  jsonforms?: {
+    input?: {
+      delete?: {
+        background?: string;
+      }
+    }
+  };
+}

--- a/packages/material/test/renderers/MaterialTextControl.test.tsx
+++ b/packages/material/test/renderers/MaterialTextControl.test.tsx
@@ -98,7 +98,7 @@ describe('Material text control', () => {
     const props = defaultControlProps();
     wrapper = mount(createMaterialTextControl(props));
     wrapper.find(Input).simulate('pointerenter');
-    expect(wrapper.find(InputAdornment).props().style).toHaveProperty('visibility', 'visible');
+    expect(wrapper.find(InputAdornment).props().style).not.toHaveProperty('display', 'none');
   });
 
   it('hides clear button when data is undefined', () => {
@@ -106,6 +106,6 @@ describe('Material text control', () => {
     delete props.data;
     wrapper = mount(createMaterialTextControl(props));
     wrapper.find(Input).simulate('pointerenter');
-    expect(wrapper.find(InputAdornment).props().style).toHaveProperty('visibility', 'hidden');
+    expect(wrapper.find(InputAdornment).props().style).toHaveProperty('display', 'none');
   });
 });


### PR DESCRIPTION
The input clear icon overlayed the input text, so
part of the text was not visible. 
This commit fixes that by replacing the 'visibility' 
with the 'display' css property. 

Fixes: #1627