### PR TITLE
Make Angular component consumable multiple times

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,3 +1,47 @@
+# Migrating to JSON Forms 2.5 for Angular users
+The JsonFormsAngularService is not provided in the root anymore. 
+To keep the old behavior, you need to provide it manually in the module.
+
+The preferred way is using the new JsonForms Component though.
+This component wraps the service and allows the user to interact with it using databinding.
+
+Example:
+
+```ts
+import { Component } from '@angular/core';
+import { angularMaterialRenderers } from '../../src/index';
+export const schema = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string'
+    }
+  },
+  required: ['name']
+};
+export const data = {name: 'Send email to Adrian'};
+
+@Component({
+  selector: 'app-root',
+  template: `
+    <div>Data: {{ data | json }}</div>
+    <jsonforms
+      [data]="data"
+      [schema]="schema"
+      [renderers]="renderers"
+      (dataChange)="onDataChange($event)"
+    ></jsonforms>
+  `
+})
+export class AppComponent {
+  readonly renderers = angularMaterialRenderers;
+  data: any;
+  onDataChange(data: any) {
+    this.data = data;
+  }
+}
+```
+
 # Migrating to JSON Forms 2.5 for React users
 
 In version 2.5 we made the `redux` dependency within the `react` package optional.

--- a/packages/angular-material/example/app/app.module.ts
+++ b/packages/angular-material/example/app/app.module.ts
@@ -1,7 +1,7 @@
 /*
   The MIT License
 
-  Copyright (c) 2017-2019 EclipseSource Munich
+  Copyright (c) 2017-2020 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -25,12 +25,8 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
-import { Actions, UISchemaTester } from '@jsonforms/core';
 import { AppComponent } from './app.component';
 import { JsonFormsAngularMaterialModule } from '../../src/module';
-
-import { initialState } from './store';
-import { JsonFormsAngularService } from '@jsonforms/angular';
 
 @NgModule({
   declarations: [AppComponent],
@@ -43,40 +39,4 @@ import { JsonFormsAngularService } from '@jsonforms/angular';
   schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })
 export class AppModule {
-  constructor(jsonformsService: JsonFormsAngularService) {
-
-    jsonformsService.init(initialState.jsonforms);
-    const example = initialState.examples.data[19];
-
-    jsonformsService.updateCore(
-      Actions.init(example.data, example.schema, example.uischema)
-    );
-
-    const uiSchema = {
-      type: 'HorizontalLayout',
-      elements: [
-        {
-          type: 'Control',
-          scope: '#/properties/buyer/properties/email'
-        },
-        {
-          type: 'Control',
-          scope: '#/properties/status'
-        }
-      ]
-    };
-    const itemTester: UISchemaTester = (_schema, schemaPath, _path) => {
-      if (schemaPath === '#/properties/warehouseitems/items') {
-        return 10;
-      }
-      return -1;
-    };
-    jsonformsService.updateUiSchema(Actions.registerUISchema(itemTester, uiSchema));
-  }
 }
-
-/*
-Copyright 2017-2018 Google Inc. All Rights Reserved.
-Use of this source code is governed by an MIT-style license that
-can be found in the LICENSE file at http://angular.io/license
-*/

