### PR TITLE
Add Vue 3 Vanilla renderers

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,14 +1,19 @@
 {
   "lerna": "2.5.1",
   "packages": [
-    "packages/*"
+    "packages/angular",
+    "packages/angular-material",
+    "packages/angular-test",
+    "packages/core",
+    "packages/example",
+    "packages/examples",
+    "packages/material",
+    "packages/react",
+    "packages/vue",
+    "packages/vue-vanilla"
   ],
   "version": "2.5.0",
   "nohoist": [
-    "core-js",
-    "vue",
-    "rollup-plugin-vue",
-    "@vue/test-utils",
-    "@vue/composition-api"
+    "core-js"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4570,37 +4570,6 @@
             }
           }
         },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "cosmiconfig": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-          "optional": true,
-          "requires": {
-            "@types/parse-json": "^4.0.0",
-            "import-fresh": "^3.1.0",
-            "parse-json": "^5.0.0",
-            "path-type": "^4.0.0",
-            "yaml": "^1.7.2"
-          },
-          "dependencies": {
-            "path-type": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-              "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-              "optional": true
-            }
-          }
-        },
         "dir-glob": {
           "version": "2.2.2",
           "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
@@ -4643,37 +4612,6 @@
             }
           }
         },
-        "fork-ts-checker-webpack-plugin-v5": {
-          "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
-          "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
-          "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
-          "optional": true,
-          "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@types/json-schema": "^7.0.5",
-            "chalk": "^4.1.0",
-            "cosmiconfig": "^6.0.0",
-            "deepmerge": "^4.2.2",
-            "fs-extra": "^9.0.0",
-            "memfs": "^3.1.2",
-            "minimatch": "^3.0.4",
-            "schema-utils": "2.7.0",
-            "semver": "^7.3.2",
-            "tapable": "^1.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "optional": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -4708,26 +4646,10 @@
             "slash": "^2.0.0"
           }
         },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "optional": true
-        },
         "ignore": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
-        },
-        "import-fresh": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-          "optional": true,
-          "requires": {
-            "parent-module": "^1.0.0",
-            "resolve-from": "^4.0.0"
-          }
         },
         "is-number": {
           "version": "3.0.0",
@@ -4745,25 +4667,6 @@
                 "is-buffer": "^1.1.5"
               }
             }
-          }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "optional": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "optional": true,
-          "requires": {
-            "yallist": "^4.0.0"
           }
         },
         "micromatch": {
@@ -4786,18 +4689,6 @@
             "to-regex": "^3.0.2"
           }
         },
-        "parse-json": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-          "optional": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "error-ex": "^1.3.1",
-            "json-parse-even-better-errors": "^2.3.0",
-            "lines-and-columns": "^1.1.6"
-          }
-        },
         "path-type": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -4813,45 +4704,10 @@
             }
           }
         },
-        "resolve-from": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-          "optional": true
-        },
-        "schema-utils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-          "optional": true,
-          "requires": {
-            "@types/json-schema": "^7.0.4",
-            "ajv": "^6.12.2",
-            "ajv-keywords": "^3.4.1"
-          }
-        },
-        "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-          "optional": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "slash": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
           "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         },
         "to-regex-range": {
           "version": "2.1.1",
@@ -4861,18 +4717,6 @@
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
           }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "optional": true
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "optional": true
         }
       }
     },
@@ -5197,16 +5041,6 @@
             "unique-filename": "^1.1.1"
           }
         },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -5334,12 +5168,6 @@
             "slash": "^2.0.0"
           }
         },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "optional": true
-        },
         "ignore": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -5361,17 +5189,6 @@
                 "is-buffer": "^1.1.5"
               }
             }
-          }
-        },
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "optional": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
           }
         },
         "lru-cache": {
@@ -5467,15 +5284,6 @@
             "ansi-regex": "^5.0.0"
           }
         },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
         "terser-webpack-plugin": {
           "version": "2.3.8",
           "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.8.tgz",
@@ -5499,17 +5307,6 @@
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
-          }
-        },
-        "vue-loader-v16": {
-          "version": "npm:vue-loader@16.1.2",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
-          "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
-          "optional": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "hash-sum": "^2.0.0",
-            "loader-utils": "^2.0.0"
           }
         },
         "wrap-ansi": {
@@ -5785,10 +5582,63 @@
       "resolved": "https://registry.npmjs.org/@vue/preload-webpack-plugin/-/preload-webpack-plugin-1.1.2.tgz",
       "integrity": "sha512-LIZMuJk38pk9U9Ur4YzHjlIyMuxPlACdBIHH9/nGYVTsaGKOSnSuELiE8vS9wa+dJpIYspYUOqk+L1Q4pgHQHQ=="
     },
+    "@vue/reactivity": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.5.tgz",
+      "integrity": "sha512-3xodUE3sEIJgS7ntwUbopIpzzvi7vDAOjVamfb2l+v1FUg0jpd3gf62N2wggJw3fxBMr+QvyxpD+dBoxLsmAjw==",
+      "requires": {
+        "@vue/shared": "3.0.5"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.5.tgz",
+          "integrity": "sha512-gYsNoGkWejBxNO6SNRjOh/xKeZ0H0V+TFzaPzODfBjkAIb0aQgBuixC1brandC/CDJy1wYPwSoYrXpvul7m6yw=="
+        }
+      }
+    },
+    "@vue/runtime-core": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.5.tgz",
+      "integrity": "sha512-Cnyi2NqREwOLcTEsIi1DQX1hHtkVj4eGm4hBG7HhokS05DqpK4/80jG6PCCnCH9rIJDB2FqtaODX397210plXg==",
+      "requires": {
+        "@vue/reactivity": "3.0.5",
+        "@vue/shared": "3.0.5"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.5.tgz",
+          "integrity": "sha512-gYsNoGkWejBxNO6SNRjOh/xKeZ0H0V+TFzaPzODfBjkAIb0aQgBuixC1brandC/CDJy1wYPwSoYrXpvul7m6yw=="
+        }
+      }
+    },
+    "@vue/runtime-dom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.5.tgz",
+      "integrity": "sha512-iilX1KySeIzHHtErT6Y44db1rhWK5tAI0CiJIPr+SJoZ2jbjoOSE6ff/jfIQakchbm1d6jq6VtRVnp5xYdOXKA==",
+      "requires": {
+        "@vue/runtime-core": "3.0.5",
+        "@vue/shared": "3.0.5",
+        "csstype": "^2.6.8"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.5.tgz",
+          "integrity": "sha512-gYsNoGkWejBxNO6SNRjOh/xKeZ0H0V+TFzaPzODfBjkAIb0aQgBuixC1brandC/CDJy1wYPwSoYrXpvul7m6yw=="
+        }
+      }
+    },
     "@vue/shared": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.3.tgz",
       "integrity": "sha512-yGgkF7u4W0Dmwri9XdeY50kOowN4UIX7aBQ///jbxx37itpzVjK7QzvD3ltQtPfWaJDGBfssGL0wpAgwX9OJpQ=="
+    },
+    "@vue/test-utils": {
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.0.0-rc.0.tgz",
+      "integrity": "sha512-sutAkUuE0gxlpzMO4V5SzzEujxdrTDr8YAK2KhhhmLKoNGX59UURXfW+DTLgaygB1n+i6nhs/WD+2A4wtjncSA=="
     },
     "@vue/web-component-wrapper": {
       "version": "1.2.0",
@@ -12161,6 +12011,156 @@
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
           }
+        }
+      }
+    },
+    "fork-ts-checker-webpack-plugin-v5": {
+      "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
+      "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
+      "optional": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@types/json-schema": "^7.0.5",
+        "chalk": "^4.1.0",
+        "cosmiconfig": "^6.0.0",
+        "deepmerge": "^4.2.2",
+        "fs-extra": "^9.0.0",
+        "memfs": "^3.1.2",
+        "minimatch": "^3.0.4",
+        "schema-utils": "2.7.0",
+        "semver": "^7.3.2",
+        "tapable": "^1.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "optional": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "optional": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "optional": true
+        },
+        "import-fresh": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+          "optional": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "optional": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "optional": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "optional": true
+        },
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "optional": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "optional": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "optional": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "optional": true
         }
       }
     },
@@ -18982,8 +18982,7 @@
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "pbkdf2": {
       "version": "3.1.1",
@@ -21198,6 +21197,16 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
           "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
         }
+      }
+    },
+    "rollup-plugin-vue": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-vue/-/rollup-plugin-vue-6.0.0.tgz",
+      "integrity": "sha512-oVvUd84d5u73M2HYM3XsMDLtZRIA/tw2U0dmHlXU2UWP5JARYHzh/U9vcxaN/x/9MrepY7VH3pHFeOhrWpxs/Q==",
+      "requires": {
+        "debug": "^4.1.1",
+        "hash-sum": "^2.0.0",
+        "rollup-pluginutils": "^2.8.2"
       }
     },
     "rollup-pluginutils": {
@@ -23893,6 +23902,54 @@
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
     },
