### PR TITLE
Add JsonFormsAbstractControl to exported classes

### DIFF
--- a/packages/angular-material/src/layouts/array-layout.renderer.ts
+++ b/packages/angular-material/src/layouts/array-layout.renderer.ts
@@ -28,8 +28,7 @@ import {
   OnDestroy,
   OnInit
 } from '@angular/core';
-import { JsonFormsAngularService } from '@jsonforms/angular';
-import { JsonFormsAbstractControl } from '@jsonforms/angular/lib/abstract-control';
+import { JsonFormsAngularService, JsonFormsAbstractControl } from '@jsonforms/angular';
 import {
   ArrayLayoutProps,
   createDefaultValue,

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -30,3 +30,4 @@ export * from './jsonforms.module';
 export * from './unknown.component';
 export * from './jsonforms.service';
 export * from './jsonforms-root.component';
+export * from './abstract-control';


### PR DESCRIPTION
The JsonFormsAbstractControl was not exported by the angular package.
This lead to duplicate instances of the angular package when using the
ArrayLayoutRenderer and thus to the ArrayLayoutRenderer not working.
By not using a deep import in the ArrayLayoutRenderer only one instance
of the angular package exists.

Fix #1781