--- a/packages/angular-material/test/autocomplete-control.spec.ts
+++ b/packages/angular-material/test/autocomplete-control.spec.ts
@@ -304,9 +304,12 @@ describe('AutoComplete control Error Tests', () => {
     setupMockStore(fixture, {
       uischema,
       schema,
-      data,
-      errors
+      data
     });
+    const formsService = getJsonFormsService(component);
+    formsService.updateCore(Actions.updateErrors(errors));
+    formsService.refresh();
+
     component.ngOnInit();
     fixture.detectChanges();
     const debugErrors: DebugElement[] = fixture.debugElement.queryAll(

--- a/packages/angular-material/test/date-control.spec.ts
+++ b/packages/angular-material/test/date-control.spec.ts
@@ -180,8 +180,9 @@ describe('Date control Base Tests', () => {
   it('id should be present in output', () => {
     component.uischema = uischema;
     component.id = 'myId';
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(Actions.init(data, schema));
+    getJsonFormsService(component).init(
+      {core: {data: data, schema: schema, uischema: uischema}}
+    );
 
     component.ngOnInit();
     fixture.detectChanges();
@@ -251,17 +252,19 @@ describe('Date control Error Tests', () => {
     setupMockStore(fixture, {
       uischema,
       schema,
-      data,
-      errors: [
-        {
-          dataPath: 'foo',
-          message: 'Hi, this is me, test error!',
-          params: '',
-          keyword: '',
-          schemaPath: ''
-        }
-      ]
+      data
     });
+    const formsService = getJsonFormsService(component);
+    formsService.updateCore(Actions.updateErrors([
+      {
+        dataPath: 'foo',
+        message: 'Hi, this is me, test error!',
+        params: '',
+        keyword: '',
+        schemaPath: ''
+      }
+    ]));
+    formsService.refresh();
 
     component.ngOnInit();
     fixture.detectChanges();

--- a/packages/angular-test/src/boolean.ts
+++ b/packages/angular-test/src/boolean.ts
@@ -90,9 +90,8 @@ export const booleanBaseTest = <C extends JsonFormsControl, I>(
   it('should render', () => {
     component.uischema = uischema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(data, defaultBooleanTestSchema)
+    getJsonFormsService(component).init(
+      {core: {data: data, schema: defaultBooleanTestSchema, uischema: uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -108,9 +107,8 @@ export const booleanBaseTest = <C extends JsonFormsControl, I>(
   it('should support updating the state', () => {
     component.uischema = uischema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(data, defaultBooleanTestSchema)
+    getJsonFormsService(component).init(
+      {core: {data: data, schema: defaultBooleanTestSchema, uischema: uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -125,9 +123,8 @@ export const booleanBaseTest = <C extends JsonFormsControl, I>(
   it('should update with undefined value', () => {
     component.uischema = uischema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(data, defaultBooleanTestSchema)
+    getJsonFormsService(component).init(
+      {core: {data: data, schema: defaultBooleanTestSchema, uischema: uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -142,9 +139,8 @@ export const booleanBaseTest = <C extends JsonFormsControl, I>(
   it('should update with null value', () => {
     component.uischema = uischema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(data, defaultBooleanTestSchema)
+    getJsonFormsService(component).init(
+      {core: {data: data, schema: defaultBooleanTestSchema, uischema: uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -159,9 +155,8 @@ export const booleanBaseTest = <C extends JsonFormsControl, I>(
   it('should not update with wrong ref', () => {
     component.uischema = uischema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(data, defaultBooleanTestSchema)
+    getJsonFormsService(component).init(
+      {core: {data: data, schema: defaultBooleanTestSchema, uischema: uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -181,9 +176,8 @@ export const booleanBaseTest = <C extends JsonFormsControl, I>(
     component.uischema = uischema;
     component.disabled = true;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(data, defaultBooleanTestSchema)
+    getJsonFormsService(component).init(
+      {core: {data: data, schema: defaultBooleanTestSchema, uischema: uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -194,9 +188,8 @@ export const booleanBaseTest = <C extends JsonFormsControl, I>(
     component.uischema = uischema;
     component.visible = false;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(data, defaultBooleanTestSchema)
+    getJsonFormsService(component).init(
+      {core: {data: data, schema: defaultBooleanTestSchema, uischema: uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -211,9 +204,8 @@ export const booleanBaseTest = <C extends JsonFormsControl, I>(
     component.uischema = uischema;
     component.id = 'myId';
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(data, defaultBooleanTestSchema)
+    getJsonFormsService(component).init(
+      {core: {data: data, schema: defaultBooleanTestSchema, uischema: uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -245,9 +237,8 @@ export const booleanInputEventTest = <C extends JsonFormsControl, I>(
 
   it('should update via input event', () => {
     component.uischema = uischema;
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(data, defaultBooleanTestSchema)
+    getJsonFormsService(component).init(
+      {core: {data: data, schema: defaultBooleanTestSchema, uischema: uischema}}
     );
     fixture.detectChanges();
     component.ngOnInit();
@@ -279,22 +270,24 @@ export const booleanErrorTest = <C extends JsonFormsControl, I>(
   it('should display errors', () => {
     component.uischema = uischema;
 
-    getJsonFormsService(component).init({
+    const formsService = getJsonFormsService(component);
+    formsService.init({
       core: {
         data,
         schema: defaultBooleanTestSchema,
-        errors: [
-          {
-            dataPath: 'foo',
-            message: 'Hi, this is me, test error!',
-            keyword: '',
-            params: '',
-            schemaPath: ''
-          }
-        ],
         uischema: undefined
       }
     });
+    formsService.updateCore(Actions.updateErrors([
+      {
+        dataPath: 'foo',
+        message: 'Hi, this is me, test error!',
+        keyword: '',
+        schemaPath: '',
+        params: ''
+      }
+    ]));
+    formsService.refresh();
 
     component.ngOnInit();
     fixture.detectChanges();

--- a/packages/angular-test/src/number.ts
+++ b/packages/angular-test/src/number.ts
@@ -236,9 +236,8 @@ export const numberBaseTest = <C extends JsonFormsControl>(
     component.uischema = testData.uischema;
     component.disabled = true;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(testData.data, testData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: testData.data, schema: testData.schema, uischema: testData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -249,9 +248,8 @@ export const numberBaseTest = <C extends JsonFormsControl>(
     component.uischema = testData.uischema;
     component.visible = false;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(testData.data, testData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: testData.data, schema: testData.schema, uischema: testData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -264,9 +262,8 @@ export const numberBaseTest = <C extends JsonFormsControl>(
   it('id should be present in output', () => {
     component.uischema = testData.uischema;
     component.id = 'myId';
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(testData.data, testData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: testData.data, schema: testData.schema, uischema: testData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -339,22 +336,24 @@ export const numberErrorTest = <C extends JsonFormsControl>(
   it('should display errors', () => {
     component.uischema = testData.uischema;
 
-    getJsonFormsService(component).init({
+    const formsService = getJsonFormsService(component);
+    formsService.init({
       core: {
         data: testData.data,
         schema: testData.schema,
-        errors: [
-          {
-            dataPath: 'foo',
-            message: 'Hi, this is me, test error!',
-            keyword: '',
-            schemaPath: '',
-            params: ''
-          }
-        ],
         uischema: undefined
       }
     });
+    formsService.updateCore(Actions.updateErrors([
+      {
+        dataPath: 'foo',
+        message: 'Hi, this is me, test error!',
+        keyword: '',
+        schemaPath: '',
+        params: ''
+      }
+    ]));
+    formsService.refresh();
     component.ngOnInit();
     fixture.detectChanges();
     const debugErrors: DebugElement[] = fixture.debugElement.queryAll(

--- a/packages/angular-test/src/range.ts
+++ b/packages/angular-test/src/range.ts
@@ -97,9 +97,8 @@ export const rangeBaseTest = <C extends JsonFormsControl, I>(
     component.uischema = rangeDefaultTestData.uischema;
     component.schema = rangeDefaultTestData.schema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(rangeDefaultTestData.data, rangeDefaultTestData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: rangeDefaultTestData.data, schema: rangeDefaultTestData.schema, uischema: rangeDefaultTestData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -146,9 +145,8 @@ export const rangeBaseTest = <C extends JsonFormsControl, I>(
     component.uischema = rangeDefaultTestData.uischema;
     component.schema = rangeDefaultTestData.schema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(rangeDefaultTestData.data, rangeDefaultTestData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: rangeDefaultTestData.data, schema: rangeDefaultTestData.schema, uischema: rangeDefaultTestData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -164,9 +162,8 @@ export const rangeBaseTest = <C extends JsonFormsControl, I>(
     component.uischema = rangeDefaultTestData.uischema;
     component.schema = rangeDefaultTestData.schema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(rangeDefaultTestData.data, rangeDefaultTestData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: rangeDefaultTestData.data, schema: rangeDefaultTestData.schema, uischema: rangeDefaultTestData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -182,9 +179,8 @@ export const rangeBaseTest = <C extends JsonFormsControl, I>(
     component.uischema = rangeDefaultTestData.uischema;
     component.schema = rangeDefaultTestData.schema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(rangeDefaultTestData.data, rangeDefaultTestData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: rangeDefaultTestData.data, schema: rangeDefaultTestData.schema, uischema: rangeDefaultTestData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -200,9 +196,8 @@ export const rangeBaseTest = <C extends JsonFormsControl, I>(
     component.uischema = rangeDefaultTestData.uischema;
     component.schema = rangeDefaultTestData.schema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(rangeDefaultTestData.data, rangeDefaultTestData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: rangeDefaultTestData.data, schema: rangeDefaultTestData.schema, uischema: rangeDefaultTestData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -224,9 +219,8 @@ export const rangeBaseTest = <C extends JsonFormsControl, I>(
     component.schema = rangeDefaultTestData.schema;
     component.disabled = true;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(rangeDefaultTestData.data, rangeDefaultTestData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: rangeDefaultTestData.data, schema: rangeDefaultTestData.schema, uischema: rangeDefaultTestData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -237,9 +231,8 @@ export const rangeBaseTest = <C extends JsonFormsControl, I>(
     component.schema = rangeDefaultTestData.schema;
     component.visible = false;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(rangeDefaultTestData.data, rangeDefaultTestData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: rangeDefaultTestData.data, schema: rangeDefaultTestData.schema, uischema: rangeDefaultTestData.uischema}}
     );
     fixture.detectChanges();
     component.ngOnInit();
@@ -249,9 +242,8 @@ export const rangeBaseTest = <C extends JsonFormsControl, I>(
     component.uischema = rangeDefaultTestData.uischema;
     component.schema = rangeDefaultTestData.schema;
     component.id = 'myId';
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(rangeDefaultTestData.data)
+    getJsonFormsService(component).init(
+      {core: {data: rangeDefaultTestData.data, schema: rangeDefaultTestData.schema, uischema: rangeDefaultTestData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -277,9 +269,8 @@ export const rangeInputEventTest = <C extends JsonFormsControl, I>(
     component.uischema = rangeDefaultTestData.uischema;
     component.schema = rangeDefaultTestData.schema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(rangeDefaultTestData.data, rangeDefaultTestData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: rangeDefaultTestData.data, schema: rangeDefaultTestData.schema, uischema: rangeDefaultTestData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -323,22 +314,25 @@ export const rangeErrorTest = <C extends JsonFormsControl, I>(
     component.uischema = rangeDefaultTestData.uischema;
     component.schema = rangeDefaultTestData.schema;
 
-    getJsonFormsService(component).init({
+    const formsService = getJsonFormsService(component);
+    formsService.init({
       core: {
         data: rangeDefaultTestData.data,
         schema: rangeDefaultTestData.schema,
-        errors: [
-          {
-            dataPath: 'foo',
-            message: 'Hi, this is me, test error!',
-            params: '',
-            schemaPath: '',
-            keyword: ''
-          }
-        ],
         uischema: undefined
       }
     });
+    formsService.updateCore(Actions.updateErrors([
+      {
+        dataPath: 'foo',
+        message: 'Hi, this is me, test error!',
+        keyword: '',
+        schemaPath: '',
+        params: ''
+      }
+    ]));
+    formsService.refresh();
+
     component.ngOnInit();
     fixture.detectChanges();
     const debugErrors: DebugElement[] = fixture.debugElement.queryAll(

--- a/packages/angular-test/src/text.ts
+++ b/packages/angular-test/src/text.ts
@@ -26,13 +26,13 @@ import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { JsonFormsControl } from '@jsonforms/angular';
-import { ControlElement, JsonSchema, Actions } from '@jsonforms/core';
+import { Actions, ControlElement, JsonSchema } from '@jsonforms/core';
 import {
   baseSetup,
   ErrorTestExpectation,
+  getJsonFormsService,
   TestConfig,
-  TestData,
-  getJsonFormsService
+  TestData
 } from './util';
 
 interface ComponentResult<C extends JsonFormsControl> {
@@ -103,9 +103,8 @@ export const textBaseTest = <C extends JsonFormsControl>(
 
   it('should render', () => {
     component.uischema = testData.uischema;
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(testData.data, testData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: testData.data, schema: testData.schema, uischema: testData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -122,9 +121,8 @@ export const textBaseTest = <C extends JsonFormsControl>(
   it('should support updating the state', () => {
     component.uischema = testData.uischema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(testData.data, testData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: testData.data, schema: testData.schema, uischema: testData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -139,9 +137,8 @@ export const textBaseTest = <C extends JsonFormsControl>(
   it('should update with undefined value', () => {
     component.uischema = testData.uischema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(testData.data, testData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: testData.data, schema: testData.schema, uischema: testData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -156,9 +153,8 @@ export const textBaseTest = <C extends JsonFormsControl>(
   it('should update with null value', () => {
     component.uischema = testData.uischema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(testData.data, testData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: testData.data, schema: testData.schema, uischema: testData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -173,9 +169,8 @@ export const textBaseTest = <C extends JsonFormsControl>(
   it('should not update with wrong ref', () => {
     component.uischema = testData.uischema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(testData.data, testData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: testData.data, schema: testData.schema, uischema: testData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -195,9 +190,8 @@ export const textBaseTest = <C extends JsonFormsControl>(
     component.uischema = testData.uischema;
     component.disabled = true;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(testData.data, testData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: testData.data, schema: testData.schema, uischema: testData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -207,9 +201,8 @@ export const textBaseTest = <C extends JsonFormsControl>(
     component.uischema = testData.uischema;
     component.visible = false;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(testData.data, testData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: testData.data, schema: testData.schema, uischema: testData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -221,9 +214,8 @@ export const textBaseTest = <C extends JsonFormsControl>(
   it('id should be present in output', () => {
     component.uischema = testData.uischema;
     component.id = 'myId';
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(testData.data, testData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: testData.data, schema: testData.schema, uischema: testData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -256,9 +248,8 @@ export const textInputEventTest = <C extends JsonFormsControl>(
   it('should update via input event', () => {
     component.uischema = testData.uischema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(testData.data, testData.schema)
+    getJsonFormsService(component).init(
+      {core: {data: testData.data, schema: testData.schema, uischema: testData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -292,22 +283,24 @@ export const textErrorTest = <C extends JsonFormsControl>(
   it('should display errors', () => {
     component.uischema = testData.uischema;
 
-    getJsonFormsService(component).init({
+    const formsService = getJsonFormsService(component);
+    formsService.init({
       core: {
         data: testData.data,
         schema: testData.schema,
-        errors: [
-          {
-            dataPath: 'foo',
-            message: 'Hi, this is me, test error!',
-            keyword: '',
-            schemaPath: '',
-            params: ''
-          }
-        ],
         uischema: undefined
       }
     });
+    formsService.updateCore(Actions.updateErrors([
+      {
+        dataPath: 'foo',
+        message: 'Hi, this is me, test error!',
+        keyword: '',
+        schemaPath: '',
+        params: ''
+      }
+    ]));
+    formsService.refresh();
     component.ngOnInit();
     fixture.detectChanges();
     const debugErrors: DebugElement[] = fixture.debugElement.queryAll(
@@ -350,11 +343,9 @@ export const textTypeTest = <C extends JsonFormsControl>(
     component.uischema = uischema;
     component.schema = schema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(testData.data, schema)
+    getJsonFormsService(component).init(
+      {core: {data: testData.data, schema: schema, uischema: uischema}}
     );
-
     component.ngOnInit();
     fixture.detectChanges();
     expect(textNativeElement.type).toBe('password');
@@ -366,9 +357,8 @@ export const textTypeTest = <C extends JsonFormsControl>(
     component.uischema = testData.uischema;
     component.schema = schema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(testData.data, schema)
+    getJsonFormsService(component).init(
+      {core: {data: testData.data, schema: schema, uischema: testData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();
@@ -381,11 +371,9 @@ export const textTypeTest = <C extends JsonFormsControl>(
     component.uischema = testData.uischema;
     component.schema = schema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(testData.data, schema)
+    getJsonFormsService(component).init(
+      {core: {data: testData.data, schema: schema, uischema: testData.uischema}}
     );
-
     component.ngOnInit();
     fixture.detectChanges();
     expect(textNativeElement.type).toBe('tel');
@@ -397,9 +385,8 @@ export const textTypeTest = <C extends JsonFormsControl>(
     component.uischema = testData.uischema;
     component.schema = schema;
 
-    getJsonFormsService(component).init();
-    getJsonFormsService(component).updateCore(
-      Actions.init(testData.data, schema)
+    getJsonFormsService(component).init(
+      {core: {data: testData.data, schema: schema, uischema: testData.uischema}}
     );
     component.ngOnInit();
     fixture.detectChanges();

--- a/packages/angular-test/src/util.ts
+++ b/packages/angular-test/src/util.ts
@@ -50,7 +50,7 @@ export const baseSetup = <C extends JsonFormsControl>(
     TestBed.configureTestingModule({
       declarations: [testConfig.componentUT],
       imports: testConfig.imports,
-      providers: testConfig.providers
+      providers: [JsonFormsAngularService].concat(testConfig.providers)
     }).compileComponents();
   });
 };

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,7 +1,7 @@
 /*
   The MIT License
   
-  Copyright (c) 2017-2019 EclipseSource Munich
+  Copyright (c) 2017-2020 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
   
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -29,3 +29,4 @@ export * from './jsonforms.component';
 export * from './jsonforms.module';
 export * from './unknown.component';
 export * from './jsonforms.service';
+export * from './jsonforms-root.component';

--- a/packages/angular/src/jsonforms-root.component.ts
+++ b/packages/angular/src/jsonforms-root.component.ts
@@ -1,0 +1,118 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017-2020 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import {
+    Component,
+    EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges
+} from '@angular/core';
+import { JsonFormsRendererRegistryEntry, JsonSchema, UISchemaElement, UISchemaTester, ValidationMode } from '@jsonforms/core';
+import { Ajv } from 'ajv';
+import { JsonFormsAngularService, USE_STATE_VALUE } from './jsonforms.service';
+@Component({
+    selector: 'jsonforms',
+    template: '<jsonforms-outlet></jsonforms-outlet>',
+    providers: [JsonFormsAngularService]
+})
+export class JsonForms implements OnChanges, OnInit {
+
+    @Input() uischema: UISchemaElement;
+    @Input() schema: JsonSchema;
+    @Input() data: any;
+    @Input() renderers: JsonFormsRendererRegistryEntry[];
+    @Input() uischemas: { tester: UISchemaTester; uischema: UISchemaElement; }[];
+    @Output() dataChange = new EventEmitter<any>();
+    @Input() locale: string;
+    @Input() readonly: boolean;
+    @Input() validationMode: ValidationMode;
+    @Input() ajv: Ajv;
+
+    private initialized = false;
+
+    constructor(private jsonformsService: JsonFormsAngularService) {
+    }
+
+    ngOnInit(): void {
+        this.jsonformsService.init({
+            core: {
+                data: this.data,
+                uischema: this.uischema,
+                schema: this.schema,
+                ajv: this.ajv,
+                validationMode: this.validationMode
+            },
+            uischemas: this.uischemas,
+            i18n: { locale: this.locale, localizedSchemas: undefined, localizedUISchemas: undefined },
+            renderers: this.renderers
+        });
+        this.jsonformsService.$state.subscribe(state => {
+            const data = state?.jsonforms?.core?.data;
+            if (data) {
+                this.dataChange.emit(data);
+            }
+        });
+        this.initialized = true;
+    }
+
+    // tslint:disable-next-line: cyclomatic-complexity
+    ngOnChanges(changes: SimpleChanges): void {
+        if (!this.initialized) {
+            return;
+        }
+        const newData = changes.data;
+        const newSchema = changes.schema;
+        const newUiSchema = changes.uischema;
+        const newRenderers = changes.renderers;
+        const newUischemas = changes.uischemas;
+        const newLocale = changes.locale;
+        const newReadonly = changes.readonly;
+        const newValidationMode = changes.validationMode;
+        const newAjv = changes.ajv;
+
+        if (newData || newSchema || newUiSchema || newValidationMode || newAjv) {
+            this.jsonformsService.updateCoreState(
+                newData ? newData.currentValue : USE_STATE_VALUE,
+                newSchema ? newSchema.currentValue : USE_STATE_VALUE,
+                newUiSchema ? newUiSchema.currentValue : USE_STATE_VALUE,
+                newAjv ? newAjv.currentValue : USE_STATE_VALUE,
+                newValidationMode ? newValidationMode.currentValue : USE_STATE_VALUE
+            );
+        }
+
+        if (newRenderers && !newRenderers.isFirstChange()) {
+            this.jsonformsService.setRenderers(newRenderers.currentValue);
+        }
+
+        if (newUischemas && !newUischemas.isFirstChange()) {
+            this.jsonformsService.setUiSchemas(newUischemas.currentValue);
+        }
+
+        if (newLocale && !newLocale.isFirstChange()) {
+            this.jsonformsService.setLocale(newLocale.currentValue);
+        }
+
+        if (newReadonly && !newReadonly.isFirstChange()) {
+            this.jsonformsService.setReadonly(newReadonly.currentValue);
+        }
+    }
+}

--- a/packages/angular/src/jsonforms.module.ts
+++ b/packages/angular/src/jsonforms.module.ts
@@ -1,7 +1,7 @@
 /*
   The MIT License
   
-  Copyright (c) 2017-2019 EclipseSource Munich
+  Copyright (c) 2017-2020 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
   
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -24,11 +24,12 @@
 */
 import { NgModule } from '@angular/core';
 
+import { JsonForms } from './jsonforms-root.component';
 import { JsonFormsOutlet } from './jsonforms.component';
 import { UnknownRenderer } from './unknown.component';
 @NgModule({
-  declarations: [JsonFormsOutlet, UnknownRenderer],
+  declarations: [JsonFormsOutlet, UnknownRenderer, JsonForms],
   entryComponents: [UnknownRenderer],
-  exports: [JsonFormsOutlet]
+  exports: [JsonFormsOutlet, JsonForms]
 })
 export class JsonFormsModule {}

--- a/packages/angular/src/jsonforms.service.ts
+++ b/packages/angular/src/jsonforms.service.ts
@@ -1,58 +1,107 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2017-2020 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
 import {
-  configReducer,
-  CoreActions,
-  coreReducer,
-  i18nReducer,
-  JsonFormsRendererRegistryEntry,
-  JsonFormsState,
-  JsonFormsSubStates,
-  LocaleActions,
-  RankedTester,
-  setConfig,
-  SetConfigAction,
-  UISchemaActions,
-  UISchemaElement,
-  uischemaRegistryReducer,
-  ValidationMode,
-  Actions
+    Actions,
+    configReducer,
+    CoreActions,
+    coreReducer,
+    generateDefaultUISchema,
+    generateJsonSchema,
+    i18nReducer,
+    JsonFormsRendererRegistryEntry,
+    JsonFormsState,
+    JsonFormsSubStates,
+    JsonSchema,
+    LocaleActions,
+    RankedTester,
+    setConfig,
+    SetConfigAction,
+    UISchemaActions,
+    UISchemaElement,
+    uischemaRegistryReducer,
+    UISchemaTester,
+    ValidationMode
 } from '@jsonforms/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { JsonFormsBaseRenderer } from './base.renderer';
 
 import { cloneDeep } from 'lodash';
-import { Injectable } from '@angular/core';
+import { Ajv } from 'ajv';
 
-@Injectable({
-    providedIn: 'root'
-})
+export const USE_STATE_VALUE = Symbol('Marker to use state value');
 export class JsonFormsAngularService {
 
     private _state: JsonFormsSubStates;
     private state: BehaviorSubject<JsonFormsState>;
 
-    init(initialState: JsonFormsSubStates = {}) {
+    init(initialState: JsonFormsSubStates = { core: { data: undefined, schema: undefined, uischema: undefined } }) {
         this._state = initialState;
         this._state.config = configReducer(undefined, setConfig(this._state.config));
         this.state = new BehaviorSubject({ jsonforms: this._state });
+        const data = initialState.core.data;
+        const schema = initialState.core.schema ?? generateJsonSchema(data);
+        const uischema = initialState.core.uischema ?? generateDefaultUISchema(schema);
+        this.updateCore(Actions.init(data, schema, uischema));
     }
 
     get $state(): Observable<JsonFormsState> {
         if (!this.state) {
-            this.init();
+            throw new Error('Please call init first!');
         }
         return this.state.asObservable();
     }
 
+    /**
+     * @deprecated use {@link JsonFormsAngularService.addRenderer}
+     */
     registerRenderer(renderer: JsonFormsBaseRenderer<UISchemaElement>, tester: RankedTester): void {
+        this.addRenderer(renderer, tester);
+    }
+    addRenderer(renderer: JsonFormsBaseRenderer<UISchemaElement>, tester: RankedTester): void {
         this._state.renderers.push({ renderer, tester });
         this.updateSubject();
     }
+
+    /**
+     * @deprecated use {@link JsonFormsAngularService.setRenderer}
+     */
     registerRenderers(renderers: JsonFormsRendererRegistryEntry[]): void {
+        this.setRenderers(renderers);
+    }
+    setRenderers(renderers: JsonFormsRendererRegistryEntry[]): void {
         this._state.renderers = renderers;
         this.updateSubject();
     }
 
+    /**
+     * @deprecated use {@link JsonFormsAngularService.removeRenderer}
+     */
     unregisterRenderer(tester: RankedTester): void {
+        this.removeRenderer(tester);
+    }
+    removeRenderer(tester: RankedTester): void {
         const findIndex = this._state.renderers.findIndex(v => v.tester === tester);
         if (findIndex === -1) {
             return;
@@ -82,11 +131,19 @@ export class JsonFormsAngularService {
         return coreAction;
     }
 
+    /**
+     * @deprecated use {@link JsonFormsAngularService.setUiSchemas}
+     */
     updateUiSchema<T extends UISchemaActions>(uischemaAction: T): T {
         const uischemaState = uischemaRegistryReducer(this._state.uischemas, uischemaAction);
         this._state.uischemas = uischemaState;
         this.updateSubject();
         return uischemaAction;
+    }
+
+    setUiSchemas(uischemas: { tester: UISchemaTester; uischema: UISchemaElement; }[]): void {
+        this._state.uischemas = uischemas;
+        this.updateSubject();
     }
 
     updateConfig<T extends SetConfigAction>(setConfigAction: T): T {
@@ -96,11 +153,64 @@ export class JsonFormsAngularService {
         return setConfigAction;
     }
 
+    setUiSchema(uischema: UISchemaElement | undefined): void {
+        const newUiSchema = uischema ?? generateDefaultUISchema(this._state.core.schema);
+        const coreState = coreReducer(this._state.core, Actions.updateCore(this._state.core.data, this._state.core.schema, newUiSchema));
+        this._state.core = coreState;
+        this.updateSubject();
+    }
+
+    setSchema(schema: JsonSchema | undefined): void {
+        const coreState = coreReducer(this._state.core,
+            Actions.updateCore(this._state.core.data, schema ?? generateJsonSchema(this._state.core.data), this._state.core.uischema)
+        );
+        this._state.core = coreState;
+        this.updateSubject();
+    }
+
+    setData(data: any): void {
+        const coreState = coreReducer(this._state.core, Actions.updateCore(data, this._state.core.schema, this._state.core.uischema));
+        this._state.core = coreState;
+        this.updateSubject();
+    }
+
+    setLocale(locale: string): void {
+        this._state.i18n.locale = locale;
+        this.updateSubject();
+    }
+
+    setReadonly(readonly: boolean): void {
+        this._state.readonly = readonly;
+        this.updateSubject();
+    }
+
     getState(): JsonFormsState {
         return cloneDeep({ jsonforms: this._state });
+    }
+
+    refresh(): void {
+        this.updateSubject();
+    }
+
+    updateCoreState(
+        data: any | typeof USE_STATE_VALUE,
+        schema: JsonSchema | typeof USE_STATE_VALUE,
+        uischema: UISchemaElement | typeof USE_STATE_VALUE,
+        ajv: Ajv | typeof USE_STATE_VALUE,
+        validationMode: ValidationMode | typeof USE_STATE_VALUE
+    ): void {
+        const newData = data === USE_STATE_VALUE ? this._state.core.data : data;
+        const newSchema = schema === USE_STATE_VALUE ? this._state.core.schema : schema ?? generateJsonSchema(newData);
+        const newUischema = uischema === USE_STATE_VALUE ? this._state.core.uischema : uischema ?? generateDefaultUISchema(newSchema);
+        const newAjv = ajv === USE_STATE_VALUE ? this._state.core.ajv : ajv;
+        const newValidationMode = validationMode === USE_STATE_VALUE ? this._state.core.validationMode : validationMode;
+        this.updateCore(
+            Actions.updateCore(newData, newSchema, newUischema, {ajv: newAjv, validationMode: newValidationMode})
+        );
     }
 
     private updateSubject(): void {
         this.state.next({ jsonforms: this._state });
     }
+
 }


### PR DESCRIPTION
The JSONForms Angular component needs the jsonforms service
to set the right data, schema, uischema etc.
The problem is, that the service is a singleton,
as it is registering as a root service.

This commit introduces a new root component `jsonforms`
which allows to pass all parameters into the component.
The component is now initializing the service internally.
Furthermore, the service is not registered as a root service anymore.
Now multiple jsonforms components can be used next to each other.