### PR TITLE
Fix useLayoutEffect warning for SSR with React

### DIFF
--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -25,7 +25,8 @@
 import isEqual from 'lodash/isEqual';
 import maxBy from 'lodash/maxBy';
 import memoize from 'lodash/memoize';
-import React, { useLayoutEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
+import { useIsomorphicLayoutEffect } from './hooks/useIsomorphicLayoutEffect';
 import AJV from 'ajv';
 import RefParser from 'json-schema-ref-parser';
 import { UnknownRenderer } from './UnknownRenderer';

--- a/packages/react/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/packages/react/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,29 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+import { useLayoutEffect, useEffect } from 'react';
+
+export const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;


### PR DESCRIPTION
We tried using the JsonForms component when doing server side rendering with react using
ReactDomServer and because of the use of the useLayoutEffect hook, we would get a  warning of 'Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format...' all the time.

This pull request removes the warning by using useEffect instead if we are not in the browser.

Thank you!