+    "vue": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.0.5.tgz",
+      "integrity": "sha512-TfaprOmtsAfhQau7WsomXZ8d9op/dkQLNIq8qPV3A0Vxs6GR5E+c1rfJS1SDkXRQj+dFyfnec7+U0Be1huiScg==",
+      "requires": {
+        "@vue/compiler-dom": "3.0.5",
+        "@vue/runtime-dom": "3.0.5",
+        "@vue/shared": "3.0.5"
+      },
+      "dependencies": {
+        "@vue/compiler-core": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.5.tgz",
+          "integrity": "sha512-iFXwk2gmU/GGwN4hpBwDWWMLvpkIejf/AybcFtlQ5V1ur+5jwfBaV0Y1RXoR6ePfBPJixtKZ3PmN+M+HgMAtfQ==",
+          "requires": {
+            "@babel/parser": "^7.12.0",
+            "@babel/types": "^7.12.0",
+            "@vue/shared": "3.0.5",
+            "estree-walker": "^2.0.1",
+            "source-map": "^0.6.1"
+          }
+        },
+        "@vue/compiler-dom": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.5.tgz",
+          "integrity": "sha512-HSOSe2XSPuCkp20h4+HXSiPH9qkhz6YbW9z9ZtL5vef2T2PMugH7/osIFVSrRZP/Ul5twFZ7MIRlp8tPX6e4/g==",
+          "requires": {
+            "@vue/compiler-core": "3.0.5",
+            "@vue/shared": "3.0.5"
+          }
+        },
+        "@vue/shared": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.5.tgz",
+          "integrity": "sha512-gYsNoGkWejBxNO6SNRjOh/xKeZ0H0V+TFzaPzODfBjkAIb0aQgBuixC1brandC/CDJy1wYPwSoYrXpvul7m6yw=="
+        },
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "vue-hot-reload-api": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
@@ -23926,6 +23983,55 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ="
+        }
+      }
+    },
+    "vue-loader-v16": {
+      "version": "npm:vue-loader@16.1.2",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
+      "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
+      "optional": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "hash-sum": "^2.0.0",
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "optional": true
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },

--- a/packages/core/src/util/index.ts
+++ b/packages/core/src/util/index.ts
@@ -152,3 +152,4 @@ export * from './combinators';
 export * from './uischema';
 export * from './array';
 export * from './type';
+export * from './schema';

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -695,6 +695,16 @@ export const layoutDefaultProps: {
   direction: 'column'
 };
 
+const getDirection = (uischema: UISchemaElement) => {
+  if (uischema.type === 'HorizontalLayout') {
+    return 'row';
+  }
+  if (uischema.type === 'VerticalLayout') {
+    return 'column';
+  }
+  return layoutDefaultProps.direction;
+};
+
 /**
  * Map state to layout props.
  * @param state JSONForms state tree
@@ -729,7 +739,7 @@ export const mapStateToLayoutProps = (
     data,
     uischema: ownProps.uischema,
     schema: ownProps.schema,
-    direction: ownProps.direction || layoutDefaultProps.direction
+    direction: ownProps.direction ?? getDirection(uischema)
   };
 };
 

--- a/packages/core/src/util/schema.ts
+++ b/packages/core/src/util/schema.ts
@@ -1,0 +1,15 @@
+import find from "lodash/find";
+
+export const getFirstPrimitiveProp = (schema: any) => {
+  if (schema.properties) {
+    return find(Object.keys(schema.properties), propName => {
+      const prop = schema.properties[propName];
+      return (
+        prop.type === 'string' ||
+        prop.type === 'number' ||
+        prop.type === 'integer'
+      );
+    });
+  }
+  return undefined;
+};

--- a/packages/material/src/layouts/ExpandPanelRenderer.tsx
+++ b/packages/material/src/layouts/ExpandPanelRenderer.tsx
@@ -19,12 +19,12 @@ import {
   Resolve,
   update,
   JsonFormsCellRendererRegistryEntry,
-  JsonFormsUISchemaRegistryEntry
+  JsonFormsUISchemaRegistryEntry,
+  getFirstPrimitiveProp
 } from '@jsonforms/core';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import IconButton from '@material-ui/core/IconButton';
 import ExpansionPanel from '@material-ui/core/ExpansionPanel';
-import find from 'lodash/find';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import { Grid } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
@@ -235,20 +235,6 @@ export const ctxDispatchToExpandPanelProps: (
     );
   }
 });
-
-const getFirstPrimitiveProp = (schema: any) => {
-  if (schema.properties) {
-    return find(Object.keys(schema.properties), propName => {
-      const prop = schema.properties[propName];
-      return (
-        prop.type === 'string' ||
-        prop.type === 'number' ||
-        prop.type === 'integer'
-      );
-    });
-  }
-  return undefined;
-};
 
 /**
  * Map state to control props.

--- a/packages/material/src/mui-controls/MuiInputText.tsx
+++ b/packages/material/src/mui-controls/MuiInputText.tsx
@@ -32,6 +32,7 @@ import InputAdornment from '@material-ui/core/InputAdornment';
 import Close from '@material-ui/icons/Close';
 import { useTheme } from '@material-ui/core/styles';
 import { JsonFormsTheme } from '../util';
+import { InputBaseComponentProps } from '@material-ui/core';
 
 interface MuiTextInputProps {
   muiInputProps?: React.HTMLAttributes<HTMLInputElement>;
@@ -54,7 +55,7 @@ export const MuiInputText = React.memo((props: CellProps & WithClassname & MuiTe
   } = props;
   const maxLength = schema.maxLength;
   const appliedUiSchemaOptions = merge({}, config, uischema.options);
-  let inputProps: any;
+  let inputProps: InputBaseComponentProps;
   if (appliedUiSchemaOptions.restrict) {
     inputProps = { maxLength: maxLength };
   } else {

--- a/packages/vue-vanilla/LICENSE
+++ b/packages/vue-vanilla/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2019 EclipseSource Munich
+https://github.com/eclipsesource/jsonforms
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/vue-vanilla/README.md
+++ b/packages/vue-vanilla/README.md
@@ -1,0 +1,147 @@
+# JSON Forms - More Forms. Less Code
+
+*Complex Forms in the blink of an eye*
+
+JSON Forms eliminates the tedious task of writing fully-featured forms by hand by leveraging the capabilities of JSON, JSON Schema and Javascript.
+
+## Vue Vanilla Renderers
+
+This is the JSON Forms Vue Vanilla renderers package which provides a HTML5-based renderer set for [JSON Forms Vue](https://www.npmjs.com/package/@jsonforms/vue).
+
+### Quick start
+
+Install JSON Forms Core, Vue and Vue Vanilla Renderers
+
+```bash
+npm i --save @jsonforms/core @jsonforms/vue @jsonforms/vue-vanilla
+```
+
+Use the `json-forms` component for each form you want to render and hand over the renderer set.
+
+```vue
+<script>
+import { JsonForms } from '@jsonforms/vue';
+import { vanillaRenderers } from '@jsonforms/vue-vanilla'
+
+const renderers = [
+  ...vanillaRenderers,
+  // here you can add custom renderers
+]
+
+export default defineComponent({
+  name: 'app',
+  components: {
+    JsonForms
+  },
+  data() {
+    return {
+      renderers: Object.freeze(renderers),
+      data,
+      schema,
+      uischema,
+    };
+  },
+  methods: {
+    onChange(event) {
+      this.data = event.data;
+    },
+  }
+});
+</script>
+<template>
+  <json-forms
+    :data="data"
+    :schema="schema"
+    :uischema="uischema"
+    :renderers="renderers"
+    @change="onChange"
+  />
+</template>
+```
+
+By default the Vanilla Renderers don't apply any CSS at all.
+For a quick start you can use `@jsonforms/vue-vanilla/vanilla.css`.
+
+For more information on how JSON Forms can be configured, please see the [README of `@jsonforms/vue`](../vue/README.md).
+
+### Styling
+
+Each rendered HTML element specifies a CSS class which can be used to style it.
+This process can also be customized so that each element declares user-specified CSS classes.
+Therefore JSON Forms Vue Vanilla can be integrated with any CSS-only UI framework quite easily.
+
+You can find the default CSS classes in `[defaultStyles.ts](src/styles/defaultStyles.ts).
+
+To render your own classes simply `provide` them as `styles`.
+These `styles` replace the `defaultStyles`.
+If you want to fall back to `defaultStyles` or combine them with your own classes you'll need to do so programmatically, e.g.:
+
+```vue
+<script>
+import { JsonForms } from '@jsonforms/vue';
+import { defaultStyles, mergeStyles, vanillaRenderers } from '@jsonforms/vue-vanilla'
+
+// mergeStyles combines all classes from both styles definitions into one
+const myStyles = mergeStyles(defaultStyles, { control: { root: 'my-control' } });
+
+export default defineComponent({
+  name: 'app',
+  components: {
+    JsonForms
+  },
+  data() {
+    return {
+      renderers: Object.freeze(vanillaRenderers),
+      data,
+      schema,
+      uischema,
+    };
+  },
+  methods: {
+    onChange(event) {
+      this.data = event.data;
+    },
+  },
+  provide() {
+    return {
+      styles: myStyles;
+    }
+  }
+});
+</script>
+<template>
+  <json-forms
+    :data="data"
+    :schema="schema"
+    :uischema="uischema"
+    :renderers="renderers"
+    @change="onChange"
+  />
+</template>
+```
+
+You can also use specify styles in the ui schema via the `options.styles` property.
+Attributes specified here override the respective `defaultStyles` or provided `styles`.
+Attributes not specified here fall back to either the `defaultStyles` or provided `styles`.
+
+```js
+{
+  type: 'Control',
+  scope: '#/properties/name',
+  options: {
+    styles: {
+      control: {
+        root: 'my-control-root'
+      }
+    }
+  }
+}
+```
+
+## License
+
+The JSONForms project is licensed under the MIT License. See the [LICENSE file](https://github.com/eclipsesource/jsonforms/blob/master/LICENSE) for more information.
+
+## Roadmap
+
+Our current roadmap is available [here](https://github.com/eclipsesource/jsonforms/blob/master/ROADMAP.md).

--- a/packages/vue-vanilla/babel.config.js
+++ b/packages/vue-vanilla/babel.config.js
@@ -1,0 +1,5 @@
+const devPresets = ['@vue/cli-plugin-babel/preset'];
+const buildPresets = ['@babel/preset-env', '@babel/preset-typescript', ];
+module.exports = {
+  presets: (process.env.NODE_ENV === 'production' ? buildPresets: devPresets)
+};

--- a/packages/vue-vanilla/config/config.ts
+++ b/packages/vue-vanilla/config/config.ts
@@ -3,7 +3,7 @@ import { PropType } from "vue";
 /**
  * Switch between Vue 3 and Vue 2 '@vue/composition-api'.
  */
