### PR TITLE
Rename ExpansionPanel to Accordion as suggested by Material UI

### DIFF
--- a/packages/material/src/layouts/ExpandPanelRenderer.tsx
+++ b/packages/material/src/layouts/ExpandPanelRenderer.tsx
@@ -22,10 +22,10 @@ import {
   JsonFormsUISchemaRegistryEntry,
   getFirstPrimitiveProp
 } from '@jsonforms/core';
-import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import IconButton from '@material-ui/core/IconButton';
-import ExpansionPanel from '@material-ui/core/ExpansionPanel';
-import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
 import { Grid } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import Avatar from '@material-ui/core/Avatar';
@@ -114,12 +114,12 @@ const ExpandPanelRenderer = (props: ExpandPanelProps) => {
   const appliedUiSchemaOptions = merge({}, config, uischema.options);
 
   return (
-    <ExpansionPanel
+    <Accordion
       aria-labelledby={labelHtmlId}
       expanded={expanded}
       onChange={handleExpansion(childPath)}
     >
-      <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
         <Grid container alignItems={'center'}>
           <Grid item xs={7} md={9}>
             <Grid container alignItems={'center'}>
@@ -180,8 +180,8 @@ const ExpandPanelRenderer = (props: ExpandPanelProps) => {
             </Grid>
           </Grid>
         </Grid>
-      </ExpansionPanelSummary>
-      <ExpansionPanelDetails>
+      </AccordionSummary>
+      <AccordionDetails>
         <JsonFormsDispatch
           schema={schema}
           uischema={foundUISchema}
@@ -190,8 +190,8 @@ const ExpandPanelRenderer = (props: ExpandPanelProps) => {
           renderers={renderers}
           cells={cells}
         />
-      </ExpansionPanelDetails>
-    </ExpansionPanel>
+      </AccordionDetails>
+    </Accordion>
   );
 };
 

--- a/packages/material/test/renderers/MaterialArrayLayout.test.tsx
+++ b/packages/material/test/renderers/MaterialArrayLayout.test.tsx
@@ -36,7 +36,7 @@ import {
 import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { JsonForms, JsonFormsStateProvider } from '@jsonforms/react';
-import { ExpansionPanel } from '@material-ui/core';
+import { Accordion } from '@material-ui/core';
 import { initCore } from './util';
 
 Enzyme.configure({ adapter: new Adapter() });
@@ -426,7 +426,7 @@ describe('Material array layout', () => {
       .find(
         `#${
         wrapper
-          .find(ExpansionPanel)
+          .find(Accordion)
           .at(index)
           .props()['aria-labelledby']
         }`


### PR DESCRIPTION
The `ExpansionPanel` component was renamed to `Accordion` within this PR:
https://github.com/mui-org/material-ui/pull/21494

With the upcoming version v5 of material UI, the expansion panel will be completely removed.

The docs suggest, just to switch to Accordion, no further migration needs to be done:
https://material-ui.com/api/expansion-panel/

Fixes: #1748
