### PR TITLE
Vanilla styles - Automatically use default styles, remove redux style support, support style def merging

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -56,6 +56,10 @@ Basically there are two different approaches:
 
 Below you can find some guidance about each approach.
 
+In any case, users of the vanilla renderers need to migrate style definitions.
+Providing style classes via the redux context is no longer supported even when using the redux fallback.
+For more information see the [vanilla renderer style guide](./packages/vanilla/Styles.md).
+
 ## Case 1: Migrate to the standalone variant (recommended)
 
 The standalone JSON Forms variant is the new default and the main focus for new features and bug fixes.

--- a/packages/vanilla/Styles.md
+++ b/packages/vanilla/Styles.md
@@ -79,3 +79,32 @@ const styleContextValue = { styles: [
   />
 </JsonFormsStyleContext.Provider>
 ```
+
+You can also extend the existing default styles.
+Thereby, the existing style classes as well as your custom ones will be applied.
+This is the case because all style definitions for an ID are merged.
+
+```typescript
+import { JsonFormsStyleContext, vanillaStyles } from '@jsonforms/vanilla-renderers';
+
+const styleContextValue = { styles: [
+  ...vanillaStyles,
+  {
+    name: 'control.input',
+    classNames: ['custom-input']
+  },
+  {
+    name: 'array.button',
+    classNames: ['custom-array-button']
+  }
+]};
+
+<JsonFormsStyleContext.Provider value={styleContextValue}>
+  <JsonForms
+    data={data}
+    schema={schema}
+    uischema={uischema}
+    ...
+  />
+</JsonFormsStyleContext.Provider>
+```

--- a/packages/vanilla/Styles.md
+++ b/packages/vanilla/Styles.md
@@ -52,7 +52,8 @@
 - input.description &rightarrow; id for the description of control
 
 ## Example of styling id contributions
-Overwrite the default styles via the `JsonFormsStyleContext`.
+By default, the `vanillaStyles` defined in [src/styles/styles.ts](./src/styles/styles.ts) are applied.
+These can be overwritten via the `JsonFormsStyleContext`.
 
 ```typescript
 import { JsonFormsStyleContext } from '@jsonforms/vanilla-renderers';

--- a/packages/vanilla/Styles.md
+++ b/packages/vanilla/Styles.md
@@ -54,6 +54,7 @@
 ## Example of styling id contributions
 By default, the `vanillaStyles` defined in [src/styles/styles.ts](./src/styles/styles.ts) are applied.
 These can be overwritten via the `JsonFormsStyleContext`.
+The following example will completely replace the default styles.
 
 ```typescript
 import { JsonFormsStyleContext } from '@jsonforms/vanilla-renderers';

--- a/packages/vanilla/example/index.ts
+++ b/packages/vanilla/example/index.ts
@@ -24,16 +24,10 @@
 */
 import { createThemeSelection } from './theme.switcher';
 import {
-  stylingReducer,
   vanillaCells,
   vanillaRenderers,
-  vanillaStyles
 } from '../src';
 import { renderExample } from '../../example/src/index';
 
-renderExample(vanillaRenderers, vanillaCells, undefined, {
-  name: 'styles',
-  reducer: stylingReducer,
-  state: vanillaStyles
-});
+renderExample(vanillaRenderers, vanillaCells, undefined);
 createThemeSelection();

--- a/packages/vanilla/src/index.ts
+++ b/packages/vanilla/src/index.ts
@@ -106,7 +106,7 @@ export * from './cells';
 export * from './layouts';
 export * from './reducers';
 export * from './util';
-export * from './styleContext';
+export * from './styles';
 
 export const vanillaRenderers: { tester: RankedTester; renderer: any }[] = [
   { tester: inputControlTester, renderer: InputControl },

--- a/packages/vanilla/src/reducers/styling.ts
+++ b/packages/vanilla/src/reducers/styling.ts
@@ -27,7 +27,7 @@ import remove from 'lodash/remove';
 import find from 'lodash/find';
 import join from 'lodash/join';
 import { REGISTER_STYLE, REGISTER_STYLES, UNREGISTER_STYLE } from '../actions';
-import { StyleDef } from '../util';
+import { StyleDef } from '../styles';
 
 const removeStyle = (styles: StyleDef[], name: string) => {
   const copy = styles.slice();

--- a/packages/vanilla/src/reducers/styling.ts
+++ b/packages/vanilla/src/reducers/styling.ts
@@ -22,10 +22,10 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import isEmpty from 'lodash/isEmpty';
 import remove from 'lodash/remove';
-import find from 'lodash/find';
 import join from 'lodash/join';
+import filter from 'lodash/filter';
+import reduce from 'lodash/reduce';
 import { REGISTER_STYLE, REGISTER_STYLES, UNREGISTER_STYLE } from '../actions';
 import { StyleDef } from '../styles';
 
@@ -47,15 +47,13 @@ export const findStyle = (styles: StyleDef[]) => (
   style: string,
   ...args: any[]
 ): string[] => {
-  const foundStyle = find(styles, s => s.name === style);
-  if (!isEmpty(foundStyle) && typeof foundStyle.classNames === 'function') {
-    const res = foundStyle.classNames(args);
-    return res;
-  } else if (!isEmpty(foundStyle)) {
-    return foundStyle.classNames as string[];
-  }
-
-  return [];
+  const foundStyles = filter(styles, s => s.name === style);
+  return reduce(foundStyles, (res: string[], style: StyleDef) => {
+    if (typeof style.classNames === 'function') {
+      return res.concat(style.classNames(args));
+    }
+    return res.concat(style.classNames);
+  }, []);
 };
 
 export const findStyleAsClassName = (styles: StyleDef[]) => (

--- a/packages/vanilla/src/styles/index.ts
+++ b/packages/vanilla/src/styles/index.ts
@@ -1,7 +1,7 @@
 /*
   The MIT License
   
-  Copyright (c) 2017-2019 EclipseSource Munich
+  Copyright (c) 2017-2021 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
   
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -23,30 +23,5 @@
   THE SOFTWARE.
 */
 
-import React, { useContext } from 'react';
-import { useJsonForms } from '@jsonforms/react';
-import { StyleDef } from './util';
-
-export interface StyleContext {
-  styles: StyleDef[];
-}
-
-const defaultContext: any = {
-  styles: []
-};
-
-export const JsonFormsStyleContext = React.createContext<StyleContext>(
-  defaultContext
-);
-
-export const useStyleContext = (): StyleContext =>
-  useContext(JsonFormsStyleContext);
-
-export const useStyles = (): StyleDef[] | undefined => {
-  const { styles } = useStyleContext();
-  const ctx = useJsonForms();
-  if (styles.length === 0 && ctx.styles) {
-    return ctx.styles;
-  }
-  return styles;
-};
+export * from './styleContext';
+export * from './styles';

--- a/packages/vanilla/src/styles/styleContext.ts
+++ b/packages/vanilla/src/styles/styleContext.ts
@@ -24,7 +24,6 @@
 */
 
 import React, { useContext } from 'react';
-import { useJsonForms } from '@jsonforms/react';
 import { StyleDef, vanillaStyles } from './styles';
 
 export interface StyleContext {
@@ -42,11 +41,7 @@ export const JsonFormsStyleContext = React.createContext(
 export const useStyleContext = (): StyleContext =>
   useContext(JsonFormsStyleContext);
 
-export const useStyles = (): StyleDef[] | undefined => {
+export const useStyles = (): StyleDef[] => {
   const { styles } = useStyleContext();
-  const ctx = useJsonForms();
-  if (styles.length === 0 && ctx.styles) {
-    return ctx.styles;
-  }
   return styles;
 };

--- a/packages/vanilla/src/styles/styleContext.ts
+++ b/packages/vanilla/src/styles/styleContext.ts
@@ -22,42 +22,31 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import { combineReducers, createStore, Store } from 'redux';
-import {
-  Actions,
-  jsonFormsReducerConfig,
-  JsonFormsState,
-  JsonSchema,
-  UISchemaElement
-} from '@jsonforms/core';
-import { vanillaStyles } from '../src/styles';
-import { stylingReducer } from '../src/reducers';
 
-export const initJsonFormsVanillaStore = ({
-  data,
-  schema,
-  uischema,
-  ...other
-}: {
-  data: any;
-  uischema: UISchemaElement;
-  schema: JsonSchema;
-  [other: string]: any;
-}): Store<JsonFormsState> => {
-  const store: Store<JsonFormsState> = createStore(
-    combineReducers({
-      jsonforms: combineReducers({...jsonFormsReducerConfig, styles: stylingReducer}),
-    }),
-    {
-      // TODO
-      jsonforms: {
-        styles: vanillaStyles,
-        ...other
-      } as any
-    }
-  );
+import React, { useContext } from 'react';
+import { useJsonForms } from '@jsonforms/react';
+import { StyleDef, vanillaStyles } from './styles';
 
-  store.dispatch(Actions.init(data, schema, uischema));
+export interface StyleContext {
+  styles: StyleDef[];
+}
 
-  return store;
+const defaultContext: StyleContext = {
+  styles: vanillaStyles
+};
+
+export const JsonFormsStyleContext = React.createContext(
+  defaultContext
+);
+
+export const useStyleContext = (): StyleContext =>
+  useContext(JsonFormsStyleContext);
+
+export const useStyles = (): StyleDef[] | undefined => {
+  const { styles } = useStyleContext();
+  const ctx = useJsonForms();
+  if (styles.length === 0 && ctx.styles) {
+    return ctx.styles;
+  }
+  return styles;
 };

--- a/packages/vanilla/src/styles/styles.ts
+++ b/packages/vanilla/src/styles/styles.ts
@@ -1,0 +1,108 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2017-2021 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+/**
+ * A style associates a name with a list of CSS class names or a function that calculates them.
+ */
+export interface StyleDef {
+  name: string;
+  classNames: string[] | ((...args: any[]) => string[]);
+}
+
+/**
+ * Pre-defined vanilla styles.
+ *
+ * @type {{name: string; classNames: string[]}[]}
+ */
+export const vanillaStyles: StyleDef[] = [
+  {
+    name: 'control',
+    classNames: ['control']
+  },
+  {
+    name: 'control.trim',
+    classNames: ['trim']
+  },
+  {
+    name: 'control.input',
+    classNames: ['input']
+  },
+  {
+    name: 'control.select',
+    classNames: ['select']
+  },
+  {
+    name: 'control.validation',
+    classNames: ['validation']
+  },
+  {
+    name: 'categorization',
+    classNames: ['categorization']
+  },
+  {
+    name: 'categorization.master',
+    classNames: ['categorization-master']
+  },
+  {
+    name: 'categorization.detail',
+    classNames: ['categorization-detail']
+  },
+  {
+    name: 'category.group',
+    classNames: ['category-group']
+  },
+  {
+    name: 'array.layout',
+    classNames: ['array-layout']
+  },
+  {
+    name: 'array.children',
+    classNames: ['children']
+  },
+  {
+    name: 'group.layout',
+    classNames: ['group-layout']
+  },
+  {
+    name: 'horizontal.layout',
+    classNames: ['horizontal-layout']
+  },
+  {
+    name: 'horizontal.layout.item',
+    classNames: ([size]: number[]) => [`horizontal-layout-${size}`]
+  },
+  {
+    name: 'vertical.layout',
+    classNames: ['vertical-layout']
+  },
+  {
+    name: 'array.table',
+    classNames: ['array-table-layout', 'control']
+  },
+  {
+    name: 'input.description',
+    classNames: ['input-description']
+  }
+];

--- a/packages/vanilla/src/util/index.tsx
+++ b/packages/vanilla/src/util/index.tsx
@@ -41,15 +41,7 @@ import { getStyle, getStyleAsClassName } from '../reducers';
 import { VanillaRendererProps } from '../index';
 import { ComponentType } from 'react';
 import { findStyle, findStyleAsClassName } from '../reducers/styling';
-import { useStyles } from '../styleContext';
-
-/**
- * A style associates a name with a list of CSS class names.
- */
-export interface StyleDef {
-  name: string;
-  classNames: string[] | ((...args: any[]) => string[]);
-}
+import { useStyles } from '../styles';
 
 /**
  * Add vanilla props to the return value of calling the given
@@ -200,78 +192,3 @@ export const withVanillaEnumCellProps = withVanillaCellPropsForType(
   'control.select'
 );
 
-/**
- * Pre-defined vanilla styles.
- *
- * @type {{name: string; classNames: string[]}[]}
- */
-export const vanillaStyles = [
-  {
-    name: 'control',
-    classNames: ['control']
-  },
-  {
-    name: 'control.trim',
-    classNames: ['trim']
-  },
-  {
-    name: 'control.input',
-    classNames: ['input']
-  },
-  {
-    name: 'control.select',
-    classNames: ['select']
-  },
-  {
-    name: 'control.validation',
-    classNames: ['validation']
-  },
-  {
-    name: 'categorization',
-    classNames: ['categorization']
-  },
-  {
-    name: 'categorization.master',
-    classNames: ['categorization-master']
-  },
-  {
-    name: 'categorization.detail',
-    classNames: ['categorization-detail']
-  },
-  {
-    name: 'category.group',
-    classNames: ['category-group']
-  },
-  {
-    name: 'array.layout',
-    classNames: ['array-layout']
-  },
-  {
-    name: 'array.children',
-    classNames: ['children']
-  },
-  {
-    name: 'group.layout',
-    classNames: ['group-layout']
-  },
-  {
-    name: 'horizontal.layout',
-    classNames: ['horizontal-layout']
-  },
-  {
-    name: 'horizontal.layout.item',
-    classNames: ([size]: number[]) => [`horizontal-layout-${size}`]
-  },
-  {
-    name: 'vertical.layout',
-    classNames: ['vertical-layout']
-  },
-  {
-    name: 'array.table',
-    classNames: ['array-table-layout', 'control']
-  },
-  {
-    name: 'input.description',
-    classNames: ['input-description']
-  }
-];

--- a/packages/vanilla/test/renderers/ArrayControl.test.tsx
+++ b/packages/vanilla/test/renderers/ArrayControl.test.tsx
@@ -57,13 +57,7 @@ const fixture = {
   },
   data: {
     test: [{ x: 1, y: 3 }]
-  },
-  styles: [
-    {
-      name: 'array.table',
-      classNames: ['array-table-layout', 'control']
-    }
-  ]
+  }
 };
 
 describe('Array control renderer', () => {

--- a/packages/vanilla/test/renderers/CategorizationRenderer.test.tsx
+++ b/packages/vanilla/test/renderers/CategorizationRenderer.test.tsx
@@ -36,6 +36,7 @@ import Adapter from 'enzyme-adapter-react-16';
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import CategorizationRenderer, { categorizationTester } from '../../src/complex/categorization';
 import { initJsonFormsVanillaStore } from '../vanillaStore';
+import { JsonFormsStyleContext } from '../../src/styles';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -273,16 +274,17 @@ describe('Categorization renderer', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema,
-      uischema,
-      styles: fixture.styles
+      uischema
     });
     wrapper = mount(
       <Provider store={store}>
         <JsonFormsReduxContext>
-          <CategorizationRenderer
-            schema={schema}
-            uischema={uischema}
-          />
+          <JsonFormsStyleContext.Provider value={{ styles: fixture.styles }}>
+            <CategorizationRenderer
+              schema={schema}
+              uischema={uischema}
+              />
+          </JsonFormsStyleContext.Provider>
         </JsonFormsReduxContext>
       </Provider>
     );
@@ -363,17 +365,18 @@ describe('Categorization renderer', () => {
     const store = initJsonFormsVanillaStore({
       data,
       schema: fixture.schema,
-      uischema,
-      styles: fixture.styles
+      uischema
     });
 
     wrapper = mount(
       <Provider store={store}>
         <JsonFormsReduxContext>
-          <CategorizationRenderer
-            schema={fixture.schema}
-            uischema={uischema}
-          />
+          <JsonFormsStyleContext.Provider value={{ styles: fixture.styles }}>
+            <CategorizationRenderer
+              schema={fixture.schema}
+              uischema={uischema}
+              />
+          </JsonFormsStyleContext.Provider>
         </JsonFormsReduxContext>
       </Provider>
     );
@@ -426,18 +429,19 @@ describe('Categorization renderer', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema: fixture.schema,
-      uischema,
-      styles: fixture.styles
+      uischema
     });
 
     wrapper = mount(
       <Provider store={store}>
         <JsonFormsReduxContext>
-          <CategorizationRenderer
-            schema={fixture.schema}
-            uischema={uischema}
-            visible={false}
-          />
+          <JsonFormsStyleContext.Provider value={{ styles: fixture.styles }}>
+            <CategorizationRenderer
+              schema={fixture.schema}
+              uischema={uischema}
+              visible={false}
+              />
+          </JsonFormsStyleContext.Provider>
         </JsonFormsReduxContext>
       </Provider>
     );
@@ -461,16 +465,17 @@ describe('Categorization renderer', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema: fixture.schema,
-      uischema,
-      styles: fixture.styles
+      uischema
     });
     wrapper = mount(
       <Provider store={store}>
         <JsonFormsReduxContext>
-          <CategorizationRenderer
-            schema={fixture.schema}
-            uischema={uischema}
-          />
+          <JsonFormsStyleContext.Provider value={{ styles: fixture.styles }}>
+            <CategorizationRenderer
+              schema={fixture.schema}
+              uischema={uischema}
+              />
+          </JsonFormsStyleContext.Provider>
         </JsonFormsReduxContext>
       </Provider>
     );

--- a/packages/vanilla/test/renderers/GroupLayout.test.tsx
+++ b/packages/vanilla/test/renderers/GroupLayout.test.tsx
@@ -37,13 +37,7 @@ const fixture = {
   uischema: {
     type: 'Group',
     elements: [{ type: 'Control' }]
-  },
-  styles: [
-    {
-      name: 'group.layout',
-      classNames: ['group-layout']
-    }
-  ]
+  }
 };
 
 test('tester', () => {
@@ -68,8 +62,7 @@ describe('Group layout', () => {
     const store = initJsonFormsVanillaStore({
       data: {},
       schema: {},
-      uischema,
-      styles: fixture.styles
+      uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -96,8 +89,7 @@ describe('Group layout', () => {
     const store = initJsonFormsVanillaStore({
       data: {},
       schema: {},
-      uischema,
-      styles: fixture.styles
+      uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -122,8 +114,7 @@ describe('Group layout', () => {
     const store = initJsonFormsVanillaStore({
       data: {},
       schema: {},
-      uischema,
-      styles: fixture.styles
+      uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -141,8 +132,7 @@ describe('Group layout', () => {
     const store = initJsonFormsVanillaStore({
       data: {},
       schema: {},
-      uischema: fixture.uischema,
-      styles: fixture.styles
+      uischema: fixture.uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -162,8 +152,7 @@ describe('Group layout', () => {
     const store = initJsonFormsVanillaStore({
       data: {},
       schema: {},
-      uischema: fixture.uischema,
-      styles: fixture.styles
+      uischema: fixture.uischema
     });
     wrapper = mount(
       <Provider store={store}>

--- a/packages/vanilla/test/renderers/HorizontalLayout.test.tsx
+++ b/packages/vanilla/test/renderers/HorizontalLayout.test.tsx
@@ -42,13 +42,7 @@ const fixture = {
   uischema: {
     type: 'HorizontalLayout',
     elements: [{ type: 'Control' }]
-  },
-  styles: [
-    {
-      name: 'horizontal.layout',
-      classNames: ['horizontal-layout']
-    }
-  ]
+  }
 };
 
 test('tester', () => {
@@ -71,8 +65,7 @@ describe('Horizontal layout', () => {
     const store = initJsonFormsVanillaStore({
       data: {},
       schema: {},
-      uischema,
-      styles: fixture.styles
+      uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -96,8 +89,7 @@ describe('Horizontal layout', () => {
     const store = initJsonFormsVanillaStore({
       data: {},
       schema: {},
-      uischema,
-      styles: fixture.styles
+      uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -122,8 +114,7 @@ describe('Horizontal layout', () => {
     const store = initJsonFormsVanillaStore({
       data: {},
       schema: {},
-      uischema,
-      styles: fixture.styles
+      uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -141,8 +132,7 @@ describe('Horizontal layout', () => {
     const store = initJsonFormsVanillaStore({
       data: {},
       schema: {},
-      uischema: fixture.uischema,
-      styles: fixture.styles
+      uischema: fixture.uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -162,8 +152,7 @@ describe('Horizontal layout', () => {
     const store = initJsonFormsVanillaStore({
       data: {},
       schema: {},
-      uischema: fixture.uischema,
-      styles: fixture.styles
+      uischema: fixture.uischema
     });
     wrapper = mount(
       <Provider store={store}>

--- a/packages/vanilla/test/renderers/LabelControl.test.tsx
+++ b/packages/vanilla/test/renderers/LabelControl.test.tsx
@@ -32,6 +32,7 @@ import LabelRenderer, {
   labelRendererTester
 } from '../../src/complex/LabelRenderer';
 import { initJsonFormsVanillaStore } from '../vanillaStore';
+import { JsonFormsStyleContext } from '../../src/styles';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -70,16 +71,17 @@ describe('Label', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema: fixture.schema,
-      uischema,
-      styles: fixture.styles
+      uischema
     });
     wrapper = mount(
       <Provider store={store}>
         <JsonFormsReduxContext>
-          <LabelRenderer
-            schema={fixture.schema}
-            uischema={uischema}
-          />
+          <JsonFormsStyleContext.Provider value={{ styles: fixture.styles }}>
+            <LabelRenderer
+              schema={fixture.schema}
+              uischema={uischema}
+              />
+          </JsonFormsStyleContext.Provider>
         </JsonFormsReduxContext>
       </Provider>
     );
@@ -97,17 +99,18 @@ describe('Label', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema: fixture.schema,
-      uischema,
-      styles: fixture.styles
+      uischema
     });
 
     wrapper = mount(
       <Provider store={store}>
         <JsonFormsReduxContext>
-          <LabelRenderer
-            schema={fixture.schema}
-            uischema={uischema}
-          />
+          <JsonFormsStyleContext.Provider value={{ styles: fixture.styles }}>
+            <LabelRenderer
+              schema={fixture.schema}
+              uischema={uischema}
+              />
+          </JsonFormsStyleContext.Provider>
         </JsonFormsReduxContext>
       </Provider>
     );
@@ -120,16 +123,17 @@ describe('Label', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema: fixture.schema,
-      uischema: fixture.uischema,
-      styles: fixture.styles
+      uischema: fixture.uischema
     });
     wrapper = mount(
       <Provider store={store}>
         <JsonFormsReduxContext>
-          <LabelRenderer
-            schema={fixture.schema}
-            uischema={fixture.uischema}
-          />
+          <JsonFormsStyleContext.Provider value={{ styles: fixture.styles }}>
+            <LabelRenderer
+              schema={fixture.schema}
+              uischema={fixture.uischema}
+              />
+          </JsonFormsStyleContext.Provider>
         </JsonFormsReduxContext>
       </Provider>
     );

--- a/packages/vanilla/test/renderers/TableArrayControl.test.tsx
+++ b/packages/vanilla/test/renderers/TableArrayControl.test.tsx
@@ -64,13 +64,7 @@ const fixture = {
   },
   data: {
     test: [{ x: 1, y: 3 }]
-  },
-  styles: [
-    {
-      name: 'array.table',
-      classNames: ['array-table-layout', 'control']
-    }
-  ]
+  }
 };
 
 const fixture2 = {
@@ -98,13 +92,7 @@ const fixture2 = {
   },
   data: {
     test: [{ x: 1, y: 3 }]
-  },
-  styles: [
-    {
-      name: 'array.table',
-      classNames: ['array-table-layout', 'control']
-    }
-  ]
+  }
 };
 
 describe('Tabe array tester', () => {
@@ -541,8 +529,7 @@ describe('Tabe array control', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema: fixture.schema,
-      uischema: fixture.uischema,
-      styles: fixture.styles
+      uischema: fixture.uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -563,8 +550,7 @@ describe('Tabe array control', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema: fixture.schema,
-      uischema: fixture.uischema,
-      styles: fixture.styles
+      uischema: fixture.uischema
     });
     wrapper = mount(
       <Provider store={store}>

--- a/packages/vanilla/test/renderers/TimeCell.test.tsx
+++ b/packages/vanilla/test/renderers/TimeCell.test.tsx
@@ -51,17 +51,7 @@ const fixture = {
     type: 'string',
     format: 'time'
   },
-  uischema: controlElement,
-  styles: [
-    {
-      name: 'control',
-      classNames: ['control']
-    },
-    {
-      name: 'control.validation',
-      classNames: ['validation']
-    }
-  ]
+  uischema: controlElement
 };
 
 describe('Time cell tester', () => {
@@ -244,8 +234,7 @@ describe('Time cell', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema: fixture.schema,
-      uischema: fixture.uischema,
-      styles: fixture.styles
+      uischema: fixture.uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -284,8 +273,7 @@ describe('Time cell', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema: fixture.schema,
-      uischema: fixture.uischema,
-      styles: fixture.styles
+      uischema: fixture.uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -304,8 +292,7 @@ describe('Time cell', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema: fixture.schema,
-      uischema: fixture.uischema,
-      styles: fixture.styles
+      uischema: fixture.uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -323,8 +310,7 @@ describe('Time cell', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema: fixture.schema,
-      uischema: fixture.uischema,
-      styles: fixture.styles
+      uischema: fixture.uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -340,8 +326,7 @@ describe('Time cell', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema: fixture.schema,
-      uischema: fixture.uischema,
-      styles: fixture.styles
+      uischema: fixture.uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -359,8 +344,7 @@ describe('Time cell', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema: fixture.schema,
-      uischema: fixture.uischema,
-      styles: fixture.styles
+      uischema: fixture.uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -378,8 +362,7 @@ describe('Time cell', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema: fixture.schema,
-      uischema: fixture.uischema,
-      styles: fixture.styles
+      uischema: fixture.uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -397,8 +380,7 @@ describe('Time cell', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema: fixture.schema,
-      uischema: fixture.uischema,
-      styles: fixture.styles
+      uischema: fixture.uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -416,8 +398,7 @@ describe('Time cell', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema: fixture.schema,
-      uischema: fixture.uischema,
-      styles: fixture.styles
+      uischema: fixture.uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -434,8 +415,7 @@ describe('Time cell', () => {
     const store = initJsonFormsVanillaStore({
       data: fixture.data,
       schema: fixture.schema,
-      uischema: fixture.uischema,
-      styles: fixture.styles
+      uischema: fixture.uischema
     });
     wrapper = mount(
       <Provider store={store}>

--- a/packages/vanilla/test/renderers/VerticalLayout.test.tsx
+++ b/packages/vanilla/test/renderers/VerticalLayout.test.tsx
@@ -33,13 +33,6 @@ import { initJsonFormsVanillaStore } from '../vanillaStore';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-const styles = [
-  {
-    name: 'vertical.layout',
-    classNames: ['vertical-layout']
-  }
-];
-
 test('tester', () => {
   expect(verticalLayoutTester(undefined, undefined)).toBe(-1);
   expect(verticalLayoutTester(null, undefined)).toBe(-1);
@@ -81,8 +74,7 @@ describe('Vertical layout', () => {
     const store = initJsonFormsVanillaStore({
       data: {},
       schema: {},
-      uischema,
-      styles
+      uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -103,8 +95,7 @@ describe('Vertical layout', () => {
     const store = initJsonFormsVanillaStore({
       data: {},
       schema: {},
-      uischema,
-      styles
+      uischema
     });
     wrapper = mount(
       <Provider store={store}>
@@ -127,8 +118,7 @@ describe('Vertical layout', () => {
     const store = initJsonFormsVanillaStore({
       data: {},
       schema: {},
-      uischema,
-      styles
+      uischema
     });
 
     wrapper = mount(
@@ -153,8 +143,7 @@ describe('Vertical layout', () => {
     const store = initJsonFormsVanillaStore({
       data: {},
       schema: {},
-      uischema,
-      styles,
+      uischema
     });
 
     wrapper = mount(

--- a/packages/vanilla/test/vanillaStore.ts
+++ b/packages/vanilla/test/vanillaStore.ts
@@ -30,8 +30,6 @@ import {
   JsonSchema,
   UISchemaElement
 } from '@jsonforms/core';
-import { vanillaStyles } from '../src/styles';
-import { stylingReducer } from '../src/reducers';
 
 export const initJsonFormsVanillaStore = ({
   data,
@@ -46,12 +44,11 @@ export const initJsonFormsVanillaStore = ({
 }): Store<JsonFormsState> => {
   const store: Store<JsonFormsState> = createStore(
     combineReducers({
-      jsonforms: combineReducers({...jsonFormsReducerConfig, styles: stylingReducer}),
+      jsonforms: combineReducers(jsonFormsReducerConfig),
     }),
     {
       // TODO
       jsonforms: {
-        styles: vanillaStyles,
         ...other
       } as any
     }


### PR DESCRIPTION
## Apply default vanilla styles if none are explicitly specified
* Set vanillaStyles as default value in JsonFormsStyleContext
* Move vanillaStyles, StyleDef interface and the styles context to new module styles
* Adapt documentation

## Remove vanilla style support via redux store
Vanilla renderer style definitions can no longer be provided via the redux store.
Instead, the plain react JsonFormsStyleContext needs to be used.

* Adapt style context
* Adapt tests
* Extend migration documentation

## Merge vanilla styles with same id
* adapt findStyle method
* extend Styles documentation