-export { computed, defineComponent, inject, onBeforeMount, onUnmounted, ref, watch, watchEffect } from "vue";
+export { computed, defineComponent, inject, ref, watch, watchEffect } from "vue";
 
 /**
  * Compatibility type as defineComponent of '@vue/composition-api' can't properly handle PropTypes.

--- a/packages/vue-vanilla/config/index.ts
+++ b/packages/vue-vanilla/config/index.ts
@@ -1,0 +1,1 @@
+export * from './config';

--- a/packages/vue-vanilla/dev/components/App.vue
+++ b/packages/vue-vanilla/dev/components/App.vue
@@ -1,0 +1,278 @@
+<script lang="ts">
+import { defineComponent } from '../../config';
+import { JsonForms, JsonFormsChangeEvent } from '@jsonforms/vue';
+import { vanillaRenderers, mergeStyles, defaultStyles } from '../../src';
+import '../../vanilla.css';
+
+const schema = {
+  properties: {
+    string: {
+      type: 'string',
+      description: 'a string'
+    },
+    multiString: {
+      type: 'string',
+      description: 'a string'
+    },
+    boolean: {
+      type: 'boolean',
+      description: 'enable / disable number'
+    },
+    boolean2: {
+      type: 'boolean',
+      description: 'show / hide integer'
+    },
+    number: {
+      type: 'number',
+      description: 'a number'
+    },
+    integer: {
+      type: 'integer',
+      description: 'an integer'
+    },
+    enum: {
+      type: 'string',
+      enum: ['a', 'b', 'c'],
+      description: 'an enum'
+    },
+    oneOfEnum: {
+      oneOf: [
+        { const: '1', title: 'Number 1' },
+        { const: 'B', title: 'Foo' }
+      ],
+      description: 'one of enum'
+    },
+    date: {
+      type: 'string',
+      format: 'date',
+      description: 'a date'
+    },
+    dateTime: {
+      type: 'string',
+      format: 'date-time',
+      description: 'a date time'
+    },
+    time: {
+      type: 'string',
+      format: 'time',
+      description: 'a time'
+    },
+    array: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'integer' }
+        }
+      }
+    }
+  },
+  required: ['string', 'number']
+} as any;
+
+const uischema = {
+  type: 'VerticalLayout',
+  elements: [
+    {
+      type: 'HorizontalLayout',
+      elements: [
+        {
+          type: 'VerticalLayout',
+          elements: [
+            {
+              type: 'Control',
+              scope: '#/properties/string'
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/multiString'
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/boolean'
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/boolean2'
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/number',
+              rule: {
+                effect: 'DISABLE',
+                condition: {
+                  scope: '#/properties/boolean',
+                  schema: {
+                    const: true
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          type: 'Group',
+          label: 'My group',
+          elements: [
+            {
+              type: 'Control',
+              scope: '#/properties/integer',
+              rule: {
+                effect: 'HIDE',
+                condition: {
+                  scope: '#/properties/boolean2',
+                  schema: {
+                    const: true
+                  }
+                }
+              }
+            },
+            {
+              type: 'HorizontalLayout',
+              elements: [
+                {
+                  type: 'Control',
+                  scope: '#/properties/enum'
+                },
+                {
+                  type: 'Control',
+                  scope: '#/properties/oneOfEnum'
+                },
+                {
+                  type: 'Control',
+                  scope: '#/properties/date'
+                }
+              ]
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/dateTime'
+            },
+            {
+              type: 'Control',
+              scope: '#/properties/time',
+              options: {
+                styles: {
+                  control: {
+                    root: 'control my-time'
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      type: 'Label',
+      text: 'This is my label'
+    },
+    {
+      type: 'Control',
+      scope: '#/properties/array',
+      options: {
+        childLabelProp: 'age'
+      }
+    }
+  ]
+} as any;
+
+// mergeStyles combines all classes from both styles definitions into one
+const myStyles = mergeStyles(defaultStyles, { control: { root: 'my-control' } });
+
+export default defineComponent({
+  name: 'app',
+  components: {
+    JsonForms
+  },
+  data: function() {
+    return {
+      renderers: Object.freeze(vanillaRenderers),
+      data: {
+        number: 5
+      },
+      schema,
+      uischema,
+      config: {
+        hideRequiredAsterisk: true
+      }
+    };
+  },
+  methods: {
+    setSchema() {
+      this.schema = {
+        properties: {
+          name: {
+            type: 'string',
+            title: 'NAME',
+            description: 'The name'
+          }
+        }
+      };
+    },
+    onChange(event: JsonFormsChangeEvent) {
+      console.log(event);
+      this.data = event.data;
+    },
+    switchAsterisk() {
+      this.config.hideRequiredAsterisk = !this.config.hideRequiredAsterisk;
+    },
+    adaptData() {
+      this.data.number = 10;
+    },
+    adaptUiSchema() {
+      this.uischema.elements[0].elements[0].elements[1].options = {
+        multi: true
+      };
+    }
+  },
+  provide() {
+    return {
+      styles: myStyles
+    }
+  }
+});
+</script>
+
+<style scoped>
+.form {
+  max-width: 500px;
+  flex: 1;
+}
+.container {
+  display: flex;
+}
+.data {
+  flex: 1;
+}
+</style>
+
+<template>
+  <div class="container">
+    <div class="form">
+      <json-forms
+        :data="data"
+        :schema="schema"
+        :uischema="uischema"
+        :renderers="renderers"
+        :config="config"
+        @change="onChange"
+      />
+      <button @click="setSchema">Set Schema</button>
+      <button @click="switchAsterisk">Switch Asterisk</button>
+      <button @click="adaptData">Adapt data</button>
+      <button @click="adaptUiSchema">Adapt uischema</button>
+    </div>
+    <div class="data">
+      <pre
+        >{{ JSON.stringify(data, null, 2) }}
+    </pre
+      >
+      <pre
+        >{{ JSON.stringify(config, null, 2) }}
+    </pre
+      >
+    </div>
+  </div>
+</template>

--- a/packages/vue-vanilla/dev/serve.ts
+++ b/packages/vue-vanilla/dev/serve.ts
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './components/App.vue';
+
+createApp(App).mount('#app');

--- a/packages/vue-vanilla/jest.config.js
+++ b/packages/vue-vanilla/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: '@vue/cli-plugin-unit-jest/presets/typescript-and-babel',
+  transform: {
+    '^.+\\.vue$': 'vue-jest'
+  }
+};

--- a/packages/vue-vanilla/package-lock.json
+++ b/packages/vue-vanilla/package-lock.json
@@ -1,0 +1,188 @@
+{
+	"name": "@jsonforms/vue-vanilla",
+	"version": "2.5.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@vue/test-utils": {
+			"version": "2.0.0-beta.12",
+			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.0.0-beta.12.tgz",
+			"integrity": "sha512-kRxM1IspG06i7smyVAgbN4C444ssKfnX67ETveZdb1AP7f6Kr3+bV4MmIwOsIZc6t7KK8gzx+clZd2jDeH4kMw==",
+			"dev": true
+		},
+		"rollup-plugin-vue": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-vue/-/rollup-plugin-vue-6.0.0.tgz",
+			"integrity": "sha512-oVvUd84d5u73M2HYM3XsMDLtZRIA/tw2U0dmHlXU2UWP5JARYHzh/U9vcxaN/x/9MrepY7VH3pHFeOhrWpxs/Q==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1",
+				"hash-sum": "^2.0.0",
+				"rollup-pluginutils": "^2.8.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"estree-walker": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+					"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+					"dev": true
+				},
+				"hash-sum": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+					"integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"rollup-pluginutils": {
+					"version": "2.8.2",
+					"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+					"integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+					"dev": true,
+					"requires": {
+						"estree-walker": "^0.6.1"
+					}
+				}
+			}
+		},
+		"vue": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-3.0.4.tgz",
+			"integrity": "sha512-2o+AiQF8sAupyhbyl3oxVCl3WCwC/n5NI7VMM+gVQ231qvSB8eI7sCBloloqDJK6yA367EEtmRSeSCf4sxCC+A==",
+			"dev": true,
+			"requires": {
+				"@vue/compiler-dom": "3.0.4",
+				"@vue/runtime-dom": "3.0.4",
+				"@vue/shared": "3.0.4"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+					"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+					"dev": true
+				},
+				"@babel/parser": {
+					"version": "7.12.7",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
+					"integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.12.7",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
+					"integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"@vue/compiler-core": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.4.tgz",
+					"integrity": "sha512-snpMICsbWTZqBFnPB03qr4DtiSxVYfDF3DvbDSkN9Z9NTM8Chl8E/lYhKBSsvauq91DAWAh8PU3lr9vrLyQsug==",
+					"dev": true,
+					"requires": {
+						"@babel/parser": "^7.12.0",
+						"@babel/types": "^7.12.0",
+						"@vue/shared": "3.0.4",
+						"estree-walker": "^2.0.1",
+						"source-map": "^0.6.1"
+					}
+				},
+				"@vue/compiler-dom": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.4.tgz",
+					"integrity": "sha512-FOxbHBIkkGjYQeTz1DlXQjS1Ms8EPXQWsdTdTPeohoS0KzCz6RiOjiAG+jLtMi6Nr5GX2h0TlCvcnI8mcsicFQ==",
+					"dev": true,
+					"requires": {
+						"@vue/compiler-core": "3.0.4",
+						"@vue/shared": "3.0.4"
+					}
+				},
+				"@vue/reactivity": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.4.tgz",
+					"integrity": "sha512-AFTABrLhUYZY2on3ea9FxeXal7w3f6qIp9gT+/oG93H7dFTL5LvVnxygCopv7tvkIl/GSGQb/yK1D1gmXx1Pww==",
+					"dev": true,
+					"requires": {
+						"@vue/shared": "3.0.4"
+					}
+				},
+				"@vue/runtime-core": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.0.4.tgz",
+					"integrity": "sha512-qH9e4kqU7b3u1JewvLmGmoAGY+mnuBqz7aEKb2mhpEgwa1yFv496BRuUfMXXMCix3+TndUVMJ8jt41FSdNppwg==",
+					"dev": true,
+					"requires": {
+						"@vue/reactivity": "3.0.4",
+						"@vue/shared": "3.0.4"
+					}
+				},
+				"@vue/runtime-dom": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.0.4.tgz",
+					"integrity": "sha512-BGIoiTSESzWUhN0Ofi2X/q+HN8f6IUFmUEyyBGKbmx7DTAJNZhFfjqsepfXQrM5IGeTfJLB1ZEVyroDQJNXq3g==",
+					"dev": true,
+					"requires": {
+						"@vue/runtime-core": "3.0.4",
+						"@vue/shared": "3.0.4",
+						"csstype": "^2.6.8"
+					}
+				},
+				"@vue/shared": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.4.tgz",
+					"integrity": "sha512-Swfbz31AaMX48CpFl+YmIrqOH9MgJMTrltG9e26A4ZxYx9LjGuMV+41WnxFzS3Bc9nbrc6sDPM37G6nIT8NJSg==",
+					"dev": true
+				},
+				"csstype": {
+					"version": "2.6.14",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+					"integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A==",
+					"dev": true
+				},
+				"estree-walker": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+					"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		}
+	}
+}

--- a/packages/vue-vanilla/package.json
+++ b/packages/vue-vanilla/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@jsonforms/vue-vanilla",
+  "version": "2.5.0",
+  "description": "Vue 3 Vanilla renderers for JSON Forms",
+  "repository": "https://github.com/eclipsesource/jsonforms",
+  "bugs": "https://github.com/eclipsesource/jsonforms/issues",
+  "homepage": "http://jsonforms.io/",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "vue",
+    "vue3",
+    "vue 3",
+    "form",
+    "forms",
+    "json",
+    "jsonforms",
+    "frontend",
+    "generator",
+    "input",
+    "renderengine",
+    "jsonschema",
+    "schema",
+    "uischema",
+    "layout",
+    "customization",
+    "html5",
+    "css",
+    "tailwind"
+  ],
+  "main": "lib/jsonforms-vue-vanilla.js",
+  "types": "lib/src/index.d.ts",
+  "files": [
+    "lib/*",
+    "src/*"
+  ],
+  "scripts": {
+    "serve": "vue-cli-service serve dev/serve.ts",
+    "build": "cross-env NODE_ENV=production rollup --config rollup.config.js",
+    "clean": "rm -rf lib",
+    "doc": "../../node_modules/.bin/typedoc --name 'JSON Forms Vue' --mode file --out docs src --ignoreCompilerErrors",
+    "test": "vue-cli-service test:unit"
+  },
+  "dependencies": {
+    "lodash": "^4.17.15"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.9.0",
+    "@babel/preset-env": "^7.9.5",
+    "@babel/preset-typescript": "^7.9.0",
+    "@jsonforms/core": "^2.5.0",
+    "@jsonforms/vue": "^2.5.0",
+    "@rollup/plugin-alias": "^2.2.0",
+    "@types/jest": "^24.0.23",
+    "@vue/cli-plugin-babel": "^4.3.1",
+    "@vue/cli-plugin-typescript": "^4.3.1",
+    "@vue/cli-plugin-unit-jest": "~4.5.0",
+    "@vue/cli-service": "^4.3.1",
+    "@vue/compiler-sfc": "^3.0.3",
+    "@vue/test-utils": "^2.0.0-0",
+    "cross-env": "^7.0.2",
+    "rollup": "^2.7.3",
+    "rollup-plugin-babel": "^4.4.0",
+    "rollup-plugin-typescript2": "^0.29.0",
+    "rollup-plugin-vue": "^6.0.0",
+    "typescript": "3.8.3",
+    "vue": "^3.0.3",
+    "vue-jest": "^5.0.0-0",
+    "vue-template-compiler": "^2.6.11"
+  },
+  "peerDependencies": {
+    "@jsonforms/core": "^2.5.0",
+    "@jsonforms/vue": "^2.5.0",
+    "vue": "^3.0.3"
+  }
+}

--- a/packages/vue-vanilla/rollup.config.js
+++ b/packages/vue-vanilla/rollup.config.js
@@ -1,0 +1,42 @@
+import vue from 'rollup-plugin-vue';
+import alias from '@rollup/plugin-alias';
+import babel from 'rollup-plugin-babel';
+import typescript from 'rollup-plugin-typescript2';
+
+const buildFormats = [
+  {
+    input: 'src/index.ts',
+    output: {
+      file: 'lib/jsonforms-vue-vanilla.js',
+      format: 'esm',
+      exports: 'named',
+      sourcemap: true
+    },
+    external: ['vue', '@jsonforms/core', '@jsonforms/vue', 'lodash/maxBy', 'lodash/merge', 'lodash/cloneDeep'],
+    plugins: [
+      typescript({
+        module: 'esnext',
+        tsconfig: 'tsconfig.json',
+        tsconfigOverride: {
+          include: null,
+          exclude: ['node_modules', 'tests', 'dev']
+        }
+      }),
+      alias({
+        resolve: ['.js', '.jsx', '.ts', '.tsx', '.vue']
+      }),
+      vue({
+        css: false,
+        template: {
+          isProduction: true
+        }
+      }),
+      babel({
+        exclude: 'node_modules/**',
+        extensions: ['.js', '.jsx', '.ts', '.tsx', '.vue']
+      })
+    ]
+  }
+];
+
+export default buildFormats;

--- a/packages/vue-vanilla/shims-vue.d.ts
+++ b/packages/vue-vanilla/shims-vue.d.ts
@@ -1,0 +1,7 @@
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+  const component: DefineComponent<{}, {}, any>
+  export default component
+
+  export const entry
+}

--- a/packages/vue-vanilla/src/array/ArrayListElement.vue
+++ b/packages/vue-vanilla/src/array/ArrayListElement.vue
@@ -1,0 +1,114 @@
+<template>
+  <div
+    @click="expandClicked"
+    :class="toolbarClasses"
+  >
+    <div :class="styles.arrayList.itemLabel">{{ label }}</div>
+    <button
+      @click="moveUpClicked"
+      :disabled="!moveUpEnabled"
+      :class="styles.arrayList.itemMoveUp"
+    >
+      ↑
+    </button>
+    <button
+      @click="moveDownClicked"
+      :disabled="!moveDownEnabled"
+      :class="styles.arrayList.itemMoveDown"
+    >
+      ↓
+    </button>
+    <button @click="deleteClicked" :class="styles.arrayList.itemDelete">
+      🗙
+    </button>
+  </div>
+  <div :class="contentClasses">
+    <slot></slot>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, CompType } from '../../config';
+import { classes, Styles } from '../styles';
+
+const listItem = defineComponent({
+  name: 'array-list-element',
+  props: {
+    initiallyExpanded: {
+      required: false,
+      type: Boolean,
+      default: false
+    },
+    label: {
+      required: false,
+      type: String,
+      default: ''
+    },
+    moveUpEnabled: {
+      required: false,
+      type: Boolean,
+      default: true
+    },
+    moveDownEnabled: {
+      required: false,
+      type: Boolean,
+      default: true
+    },
+    moveUp: {
+      required: false,
+      type: Function,
+      default: undefined
+    },
+    moveDown: {
+      required: false,
+      type: Function,
+      default: undefined
+    },
+    delete: {
+      required: false,
+      type: Function,
+      default: undefined
+    },
+    styles: {
+      required: true,
+      type: Object as CompType<Styles, ObjectConstructor>,
+    }
+  },
+  data() {
+    return {
+      expanded: this.initiallyExpanded
+    };
+  },
+  computed: {
+    contentClasses(): string {
+      return classes`${this.styles.arrayList.itemContent} ${
+        this.expanded && this.styles.arrayList.itemExpanded
+      }`;
+    },
+    toolbarClasses(): string {
+      return classes`${this.styles.arrayList.itemToolbar} ${
+        this.expanded && this.styles.arrayList.itemExpanded
+      }`;
+    }
+  },
+  methods: {
+    expandClicked(): void {
+      this.expanded = !this.expanded;
+    },
+    moveUpClicked(event: Event): void {
+      event.stopPropagation();
+      this.moveUp?.();
+    },
+    moveDownClicked(event: Event): void {
+      event.stopPropagation();
+      this.moveDown?.();
+    },
+    deleteClicked(event: Event): void {
+      event.stopPropagation();
+      this.delete?.();
+    }
+  }
+});
+
+export default listItem;
+</script>

--- a/packages/vue-vanilla/src/array/ArrayListRenderer.vue
+++ b/packages/vue-vanilla/src/array/ArrayListRenderer.vue
@@ -1,0 +1,94 @@
+<template>
+  <fieldset v-if="control.visible" :class="styles.arrayList.root">
+    <legend :class="styles.arrayList.legend">
+      <button :class="styles.arrayList.addButton" @click="addButtonClick">
+        +
+      </button>
+      <label :class="styles.arrayList.label">
+        {{ control.label }}
+      </label>
+    </legend>
+    <div
+      v-for="(element, index) in control.data"
+      :key="`${control.path}-${index}`"
+      :class="styles.arrayList.item"
+    >
+      <array-list-element
+        :moveUp="moveUp(control.path, index)"
+        :moveUpEnabled="index > 0"
+        :moveDown="moveDown(control.path, index)"
+        :moveDownEnabled="index < control.data.length - 1"
+        :delete="removeItems(control.path, [index])"
+        :label="childLabelForIndex(index)"
+        :styles="styles"
+      >
+        <dispatch-renderer
+          :schema="control.schema"
+          :uischema="childUiSchema"
+          :path="composePaths(control.path, `${index}`)"
+          :enabled="control.enabled"
+          :renderers="control.renderers"
+          :cells="control.cells"
+        />
+      </array-list-element>
+    </div>
+    <div v-if="noData" :class="styles.arrayList.noData">
+      No data
+    </div>
+  </fieldset>
+</template>
+
+<script lang="ts">
+import {
+  composePaths,
+  createDefaultValue,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  ControlElement,
+  schemaTypeIs
+} from '@jsonforms/core';
+import { defineComponent } from '../../config';
+import {
+  DispatchRenderer,
+  rendererProps,
+  useJsonFormsArrayControl
+} from '@jsonforms/vue';
+import { useVanillaArrayControl } from '../util';
+import ArrayListElement from './ArrayListElement.vue';
+
+const controlRenderer = defineComponent({
+  name: 'array-list-renderer',
+  components: {
+    ArrayListElement,
+    DispatchRenderer
+  },
+  props: {
+    ...rendererProps<ControlElement>()
+  },
+  setup(props) {
+    return useVanillaArrayControl(useJsonFormsArrayControl(props));
+  },
+  computed: {
+    noData(): boolean {
+      return !this.control.data || this.control.data.length === 0;
+    }
+  },
+  methods: {
+    composePaths,
+    createDefaultValue,
+    addButtonClick() {
+      this.addItem(
+        this.control.path,
+        createDefaultValue(this.control.schema)
+      )();
+    }
+  }
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, schemaTypeIs('array'))
+};
+</script>

--- a/packages/vue-vanilla/src/array/index.ts
+++ b/packages/vue-vanilla/src/array/index.ts
@@ -1,0 +1,7 @@
+export { default as ArrayListRenderer } from './ArrayListRenderer.vue';
+
+import { entry as arrayListRendererEntry } from './ArrayListRenderer.vue';
+
+export const arrayRenderers = [
+  arrayListRendererEntry
+]

--- a/packages/vue-vanilla/src/controls/BooleanControlRenderer.vue
+++ b/packages/vue-vanilla/src/controls/BooleanControlRenderer.vue
@@ -1,0 +1,53 @@
+<template>
+  <control-wrapper
+    v-bind="control"
+    :styles="styles"
+    :isFocused="isFocused"
+    :appliedOptions="appliedOptions"
+  >
+    <input
+      type="checkbox"
+      :class="styles.control.input"
+      :id="control.id + '-input'"
+      :checked="!!control.data"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    />
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isBooleanControl
+} from '@jsonforms/core';
+import { defineComponent } from '../../config';
+import { rendererProps, useJsonFormsControl } from '@jsonforms/vue';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'boolean-control-renderer',
+  components: {
+    ControlWrapper
+  },
+  props: {
+    ...rendererProps<ControlElement>()
+  },
+  setup(props) {
+    return useVanillaControl(useJsonFormsControl(props), target => target.checked);
+  }
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(1, isBooleanControl)
+};
+</script>

--- a/packages/vue-vanilla/src/controls/ControlWrapper.vue
+++ b/packages/vue-vanilla/src/controls/ControlWrapper.vue
@@ -1,0 +1,86 @@
+<template>
+  <div v-if="visible" :class="styles.control.root" :id="id">
+    <label :for="id + '-input'" :class="styles.control.label">
+      {{ computedLabel }}
+    </label>
+    <div :class="styles.control.wrapper">
+      <slot></slot>
+    </div>
+    <div :class="errors ? styles.control.error : styles.control.description">
+      {{ errors ? errors : showDescription ? description : null }}
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { isDescriptionHidden, computeLabel } from '@jsonforms/core';
+import { defineComponent, CompType } from '../../config';
+import { Styles } from '../styles';
+import { Options } from '../util';
+
+export default defineComponent({
+  name: 'control-wrapper',
+  props: {
+    id: {
+      required: true as true,
+      type: String
+    },
+    description: {
+      required: false as false,
+      type: String,
+      default: undefined
+    },
+    errors: {
+      required: false as false,
+      type: String,
+      default: undefined
+    },
+    label: {
+      required: false as false,
+      type: String,
+      default: undefined
+    },
+    appliedOptions: {
+      required: false as false,
+      type: Object as CompType<Options, ObjectConstructor>,
+      default: undefined
+    },
+    visible: {
+      required: false as false,
+      type: Boolean,
+      default: true
+    },
+    required: {
+      required: false as false,
+      type: Boolean,
+      default: false
+    },
+    isFocused: {
+      required: false as false,
+      type: Boolean,
+      default: false
+    },
+    styles: {
+      required: true,
+      type: Object as CompType<Styles, ObjectConstructor>
+    }
+  },
+  computed: {
+    showDescription(): boolean {
+      return !isDescriptionHidden(
+        this.visible,
+        this.description,
+        this.isFocused,
+        !!this.appliedOptions?.showUnfocusedDescription
+      );
+    },
+    computedLabel(): string {
+      return computeLabel(
+        this.label,
+        this.required,
+        !!this.appliedOptions?.hideRequiredAsterisk
+      );
+    }
+  }
+});
+</script>

--- a/packages/vue-vanilla/src/controls/DateControlRenderer.vue
+++ b/packages/vue-vanilla/src/controls/DateControlRenderer.vue
@@ -1,0 +1,53 @@
+<template>
+  <control-wrapper
+    v-bind="control"
+    :styles="styles"
+    :isFocused="isFocused"
+    :appliedOptions="appliedOptions"
+  >
+    <input
+      type="date"
+      :id="control.id + '-input'"
+      :class="styles.control.input"
+      :value="control.data"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    />
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isDateControl
+} from '@jsonforms/core';
+import { defineComponent } from '../../config';
+import { rendererProps, useJsonFormsControl } from '@jsonforms/vue';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'date-control-renderer',
+  components: {
+    ControlWrapper
+  },
+  props: {
+    ...rendererProps<ControlElement>()
+  },
+  setup(props) {
+    return useVanillaControl(useJsonFormsControl(props));
+  },
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, isDateControl)
+};
+</script>

--- a/packages/vue-vanilla/src/controls/DateTimeControlRenderer.vue
+++ b/packages/vue-vanilla/src/controls/DateTimeControlRenderer.vue
@@ -1,0 +1,62 @@
+<template>
+  <control-wrapper
+    v-bind="control"
+    :styles="styles"
+    :isFocused="isFocused"
+    :appliedOptions="appliedOptions"
+  >
+    <input
+      type="datetime-local"
+      :id="control.id + '-input'"
+      :class="styles.control.input"
+      :value="dataTime"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    />
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isDateTimeControl
+} from '@jsonforms/core';
+import { defineComponent } from '../../config';
+import { rendererProps, useJsonFormsControl } from '@jsonforms/vue';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const toISOString = (inputDateTime: string) => {
+  return inputDateTime === '' ? '' : inputDateTime + ':00.000Z';
+};
+
+const controlRenderer = defineComponent({
+  name: 'datetime-control-renderer',
+  components: {
+    ControlWrapper
+  },
+  props: {
+    ...rendererProps<ControlElement>()
+  },
+  setup(props) {
+    return useVanillaControl(useJsonFormsControl(props), target => toISOString(target.value));
+  },
+  computed: {
+    dataTime(): string {
+      return (this.control.data ?? '').substr(0, 16);
+    }
+  },
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, isDateTimeControl)
+};
+</script>

--- a/packages/vue-vanilla/src/controls/EnumControlRenderer.vue
+++ b/packages/vue-vanilla/src/controls/EnumControlRenderer.vue
@@ -1,0 +1,62 @@
+<template>
+  <control-wrapper
+    v-bind="control"
+    :styles="styles"
+    :isFocused="isFocused"
+    :appliedOptions="appliedOptions"
+  >
+    <select
+      :id="control.id + '-select'"
+      :class="styles.control.select"
+      :value="control.data"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    >
+      <option value="" key="empty" :class="styles.control.option"/>
+      <option
+        v-for="optionElement in control.options"
+        :key="optionElement.value"
+        :value="optionElement.value"
+        :label="optionElement.label"
+        :class="styles.control.option"
+      >
+      </option
+    ></select>
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isEnumControl
+} from '@jsonforms/core';
+import { defineComponent } from '../../config';
+import { rendererProps, useJsonFormsEnumControl } from '@jsonforms/vue';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'enum-control-renderer',
+  components: {
+    ControlWrapper
+  },
+  props: {
+    ...rendererProps<ControlElement>()
+  },
+  setup(props) {
+    return useVanillaControl(useJsonFormsEnumControl(props));
+  }
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, isEnumControl)
+};
+</script>

--- a/packages/vue-vanilla/src/controls/EnumOneOfControlRenderer.vue
+++ b/packages/vue-vanilla/src/controls/EnumOneOfControlRenderer.vue
@@ -1,0 +1,62 @@
+<template>
+  <control-wrapper
+    v-bind="control"
+    :styles="styles"
+    :isFocused="isFocused"
+    :appliedOptions="appliedOptions"
+  >
+    <select
+      :id="control.id + '-input'"
+      :class="styles.control.select"
+      :value="control.data"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    >
+      <option value="" key="empty" :class="styles.control.option"/>
+      <option
+        v-for="optionElement in control.options"
+        :key="optionElement.value"
+        :value="optionElement.value"
+        :label="optionElement.label"
+        :class="styles.control.option"
+      >
+      </option
+    ></select>
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isOneOfEnumControl
+} from '@jsonforms/core';
+import { defineComponent } from '../../config';
+import { rendererProps, useJsonFormsOneOfEnumControl } from '@jsonforms/vue';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'enum-oneof-control-renderer',
+  components: {
+    ControlWrapper
+  },
+  props: {
+    ...rendererProps<ControlElement>()
+  },
+  setup(props) {
+    return useVanillaControl(useJsonFormsOneOfEnumControl(props));
+  }
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, isOneOfEnumControl)
+};
+</script>

--- a/packages/vue-vanilla/src/controls/IntegerControlRenderer.vue
+++ b/packages/vue-vanilla/src/controls/IntegerControlRenderer.vue
@@ -1,0 +1,54 @@
+<template>
+  <control-wrapper
+    v-bind="control"
+    :styles="styles"
+    :isFocused="isFocused"
+    :appliedOptions="appliedOptions"
+  >
+    <input
+      type="number"
+      :step="1"
+      :id="control.id + '-input'"
+      :class="styles.control.input"
+      :value="control.data"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    />
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isIntegerControl
+} from '@jsonforms/core';
+import { defineComponent } from '../../config';
+import { rendererProps, useJsonFormsControl } from '@jsonforms/vue';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'integer-control-renderer',
+  components: {
+    ControlWrapper
+  },
+  props: {
+    ...rendererProps<ControlElement>()
+  },
+  setup(props) {
+    return useVanillaControl(useJsonFormsControl(props), target => parseInt(target.value, 10));
+  },
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(1, isIntegerControl)
+};
+</script>

--- a/packages/vue-vanilla/src/controls/MultiStringControlRenderer.vue
+++ b/packages/vue-vanilla/src/controls/MultiStringControlRenderer.vue
@@ -1,0 +1,54 @@
+<template>
+  <control-wrapper
+    v-bind="control"
+    :styles="styles"
+    :isFocused="isFocused"
+    :appliedOptions="appliedOptions"
+  >
+    <textarea
+      :id="control.id + '-input'"
+      :class="styles.control.textarea"
+      :value="control.data"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    />
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isStringControl,
+  isMultiLineControl,
+  and
+} from '@jsonforms/core';
+import { defineComponent } from '../../config';
+import { rendererProps, useJsonFormsControl } from '@jsonforms/vue';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'multi-string-control-renderer',
+  components: {
+    ControlWrapper
+  },
+  props: {
+    ...rendererProps<ControlElement>()
+  },
+  setup(props) {
+    return useVanillaControl(useJsonFormsControl(props));
+  }
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, and(isStringControl, isMultiLineControl))
+};
+</script>

--- a/packages/vue-vanilla/src/controls/NumberControlRenderer.vue
+++ b/packages/vue-vanilla/src/controls/NumberControlRenderer.vue
@@ -1,0 +1,56 @@
+<template>
+  <control-wrapper
+    v-bind="control"
+    :styles="styles"
+    :isFocused="isFocused"
+    :appliedOptions="appliedOptions"
+  >
+    <input
+      type="number"
+      :step="appliedOptions.step ?? 0.1"
+      :id="control.id + '-input'"
+      :class="styles.control.input"
+      :value="control.data"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    />
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isNumberControl
+} from '@jsonforms/core';
+import { defineComponent } from '../../config';
+import { rendererProps, useJsonFormsControl } from '@jsonforms/vue';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'number-control-renderer',
+  components: {
+    ControlWrapper
+  },
+  props: {
+    ...rendererProps<ControlElement>()
+  },
+  setup(props) {
+    return useVanillaControl(useJsonFormsControl(props), target =>
+      Number(target.value)
+    );
+  }
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(1, isNumberControl)
+};
+</script>

--- a/packages/vue-vanilla/src/controls/StringControlRenderer.vue
+++ b/packages/vue-vanilla/src/controls/StringControlRenderer.vue
@@ -1,0 +1,52 @@
+<template>
+  <control-wrapper
+    v-bind="control"
+    :styles="styles"
+    :isFocused="isFocused"
+    :appliedOptions="appliedOptions"
+  >
+    <input
+      :id="control.id + '-input'"
+      :class="styles.control.input"
+      :value="control.data"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    />
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isStringControl
+} from '@jsonforms/core';
+import { defineComponent } from '../../config';
+import { rendererProps, useJsonFormsControl } from '@jsonforms/vue';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'string-control-renderer',
+  components: {
+    ControlWrapper
+  },
+  props: {
+    ...rendererProps<ControlElement>()
+  },
+  setup(props) {
+    return useVanillaControl(useJsonFormsControl(props));
+  }
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(1, isStringControl)
+};
+</script>

--- a/packages/vue-vanilla/src/controls/TimeControlRenderer.vue
+++ b/packages/vue-vanilla/src/controls/TimeControlRenderer.vue
@@ -1,0 +1,53 @@
+<template>
+  <control-wrapper
+    v-bind="control"
+    :styles="styles"
+    :isFocused="isFocused"
+    :appliedOptions="appliedOptions"
+  >
+    <input
+      type="time"
+      :id="control.id + '-input'"
+      :class="styles.control.input"
+      :value="control.data"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    />
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isTimeControl
+} from '@jsonforms/core';
+import { defineComponent } from '../../config';
+import { rendererProps, useJsonFormsControl } from '@jsonforms/vue';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'time-control-renderer',
+  components: {
+    ControlWrapper
+  },
+  props: {
+    ...rendererProps<ControlElement>()
+  },
+  setup(props) {
+    return useVanillaControl(useJsonFormsControl(props));
+  }
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, isTimeControl)
+};
+</script>

--- a/packages/vue-vanilla/src/controls/index.ts
+++ b/packages/vue-vanilla/src/controls/index.ts
@@ -1,0 +1,38 @@
+export { default as ControlWrapper } from './ControlWrapper.vue';
+export { default as StringControlRenderer } from './StringControlRenderer.vue';
+export { default as MultiStringControlRenderer } from './MultiStringControlRenderer.vue';
+export { default as NumberControlRenderer } from './NumberControlRenderer.vue';
+export { default as IntegerControlRenderer } from './IntegerControlRenderer.vue';
+export { default as EnumControlRenderer } from './EnumControlRenderer.vue';
+export { default as oneOfEnumControlRenderer} from './EnumOneOfControlRenderer.vue';
+export { default as DateControlRenderer} from './DateControlRenderer.vue';
+export { default as DateTimeControlRenderer} from './DateTimeControlRenderer.vue';
+export { default as TimeControlRenderer} from './TimeControlRenderer.vue';
+export { default as BooleanControlRenderer } from './BooleanControlRenderer.vue'
+
+
+import { entry as stringControlRendererEntry } from './StringControlRenderer.vue';
+import { entry as multiStringControlRendererEntry } from './MultiStringControlRenderer.vue';
+import { entry as numberControlRendererEntry } from './NumberControlRenderer.vue';
+import { entry as integerControlRendererEntry } from './IntegerControlRenderer.vue';
+import { entry as enumControlRendererEntry } from './EnumControlRenderer.vue';
+import { entry as oneOfEnumControlRendererEntry } from './EnumOneOfControlRenderer.vue';
+import { entry as dateControlRendererEntry } from './DateControlRenderer.vue';
+import { entry as dateTimeControlRendererEntry } from './DateTimeControlRenderer.vue';
+import { entry as timeControlRendererEntry } from './TimeControlRenderer.vue';
+import { entry as booleanControlRendererEntry} from './BooleanControlRenderer.vue';
+
+
+
+export const controlRenderers = [
+  stringControlRendererEntry,
+  multiStringControlRendererEntry,
+  numberControlRendererEntry,
+  integerControlRendererEntry,
+  enumControlRendererEntry,
+  oneOfEnumControlRendererEntry,
+  dateControlRendererEntry,
+  dateTimeControlRendererEntry,
+  timeControlRendererEntry,
+  booleanControlRendererEntry
+]

--- a/packages/vue-vanilla/src/index.ts
+++ b/packages/vue-vanilla/src/index.ts
@@ -1,0 +1,7 @@
+export * from './array';
+export * from './controls';
+export * from './layouts';
+export * from './renderers'
+export * from './styles';
+export * from './util';
+export * from './label';

--- a/packages/vue-vanilla/src/label/LabelRenderer.vue
+++ b/packages/vue-vanilla/src/label/LabelRenderer.vue
@@ -1,0 +1,42 @@
+<template>
+  <label v-if="layout.visible" :class="styles.label">
+    {{ this.layout.uischema.text }}
+  </label>
+</template>
+
+<script lang="ts">
+import {
+  JsonFormsRendererRegistryEntry,
+  Layout,
+  rankWith,
+  uiTypeIs
+} from '@jsonforms/core';
+import { defineComponent } from '../../config';
+import {
+  DispatchRenderer,
+  rendererProps,
+  useJsonFormsLayout
+} from '@jsonforms/vue';
+import { useVanillaLayout } from '../util';
+
+const labelRenderer = defineComponent({
+  name: 'label-renderer',
+  components: {
+    DispatchRenderer
+  },
+  props: {
+    ...rendererProps<Layout>()
+  },
+  setup(props) {
+    // reuse layout bindings for label
+    return useVanillaLayout(useJsonFormsLayout(props));
+  }
+});
+
+export default labelRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: labelRenderer,
+  tester: rankWith(1, uiTypeIs('Label'))
+};
+</script>

--- a/packages/vue-vanilla/src/label/index.ts
+++ b/packages/vue-vanilla/src/label/index.ts
@@ -1,0 +1,7 @@
+export { default as LabelRenderer } from './LabelRenderer.vue';
+
+import { entry as labelRendererEntry } from './LabelRenderer.vue';
+
+export const labelRenderers = [
+  labelRendererEntry
+]

--- a/packages/vue-vanilla/src/layouts/GroupRenderer.vue
+++ b/packages/vue-vanilla/src/layouts/GroupRenderer.vue
@@ -1,0 +1,59 @@
+<template>
+  <fieldset v-if="layout.visible" :class="styles.group.root">
+    <legend v-if="layout.uischema.label" :class="styles.group.label">
+      {{ layout.uischema.label }}
+    </legend>
+    <div
+      v-for="(element, index) in layout.uischema.elements"
+      :key="`${layout.path}-${index}`"
+      :class="styles.group.item"
+    >
+      <dispatch-renderer
+        :schema="layout.schema"
+        :uischema="element"
+        :path="layout.path"
+        :enabled="layout.enabled"
+        :renderers="layout.renderers"
+        :cells="layout.cells"
+      />
+    </div>
+  </fieldset>
+</template>
+
+<script lang="ts">
+import {
+  JsonFormsRendererRegistryEntry,
+  Layout,
+  rankWith,
+  and,
+  isLayout,
+  uiTypeIs
+} from '@jsonforms/core';
+import { defineComponent } from '../../config';
+import {
+  DispatchRenderer,
+  rendererProps,
+  useJsonFormsLayout
+} from '@jsonforms/vue';
+import { useVanillaLayout } from '../util';
+
+const layoutRenderer = defineComponent({
+  name: 'group-renderer',
+  components: {
+    DispatchRenderer
+  },
+  props: {
+    ...rendererProps<Layout>()
+  },
+  setup(props) {
+    return useVanillaLayout(useJsonFormsLayout(props));
+  }
+});
+
+export default layoutRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: layoutRenderer,
+  tester: rankWith(2, and(isLayout, uiTypeIs('Group')))
+};
+</script>

--- a/packages/vue-vanilla/src/layouts/LayoutRenderer.vue
+++ b/packages/vue-vanilla/src/layouts/LayoutRenderer.vue
@@ -1,0 +1,59 @@
+<template>
+  <div v-if="layout.visible" :class="styles[className].root">
+    <div
+      v-for="(element, index) in layout.uischema.elements"
+      :key="`${layout.path}-${index}`"
+      :class="styles[className]?.item"
+    >
+      <dispatch-renderer
+        :schema="layout.schema"
+        :uischema="element"
+        :path="layout.path"
+        :enabled="layout.enabled"
+        :renderers="layout.renderers"
+        :cells="layout.cells"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import {
+  isLayout,
+  JsonFormsRendererRegistryEntry,
+  Layout,
+  rankWith
+} from '@jsonforms/core';
+import { defineComponent } from "../../config";
+import {
+  DispatchRenderer,
+  rendererProps,
+  useJsonFormsLayout
+} from '@jsonforms/vue';
+import { useVanillaLayout } from '../util';
+
+const layoutRenderer = defineComponent({
+  name: 'layout-renderer',
+  components: {
+    DispatchRenderer
+  },
+  props: {
+    ...rendererProps<Layout>()
+  },
+  setup(props) {
+    return useVanillaLayout(useJsonFormsLayout(props));
+  },
+  computed: {
+    className(): string {
+      return this.layout.direction === 'row' ? 'horizontalLayout' : 'verticalLayout';
+    }
+  }
+});
+
+export default layoutRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: layoutRenderer,
+  tester: rankWith(1, isLayout)
+};
+</script>

--- a/packages/vue-vanilla/src/layouts/index.ts
+++ b/packages/vue-vanilla/src/layouts/index.ts
@@ -1,0 +1,10 @@
+export { default as LayoutRenderer } from './LayoutRenderer.vue';
+export { default as GroupRenderer } from './GroupRenderer.vue';
+
+import { entry as layoutRendererEntry } from './LayoutRenderer.vue';
+import { entry as groupRendererEntry} from './GroupRenderer.vue';
+
+export const layoutRenderers = [
+  layoutRendererEntry,
+  groupRendererEntry
+]

--- a/packages/vue-vanilla/src/renderers.ts
+++ b/packages/vue-vanilla/src/renderers.ts
@@ -1,0 +1,11 @@
+import { arrayRenderers } from './array';
+import { controlRenderers } from './controls';
+import { labelRenderers } from './label';
+import { layoutRenderers } from './layouts';
+
+export const vanillaRenderers = [
+  ...controlRenderers,
+  ...layoutRenderers,
+  ...arrayRenderers,
+  ...labelRenderers
+];

--- a/packages/vue-vanilla/src/styles/defaultStyles.ts
+++ b/packages/vue-vanilla/src/styles/defaultStyles.ts
@@ -1,0 +1,45 @@
+import { Styles } from "./styles";
+
+export const defaultStyles: Styles = {
+  control: {
+    root: 'control',
+    wrapper: 'wrapper',
+    label: 'label',
+    description: 'description',
+    error: 'error',
+    textarea: 'text-area',
+    select: 'select',
+    option: 'option'
+  },
+  verticalLayout: {
+    root: 'vertical-layout',
+    item: 'vertical-layout-item'
+  },
+  horizontalLayout: {
+    root: 'horizontal-layout',
+    item: 'horizontal-layout-item'
+  },
+  group: {
+    root: 'group',
+    label: 'group-label',
+    item: 'group-item'
+  },
+  arrayList: {
+    root: 'array-list',
+    legend: 'array-list-legend',
+    addButton: 'array-list-add',
+    label: 'array-list-label',
+    item: 'array-list-item',
+    noData: 'array-list-no-data',
+    itemToolbar: 'array-list-item-toolbar',
+    itemLabel: 'array-list-item-label',
+    itemContent: 'array-list-item-content',
+    itemExpanded: 'expanded',
+    itemMoveUp: 'array-list-item-move-up',
+    itemMoveDown: 'array-list-item-move-down',
+    itemDelete: 'array-list-item-delete'
+  },
+  label: {
+    root: 'label-element'
+  }
+};

--- a/packages/vue-vanilla/src/styles/index.ts
+++ b/packages/vue-vanilla/src/styles/index.ts
@@ -1,0 +1,3 @@
+export * from './styles';
+export * from './util';
+export * from './defaultStyles';

--- a/packages/vue-vanilla/src/styles/styles.ts
+++ b/packages/vue-vanilla/src/styles/styles.ts
@@ -1,0 +1,74 @@
+import { UISchemaElement } from '@jsonforms/core';
+import { inject } from 'vue';
+import merge from 'lodash/merge';
+import { defaultStyles } from './defaultStyles';
+
+const createEmptyStyles = (): Styles => ({
+  control: {},
+  verticalLayout: {},
+  horizontalLayout: {},
+  group: {},
+  arrayList: {},
+  label: {}
+});
+
+export interface Styles {
+  control: {
+    root?: String;
+    wrapper?: String;
+    label?: String;
+    description?: String;
+    error?: String;
+    textarea?: String;
+    select?: String;
+    option?: String;
+  };
+  verticalLayout: {
+    root?: String;
+    item?: String;
+  };
+  horizontalLayout: {
+    root?: String;
+    item?: String;
+  };
+  group: {
+    root?: String;
+    label?: String;
+    item?: String;
+  };
+  arrayList: {
+    root?: String;
+    legend?: String;
+    addButton?: String;
+    label?: String;
+    item?: String;
+    noData?: String;
+    itemToolbar?: String;
+    itemLabel?: String;
+    itemContent?: String;
+    itemExpanded?: String;
+    itemMoveUp?: String;
+    itemMoveDown?: String;
+    itemDelete?: String;
+  };
+  label: {
+    root?: String;
+  };
+}
+
+export const useStyles = (element?: UISchemaElement) => {
+  const userStyles = inject('styles');
+  if (!userStyles && !element?.options?.styles) {
+    return defaultStyles;
+  }
+  const styles = createEmptyStyles();
+  if (userStyles) {
+    merge(styles, userStyles);
+  } else {
+    merge(styles, defaultStyles);
+  }
+  if (element?.options?.styles) {
+    merge(styles, element.options.styles);
+  }
+  return styles;
+};

--- a/packages/vue-vanilla/src/styles/util.ts
+++ b/packages/vue-vanilla/src/styles/util.ts
@@ -1,0 +1,30 @@
+import { Styles } from './styles';
+import cloneDeep from 'lodash/cloneDeep';
+import mergeWith from 'lodash/mergeWith';
+
+export const classes = (strings: TemplateStringsArray, ...variables: any[]) => {
+  return strings
+    .reduce((acc, curr, index) => {
+      return `${acc}${curr}${variables[index] || ''}`;
+    }, '')
+    .trim();
+};
+
+/**
+ * Helper function to merge two styles definitions. The contained classes will be combined, not overwritten.
+ * 
+ * Example usage:
+ * ```ts
+ * const myStyles = mergeStyles(defaultStyles, { control: { root: 'mycontrol' } });
+ * ```
+ */
+export const mergeStyles = (stylesA: Partial<Styles>, stylesB: Partial<Styles>): Partial<Styles> => {
+  const styles = cloneDeep(stylesA);
+  mergeWith(styles, stylesB, (aValue, bValue) => {
+    if (typeof aValue === 'string' && typeof bValue === 'string') {
+      return `${aValue} ${bValue}`;
+    }
+    return undefined;
+  });
+  return styles;
+};

