### PR TITLE
add remove-when-empty feature

### DIFF
--- a/packages/vue/vue-vanilla/dev/components/App.vue
+++ b/packages/vue/vue-vanilla/dev/components/App.vue
@@ -210,7 +210,8 @@ export default defineComponent({
       schema,
       uischema,
       config: {
-        hideRequiredAsterisk: true
+        hideRequiredAsterisk: true,
+        removeWhenEmpty: false
       }
     };
   },
@@ -232,6 +233,9 @@ export default defineComponent({
     },
     switchAsterisk() {
       this.config.hideRequiredAsterisk = !this.config.hideRequiredAsterisk;
+    },
+    switchRemoveWhenEmpty() {
+      this.config.removeWhenEmpty = !this.config.removeWhenEmpty;
     },
     adaptData() {
       this.data.number = 10;
@@ -392,6 +396,7 @@ export default defineComponent({
       />
       <button @click="setSchema">Set Schema</button>
       <button @click="switchAsterisk">Switch Asterisk</button>
+      <button @click="switchRemoveWhenEmpty">Switch removeWhenEmpty</button>
       <button @click="adaptData">Adapt data</button>
       <button @click="adaptUiSchema">Adapt uischema</button>
     </div>


### PR DESCRIPTION
### Adds a new option for the vue-vanilla renderers: `removeWhenEmpty`.

If it is set to `true` als values/data that are considered `empty` will be set to `undefined` so they are removed from the whole `data` object.

This is very useful if you don't want to show empty strings as "ok" when a property is required.

## Whats considered empty?

### String
`!data`

### Number
`!number && number !== 0`

### Boolean
Stays as it is (not touched at all)