### PR TITLE
Empty FormHelperText should be visible

### DIFF
--- a/packages/material/src/complex/MaterialEnumArrayRenderer.tsx
+++ b/packages/material/src/complex/MaterialEnumArrayRenderer.tsx
@@ -72,7 +72,7 @@ export const MaterialEnumArrayRenderer = ({
             );
           })}
         </FormGroup>
-        <FormHelperText error hidden={isEmpty(errors)}>
+        <FormHelperText error>
           {errors}
         </FormHelperText>
       </FormControl>


### PR DESCRIPTION
The FormHelperText should be visible even when empty, to allow it to be styled.