### PR TITLE
modified table controls to recognize titles in table properties

### DIFF
--- a/packages/material/src/complex/MaterialTableControl.tsx
+++ b/packages/material/src/complex/MaterialTableControl.tsx
@@ -92,12 +92,11 @@ const generateCells = (
 ) => {
   if (schema.type === 'object') {
     return getValidColumnProps(schema).map(prop => {
-      const title = schema.properties?.[prop]?.title ?? startCase(prop);
       const cellPath = Paths.compose(rowPath, prop);
       const props = {
         propName: prop,
         schema,
-        title,
+        title: schema.properties?.[prop]?.title ?? startCase(prop),
         rowPath,
         cellPath,
         enabled,

--- a/packages/material/src/complex/MaterialTableControl.tsx
+++ b/packages/material/src/complex/MaterialTableControl.tsx
@@ -92,11 +92,15 @@ const generateCells = (
 ) => {
   if (schema.type === 'object') {
     return getValidColumnProps(schema).map(prop => {
+      let title = prop;
+      if (schema.properties && schema.properties[prop].title) {
+        title = schema.properties[prop].title;
+      }
       const cellPath = Paths.compose(rowPath, prop);
       const props = {
         propName: prop,
         schema,
-        title: schema.properties[prop].title ? schema.properties[prop].title : startCase(prop),
+        title,
         rowPath,
         cellPath,
         enabled,

--- a/packages/material/src/complex/MaterialTableControl.tsx
+++ b/packages/material/src/complex/MaterialTableControl.tsx
@@ -90,7 +90,6 @@ const generateCells = (
   enabled: boolean,
   cells?: JsonFormsCellRendererRegistryEntry[]
 ) => {
-  console.log(schema)
   if (schema.type === 'object') {
     return getValidColumnProps(schema).map(prop => {
       const title = schema.properties?.[prop]?.title ?? startCase(prop);

--- a/packages/material/src/complex/MaterialTableControl.tsx
+++ b/packages/material/src/complex/MaterialTableControl.tsx
@@ -96,6 +96,7 @@ const generateCells = (
       const props = {
         propName: prop,
         schema,
+        title: schema.properties[prop].title ? schema.properties[prop].title : startCase(prop),
         rowPath,
         cellPath,
         enabled,
@@ -109,6 +110,7 @@ const generateCells = (
       schema,
       rowPath,
       cellPath: rowPath,
+      title: schema.title ? schema.title : '',
       enabled
     };
     return <Cell key={rowPath} {...props} />;
@@ -138,11 +140,11 @@ const EmptyTable = ({ numColumns }: EmptyTableProps) => (
 );
 
 interface TableHeaderCellProps {
-  propName: string;
+  title: string;
 }
 
-const TableHeaderCell = React.memo(({ propName }: TableHeaderCellProps) => (
-  <TableCell>{startCase(propName)}</TableCell>
+const TableHeaderCell = React.memo(({ title }: TableHeaderCellProps) => (
+  <TableCell>{title}</TableCell>
 ));
 
 interface NonEmptyCellProps extends OwnPropsOfNonEmptyCell {
@@ -154,6 +156,7 @@ interface NonEmptyCellProps extends OwnPropsOfNonEmptyCell {
 interface OwnPropsOfNonEmptyCell {
   rowPath: string;
   propName?: string;
+  title: string;
   schema: JsonSchema;
   enabled: boolean;
   renderers?: JsonFormsRendererRegistryEntry[];
@@ -178,6 +181,7 @@ const ctxToNonEmptyCellProps = (
   return {
     rowPath: ownProps.rowPath,
     propName: ownProps.propName,
+    title: ownProps.title ? ownProps.title : startCase(ownProps.propName),
     schema: ownProps.schema,
     rootSchema: ctx.core.schema,
     errors,

--- a/packages/material/src/complex/MaterialTableControl.tsx
+++ b/packages/material/src/complex/MaterialTableControl.tsx
@@ -92,7 +92,7 @@ const generateCells = (
 ) => {
   if (schema.type === 'object') {
     return getValidColumnProps(schema).map(prop => {
-      let title = prop;
+      let title = startCase(prop);
       if (schema.properties && schema.properties[prop].title) {
         title = schema.properties[prop].title;
       }

--- a/packages/material/src/complex/MaterialTableControl.tsx
+++ b/packages/material/src/complex/MaterialTableControl.tsx
@@ -90,12 +90,10 @@ const generateCells = (
   enabled: boolean,
   cells?: JsonFormsCellRendererRegistryEntry[]
 ) => {
+  console.log(schema)
   if (schema.type === 'object') {
     return getValidColumnProps(schema).map(prop => {
-      let title = startCase(prop);
-      if (schema.properties && schema.properties[prop].title) {
-        title = schema.properties[prop].title;
-      }
+      const title = schema.properties?.[prop]?.title ?? startCase(prop);
       const cellPath = Paths.compose(rowPath, prop);
       const props = {
         propName: prop,
@@ -114,7 +112,6 @@ const generateCells = (
       schema,
       rowPath,
       cellPath: rowPath,
-      title: schema.title ? schema.title : '',
       enabled
     };
     return <Cell key={rowPath} {...props} />;
@@ -160,7 +157,6 @@ interface NonEmptyCellProps extends OwnPropsOfNonEmptyCell {
 interface OwnPropsOfNonEmptyCell {
   rowPath: string;
   propName?: string;
-  title: string;
   schema: JsonSchema;
   enabled: boolean;
   renderers?: JsonFormsRendererRegistryEntry[];
@@ -185,7 +181,6 @@ const ctxToNonEmptyCellProps = (
   return {
     rowPath: ownProps.rowPath,
     propName: ownProps.propName,
-    title: ownProps.title ? ownProps.title : startCase(ownProps.propName),
     schema: ownProps.schema,
     rootSchema: ctx.core.schema,
     errors,

--- a/packages/material/test/renderers/MaterialArrayControl.test.tsx
+++ b/packages/material/test/renderers/MaterialArrayControl.test.tsx
@@ -202,6 +202,55 @@ describe('Material array control', () => {
     expect(headerColumns).toHaveLength(2);
   });
 
+  it('should use title as a header if it exists', () => {
+    const store = initJsonFormsStore();
+    // re-init
+    const data: any = { test: [] };
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+          test: {
+              type: 'array',
+              items: {
+                  type: 'object',
+                  properties: {
+                      test1: {
+                          type: 'string',
+                          title: 'my first test'
+                      },
+                      test_2: {
+                          type: 'string',
+                      }
+                  }
+              }
+          }
+      }
+    };
+    const uischema: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/test'
+    };
+    store.dispatch(Actions.init(data, schema, uischema));
+
+    wrapper = mount(
+      <Provider store={store}>
+        <JsonFormsReduxContext>
+          <MaterialArrayControlRenderer schema={schema} uischema={uischema} />
+        </JsonFormsReduxContext>
+      </Provider>
+    );
+
+    //column headings are in the second row of the table, wrapped in <th>
+    const headers = wrapper.find('tr').at(1).find('th');
+
+    // the first property has a title, so we expect it to be rendered as the first column heading
+    expect(headers.at(0).text()).toEqual("my first test");
+
+    // the second property has no title, so we expect to see the property name in start case
+    expect(headers.at(1).text()).toEqual("Test 2");
+ 
+  });
+
   it('should render empty primitives', () => {
     const store = initJsonFormsStore();
     // re-init

--- a/packages/material/test/renderers/MaterialArrayControl.test.tsx
+++ b/packages/material/test/renderers/MaterialArrayControl.test.tsx
@@ -216,7 +216,7 @@ describe('Material array control', () => {
                   properties: {
                       test1: {
                           type: 'string',
-                          title: 'my first test'
+                          title: 'first test'
                       },
                       test_2: {
                           type: 'string',
@@ -244,7 +244,7 @@ describe('Material array control', () => {
     const headers = wrapper.find('tr').at(1).find('th');
 
     // the first property has a title, so we expect it to be rendered as the first column heading
-    expect(headers.at(0).text()).toEqual("my first test");
+    expect(headers.at(0).text()).toEqual("first test");
 
     // the second property has no title, so we expect to see the property name in start case
     expect(headers.at(1).text()).toEqual("Test 2");

--- a/packages/vanilla/src/complex/TableArrayControl.tsx
+++ b/packages/vanilla/src/complex/TableArrayControl.tsx
@@ -120,7 +120,7 @@ class TableArrayControl extends React.Component<ArrayControlProps & VanillaRende
                 fpflow(
                   fpkeys,
                   fpfilter(prop => schema.properties[prop].type !== 'array'),
-                  fpmap(prop => <th key={prop}>{fpstartCase(prop)}</th>)
+                  fpmap(prop => <th key={prop}>{schema.properties[prop].title ? schema.properties[prop].title : fpstartCase(prop)}</th>)
                 )(schema.properties)
               ) : (
                   <th>Items</th>

--- a/packages/vanilla/src/complex/TableArrayControl.tsx
+++ b/packages/vanilla/src/complex/TableArrayControl.tsx
@@ -120,7 +120,7 @@ class TableArrayControl extends React.Component<ArrayControlProps & VanillaRende
                 fpflow(
                   fpkeys,
                   fpfilter(prop => schema.properties[prop].type !== 'array'),
-                  fpmap(prop => <th key={prop}>{schema.properties[prop].title ? schema.properties[prop].title : fpstartCase(prop)}</th>)
+                  fpmap(prop => <th key={prop}>{schema.properties[prop].title ?? fpstartCase(prop)}</th>)
                 )(schema.properties)
               ) : (
                   <th>Items</th>

--- a/packages/vanilla/test/renderers/TableArrayControl.test.tsx
+++ b/packages/vanilla/test/renderers/TableArrayControl.test.tsx
@@ -717,6 +717,4 @@ describe('Tabe array control', () => {
     expect(validation.at(1).getDOMNode().textContent).toBe('is a required property');
     expect(validation.at(2).getDOMNode().textContent).toBe('is a required property');
   });
-
-  
 });

--- a/packages/vanilla/test/renderers/TableArrayControl.test.tsx
+++ b/packages/vanilla/test/renderers/TableArrayControl.test.tsx
@@ -73,6 +73,40 @@ const fixture = {
   ]
 };
 
+const fixture2 = {
+  schema: {
+    type: 'object',
+    properties: {
+      test: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            x: {
+              type: 'integer',
+              title: 'Column X',
+            },
+            y: { type: 'integer' }
+          }
+        }
+      }
+    }
+  },
+  uischema: {
+    type: 'Control',
+    scope: '#/properties/test'
+  },
+  data: {
+    test: [{ x: 1, y: 3 }]
+  },
+  styles: [
+    {
+      name: 'array.table',
+      classNames: ['array-table-layout', 'control']
+    }
+  ]
+};
+
 describe('Tabe array tester', () => {
   test('tester with recursive document ref only', () => {
     const control: ControlElement = {
@@ -309,6 +343,36 @@ describe('Tabe array control', () => {
     const noDataColumn = noDataRow.children[0];
     expect(noDataColumn.tagName).toBe('TD');
     expect(noDataColumn.textContent).toBe('No data');
+  });
+
+  test('use property title as a column header if it exists', () => {
+    const store = initJsonFormsVanillaStore({
+      data: fixture2.data,
+      schema: fixture2.schema,
+      uischema: fixture2.uischema,
+      cells: [
+        { tester: integerCellTester, cell: IntegerCell }
+      ]
+    });
+    wrapper = mount(
+      <Provider store={store}>
+        <JsonFormsReduxContext>
+          <TableArrayControl
+            schema={fixture2.schema}
+            uischema={fixture2.uischema}
+          />
+        </JsonFormsReduxContext>
+      </Provider>
+    );
+
+    //column headings are wrapped in a <thead> tag
+    const headers = wrapper.find('thead').find('th');
+
+    // the first property has a title, so we expect it to be rendered as the first column heading
+    expect(headers.at(0).text()).toEqual("Column X");
+
+    // the second property has no title, so we expect to see the property name in start case
+    expect(headers.at(1).text()).toEqual("Y");
   });
 
   test('render new child (empty init data)', () => {
@@ -653,4 +717,6 @@ describe('Tabe array control', () => {
     expect(validation.at(1).getDOMNode().textContent).toBe('is a required property');
     expect(validation.at(2).getDOMNode().textContent).toBe('is a required property');
   });
+
+  
 });


### PR DESCRIPTION
This is intended to address this issue: https://github.com/eclipsesource/jsonforms/issues/1610 (Table column should respect 'title' #1610)