### PR TITLE
Limit github actions run to 30 min to avoid 6h runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   ci:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -20,7 +21,7 @@ jobs:
       with:
         node-version: 12
     - name: Build
-      run: | 
+      run: |
         npm ci
         npm run init
         npm run build


### PR DESCRIPTION
Sometimes Github actions don't finish and then they run for 6h:
https://github.com/eclipsesource/jsonforms/actions/runs/970989014

To avoid this, this PR sets a timeout of 30m, which should work just fine (last successful builds took ~ 15m - 19m).