--- a/packages/vue-vanilla/src/util/composition.ts
+++ b/packages/vue-vanilla/src/util/composition.ts
@@ -1,0 +1,112 @@
+import { useStyles } from '../styles';
+import { Options, optionsInit } from './options';
+import { ref, watchEffect } from '../../config';
+import merge from 'lodash/merge';
+import {
+  composePaths,
+  findUISchema,
+  getFirstPrimitiveProp,
+  Resolve,
+  UISchemaElement
+} from '@jsonforms/core';
+
+export type Nullable<T> = {
+  [P in keyof T]: P | null;
+};
+
+/**
+ * Adds styles, isFocused, appliedOptions and onChange
+ */
+export const useVanillaControl = <
+  I extends { control: any; handleChange: any }
+>(
+  input: I,
+  adaptTarget: (target: any) => any = v => v.value
+) => {
+  const appliedOptions = ref<Nullable<Options>>(optionsInit());
+  watchEffect(() => {
+    appliedOptions.value = merge(
+      {},
+      input.control.value.config,
+      input.control.value.uischema.options
+    );
+  });
+  const isFocused = ref(false);
+  const onChange = (event: Event) => {
+    input.handleChange(input.control.value.path, adaptTarget(event.target));
+  };
+  return {
+    ...input,
+    styles: useStyles(input.control.value.uischema),
+    isFocused,
+    appliedOptions,
+    onChange
+  };
+};
+
+/**
+ * Adds styles and appliedOptions
+ */
+export const useVanillaLayout = <I extends { layout: any }>(input: I) => {
+  const appliedOptions = ref<Nullable<Options>>(optionsInit());
+  watchEffect(() => {
+    appliedOptions.value = merge(
+      {},
+      input.layout.value.config,
+      input.layout.value.uischema.options
+    );
+  });
+  return {
+    ...input,
+    styles: useStyles(input.layout.value.uischema),
+    appliedOptions
+  };
+};
+
+/**
+ * Adds styles, appliedOptions and childUiSchema
+ */
+export const useVanillaArrayControl = <I extends { control: any }>(
+  input: I
+) => {
+  const appliedOptions = ref<Nullable<Options>>(optionsInit());
+  watchEffect(() => {
+    appliedOptions.value = merge(
+      {},
+      input.control.value.config,
+      input.control.value.uischema.options
+    );
+  });
+  const childUiSchema = ref<UISchemaElement>();
+  watchEffect(() => {
+    childUiSchema.value = findUISchema(
+      input.control.value.uischemas,
+      input.control.value.schema,
+      input.control.value.uischema.scope,
+      input.control.value.path
+    );
+  });
+  const childLabelForIndex = (index: number) => {
+    const childLabelProp =
+      input.control.value.uischema.options?.childLabelProp ??
+      getFirstPrimitiveProp(input.control.value.schema);
+    if (!childLabelProp) {
+      return `${index}`;
+    }
+    const labelValue = Resolve.data(
+      input.control.value.data,
+      composePaths(`${index}`, childLabelProp)
+    );
+    if (labelValue === undefined || labelValue === null || labelValue === NaN) {
+      return '';
+    }
+    return `${labelValue}`;
+  };
+  return {
+    ...input,
+    styles: useStyles(input.control.value.uischema),
+    appliedOptions,
+    childUiSchema,
+    childLabelForIndex
+  };
+};

