### PR TITLE
Set Vue Vanilla button types

### DIFF
--- a/packages/vue/vue-vanilla/src/array/ArrayListElement.vue
+++ b/packages/vue/vue-vanilla/src/array/ArrayListElement.vue
@@ -6,6 +6,7 @@
         @click="moveUpClicked"
         :disabled="!moveUpEnabled"
         :class="styles.arrayList.itemMoveUp"
+        type="button"
       >
         ↑
       </button>
@@ -13,10 +14,15 @@
         @click="moveDownClicked"
         :disabled="!moveDownEnabled"
         :class="styles.arrayList.itemMoveDown"
+        type="button"
       >
         ↓
       </button>
-      <button @click="deleteClicked" :class="styles.arrayList.itemDelete">
+      <button
+        @click="deleteClicked"
+        :class="styles.arrayList.itemDelete"
+        type="button"
+      >
         🗙
       </button>
     </div>

--- a/packages/vue/vue-vanilla/src/array/ArrayListRenderer.vue
+++ b/packages/vue/vue-vanilla/src/array/ArrayListRenderer.vue
@@ -1,7 +1,11 @@
 <template>
   <fieldset v-if="control.visible" :class="styles.arrayList.root">
     <legend :class="styles.arrayList.legend">
-      <button :class="styles.arrayList.addButton" @click="addButtonClick">
+      <button
+        :class="styles.arrayList.addButton"
+        @click="addButtonClick"
+        type="button"
+      >
         +
       </button>
       <label :class="styles.arrayList.label">

--- a/packages/vue/vue-vanilla/tests/unit/array/ArrayListRenderer.spec.ts
+++ b/packages/vue/vue-vanilla/tests/unit/array/ArrayListRenderer.spec.ts
@@ -57,4 +57,13 @@ describe('ArrayListRenderer.vue', () => {
     await moveDownButtons[1].trigger('click');
     expect(wrapper.vm.data).to.deep.equal(['a', 'c', 'b']);
   });
+
+  it('all buttons have type button', async () => {
+    const wrapper = mountJsonForms(['a'], schema, uischema);
+    const buttons = wrapper.findAll('button');
+    for (let button of buttons) {
+      let type = button.attributes('type');
+      expect(type).to.equal('button');
+    }
+  });
 });


### PR DESCRIPTION
Buttons contained in forms are by default of type 'submit'. We now
explicitely set the ArrayListRenderer's buttons to type 'button' to
avoid submitting forms in case that they are rendered as part of a form.