### PR TITLE
Add RadioGroupControl support for "oneOf" enums

### DIFF
--- a/packages/examples/src/radioGroup.ts
+++ b/packages/examples/src/radioGroup.ts
@@ -33,17 +33,49 @@ const schema = {
       exampleRadioEnum: {
         type: 'string',
         enum: ['One', 'Two', 'Three']
-      }
+      },
+      exampleRadioOneOfEnum: {
+        type: 'string',
+        oneOf: [
+            {const: 'foo', title: 'Foo'},
+            {const: 'bar', title: 'Bar'},
+            {const: 'foobar', title: 'FooBar'}
+        ]
+    }
     }
   };
+ const uischema = {
+   type: 'VerticalLayout',
+   elements: [
+     {
+       type: 'Group',
+       label: 'Simple enum',
+       elements: [
+         {
+           type: 'Control',
+           scope: '#/properties/exampleRadioEnum',
+           options: {
+             format: 'radio'
+           }
+         }
+       ]
+     },
+     {
+       type: 'Group',
+       label: 'One of Enum',
+       elements: [
+         {
+           type: 'Control',
+           scope: '#/properties/exampleRadioOneOfEnum',
+           options: {
+             format: 'radio'
+           }
+         }
+       ]
+     }
+   ]
+ };
 
