### PR TITLE
fix: make NumberCell for Vanilla Renderer show 0

### DIFF
--- a/packages/vanilla/src/cells/NumberCell.tsx
+++ b/packages/vanilla/src/cells/NumberCell.tsx
@@ -40,7 +40,7 @@ export const NumberCell = (props: CellProps & VanillaRendererProps) => {
     <input
       type='number'
       step='0.1'
-      value={data || ''}
+      value={data ?? ''}
       onChange={ev => handleChange(path, Number(ev.target.value))}
       className={className}
       id={id}

--- a/packages/vanilla/test/renderers/NumberCell.test.tsx
+++ b/packages/vanilla/test/renderers/NumberCell.test.tsx
@@ -466,4 +466,21 @@ describe('Number cell', () => {
     const input = wrapper.find('input').getDOMNode() as HTMLInputElement;
     expect(input.disabled).toBe(false);
   });
+
+  test('shows 0 instead of empty string', () => {
+    const store = initJsonFormsVanillaStore({
+      data: { foo: 0 },
+      schema: fixture.schema,
+      uischema: fixture.uischema
+    });
+    wrapper = mount(
+      <Provider store={store}>
+        <JsonFormsReduxContext>
+          <NumberCell schema={fixture.schema} uischema={fixture.uischema} path='foo' />
+        </JsonFormsReduxContext>
+      </Provider>
+    );
+    const input = wrapper.find('input').getDOMNode() as HTMLInputElement;
+    expect(input.value).toBe('0');
+  });
 });


### PR DESCRIPTION
When using a default value of 0 for a number cell with vanilla renderers, the input is shown with an empty string. This is a quick fix for it.