### PR TITLE
Improve performance

### DIFF
--- a/packages/core/src/actions/index.ts
+++ b/packages/core/src/actions/index.ts
@@ -32,6 +32,7 @@ import { UISchemaTester } from '../reducers/uischemas';
 import { ValidationMode } from '../reducers/core';
 
 export const INIT: 'jsonforms/INIT' = 'jsonforms/INIT';
+export const UPDATE_CORE: 'jsonforms/UPDATE_CORE' = `jsonforms/UPDATE_CORE`;
 export const SET_AJV: 'jsonforms/SET_AJV' = 'jsonforms/SET_AJV';
 export const UPDATE_DATA: 'jsonforms/UPDATE' = 'jsonforms/UPDATE';
 export const UPDATE_ERRORS: 'jsonforms/UPDATE_ERRORS' =
@@ -61,6 +62,7 @@ export const REMOVE_DEFAULT_DATA: 'jsonforms/REMOVE_DEFAULT_DATA' = `jsonforms/R
 
 export type CoreActions =
   | InitAction
+  | UpdateCoreAction
   | UpdateAction
   | UpdateErrorsAction
   | SetAjvAction
@@ -87,6 +89,14 @@ export interface InitAction {
   options?: InitActionOptions | AJV.Ajv;
 }
 
+export interface UpdateCoreAction {
+  type: 'jsonforms/UPDATE_CORE';
+  data?: any;
+  schema?: JsonSchema;
+  uischema?: UISchemaElement;
+  options?: InitActionOptions | AJV.Ajv;
+}
+
 export interface InitActionOptions {
   ajv?: AJV.Ajv;
   refParserOptions?: RefParser.Options;
@@ -109,6 +119,19 @@ export const init = (
   schema,
   uischema:
     typeof uischema === 'object' ? uischema : generateDefaultUISchema(schema),
+  options
+});
+
+export const updateCore = (
+  data: any,
+  schema: JsonSchema,
+  uischema?: UISchemaElement,
+  options?: AJV.Ajv | InitActionOptions
+): UpdateCoreAction => ({
+  type: UPDATE_CORE,
+  data,
+  schema,
+  uischema,
   options
 });
 

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -250,10 +250,12 @@ export const coreReducer: Reducer<JsonFormsCore, CoreActions> = (
       const v = needsNewValidator
         ? reuseAjvForSchema(state.ajv, action.schema).compile(action.schema)
         : state.validator;
+      const errors = sanitizeErrors(v, state.data);
       return {
         ...state,
         validator: v,
-        schema: action.schema
+        schema: action.schema,
+        errors
       };
     }
     case SET_UISCHEMA: {

--- a/packages/core/test/reducers/core.test.ts
+++ b/packages/core/test/reducers/core.test.ts
@@ -35,7 +35,7 @@ import {
   subErrorsAt
 } from '../../src/reducers/core';
 
-import { createAjv } from '../../src';
+import { createAjv, updateCore } from '../../src';
 import { setSchema, setValidationMode } from '../../lib';
 import { cloneDeep } from 'lodash';
 
@@ -1437,6 +1437,82 @@ test('core reducer - update - ValidateAndHide should produce errors', t => {
     update('animal', () => 100)
   );
   t.is(after.errors.length, 1);
+});
+
+test('core reducer - update core - state should be unchanged when nothing changes', t => {
+  const schema = {
+    type: 'object',
+    properties: {
+      animal: {
+        type: 'string'
+      }
+    }
+  };
+
+  const data = {
+    animal: 'dog'
+  };
+  const before: JsonFormsCore = coreReducer(
+    undefined,
+    init(data, schema)
+    );
+
+  const after: JsonFormsCore = coreReducer(
+    before,
+    updateCore(before.data, before.schema, before.uischema, before.ajv)
+  );
+  t.true(before === after);
+});
+
+test('core reducer - update core - unchanged state properties should be unchanged when state changes', t => {
+  const schema = {
+    type: 'object',
+    properties: {
+      animal: {
+        type: 'string'
+      }
+    }
+  };
+
+  const data = {
+    animal: 'dog'
+  };
+  const before: JsonFormsCore = coreReducer(
+    undefined,
+    init(data, schema)
+    );
+
+  const afterDataUpdate: JsonFormsCore = coreReducer(
+    before,
+    updateCore({
+      animal: 'cat'
+    }, before.schema, before.uischema, before.ajv)
+  );
+  t.true(before.schema === afterDataUpdate.schema);
+  t.true(before.ajv === afterDataUpdate.ajv);
+  t.true(before.errors === afterDataUpdate.errors);
+  t.true(before.refParserOptions === afterDataUpdate.refParserOptions);
+  t.true(before.uischema === afterDataUpdate.uischema);
+  t.true(before.validationMode === afterDataUpdate.validationMode);
+  t.true(before.validator === afterDataUpdate.validator);
+
+  const updatedSchema = {
+    type: 'object',
+    properties: {
+      animal: {
+        type: 'string'
+      },
+      id: {
+        type: 'number'
+      }
+    }
+  };
+  // check that data stays unchanged as well
+  const afterSchemaUpdate : JsonFormsCore = coreReducer(
+    before,
+    updateCore(before.data, updatedSchema, before.uischema, before.ajv)
+  );
+  t.true(before.data === afterSchemaUpdate.data);
 });
 
 test('core reducer - setSchema - schema with id', t => {

--- a/packages/material/src/additional/MaterialListWithDetailRenderer.tsx
+++ b/packages/material/src/additional/MaterialListWithDetailRenderer.tsx
@@ -42,7 +42,7 @@ import {
 import { Grid, Hidden, List, Typography } from '@material-ui/core';
 import map from 'lodash/map';
 import range from 'lodash/range';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { ArrayLayoutToolbar } from '../layouts/ArrayToolbar';
 import ListWithDetailMasterItem from './ListWithDetailMasterItem';
 import merge from 'lodash/merge';
@@ -83,13 +83,17 @@ export const MaterialListWithDetailRenderer = ({
     () => createDefaultValue(schema),
     [createDefaultValue]
   );
-  const foundUISchema = findUISchema(
-    uischemas,
-    schema,
-    uischema.scope,
-    path,
-    undefined,
-    uischema
+  const foundUISchema = useMemo(
+    () =>
+      findUISchema(
+        uischemas,
+        schema,
+        uischema.scope,
+        path,
+        undefined,
+        uischema
+      ),
+    [uischemas, schema, uischema.scope, path, uischema]
   );
   const appliedUiSchemaOptions = merge({}, config, uischema.options);
 

--- a/packages/material/src/complex/MaterialObjectRenderer.tsx
+++ b/packages/material/src/complex/MaterialObjectRenderer.tsx
@@ -35,7 +35,7 @@ import {
 } from '@jsonforms/core';
 import { ResolvedJsonFormsDispatch, withJsonFormsDetailProps } from '@jsonforms/react';
 import { Hidden } from '@material-ui/core';
-import React from 'react';
+import React, { useMemo } from 'react';
 
 const MaterialObjectRenderer = ({
   renderers,
@@ -49,14 +49,18 @@ const MaterialObjectRenderer = ({
   uischema,
   rootSchema
 }: StatePropsOfControlWithDetail) => {
-  const detailUiSchema = findUISchema(
-    uischemas,
-    schema,
-    uischema.scope,
-    path,
-    'Group',
-    uischema,
-    rootSchema
+  const detailUiSchema = useMemo(
+    () =>
+      findUISchema(
+        uischemas,
+        schema,
+        uischema.scope,
+        path,
+        'Group',
+        uischema,
+        rootSchema
+      ),
+    [uischemas, schema, uischema.scope, path, uischema, rootSchema]
   );
   if (isEmpty(path)) {
     detailUiSchema.type = 'VerticalLayout';

--- a/packages/material/src/layouts/ExpandPanelRenderer.tsx
+++ b/packages/material/src/layouts/ExpandPanelRenderer.tsx
@@ -1,6 +1,6 @@
 import merge from 'lodash/merge';
 import get from 'lodash/get';
-import React, { Dispatch, Fragment, ReducerAction, useState } from 'react';
+import React, { Dispatch, Fragment, ReducerAction, useMemo, useState } from 'react';
 import { ComponentType } from 'enzyme';
 import {
   areEqual,
@@ -97,14 +97,18 @@ const ExpandPanelRenderer = (props: ExpandPanelProps) => {
     config
   } = props;
 
-  const foundUISchema = findUISchema(
-    uischemas,
-    schema,
-    uischema.scope,
-    path,
-    undefined,
-    uischema,
-    rootSchema
+  const foundUISchema = useMemo(
+    () =>
+      findUISchema(
+        uischemas,
+        schema,
+        uischema.scope,
+        path,
+        undefined,
+        uischema,
+        rootSchema
+      ),
+    [uischemas, schema, uischema.scope, path, uischema, rootSchema]
   );
 
   const appliedUiSchemaOptions = merge({}, config, uischema.options);

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -25,7 +25,7 @@
 import isEqual from 'lodash/isEqual';
 import maxBy from 'lodash/maxBy';
 import memoize from 'lodash/memoize';
-import React, { useLayoutEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import AJV from 'ajv';
 import RefParser from 'json-schema-ref-parser';
 import { UnknownRenderer } from './UnknownRenderer';
@@ -212,10 +212,6 @@ export class JsonFormsDispatchRenderer extends ResolvedJsonFormsDispatchRenderer
 function useJsonFormsDispatchRendererProps(props: OwnPropsOfJsonFormsRenderer & JsonFormsReactProps) {
   const ctx = useJsonForms();
   const { refResolver } = ctxToJsonFormsDispatchProps(ctx, props);
-  const { data, errors } = ctx.core;
-  useLayoutEffect(() => {
-    props.onChange && props.onChange({ data, errors });
-  }, [data, errors]);
 
   return {
     schema: props.schema || ctx.core.schema,
@@ -301,8 +297,9 @@ export const JsonForms = (
         cells,
         readonly,
       }}
+      onChange={onChange}
     >
-      <JsonFormsDispatch onChange={onChange}/>
+      <JsonFormsDispatch />
     </JsonFormsStateProvider>
   );
 };

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -146,25 +146,56 @@ export class ResolvedJsonFormsDispatchRenderer extends React.Component<
       return <div>Loading...</div>;
     }
 
-    const renderer = maxBy(renderers, r => r.tester(uischema, _schema));
-    if (renderer === undefined || renderer.tester(uischema, _schema) === -1) {
+    return (
+      <TestAndRender
+        uischema={uischema}
+        schema={_schema}
+        path={path}
+        enabled={enabled}
+        renderers={renderers}
+        cells={cells}
+        id={this.state.id}
+      />
+    );
+  }
+}
+
+const TestAndRender = React.memo(
+  (props: {
+    uischema: UISchemaElement;
+    schema: JsonSchema;
+    path: string;
+    enabled: boolean;
+    renderers: JsonFormsRendererRegistryEntry[];
+    cells: JsonFormsCellRendererRegistryEntry[];
+    id: string;
+  }) => {
+    const renderer = useMemo(
+      () => maxBy(props.renderers, r => r.tester(props.uischema, props.schema)),
+      [props.renderers, props.uischema, props.schema]
+    );
+    if (
+      renderer === undefined ||
+      renderer.tester(props.uischema, props.schema) === -1
+    ) {
       return <UnknownRenderer type={'renderer'} />;
     } else {
       const Render = renderer.renderer;
       return (
         <Render
-          uischema={uischema}
-          schema={_schema}
-          path={path}
-          enabled={enabled}
-          renderers={renderers}
-          cells={cells}
-          id={this.state.id}
+          uischema={props.uischema}
+          schema={props.schema}
+          path={props.path}
+          enabled={props.enabled}
+          renderers={props.renderers}
+          cells={props.cells}
+          id={props.id}
         />
       );
     }
   }
-}
+);
+
 
 export class JsonFormsDispatchRenderer extends ResolvedJsonFormsDispatchRenderer {
   constructor(props: JsonFormsProps) {
@@ -271,7 +302,7 @@ export const JsonForms = (
         readonly,
       }}
     >
-      <JsonFormsDispatch onChange={onChange} />
+      <JsonFormsDispatch onChange={onChange}/>
     </JsonFormsStateProvider>
   );
 };

--- a/packages/react/src/JsonFormsContext.tsx
+++ b/packages/react/src/JsonFormsContext.tsx
@@ -110,7 +110,7 @@ const useEffectAfterFirstRender = (
   }, dependencies);
 };
 
-export const JsonFormsStateProvider = ({ children, initState }: any) => {
+export const JsonFormsStateProvider = ({ children, initState, onChange }: any) => {
   const { data, schema, uischema, ajv, refParserOptions , validationMode} = initState.core;
   // Initialize core immediately
   const [core, coreDispatch] = useReducer(
@@ -146,6 +146,15 @@ export const JsonFormsStateProvider = ({ children, initState }: any) => {
     // only core dispatch available
     dispatch: coreDispatch,
   }), [core, initState.renderers, initState.cells, config, initState.readonly]);
+
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    onChangeRef.current?.({ data: core.data, errors: core.errors });
+  }, [core.data, core.errors]);
 
   return (
     <JsonFormsContext.Provider

--- a/packages/react/src/JsonFormsContext.tsx
+++ b/packages/react/src/JsonFormsContext.tsx
@@ -120,9 +120,9 @@ export const JsonFormsStateProvider = ({ children, initState }: any) => {
       Actions.init(data, schema, uischema, { ajv, refParserOptions, validationMode })
     )
   );
-  useEffectAfterFirstRender(() => {
+  useEffect(() => {
     coreDispatch(
-      Actions.init(data, schema, uischema, { ajv, refParserOptions, validationMode })
+      Actions.updateCore(data, schema, uischema, { ajv, refParserOptions, validationMode })
     );
   }, [data, schema, uischema, ajv, refParserOptions, validationMode]);
 

--- a/packages/react/test/renderers/JsonForms.test.tsx
+++ b/packages/react/test/renderers/JsonForms.test.tsx
@@ -312,7 +312,7 @@ test('render schema with $ref', () => {
   const promise = Promise.resolve(resolvedSchema);
   jest.spyOn(RefParser, 'dereference').mockImplementation(() => promise);
 
-  const wrapper = shallow(
+  const wrapper = mount(
     <JsonFormsDispatchRenderer
       path={''}
       uischema={fixture.uischema}

--- a/packages/vanilla/src/complex/array/ArrayControl.tsx
+++ b/packages/vanilla/src/complex/array/ArrayControl.tsx
@@ -23,7 +23,7 @@
   THE SOFTWARE.
 */
 import range from 'lodash/range';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { ArrayControlProps, composePaths, createDefaultValue, findUISchema } from '@jsonforms/core';
 import { ResolvedJsonFormsDispatch } from '@jsonforms/react';
 import { VanillaRendererProps } from '../../index';
@@ -39,6 +39,10 @@ export const ArrayControl = ({
   uischemas,
   renderers
 }: ArrayControlProps & VanillaRendererProps) => {
+  const childUiSchema = useMemo(
+    () => findUISchema(uischemas, schema, uischema.scope, path),
+    [uischemas, schema, uischema.scope, path]
+  );
   return (
     <div className={classNames.wrapper}>
       <fieldset className={classNames.fieldSet}>
@@ -54,13 +58,12 @@ export const ArrayControl = ({
         <div className={classNames.children}>
           {data ? (
             range(0, data.length).map(index => {
-              const foundUISchema = findUISchema(uischemas, schema, uischema.scope, path);
               const childPath = composePaths(path, `${index}`);
 
               return (
                 <ResolvedJsonFormsDispatch
                   schema={schema}
-                  uischema={foundUISchema || uischema}
+                  uischema={childUiSchema || uischema}
                   path={childPath}
                   key={childPath}
                   renderers={renderers}


### PR DESCRIPTION
### Avoid unnecessary initialization calls in React
Use the initialization function of 'useReducer' to avoid unnecessary dispatching of init actions whose result is ignored anyway.

### Make sure validation is run on set schema

### Only update state with changed properties of JsonFormsCore
Instead of calling the INIT action when one of the core properties changes, introduce a new action (UPDATE_CORE) which updates only the changed properties in the state.