### PR TITLE
Use default calculated i18n keys

### DIFF
--- a/packages/core/src/i18n/i18nUtil.ts
+++ b/packages/core/src/i18n/i18nUtil.ts
@@ -1,32 +1,60 @@
 import { ErrorObject } from 'ajv';
 import { UISchemaElement } from '../models';
+import { getControlPath } from '../reducers';
 import { formatErrorMessage } from '../util';
 import { i18nJsonSchema, ErrorTranslator, Translator } from './i18nTypes';
+
+export const getI18nKeyPrefixBySchema = (
+  schema: i18nJsonSchema | undefined,
+  uischema: UISchemaElement | undefined
+): string | undefined => {
+  return uischema?.options?.i18n ?? schema?.i18n ?? undefined;
+};
+
+/**
+ * Transforms a given path to a prefix which can be used for i18n keys.
+ * Returns 'root' for empty paths and removes array indices
+ */
+export const transformPathToI18nPrefix = (path: string) => {
+  return (
+    path
+      ?.split('.')
+      .filter(segment => !/^\d+$/.test(segment))
+      .join('.') || 'root'
+  );
+};
+
+export const getI18nKeyPrefix = (
+  schema: i18nJsonSchema | undefined,
+  uischema: UISchemaElement | undefined,
+  path: string | undefined
+): string | undefined => {
+  return (
+    getI18nKeyPrefixBySchema(schema, uischema) ??
+    transformPathToI18nPrefix(path)
+  );
+};
 
 export const getI18nKey = (
   schema: i18nJsonSchema | undefined,
   uischema: UISchemaElement | undefined,
+  path: string | undefined,
   key: string
 ): string | undefined => {
-  if (uischema?.options?.i18n) {
-    return `${uischema.options.i18n}.${key}`;
-  }
-  if (schema?.i18n) {
-    return `${schema.i18n}.${key}`;
-  }
-  return undefined;
+  return `${getI18nKeyPrefix(schema, uischema, path)}.${key}`;
 };
 
 export const defaultTranslator: Translator = (_id: string, defaultMessage: string | undefined) => defaultMessage;
 
 export const defaultErrorTranslator: ErrorTranslator = (error, t, uischema) => {
   // check whether there is a special keyword message
-  const keyInSchemas = getI18nKey(
+  const i18nKey = getI18nKey(
     error.parentSchema,
     uischema,
+    getControlPath(error),
     `error.${error.keyword}`
   );
-  const specializedKeywordMessage = keyInSchemas && t(keyInSchemas, undefined);
+  const specializedKeywordMessage = t(i18nKey, undefined);
   if (specializedKeywordMessage !== undefined) {
     return specializedKeywordMessage;
   }
@@ -44,7 +72,7 @@ export const defaultErrorTranslator: ErrorTranslator = (error, t, uischema) => {
   }
 
   // rewrite required property messages (if they were not customized) as we place them next to the respective input
-  if (error.keyword === 'required') {
+  if (error.keyword === 'required' && error.message?.startsWith('must have required property')) {
     return t('is a required property', 'is a required property');
   }
 
@@ -53,19 +81,20 @@ export const defaultErrorTranslator: ErrorTranslator = (error, t, uischema) => {
 
 /**
  * Returns the determined error message for the given errors.
- * All errors must correspond to the given schema and uischema.
+ * All errors must correspond to the given schema, uischema or path.
  */
 export const getCombinedErrorMessage = (
   errors: ErrorObject[],
   et: ErrorTranslator,
   t: Translator,
   schema?: i18nJsonSchema,
-  uischema?: UISchemaElement
+  uischema?: UISchemaElement,
+  path?: string
 ) => {
   if (errors.length > 0 && t) {
     // check whether there is a special message which overwrites all others
-    const keyInSchemas = getI18nKey(schema, uischema, 'error.custom');
-    const specializedErrorMessage = keyInSchemas && t(keyInSchemas, undefined);
+    const customErrorKey = getI18nKey(schema, uischema, path, 'error.custom');
+    const specializedErrorMessage = t(customErrorKey, undefined);
     if (specializedErrorMessage !== undefined) {
       return specializedErrorMessage;
     }

--- a/packages/core/src/reducers/reducers.ts
+++ b/packages/core/src/reducers/reducers.ts
@@ -27,11 +27,7 @@ import { ControlElement, UISchemaElement } from '../models';
 import {
   coreReducer,
   errorAt,
-  errorsAt,
-  getControlPath,
-  JsonFormsCore,
   subErrorsAt,
-  ValidationMode
 } from './core';
 import { defaultDataReducer } from './default-data';
 import { rendererReducer } from './renderers';
@@ -40,7 +36,6 @@ import {
   findMatchingUISchema,
   JsonFormsUISchemaRegistryEntry,
   uischemaRegistryReducer,
-  UISchemaTester
 } from './uischemas';
 import {
   fetchErrorTranslator,
@@ -56,19 +51,6 @@ import { configReducer } from './config';
 import get from 'lodash/get';
 import { fetchTranslator } from '.';
 import { ErrorTranslator, Translator } from '../i18n';
-
-export {
-  rendererReducer,
-  cellReducer,
-  coreReducer,
-  i18nReducer,
-  configReducer,
-  UISchemaTester,
-  uischemaRegistryReducer,
-  findMatchingUISchema,
-  JsonFormsUISchemaRegistryEntry
-};
-export { JsonFormsCore, ValidationMode };
 
 export const jsonFormsReducerConfig = {
   core: coreReducer,
@@ -127,8 +109,6 @@ export const getErrorAt = (instancePath: string, schema: JsonSchema) => (
 ) => {
   return errorAt(instancePath, schema)(state.jsonforms.core);
 };
-
-export { errorsAt, getControlPath };
 
 export const getSubErrorsAt = (instancePath: string, schema: JsonSchema) => (
   state: JsonFormsState

--- a/packages/core/src/util/cell.ts
+++ b/packages/core/src/util/cell.ts
@@ -55,7 +55,7 @@ import {
 } from './renderer';
 import { JsonFormsState } from '../store';
 import { JsonSchema } from '../models';
-import { getI18nKeyPrefix } from '..';
+import { getI18nKeyPrefix } from '../i18n';
 
 export { JsonFormsCellRendererRegistryEntry };
 

--- a/packages/core/src/util/cell.ts
+++ b/packages/core/src/util/cell.ts
@@ -55,7 +55,7 @@ import {
 } from './renderer';
 import { JsonFormsState } from '../store';
 import { JsonSchema } from '../models';
-import { i18nJsonSchema } from '..';
+import { getI18nKeyPrefix } from '..';
 
 export { JsonFormsCellRendererRegistryEntry };
 
@@ -202,14 +202,14 @@ export const defaultMapStateToEnumCellProps = (
       enumToEnumOptionMapper(
         e,
         getTranslator()(state),
-        props.uischema?.options?.i18n ?? (props.schema as i18nJsonSchema).i18n
+        getI18nKeyPrefix(props.schema, props.uischema, props.path)
       )
     ) ||
     (props.schema.const && [
       enumToEnumOptionMapper(
         props.schema.const,
         getTranslator()(state),
-        props.uischema?.options?.i18n ?? (props.schema as i18nJsonSchema).i18n
+        getI18nKeyPrefix(props.schema, props.uischema, props.path)
       )
     ]);
   return {
@@ -235,7 +235,7 @@ export const mapStateToOneOfEnumCellProps = (
       oneOfToEnumOptionMapper(
         oneOfSubSchema,
         getTranslator()(state),
-        props.uischema?.options?.i18n
+        getI18nKeyPrefix(props.schema, props.uischema, props.path)
       )
     );
   return {

--- a/packages/core/test/i18n/i18nUtil.test.ts
+++ b/packages/core/test/i18n/i18nUtil.test.ts
@@ -1,0 +1,48 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2017-2021 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import test from 'ava';
+
+import { transformPathToI18nPrefix } from '../../src';
+
+test('transformPathToI18nPrefix returns root when empty', t => {
+  t.is(transformPathToI18nPrefix(''), 'root');
+});
+
+test('transformPathToI18nPrefix does not modify non-array paths', t => {
+  t.is(transformPathToI18nPrefix('foo'), 'foo');
+  t.is(transformPathToI18nPrefix('foo.bar'), 'foo.bar');
+  t.is(transformPathToI18nPrefix('bar3.foo2'), 'bar3.foo2');
+});
+
+test('transformPathToI18nPrefix removes array indices', t => {
+  t.is(transformPathToI18nPrefix('foo.2.bar'), 'foo.bar');
+  t.is(transformPathToI18nPrefix('foo.234324234.bar'), 'foo.bar');
+  t.is(transformPathToI18nPrefix('foo.0.bar'), 'foo.bar');
+  t.is(transformPathToI18nPrefix('foo.0.bar.1.foobar'), 'foo.bar.foobar');
+  t.is(transformPathToI18nPrefix('3.foobar'), 'foobar');
+  t.is(transformPathToI18nPrefix('foobar.3'), 'foobar');
+  t.is(transformPathToI18nPrefix('foo1.23.b2ar3.1.5.foo'), 'foo1.b2ar3.foo');
+  t.is(transformPathToI18nPrefix('3'), 'root');
+});

--- a/packages/core/test/reducers/core.test.ts
+++ b/packages/core/test/reducers/core.test.ts
@@ -25,7 +25,7 @@
 import test from 'ava';
 import Ajv from 'ajv';
 import { coreReducer } from '../../src/reducers';
-import { init, update, updateErrors } from '../../src/actions';
+import { init, setSchema, setValidationMode, update, updateCore, updateErrors } from '../../src/actions';
 import { JsonSchema } from '../../src/models/jsonSchema';
 import {
   errorAt,
@@ -34,9 +34,8 @@ import {
   subErrorsAt
 } from '../../src/reducers/core';
 
-import { createAjv, updateCore } from '../../src';
-import { setSchema, setValidationMode } from '../../lib';
 import { cloneDeep } from 'lodash';
+import { createAjv } from '../../src/util/validator';
 
 test('core reducer should support v7', t => {
   const schema: JsonSchema = {


### PR DESCRIPTION
If there is no 'i18n' key in schema or ui schema a default
calculated key based on the data path of the respective control
is used.

Additionally fixes the issue that the 'required' message of
localized errors were overwritten by JSON Forms.

Also removed redundant exports in JSON Forms core and
cleans up imports in test cases which lead to errors when
executing ava.