-const uischema = {
-    type: 'Control',
-    scope: '#/properties/exampleRadioEnum',
-    options: {
-      format: 'radio'
-    }
-  };
 
 registerExamples([
   {

--- a/packages/material/src/controls/MaterialOneOfRadioGroupControl.tsx
+++ b/packages/material/src/controls/MaterialOneOfRadioGroupControl.tsx
@@ -1,7 +1,7 @@
 /*
   The MIT License
 
-  Copyright (c) 2017-2019 EclipseSource Munich
+  Copyright (c) 2018-2020 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -24,19 +24,24 @@
 */
 import React from 'react';
 import {
-  and,
+    and,
   ControlProps,
-  isEnumControl,
-  optionIs, OwnPropsOfEnum, RankedTester, rankWith
+  isOneOfEnumControl,
+  optionIs,
+  OwnPropsOfEnum,
+  RankedTester,
+  rankWith,
 } from '@jsonforms/core';
-import {  withJsonFormsEnumProps } from '@jsonforms/react';
+import { withJsonFormsOneOfEnumProps } from '@jsonforms/react';
 import { MaterialRadioGroup } from './MaterialRadioGroup';
-export const MaterialRadioGroupControl = (props: ControlProps & OwnPropsOfEnum) => {
-   return <MaterialRadioGroup {...props} />;
+
+export const MaterialOneOfRadioGroupControl = (props: ControlProps & OwnPropsOfEnum) => {
+   return <MaterialRadioGroup {...props}/>;
 };
 
-export const materialRadioGroupControlTester: RankedTester = rankWith(
-  20,
-  and(isEnumControl, optionIs('format', 'radio'))
-);
-export default withJsonFormsEnumProps(MaterialRadioGroupControl);
+export const materialOneOfRadioGroupControlTester: RankedTester = rankWith(
+    20,
+    and(isOneOfEnumControl, optionIs('format', 'radio'))
+  );
+
+export default withJsonFormsOneOfEnumProps(MaterialOneOfRadioGroupControl);

--- a/packages/material/src/controls/MaterialRadioGroup.tsx
+++ b/packages/material/src/controls/MaterialRadioGroup.tsx
@@ -1,0 +1,114 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import merge from 'lodash/merge';
+import React from 'react';
+import {
+  computeLabel,
+  ControlProps,
+  ControlState,
+  isDescriptionHidden,
+  isPlainLabel,
+  OwnPropsOfEnum
+} from '@jsonforms/core';
+import { Control } from '@jsonforms/react';
+import Radio from '@material-ui/core/Radio';
+import RadioGroup from '@material-ui/core/RadioGroup';
+import {
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  FormLabel,
+  Hidden
+} from '@material-ui/core';
+
+export class MaterialRadioGroup extends Control<
+  ControlProps & OwnPropsOfEnum,
+  ControlState
+> {
+  render() {
+    const {
+      config,
+      id,
+      label,
+      required,
+      description,
+      errors,
+      data,
+      visible,
+      options
+    } = this.props;
+    const isValid = errors.length === 0;
+    const appliedUiSchemaOptions = merge(
+      {},
+      config,
+      this.props.uischema.options
+    );
+    const showDescription = !isDescriptionHidden(
+      visible,
+      description,
+      this.state.isFocused,
+      appliedUiSchemaOptions.showUnfocusedDescription
+    );
+
+    return (
+      <Hidden xsUp={!visible}>
+        <FormControl
+          component={'fieldset' as 'div'}
+          fullWidth={!appliedUiSchemaOptions.trim}
+        >
+          <FormLabel
+            htmlFor={id}
+            error={!isValid}
+            component={'legend' as 'label'}
+          >
+            {computeLabel(
+              isPlainLabel(label) ? label : label.default,
+              required,
+              appliedUiSchemaOptions.hideRequiredAsterisk
+            )}
+          </FormLabel>
+
+          <RadioGroup
+            value={this.state.value}
+            onChange={(_ev, value) => this.handleChange(value)}
+            row={true}
+          >
+            {options.map(option => (
+              <FormControlLabel
+                value={option.value}
+                key={option.label}
+                control={<Radio checked={data === option.value} />}
+                label={option.label}
+              />
+            ))}
+          </RadioGroup>
+          <FormHelperText error={!isValid}>
+            {!isValid ? errors : showDescription ? description : null}
+          </FormHelperText>
+        </FormControl>
+      </Hidden>
+    );
+  }
+}

--- a/packages/material/src/controls/index.ts
+++ b/packages/material/src/controls/index.ts
@@ -73,6 +73,11 @@ import MaterialOneOfEnumControl, {
   MaterialOneOfEnumControl as MaterialOneOfEnumControlUnwrapped
 } from './MaterialOneOfEnumControl';
 
+import MaterialOneOfRadioGroupControl, {
+  materialOneOfRadioGroupControlTester,
+  MaterialOneOfRadioGroupControl as MaterialOneOfRadioGroupControlUnwrapped
+} from './MaterialOneOfRadioGroupControl';
+
 export const Unwrapped = {
   MaterialBooleanControl: MaterialBooleanControlUnwrapped,
   MaterialEnumControl: MaterialEnumControlUnwrapped,
@@ -86,6 +91,7 @@ export const Unwrapped = {
   MaterialTextControl: MaterialTextControlUnwrapped,
   MaterialAnyOfStringOrEnumControl: MaterialAnyOfStringOrEnumControlUnwrapped,
   MaterialOneOfEnumControl: MaterialOneOfEnumControlUnwrapped,
+  MaterialOneOfRadioGroupControl: MaterialOneOfRadioGroupControlUnwrapped
 };
 
 export {
@@ -112,5 +118,7 @@ export {
   MaterialAnyOfStringOrEnumControl,
   materialAnyOfStringOrEnumControlTester,
   MaterialOneOfEnumControl,
-  materialOneOfEnumControlTester
+  materialOneOfEnumControlTester,
+  MaterialOneOfRadioGroupControl,
+  materialOneOfRadioGroupControlTester
 };

--- a/packages/material/src/index.ts
+++ b/packages/material/src/index.ts
@@ -69,6 +69,8 @@ import {
   materialSliderControlTester,
   MaterialTextControl,
   materialTextControlTester,
+  MaterialOneOfRadioGroupControl,
+  materialOneOfRadioGroupControlTester
 } from './controls';
 import {
   MaterialArrayLayout,
@@ -133,6 +135,10 @@ export const materialRenderers: JsonFormsRendererRegistryEntry[] = [
   {
     tester: materialRadioGroupControlTester,
     renderer: MaterialRadioGroupControl
+  },
+  {
+    tester: materialOneOfRadioGroupControlTester,
+    renderer: MaterialOneOfRadioGroupControl
   },
   { tester: materialOneOfEnumControlTester, renderer: MaterialOneOfEnumControl },
   // layouts

--- a/packages/material/test/renderers/MaterialOneOfRadioGroupControl.test.tsx
+++ b/packages/material/test/renderers/MaterialOneOfRadioGroupControl.test.tsx
@@ -1,0 +1,107 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import './MatchMediaMock';
+import * as React from 'react';
+import {
+  ControlElement,
+  NOT_APPLICABLE,
+} from '@jsonforms/core';
+import MaterialOneOfRadioGroupControl, {
+  materialOneOfRadioGroupControlTester
+} from '../../src/controls/MaterialOneOfRadioGroupControl';
+import { materialRenderers } from '../../src';
+import Enzyme, { mount, ReactWrapper } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import {
+  JsonFormsStateProvider
+} from '@jsonforms/react';
+import { initCore } from './util';
+Enzyme.configure({ adapter: new Adapter() });
+
+const oneOfSchema = {
+  type: 'object',
+  properties: {
+    foo: {
+      type: 'string',
+      oneOf: [
+        { const: 'A', title: 'Option A' },
+        { const: 'B' },
+        { const: 'C', title: 'Option C' }
+      ]
+    }
+  }
+};
+const uischema: ControlElement = {
+  type: 'Control',
+  scope: '#/properties/foo',
+  options: {
+    format: 'radio'
+  }
+};
+
+describe('Material oneof radio group tester', () => {
+  it('should return valid rank for oneof enums with radio format', () => {
+    const rank = materialOneOfRadioGroupControlTester(uischema, oneOfSchema);
+    expect(rank).not.toBe(NOT_APPLICABLE);
+  });
+
+  it('should return NOT_APPLICABLE for enums without radio format', () => {
+    const uiSchemaNoRadio = {
+      type: 'Control',
+      scope: '#/properties/foo'
+    };
+    const rank = materialOneOfRadioGroupControlTester(
+      uiSchemaNoRadio,
+      oneOfSchema
+    );
+    expect(rank).toBe(NOT_APPLICABLE);
+  });
+});
+
+describe('Material oneof radio group control', () => {
+  let wrapper: ReactWrapper;
+
+  afterEach(() => wrapper.unmount());
+
+  it('should render oneOf schemas ', () => {
+    const core = initCore(oneOfSchema, uischema, { foo: 'B' });
+
+    wrapper = mount(
+      <JsonFormsStateProvider
+        initState={{ renderers: materialRenderers, core }}
+      >
+        <MaterialOneOfRadioGroupControl
+          schema={oneOfSchema}
+          uischema={uischema}
+        />
+      </JsonFormsStateProvider>
+    );
+    const inputs = wrapper.find('input[type="radio"]');
+    expect(inputs.length).toBe(3);
+    const currentlyChecked = inputs.find('[checked=true]');
+    expect(currentlyChecked.length).toBe(1);
+    expect(currentlyChecked.first().props().value).toBe('B');
+  });
+});


### PR DESCRIPTION
- the radio group control can now handle 'oneOf' schemas as well. If the
oneOf item has a title, it will be shown as the label for the option
- update Radio Group example with a oneOf demo
- add test