--- a/packages/vue-vanilla/src/util/index.ts
+++ b/packages/vue-vanilla/src/util/index.ts
@@ -1,0 +1,2 @@
+export * from './options';
+export * from './composition';

--- a/packages/vue-vanilla/src/util/options.ts
+++ b/packages/vue-vanilla/src/util/options.ts
@@ -1,0 +1,13 @@
+export interface Options {
+  showUnfocusedDescription?: boolean;
+  hideRequiredAsterisk?: boolean;
+  focus?: boolean;
+  step?: number;
+}
+
+export const optionsInit = () => ({
+  showUnfocusedDescription: null,
+  hideRequiredAsterisk:null,
+  focus: null,
+  step: null
+})

--- a/packages/vue-vanilla/tests/testHelper.ts
+++ b/packages/vue-vanilla/tests/testHelper.ts
@@ -1,0 +1,1 @@
+export const bindings = <B> (b:B) : B => b;

--- a/packages/vue-vanilla/tests/unit/JsonForms.spec.ts
+++ b/packages/vue-vanilla/tests/unit/JsonForms.spec.ts
@@ -1,0 +1,40 @@
+import { JsonFormsUISchemaRegistryEntry } from '@jsonforms/core';
+import { shallowMount } from '@vue/test-utils';
+import { JsonForms } from '../../src';
+import { Generate } from '@jsonforms/core';
+import { bindings } from '../testHelper';
+
+describe('JsonForms.vue', () => {
+  it('uses undefined as schema prop when not given', () => {
+    const data = { number: 5 };
+    const renderers: JsonFormsUISchemaRegistryEntry[] = [];
+    const wrapper = shallowMount(JsonForms, bindings({
+      props: { data, renderers }
+    }));
+    expect(wrapper.props('schema')).toBe(undefined);
+  });
+
+  it('generates schema when not given via prop', () => {
+    const data = { number: 5.5 };
+    const renderers: JsonFormsUISchemaRegistryEntry[] = [];
+    const wrapper = shallowMount(JsonForms, bindings({
+      props: { data, renderers }
+    }));
+    expect((wrapper.vm as any).jsonforms.core.schema).toEqual(Generate.jsonSchema(data));
+  });
+
+  it('generates ui schema when not given via prop', () => {
+    const data = { number: 5.5 };
+    const schema = {
+      type: 'object',
+      properties: { number: { type: 'number' } }
+    };
+    const renderers: JsonFormsUISchemaRegistryEntry[] = [];
+    const wrapper = shallowMount(JsonForms, bindings({
+      props: { data, schema, renderers }
+    }));
+    expect((wrapper.vm as any).jsonforms.core.uischema).toEqual(
+      Generate.uiSchema(schema)
+    );
+  });
+});

