### PR TITLE
Rework i18n support in JSON Forms core

### DIFF
--- a/packages/angular-material/example/app/app.component.ts
+++ b/packages/angular-material/example/app/app.component.ts
@@ -75,7 +75,7 @@ const itemTester: UISchemaTester = (_schema, schemaPath, _path) => {
       [schema]="selectedExample.schema"
       [uischema]="selectedExample.uischema"
       [renderers]="renderers"
-      [locale]="currentLocale"
+      [i18n]="i18n"
       [uischemas]="uischemas"
       [readonly]="readonly"
       [config]="config"
@@ -86,7 +86,9 @@ export class AppComponent {
   readonly renderers = angularMaterialRenderers;
   readonly examples = getExamples();
   selectedExample: ExampleDescription;
-  currentLocale = 'en-US';
+  i18n = {
+    locale: 'en-US'
+  }
   private readonly = false;
   data: any;
   uischemas: { tester: UISchemaTester; uischema: UISchemaElement; }[] = [
@@ -102,7 +104,7 @@ export class AppComponent {
   }
 
   changeLocale(locale: string) {
-    this.currentLocale = locale;
+    this.i18n.locale = locale;
   }
 
   toggleReadonly() {

--- a/packages/angular-material/test/number-control.spec.ts
+++ b/packages/angular-material/test/number-control.spec.ts
@@ -144,8 +144,6 @@ describe(
       getJsonFormsService(component).init({
         core: state, i18n: {
           locale: 'en',
-          localizedSchemas: undefined,
-          localizedUISchemas: undefined
         }
       });
       getJsonFormsService(component).updateCore(
@@ -168,8 +166,6 @@ describe(
       getJsonFormsService(component).init({
         core: state, i18n: {
           locale: 'en',
-          localizedSchemas: undefined,
-          localizedUISchemas: undefined
         },config: {
           useGrouping: false
         },
@@ -196,8 +192,6 @@ describe(
       getJsonFormsService(component).init({
         core: state, i18n: {
           locale: 'en',
-          localizedSchemas: undefined,
-          localizedUISchemas: undefined
         },config: {
           useGrouping: true
         },

--- a/packages/core/src/actions/actions.ts
+++ b/packages/core/src/actions/actions.ts
@@ -29,6 +29,7 @@ import { generateDefaultUISchema, generateJsonSchema } from '../generators';
 
 import { RankedTester } from '../testers';
 import { UISchemaTester, ValidationMode } from '../reducers';
+import { ErrorTranslator, Translator } from '../i18n';
 
 export const INIT: 'jsonforms/INIT' = 'jsonforms/INIT';
 export const UPDATE_CORE: 'jsonforms/UPDATE_CORE' = `jsonforms/UPDATE_CORE`;
@@ -51,10 +52,10 @@ export const SET_VALIDATION_MODE: 'jsonforms/SET_VALIDATION_MODE' =
   'jsonforms/SET_VALIDATION_MODE';
 
 export const SET_LOCALE: 'jsonforms/SET_LOCALE' = `jsonforms/SET_LOCALE`;
-export const SET_LOCALIZED_SCHEMAS: 'jsonforms/SET_LOCALIZED_SCHEMAS' =
-  'jsonforms/SET_LOCALIZED_SCHEMAS';
-export const SET_LOCALIZED_UISCHEMAS: 'jsonforms/SET_LOCALIZED_UISCHEMAS' =
-  'jsonforms/SET_LOCALIZED_UISCHEMAS';
+export const SET_TRANSLATOR: 'jsonforms/SET_TRANSLATOR' =
+  'jsonforms/SET_TRANSLATOR';
+export const UPDATE_I18N: 'jsonforms/UPDATE_I18N' =
+  'jsonforms/UPDATE_I18N';
 
 export const ADD_DEFAULT_DATA: 'jsonforms/ADD_DEFAULT_DATA' = `jsonforms/ADD_DEFAULT_DATA`;
 export const REMOVE_DEFAULT_DATA: 'jsonforms/REMOVE_DEFAULT_DATA' = `jsonforms/REMOVE_DEFAULT_DATA`;
@@ -275,31 +276,19 @@ export const unregisterUISchema = (
   };
 };
 
-export type LocaleActions =
+export type I18nActions =
   | SetLocaleAction
-  | SetLocalizedSchemasAction
-  | SetLocalizedUISchemasAction;
+  | SetTranslatorAction
+  | UpdateI18nAction
 
 export interface SetLocaleAction {
   type: 'jsonforms/SET_LOCALE';
-  locale: string;
+  locale: string | undefined;
 }
 
-export const setLocale = (locale: string): SetLocaleAction => ({
+export const setLocale = (locale: string | undefined): SetLocaleAction => ({
   type: SET_LOCALE,
   locale
-});
-
-export interface SetLocalizedSchemasAction {
-  type: 'jsonforms/SET_LOCALIZED_SCHEMAS';
-  localizedSchemas: Map<string, JsonSchema>;
-}
-
-export const setLocalizedSchemas = (
-  localizedSchemas: Map<string, JsonSchema>
-): SetLocalizedSchemasAction => ({
-  type: SET_LOCALIZED_SCHEMAS,
-  localizedSchemas
 });
 
 export interface SetSchemaAction {
@@ -312,16 +301,37 @@ export const setSchema = (schema: JsonSchema): SetSchemaAction => ({
   schema
 });
 
-export interface SetLocalizedUISchemasAction {
-  type: 'jsonforms/SET_LOCALIZED_UISCHEMAS';
-  localizedUISchemas: Map<string, UISchemaElement>;
+export interface SetTranslatorAction {
+  type: 'jsonforms/SET_TRANSLATOR';
+  translator?: Translator;
+  errorTranslator?: ErrorTranslator; 
 }
 
-export const setLocalizedUISchemas = (
-  localizedUISchemas: Map<string, UISchemaElement>
-): SetLocalizedUISchemasAction => ({
-  type: SET_LOCALIZED_UISCHEMAS,
-  localizedUISchemas
+export const setTranslator = (
+  translator?: Translator,
+  errorTranslator?: ErrorTranslator
+): SetTranslatorAction => ({
+  type: SET_TRANSLATOR,
+  translator,
+  errorTranslator
+});
+
+export interface UpdateI18nAction {
+  type: 'jsonforms/UPDATE_I18N';
+  locale: string | undefined;
+  translator: Translator | undefined;
+  errorTranslator: ErrorTranslator | undefined; 
+}
+
+export const updateI18n = (
+  locale: string | undefined,
+  translator: Translator | undefined,
+  errorTranslator: ErrorTranslator | undefined
+): UpdateI18nAction => ({
+  type: UPDATE_I18N,
+  locale,
+  translator,
+  errorTranslator
 });
 
 export interface SetUISchemaAction {

--- a/packages/core/src/i18n/i18nTypes.ts
+++ b/packages/core/src/i18n/i18nTypes.ts
@@ -1,0 +1,17 @@
+import { ErrorObject } from 'ajv';
+import { JsonSchema, UISchemaElement } from '../models';
+
+export type Translator = {
+    (id: string, defaultMessage: string, values?: any): string;
+    (id: string, defaultMessage: undefined, values?: any): string | undefined;
+}
+
+export type ErrorTranslator = (error: ErrorObject, translate: Translator, uischema?: UISchemaElement) => string;
+
+export interface JsonFormsI18nState {
+  locale?: string;
+  translate?: Translator;
+  translateError?: ErrorTranslator;
+}
+
+export type i18nJsonSchema = JsonSchema & {i18n?: string};

--- a/packages/core/src/i18n/i18nUtil.ts
+++ b/packages/core/src/i18n/i18nUtil.ts
@@ -1,0 +1,76 @@
+import { ErrorObject } from 'ajv';
+import { UISchemaElement } from '../models';
+import { formatErrorMessage } from '../util';
+import { i18nJsonSchema, ErrorTranslator, Translator } from './i18nTypes';
+
+export const getI18nKey = (
+  schema: i18nJsonSchema | undefined,
+  uischema: UISchemaElement | undefined,
+  key: string
+): string | undefined => {
+  if (uischema?.options?.i18n) {
+    return `${uischema.options.i18n}.${key}`;
+  }
+  if (schema?.i18n) {
+    return `${schema.i18n}.${key}`;
+  }
+  return undefined;
+};
+
+export const defaultTranslator: Translator = (_id: string, defaultMessage: string | undefined) => defaultMessage;
+
+export const defaultErrorTranslator: ErrorTranslator = (error, t, uischema) => {
+  // check whether there is a special keyword message
+  const keyInSchemas = getI18nKey(
+    error.parentSchema,
+    uischema,
+    `error.${error.keyword}`
+  );
+  const specializedKeywordMessage = keyInSchemas && t(keyInSchemas, undefined);
+  if (specializedKeywordMessage !== undefined) {
+    return specializedKeywordMessage;
+  }
+
+  // check whether there is a generic keyword message
+  const genericKeywordMessage = t(`error.${error.keyword}`, undefined);
+  if (genericKeywordMessage !== undefined) {
+    return genericKeywordMessage;
+  }
+
+  // check whether there is a customization for the default message
+  const messageCustomization = t(error.message, undefined);
+  if (messageCustomization !== undefined) {
+    return messageCustomization;
+  }
+
+  // rewrite required property messages (if they were not customized) as we place them next to the respective input
+  if (error.keyword === 'required') {
+    return t('is a required property', 'is a required property');
+  }
+
+  return error.message;
+};
+
+/**
+ * Returns the determined error message for the given errors.
+ * All errors must correspond to the given schema and uischema.
+ */
+export const getCombinedErrorMessage = (
+  errors: ErrorObject[],
+  et: ErrorTranslator,
+  t: Translator,
+  schema?: i18nJsonSchema,
+  uischema?: UISchemaElement
+) => {
+  if (errors.length > 0 && t) {
+    // check whether there is a special message which overwrites all others
+    const keyInSchemas = getI18nKey(schema, uischema, 'error.custom');
+    const specializedErrorMessage = keyInSchemas && t(keyInSchemas, undefined);
+    if (specializedErrorMessage !== undefined) {
+      return specializedErrorMessage;
+    }
+  }
+  return formatErrorMessage(
+    errors.map(error => et(error, t, uischema))
+  );
+};

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -1,0 +1,2 @@
+export * from './i18nTypes';
+export * from './i18nUtil';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,3 +34,4 @@ export * from './util';
 
 export * from './Helpers';
 export * from './store';
+export * from './i18n';

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -77,7 +77,7 @@ const initState: JsonFormsCore = {
   errors: [],
   validator: undefined,
   ajv: undefined,
-  validationMode: 'ValidateAndShow'
+  validationMode: 'ValidateAndShow',
 };
 
 const reuseAjvForSchema = (ajv: Ajv, schema: JsonSchema): Ajv => {
@@ -154,7 +154,7 @@ export const coreReducer: Reducer<JsonFormsCore, CoreActions> = (
         errors: e,
         validator: v,
         ajv: thisAjv,
-        validationMode
+        validationMode,
       };
     }
     case UPDATE_CORE: {
@@ -184,17 +184,17 @@ export const coreReducer: Reducer<JsonFormsCore, CoreActions> = (
         state.ajv !== thisAjv ||
         state.errors !== errors ||
         state.validator !== validator ||
-        state.validationMode !== validationMode;
+        state.validationMode !== validationMode
       return stateChanged
         ? {
             ...state,
-            data: state.data === action.data ? state.data : action.data,
-            schema: state.schema === action.schema ? state.schema : action.schema,
-            uischema: state.uischema === action.uischema ? state.uischema : action.uischema,
-            ajv: thisAjv === state.ajv ? state.ajv : thisAjv,
+            data: action.data,
+            schema: action.schema,
+            uischema: action.uischema,
+            ajv: thisAjv,
             errors: isEqual(errors, state.errors) ? state.errors : errors,
-            validator: validator === state.validator ? state.validator : validator,
-            validationMode: validationMode === state.validationMode ? state.validationMode : validationMode
+            validator: validator,
+            validationMode: validationMode,
           }
         : state;
     }

--- a/packages/core/src/reducers/i18n.ts
+++ b/packages/core/src/reducers/i18n.ts
@@ -23,66 +23,72 @@
   THE SOFTWARE.
 */
 
-import { SET_LOCALE, SET_LOCALIZED_SCHEMAS, SET_LOCALIZED_UISCHEMAS } from '../actions';
-import { JsonSchema, UISchemaElement } from '../models';
+import { defaultErrorTranslator, defaultTranslator, JsonFormsI18nState } from '../i18n';
+import { I18nActions, SET_LOCALE, SET_TRANSLATOR, UPDATE_I18N } from '../actions';
 import { Reducer } from '../util';
 
-export interface JsonFormsLocaleState {
-  locale?: string;
-  localizedSchemas: Map<string, JsonSchema>;
-  localizedUISchemas: Map<string, UISchemaElement>;
-}
-
-const initState: JsonFormsLocaleState = {
-  locale: undefined,
-  localizedSchemas: new Map(),
-  localizedUISchemas: new Map()
+export const defaultJsonFormsI18nState: JsonFormsI18nState = {
+  locale: 'en',
+  translate: defaultTranslator,
+  translateError: defaultErrorTranslator
 };
 
-export const i18nReducer: Reducer<any, any> = (state = initState, action) => {
+export const i18nReducer: Reducer<JsonFormsI18nState, I18nActions> = (state = defaultJsonFormsI18nState, action) => {
   switch (action.type) {
-    case SET_LOCALIZED_SCHEMAS:
+    case UPDATE_I18N: {
+      const locale = action.locale ?? defaultJsonFormsI18nState.locale;
+      const translate =
+        action.translator ?? defaultJsonFormsI18nState.translate;
+      const translateError =
+        action.errorTranslator ?? defaultJsonFormsI18nState.translateError;
+
+      if (
+        locale !== state.locale ||
+        translate !== state.translate ||
+        translateError !== state.translateError
+      ) {
+        return {
+          ...state,
+          locale,
+          translate,
+          translateError
+        };
+      }
+      return state;
+    }
+    case SET_TRANSLATOR:
       return {
         ...state,
-        localizedSchemas: action.localizedSchemas
-      };
-    case SET_LOCALIZED_UISCHEMAS:
-      return {
-        ...state,
-        localizedUISchemas: action.localizedUISchemas
+        translate: action.translator ?? defaultTranslator,
+        translateError: action.errorTranslator ?? defaultErrorTranslator
       };
     case SET_LOCALE:
       return {
         ...state,
-        locale:
-          action.locale === undefined ? navigator.languages[0] : action.locale
+        locale: action.locale ?? navigator.languages[0]
       };
     default:
       return state;
   }
 };
 
-export const fetchLocale = (state?: JsonFormsLocaleState) => {
+export const fetchLocale = (state?: JsonFormsI18nState) => {
   if (state === undefined) {
     return undefined;
   }
   return state.locale;
 };
 
-export const findLocalizedSchema = (locale: string) => (
-  state?: JsonFormsLocaleState
-): JsonSchema => {
+export const fetchTranslator = (state?: JsonFormsI18nState) => {
   if (state === undefined) {
-    return undefined;
+    return defaultTranslator;
   }
-  return state.localizedSchemas.get(locale);
-};
+  return state.translate;
+}
 
-export const findLocalizedUISchema = (locale: string) => (
-  state?: JsonFormsLocaleState
-): UISchemaElement => {
+export const fetchErrorTranslator = (state?: JsonFormsI18nState) => {
   if (state === undefined) {
-    return undefined;
+    return defaultErrorTranslator;
   }
-  return state.localizedUISchemas.get(locale);
-};
+  return state.translateError;
+}

--- a/packages/core/src/reducers/reducers.ts
+++ b/packages/core/src/reducers/reducers.ts
@@ -43,10 +43,9 @@ import {
   UISchemaTester
 } from './uischemas';
 import {
+  fetchErrorTranslator,
   fetchLocale,
-  findLocalizedSchema,
-  findLocalizedUISchema,
-  i18nReducer
+  i18nReducer,
 } from './i18n';
 
 import { Generate } from '../generators';
@@ -55,6 +54,8 @@ import { JsonSchema } from '../models/jsonSchema';
 import { cellReducer } from './cells';
 import { configReducer } from './config';
 import get from 'lodash/get';
+import { fetchTranslator } from '.';
+import { ErrorTranslator, Translator } from '../i18n';
 
 export {
   rendererReducer,
@@ -138,11 +139,10 @@ export const getConfig = (state: JsonFormsState) => state.jsonforms.config;
 export const getLocale = (state: JsonFormsState) =>
   fetchLocale(get(state, 'jsonforms.i18n'));
 
-export const getLocalizedSchema = (locale: string) => (
+export const getTranslator = () => (
   state: JsonFormsState
-): JsonSchema => findLocalizedSchema(locale)(get(state, 'jsonforms.i18n'));
+): Translator => fetchTranslator(get(state, 'jsonforms.i18n'));
 
-export const getLocalizedUISchema = (locale: string) => (
+export const getErrorTranslator = () => (
   state: JsonFormsState
-): UISchemaElement =>
-  findLocalizedUISchema(locale)(get(state, 'jsonforms.i18n'));
+): ErrorTranslator => fetchErrorTranslator(get(state, 'jsonforms.i18n'));

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -28,9 +28,9 @@ import {
   JsonFormsCore,
   JsonFormsCellRendererRegistryEntry,
   JsonFormsRendererRegistryEntry,
-  JsonFormsLocaleState,
   JsonFormsUISchemaRegistryEntry
 } from './reducers';
+import { JsonFormsI18nState } from './i18n';
 
 /**
  * JSONForms store.
@@ -65,11 +65,11 @@ export interface JsonFormsSubStates {
    */
   cells?: JsonFormsCellRendererRegistryEntry[];
   /**
-   *
+   * I18n settings.
    */
-  i18n?: JsonFormsLocaleState;
+  i18n?: JsonFormsI18nState;
   /**
-   *
+   * The UI schema registry used in detail renderers.
    */
   uischemas?: JsonFormsUISchemaRegistryEntry[];
   /**

--- a/packages/core/src/util/cell.ts
+++ b/packages/core/src/util/cell.ts
@@ -31,7 +31,8 @@ import {
   getErrorAt,
   getSchema,
   getAjv,
-  JsonFormsCellRendererRegistryEntry
+  JsonFormsCellRendererRegistryEntry,
+  getTranslator
 } from '../reducers';
 import { AnyAction, Dispatch } from './type';
 import {
@@ -54,6 +55,7 @@ import {
 } from './renderer';
 import { JsonFormsState } from '../store';
 import { JsonSchema } from '../models';
+import { i18nJsonSchema } from '..';
 
 export { JsonFormsCellRendererRegistryEntry };
 
@@ -196,8 +198,20 @@ export const defaultMapStateToEnumCellProps = (
   const props: StatePropsOfCell = mapStateToCellProps(state, ownProps);
   const options: EnumOption[] =
     ownProps.options ||
-    props.schema.enum?.map(enumToEnumOptionMapper) ||
-    (props.schema.const && [enumToEnumOptionMapper(props.schema.const)]);
+    props.schema.enum?.map(e =>
+      enumToEnumOptionMapper(
+        e,
+        getTranslator()(state),
+        props.uischema?.options?.i18n ?? (props.schema as i18nJsonSchema).i18n
+      )
+    ) ||
+    (props.schema.const && [
+      enumToEnumOptionMapper(
+        props.schema.const,
+        getTranslator()(state),
+        props.uischema?.options?.i18n ?? (props.schema as i18nJsonSchema).i18n
+      )
+    ]);
   return {
     ...props,
     options
@@ -217,7 +231,13 @@ export const mapStateToOneOfEnumCellProps = (
   const props: StatePropsOfCell = mapStateToCellProps(state, ownProps);
   const options: EnumOption[] =
     ownProps.options ||
-    (props.schema.oneOf as JsonSchema[])?.map(oneOfToEnumOptionMapper);
+    (props.schema.oneOf as JsonSchema[])?.map(oneOfSubSchema =>
+      oneOfToEnumOptionMapper(
+        oneOfSubSchema,
+        getTranslator()(state),
+        props.uischema?.options?.i18n
+      )
+    );
   return {
     ...props,
     options

--- a/packages/core/src/util/validator.ts
+++ b/packages/core/src/util/validator.ts
@@ -30,6 +30,7 @@ export const createAjv = (options?: Options) => {
   const ajv = new Ajv({
     allErrors: true,
     verbose: true,
+    strict: false,
     ...options
   });
   addFormats(ajv);

--- a/packages/core/test/util/cell.test.ts
+++ b/packages/core/test/util/cell.test.ts
@@ -286,7 +286,7 @@ test('mapStateToEnumCellProps - set default options for dropdown list', t => {
   const props = defaultMapStateToEnumCellProps(createState(uischema), ownProps);
   t.deepEqual(
     props.options,
-    ['DE', 'IT', 'JP', 'US', 'RU', 'Other'].map(enumToEnumOptionMapper)
+    ['DE', 'IT', 'JP', 'US', 'RU', 'Other'].map(e => enumToEnumOptionMapper(e))
   );
   t.is(props.data, undefined);
 });
@@ -315,7 +315,7 @@ test('mapStateToOneOfEnumCellProps - set one of options for dropdown list', t =>
   };
 
   const props = mapStateToOneOfEnumCellProps(createState(uischema), ownProps);
-  t.deepEqual(props.options, [{title: 'Australia' , const: 'AU', }, { title: 'New Zealand', const: 'NZ' }].map(oneOfToEnumOptionMapper));
+  t.deepEqual(props.options, [{title: 'Australia' , const: 'AU', }, { title: 'New Zealand', const: 'NZ' }].map(schema => oneOfToEnumOptionMapper(schema)));
   t.is(props.data, undefined);
 });
 

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -32,6 +32,7 @@ import {
   isControl,
   JsonFormsCellRendererRegistryEntry,
   JsonFormsCore,
+  JsonFormsI18nState,
   JsonFormsProps,
   JsonFormsRendererRegistryEntry,
   JsonFormsUISchemaRegistryEntry,
@@ -181,6 +182,7 @@ export interface JsonFormsInitStateProps {
   uischemas?: JsonFormsUISchemaRegistryEntry[];
   readonly?: boolean;
   validationMode?: ValidationMode;
+  i18n?: JsonFormsI18nState;
 }
 
 export const JsonForms = (
@@ -197,7 +199,8 @@ export const JsonForms = (
     config,
     uischemas,
     readonly,
-    validationMode
+    validationMode,
+    i18n
   } = props;
   const schemaToUse = useMemo(
     () => (schema !== undefined ? schema : Generate.jsonSchema(data)),
@@ -224,6 +227,7 @@ export const JsonForms = (
         renderers,
         cells,
         readonly,
+        i18n
       }}
       onChange={onChange}
     >

--- a/packages/react/src/JsonFormsContext.tsx
+++ b/packages/react/src/JsonFormsContext.tsx
@@ -67,7 +67,8 @@ import {
   mapStateToMultiEnumControlProps,
   DispatchPropsOfMultiEnumControl,
   mapDispatchToControlProps,
-  mapDispatchToArrayControlProps
+  mapDispatchToArrayControlProps,
+  i18nReducer
 } from '@jsonforms/core';
 import React, { ComponentType, Dispatch, ReducerAction, useContext, useEffect, useMemo, useReducer, useRef } from 'react';
 
@@ -108,7 +109,7 @@ const useEffectAfterFirstRender = (
 };
 
 export const JsonFormsStateProvider = ({ children, initState, onChange }: any) => {
-  const { data, schema, uischema, ajv, validationMode} = initState.core;
+  const { data, schema, uischema, ajv, validationMode } = initState.core;
   // Initialize core immediately
   const [core, coreDispatch] = useReducer(
     coreReducer,
@@ -133,6 +134,20 @@ export const JsonFormsStateProvider = ({ children, initState, onChange }: any) =
     configDispatch(Actions.setConfig(initState.config));
   }, [initState.config]);
 
+  const [i18n, i18nDispatch] = useReducer(
+    i18nReducer,
+    undefined,
+    () => i18nReducer(
+      initState.i18n,
+      Actions.updateI18n(initState.i18n?.locale, initState.i18n?.translate, initState.i18n?.translateError)
+    )
+  );
+  useEffect(() => {
+    i18nDispatch(
+      Actions.updateI18n(initState.i18n?.locale, initState.i18n?.translate, initState.i18n?.translateError)
+    );
+  }, [initState.i18n?.locale, initState.i18n?.translate, initState.i18n?.translateError]);
+
   const contextValue = useMemo(() => ({
     core,
     renderers: initState.renderers,
@@ -140,9 +155,10 @@ export const JsonFormsStateProvider = ({ children, initState, onChange }: any) =
     config: config,
     uischemas: initState.uischemas,
     readonly: initState.readonly,
+    i18n: i18n,
     // only core dispatch available
     dispatch: coreDispatch,
-  }), [core, initState.renderers, initState.cells, config, initState.readonly]);
+  }), [core, initState.renderers, initState.cells, config, initState.readonly, i18n]);
 
   const onChangeRef = useRef(onChange);
   useEffect(() => {

--- a/packages/vue/vue-vanilla/dev/components/App.vue
+++ b/packages/vue/vue-vanilla/dev/components/App.vue
@@ -3,59 +3,62 @@ import { defineComponent } from '../../config/vue';
 import { JsonForms, JsonFormsChangeEvent } from '../../config/jsonforms';
 import { vanillaRenderers, mergeStyles, defaultStyles } from '../../src';
 import '../../vanilla.css';
+import { get } from 'lodash';
+import { JsonFormsI18nState } from '@jsonforms/core';
 
 const schema = {
   properties: {
     string: {
       type: 'string',
-      description: 'a string'
+      description: 'a string',
+      pattern: '[a-z]+'
     },
     multiString: {
       type: 'string',
-      description: 'a string'
+      description: 'a string',
     },
     boolean: {
       type: 'boolean',
-      description: 'enable / disable number'
+      description: 'enable / disable number',
     },
     boolean2: {
       type: 'boolean',
-      description: 'show / hide integer'
+      description: 'show / hide integer',
     },
     number: {
       type: 'number',
-      description: 'a number'
+      description: 'a number',
     },
     integer: {
       type: 'integer',
-      description: 'an integer'
+      description: 'an integer',
     },
     enum: {
       type: 'string',
       enum: ['a', 'b', 'c'],
-      description: 'an enum'
+      description: 'an enum',
     },
     oneOfEnum: {
       oneOf: [
         { const: '1', title: 'Number 1' },
-        { const: 'B', title: 'Foo' }
+        { const: 'B', title: 'Foo' },
       ],
-      description: 'one of enum'
+      description: 'one of enum',
     },
     date: {
       type: 'string',
       format: 'date',
-      description: 'a date'
+      description: 'a date',
     },
     dateTime: {
       type: 'string',
       format: 'date-time',
-      description: 'a date time'
+      description: 'a date time',
     },
     time: {
       type: 'string',
       format: 'time',
-      description: 'a time'
+      description: 'a time',
     },
     array: {
       type: 'array',
@@ -63,12 +66,12 @@ const schema = {
         type: 'object',
         properties: {
           name: { type: 'string' },
-          age: { type: 'integer' }
-        }
-      }
-    }
+          age: { type: 'integer' },
+        },
+      },
+    },
   },
-  required: ['string', 'number']
+  required: ['string', 'number'],
 } as any;
 
 const uischema = {
@@ -84,23 +87,23 @@ const uischema = {
               type: 'Control',
               scope: '#/properties/string',
               options: {
-                placeholder: 'this is a placeholder'
-              }
+                placeholder: 'this is a placeholder',
+              },
             },
             {
               type: 'Control',
-              scope: '#/properties/multiString'
+              scope: '#/properties/multiString',
             },
             {
               type: 'Control',
               scope: '#/properties/boolean',
               options: {
-                placeholder: 'boolean placeholder'
-              }
+                placeholder: 'boolean placeholder',
+              },
             },
             {
               type: 'Control',
-              scope: '#/properties/boolean2'
+              scope: '#/properties/boolean2',
             },
             {
               type: 'Control',
@@ -110,12 +113,12 @@ const uischema = {
                 condition: {
                   scope: '#/properties/boolean',
                   schema: {
-                    const: true
-                  }
-                }
-              }
-            }
-          ]
+                    const: true,
+                  },
+                },
+              },
+            },
+          ],
         },
         {
           type: 'Group',
@@ -129,37 +132,37 @@ const uischema = {
                 condition: {
                   scope: '#/properties/boolean2',
                   schema: {
-                    const: true
-                  }
-                }
-              }
+                    const: true,
+                  },
+                },
+              },
             },
             {
               type: 'HorizontalLayout',
               elements: [
                 {
                   type: 'Control',
-                  scope: '#/properties/enum'
+                  scope: '#/properties/enum',
                 },
                 {
                   type: 'Control',
-                  scope: '#/properties/oneOfEnum'
+                  scope: '#/properties/oneOfEnum',
                 },
                 {
                   type: 'Control',
                   scope: '#/properties/date',
                   options: {
-                    placeholder: 'date placeholder'
-                  }
-                }
-              ]
+                    placeholder: 'date placeholder',
+                  },
+                },
+              ],
             },
             {
               type: 'Control',
               scope: '#/properties/dateTime',
               options: {
-                placeholder: 'date-time placeholder'
-              }
+                placeholder: 'date-time placeholder',
+              },
             },
             {
               type: 'Control',
@@ -168,50 +171,52 @@ const uischema = {
                 placeholder: 'time placeholder',
                 styles: {
                   control: {
-                    root: 'control my-time'
-                  }
-                }
-              }
-            }
-          ]
-        }
-      ]
+                    root: 'control my-time',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
     },
     {
       type: 'Label',
-      text: 'This is my label'
+      text: 'This is my label',
     },
     {
       type: 'Control',
       scope: '#/properties/array',
       options: {
-        childLabelProp: 'age'
-      }
-    }
-  ]
+        childLabelProp: 'age',
+      },
+    },
+  ],
 } as any;
 
 // mergeStyles combines all classes from both styles definitions into one
 const myStyles = mergeStyles(defaultStyles, {
-  control: { root: 'my-control' }
+  control: { root: 'my-control' },
 });
 
 export default defineComponent({
   name: 'app',
   components: {
-    JsonForms
+    JsonForms,
   },
-  data: function() {
+  data: function () {
+    const i18n: Partial<JsonFormsI18nState> = { locale: 'en' };
     return {
       renderers: Object.freeze(vanillaRenderers),
       data: {
-        number: 5
+        number: 5,
       },
       schema,
       uischema,
       config: {
-        hideRequiredAsterisk: true
-      }
+        hideRequiredAsterisk: true,
+      },
+      i18n
     };
   },
   methods: {
@@ -221,14 +226,25 @@ export default defineComponent({
           name: {
             type: 'string',
             title: 'NAME',
-            description: 'The name'
-          }
-        }
+            description: 'The name',
+          },
+        },
       };
     },
     onChange(event: JsonFormsChangeEvent) {
       console.log(event);
       this.data = event.data;
+    },
+    translationChange(event: any) {
+      try {
+        const input = JSON.parse(event.target.value);
+        (this as any).i18n.translate = (key: string, defaultMessage: string | undefined) => {
+          const translated = get(input, key) as string;
+          return translated ?? defaultMessage;
+        };
+      } catch (error) {
+        console.log('invalid translation input');
+      }
     },
     switchAsterisk() {
       this.config.hideRequiredAsterisk = !this.config.hideRequiredAsterisk;
@@ -250,23 +266,23 @@ export default defineComponent({
                     type: 'Control',
                     scope: '#/properties/string',
                     options: {
-                      placeholder: 'this is a placeholder'
-                    }
+                      placeholder: 'this is a placeholder',
+                    },
                   },
                   {
                     type: 'Control',
-                    scope: '#/properties/multiString'
+                    scope: '#/properties/multiString',
                   },
                   {
                     type: 'Control',
                     scope: '#/properties/boolean',
                     options: {
-                      placeholder: 'boolean placeholder'
-                    }
+                      placeholder: 'boolean placeholder',
+                    },
                   },
                   {
                     type: 'Control',
-                    scope: '#/properties/boolean2'
+                    scope: '#/properties/boolean2',
                   },
                   {
                     type: 'Control',
@@ -276,12 +292,12 @@ export default defineComponent({
                       condition: {
                         scope: '#/properties/boolean',
                         schema: {
-                          const: true
-                        }
-                      }
-                    }
-                  }
-                ]
+                          const: true,
+                        },
+                      },
+                    },
+                  },
+                ],
               },
               {
                 type: 'Group',
@@ -295,37 +311,37 @@ export default defineComponent({
                       condition: {
                         scope: '#/properties/boolean2',
                         schema: {
-                          const: true
-                        }
-                      }
-                    }
+                          const: true,
+                        },
+                      },
+                    },
                   },
                   {
                     type: 'HorizontalLayout',
                     elements: [
                       {
                         type: 'Control',
-                        scope: '#/properties/enum'
+                        scope: '#/properties/enum',
                       },
                       {
                         type: 'Control',
-                        scope: '#/properties/oneOfEnum'
+                        scope: '#/properties/oneOfEnum',
                       },
                       {
                         type: 'Control',
                         scope: '#/properties/date',
                         options: {
-                          placeholder: 'date placeholder'
-                        }
-                      }
-                    ]
+                          placeholder: 'date placeholder',
+                        },
+                      },
+                    ],
                   },
                   {
                     type: 'Control',
                     scope: '#/properties/dateTime',
                     options: {
-                      placeholder: 'date-time placeholder'
-                    }
+                      placeholder: 'date-time placeholder',
+                    },
                   },
                   {
                     type: 'Control',
@@ -334,35 +350,35 @@ export default defineComponent({
                       placeholder: 'time placeholder',
                       styles: {
                         control: {
-                          root: 'control my-time'
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            ]
+                          root: 'control my-time',
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
           },
           {
             type: 'Label',
-            text: 'This is my label'
+            text: 'This is my label',
           },
           {
             type: 'Control',
             scope: '#/properties/array',
             options: {
-              childLabelProp: 'age'
-            }
-          }
-        ]
+              childLabelProp: 'age',
+            },
+          },
+        ],
       };
-    }
+    },
   },
   provide() {
     return {
-      styles: myStyles
+      styles: myStyles,
     };
-  }
+  },
 });
 </script>
 
@@ -388,6 +404,7 @@ export default defineComponent({
         :uischema="uischema"
         :renderers="renderers"
         :config="config"
+        :i18n="i18n"
         @change="onChange"
       />
       <button @click="setSchema">Set Schema</button>
@@ -404,6 +421,7 @@ export default defineComponent({
         >{{ JSON.stringify(config, null, 2) }}
     </pre
       >
+      <textarea @change="translationChange" />
     </div>
   </div>
 </template>

--- a/packages/vue/vue/src/components/JsonForms.vue
+++ b/packages/vue/vue/src/components/JsonForms.vue
@@ -21,7 +21,9 @@ import {
   JsonFormsUISchemaRegistryEntry,
   JsonFormsRendererRegistryEntry,
   JsonFormsCellRendererRegistryEntry,
-  CoreActions
+  CoreActions,
+  i18nReducer,
+  JsonFormsI18nState
 } from '@jsonforms/core';
 import { JsonFormsChangeEvent } from '../types';
 import DispatchRenderer from './DispatchRenderer.vue';
@@ -87,6 +89,11 @@ export default defineComponent({
       type: Object as PropType<Ajv>,
       default: undefined
     },
+    i18n: {
+      required: false,
+      type: Object as PropType<JsonFormsI18nState>,
+      default: undefined
+    }
   },
   data() {
     const generatorData = isObject(this.data) ? this.data : {};
@@ -113,6 +120,7 @@ export default defineComponent({
       jsonforms: {
         core: initCore(),
         config: configReducer(undefined, Actions.setConfig(this.config)),
+        i18n: i18nReducer(this.i18n, Actions.updateI18n(this.i18n?.locale, this.i18n?.translate, this.i18n?.translateError)),
         renderers: this.renderers,
         cells: this.cells,
         uischemas: this.uischemas,
@@ -163,6 +171,15 @@ export default defineComponent({
     },
     eventToEmit(newEvent) {
       this.$emit('change', newEvent);
+    },
+    i18n: {
+      handler(newI18n) {
+        this.jsonforms.i18n = i18nReducer(
+          this.jsonforms.i18n,
+          Actions.updateI18n(newI18n?.locale, newI18n?.translate, newI18n?.translateError)
+        );
+      },
+      deep: true
     }
   },
   computed: {


### PR DESCRIPTION
Labels, descriptions and error messages can now be translated via
special translation functions handed over to JSON Forms.

The translations are automatically handed within the default
mapping functions and are therefore available in all renderer sets.
This includes a key-determination algorithm, allowing to either rely
on using labels as keys or specifying 'i18n' keys in UI Schema options
or directly within the JSON Schema. Errors are handled separately to
allow for maximum flexibility.

Includes test cases for the most common mapping functions.

Also AJV is set to non-strict by default to not throw errors when
handing over JSON Schemas containing 'i18n' keys.