### PR TITLE
update: vue2-vanilla json:

### DIFF
--- a/packages/vue/vue-vanilla/README.md
+++ b/packages/vue/vue-vanilla/README.md
@@ -130,12 +130,12 @@ Attributes not specified here fall back to either the `defaultStyles` or provide
 
 ```js
 {
-  type: 'Control',
-  scope: '#/properties/name',
-  options: {
-    styles: {
-      control: {
-        root: 'my-control-root'
+  "type": "Control",
+  "scope": "#/properties/name",
+  "options": {
+    "styles": {
+      "control": {
+        "root": "my-control-root"
       }
     }
   }

--- a/packages/vue2/vue2-vanilla/README.md
+++ b/packages/vue2/vue2-vanilla/README.md
@@ -138,14 +138,14 @@ You can also use specify styles in the ui schema via the `options.styles` proper
 Attributes specified here override the respective `defaultStyles` or provided `styles`.
 Attributes not specified here fall back to either the `defaultStyles` or provided `styles`.
 
-```js
+```json
 {
-  type: 'Control',
-  scope: '#/properties/name',
-  options: {
-    styles: {
-      control: {
-        root: 'my-control-root'
+  "type": "Control",
+  "scope": "#/properties/name",
+  "options": {
+    "styles": {
+      "control": {
+        "root": "my-control-root"
       }
     }
   }


### PR DESCRIPTION
provide the custom styles example as actual json instead of js-code.

I'n my opinion I think its better to provide the example as a json and not as pseudo json in js-code since thats what are are actually working with