--- a/packages/vue-vanilla/tsconfig.json
+++ b/packages/vue-vanilla/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "skipLibCheck": true,
+    "strict": true,
+    "declaration": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "importHelpers": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "sourceMap": true,
+    "outDir": "./lib",
+    "types": ["node", "vue", "jest"],
+    "lib": ["esnext", "dom", "dom.iterable", "scripthost"],
+  },
+  "exclude": ["node_modules", "lib"]
+}

--- a/packages/vue-vanilla/vanilla.css
+++ b/packages/vue-vanilla/vanilla.css
@@ -1,0 +1,74 @@
+.horizontal-layout {
+  display: flex;
+  flex-direction: row;
+}
+
+.vertical-layout {
+  display: flex;
+  flex-direction: column;
+}
+
+.error {
+  color: red;
+}
+
+.control {
+  display: flex;
+  flex-direction: column;
+}
+
+.control > .wrapper {
+  display: flex;
+}
+
+.control > .wrapper > input,
+.control > .wrapper > select,
+.control > .wrapper > textarea {
+  flex: 1
+}
+
+.control > .error,
+.control > .description {
+  min-height: 1.5em;
+}
+
+.array-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.array-list-item-toolbar {
+  cursor: pointer;
+  display: flex;
+  justify-content: flex-end;
+  align-items: stretch;
+  margin: 0.2em 0;
+}
+
+.array-list-item-toolbar > button {
+  user-select: none;
+  cursor: pointer;
+}
+.array-list-item-toolbar > button:disabled {
+  cursor:initial;
+}
+
+.array-list-item-label {
+  background-color: rgb(238,238,238);
+  flex: 1;
+  padding-left: 0.5em;
+  height: 1.5em;
+  line-height: 1.5em;
+}
+.array-list-item-label:hover {
+  background-color: rgb(221, 221, 221);
+}
+
+.array-list-item-content {
+  display: none;
+  padding: 0 1em;
+}
+
+.array-list-item-content.expanded {
+  display: block;
+}

