### PR TITLE
Angular-material: NumberControlRenderer now sets the 'useGrouping' property

### DIFF
--- a/packages/angular-material/src/controls/number.renderer.ts
+++ b/packages/angular-material/src/controls/number.renderer.ts
@@ -135,6 +135,7 @@ export class NumberControlRenderer extends JsonFormsControl {
       if (this.locale === undefined || this.locale !== currentLocale) {
         this.locale = currentLocale;
         this.numberFormat = new Intl.NumberFormat(this.locale, {
+          useGrouping: this.uischema.options ? this.uischema.options.useGrouping : undefined,
           maximumFractionDigits: this.MAXIMUM_FRACTIONAL_DIGITS
         });
         this.determineDecimalSeparator();


### PR DESCRIPTION
NumberControlRenderer now sets the 'useGrouping' property in the NumberFormatOptions object passed to the Intl.NumberFormat constructor to the value of the uischema options element `useGrouping`, if defined.

See https://github.com/eclipsesource/jsonforms/issues/1668

**Note**: I cannot run the `npm run dev` in packages\material on my Windows OS. There are syntax errors.  
The change is tested by copy pasting the NumberControlRenderer code and creating it as a custom renderer in my project that depends on jsonforms.

It works when setting the options in `uischema`, e.g.
```json
                {
                  "type": "Control",
                  "scope": "#/properties/cvr",
                  "label": "CVR number",
                  "options": {
                    "useGrouping": false
                  }
                }
```