### PR TITLE
Add readonly type to renderers prop in JsonForms.vue

### DIFF
--- a/packages/vue/vue/src/components/JsonForms.vue
+++ b/packages/vue/vue/src/components/JsonForms.vue
@@ -57,7 +57,7 @@ export default defineComponent({
     },
     renderers: {
       required: true,
-      type: Array as PropType<JsonFormsRendererRegistryEntry[]>
+      type: Array as PropType<JsonFormsRendererRegistryEntry[] | Readonly<JsonFormsRendererRegistryEntry[]>>
     },
     cells: {
       required: false,

--- a/packages/vue/vue/src/components/JsonForms.vue
+++ b/packages/vue/vue/src/components/JsonForms.vue
@@ -25,7 +25,7 @@ import {
   i18nReducer,
   JsonFormsI18nState
 } from '@jsonforms/core';
-import { JsonFormsChangeEvent } from '../types';
+import { JsonFormsChangeEvent, MaybeReadonly } from '../types';
 import DispatchRenderer from './DispatchRenderer.vue';
 
 import Ajv from 'ajv';
@@ -57,11 +57,11 @@ export default defineComponent({
     },
     renderers: {
       required: true,
-      type: Array as PropType<JsonFormsRendererRegistryEntry[] | Readonly<JsonFormsRendererRegistryEntry[]>>
+      type: Array as PropType<MaybeReadonly<JsonFormsRendererRegistryEntry[]>>
     },
     cells: {
       required: false,
-      type: Array as PropType<JsonFormsCellRendererRegistryEntry[]>,
+      type: Array as PropType<MaybeReadonly<JsonFormsCellRendererRegistryEntry[]>>,
       default: () => []
     },
     config: {
@@ -76,7 +76,7 @@ export default defineComponent({
     },
     uischemas: {
       required: false,
-      type: Array as PropType<JsonFormsUISchemaRegistryEntry[]>,
+      type: Array as PropType<MaybeReadonly<JsonFormsUISchemaRegistryEntry[]>>,
       default: () => []
     },
     validationMode: {

--- a/packages/vue/vue/src/types.ts
+++ b/packages/vue/vue/src/types.ts
@@ -13,3 +13,5 @@ export interface InjectJsonFormsDispatch {
 }
 
 export type JsonFormsChangeEvent = Pick<JsonFormsCore, 'data' | 'errors'>
+
+export type MaybeReadonly<T> = T | Readonly<T>


### PR DESCRIPTION
Fix #1859

This PR adds the readonly type to `renderers` props in JsonForms.vue.

According to the README of jsonforms/vue, `renderers` may be the value of `Object.freeze`. So it might be better that `renderers` also accept readonly types.