--- a/packages/vue/src/components/JsonForms.vue
+++ b/packages/vue/src/components/JsonForms.vue
@@ -61,7 +61,7 @@ export default defineComponent({
     cells: {
       required: false,
       type: Array as PropType<JsonFormsCellRendererRegistryEntry[]>,
-      default: () =>[]
+      default: () => []
     },
     config: {
       required: false,
@@ -129,7 +129,6 @@ export default defineComponent({
   },
   watch: {
     schema(newSchema) {
-      console.log("schema updated");
       const generatorData = isObject(this.data) ? this.data : {};
       this.schemaToUse = newSchema ?? Generate.jsonSchema(generatorData);
       if (!this.uischema) {
@@ -137,7 +136,6 @@ export default defineComponent({
       }
     },
     uischema(newUischema) {
-      console.log("uischema updated");
       this.uischemaToUse = newUischema ?? Generate.uiSchema(this.schemaToUse);
     },
     renderers(newRenderers) {
@@ -149,11 +147,14 @@ export default defineComponent({
     uischemas(newUischemas) {
       this.jsonforms.uischemas = newUischemas;
     },
-    config(newConfig) {
-      this.jsonforms.config = configReducer(
-        undefined,
-        Actions.setConfig(newConfig)
-      );
+    config: {
+      handler(newConfig) {
+        this.jsonforms.config = configReducer(
+          undefined,
+          Actions.setConfig(newConfig)
+        );
+      },
+      deep: true
     },
     readonly(newReadonly) {
       this.jsonforms.readonly = newReadonly;


### PR DESCRIPTION
Adds primitive control renderers, basic layout renderers as well as an
array list renderer based on Vanilla HTML5.

CSS classes are completely customizable programmatically as well as via
the ui schema to allow straightforward integration with CSS libraries
like Tailwind.

Complimentary changes:

The Vue 'config' object was only top-level reactive. Now JSON Forms
will also react to nested changes.

Export the whole content of Vue `jsonFormsCompositions` to make them
reusable by the vanilla-renderers as well as any custom library.