### PR TITLE
Fix "dot-separated" paths by making paths type `string[]` (instead of `string`)

### DIFF
--- a/packages/core/src/actions/actions.ts
+++ b/packages/core/src/actions/actions.ts
@@ -72,7 +72,7 @@ export type CoreActions =
 
 export interface UpdateAction {
   type: 'jsonforms/UPDATE';
-  path: string;
+  path: string[];
   updater(existingData?: any): any;
 }
 
@@ -167,7 +167,7 @@ export const setAjv = (ajv: AJV) => ({
 });
 
 export const update = (
-  path: string,
+  path: string[],
   updater: (existingData: any) => any
 ): UpdateAction => ({
   type: UPDATE_DATA,

--- a/packages/core/src/i18n/i18nUtil.ts
+++ b/packages/core/src/i18n/i18nUtil.ts
@@ -15,11 +15,10 @@ export const getI18nKeyPrefixBySchema = (
  * Transforms a given path to a prefix which can be used for i18n keys.
  * Returns 'root' for empty paths and removes array indices
  */
-export const transformPathToI18nPrefix = (path: string) => {
+export const transformPathToI18nPrefix = (path: string[]) => {
   return (
     path
-      ?.split('.')
-      .filter(segment => !/^\d+$/.test(segment))
+      ?.filter(segment => !/^\d+$/.test(segment))
       .join('.') || 'root'
   );
 };
@@ -27,7 +26,7 @@ export const transformPathToI18nPrefix = (path: string) => {
 export const getI18nKeyPrefix = (
   schema: i18nJsonSchema | undefined,
   uischema: UISchemaElement | undefined,
-  path: string | undefined
+  path: string[] | undefined
 ): string | undefined => {
   return (
     getI18nKeyPrefixBySchema(schema, uischema) ??
@@ -38,7 +37,7 @@ export const getI18nKeyPrefix = (
 export const getI18nKey = (
   schema: i18nJsonSchema | undefined,
   uischema: UISchemaElement | undefined,
-  path: string | undefined,
+  path: string[] | undefined,
   key: string
 ): string | undefined => {
   return `${getI18nKeyPrefix(schema, uischema, path)}.${key}`;
@@ -89,7 +88,7 @@ export const getCombinedErrorMessage = (
   t: Translator,
   schema?: i18nJsonSchema,
   uischema?: UISchemaElement,
-  path?: string
+  path?: string[],
 ) => {
   if (errors.length > 0 && t) {
     // check whether there is a special message which overwrites all others

--- a/packages/core/src/reducers/reducers.ts
+++ b/packages/core/src/reducers/reducers.ts
@@ -74,7 +74,7 @@ export const findUISchema = (
   uischemas: JsonFormsUISchemaRegistryEntry[],
   schema: JsonSchema,
   schemaPath: string,
-  path: string,
+  path: string[],
   fallbackLayoutType = 'VerticalLayout',
   control?: ControlElement,
   rootSchema?: JsonSchema
@@ -104,13 +104,13 @@ export const findUISchema = (
   return uiSchema;
 };
 
-export const getErrorAt = (instancePath: string, schema: JsonSchema) => (
+export const getErrorAt = (instancePath: string[], schema: JsonSchema) => (
   state: JsonFormsState
 ) => {
   return errorAt(instancePath, schema)(state.jsonforms.core);
 };
 
-export const getSubErrorsAt = (instancePath: string, schema: JsonSchema) => (
+export const getSubErrorsAt = (instancePath: string[], schema: JsonSchema) => (
   state: JsonFormsState
 ) => subErrorsAt(instancePath, schema)(state.jsonforms.core);
 

--- a/packages/core/src/reducers/uischemas.ts
+++ b/packages/core/src/reducers/uischemas.ts
@@ -33,7 +33,7 @@ import { Reducer } from '../util';
 export type UISchemaTester = (
   schema: JsonSchema,
   schemaPath: string,
-  path: string
+  path: string[],
 ) => number;
 
 export interface JsonFormsUISchemaRegistryEntry {
@@ -64,7 +64,7 @@ export const findMatchingUISchema = (
 ) => (
   jsonSchema: JsonSchema,
   schemaPath: string,
-  path: string
+  path: string[],
 ): UISchemaElement => {
   const match = maxBy(state, entry =>
     entry.tester(jsonSchema, schemaPath, path)

--- a/packages/core/src/util/combinators.ts
+++ b/packages/core/src/util/combinators.ts
@@ -70,7 +70,7 @@ export const createCombinatorRenderInfos = (
   rootSchema: JsonSchema,
   keyword: CombinatorKeyword,
   control: ControlElement,
-  path: string,
+  path: string[],
   uischemas: JsonFormsUISchemaRegistryEntry[]
 ): CombinatorSubSchemaRenderInfo[] =>
   combinatorSubSchemas.map((subSchema, subSchemaIndex) => ({

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -238,7 +238,7 @@ export interface OwnPropsOfRenderer {
    * path can not be inferred via the UI schema element as
    * it is the case with nested controls.
    */
-  path?: string;
+  path?: string[];
 
   renderers?: JsonFormsRendererRegistryEntry[];
 
@@ -297,7 +297,7 @@ export interface StatePropsOfRenderer {
   /**
    * Instance path the data is written to, in case of a control.
    */
-  path: string;
+  path: string[];
 
   /**
    * All available renderers.
@@ -378,7 +378,7 @@ export interface DispatchPropsOfControl {
    * @param {string} path the path to the data to be updated
    * @param {any} value the new value that should be written to the given path
    */
-  handleChange(path: string, value: any): void;
+  handleChange(path: string[], value: any): void;
 }
 
 /**
@@ -637,10 +637,10 @@ export interface StatePropsOfControlWithDetail extends StatePropsOfControl {
 export interface OwnPropsOfMasterListItem {
   index: number;
   selected: boolean;
-  path: string;
+  path: string[];
   schema: JsonSchema;
   handleSelect(index: number): () => void;
-  removeItem(path: string, value: number): () => void;
+  removeItem(path: string[], value: number): () => void;
 }
 
 export interface StatePropsOfMasterItem extends OwnPropsOfMasterListItem {
@@ -712,10 +712,10 @@ export const mapStateToArrayControlProps = (
  * Dispatch props of a table control
  */
 export interface DispatchPropsOfArrayControl {
-  addItem(path: string, value: any): () => void;
-  removeItems?(path: string, toDelete: number[]): () => void;
-  moveUp?(path: string, toMove: number): () => void;
-  moveDown?(path: string, toMove: number): () => void;
+  addItem(path: string[], value: any): () => void;
+  removeItems?(path: string[], toDelete: number[]): () => void;
+  moveUp?(path: string[], toMove: number): () => void;
+  moveDown?(path: string[], toMove: number): () => void;
 }
 
 /**
@@ -727,7 +727,7 @@ export interface DispatchPropsOfArrayControl {
 export const mapDispatchToArrayControlProps = (
   dispatch: Dispatch<CoreActions>
 ): DispatchPropsOfArrayControl => ({
-  addItem: (path: string, value: any) => () => {
+  addItem: (path: string[], value: any) => () => {
     dispatch(
       update(path, array => {
         if (array === undefined || array === null) {
@@ -739,7 +739,7 @@ export const mapDispatchToArrayControlProps = (
       })
     );
   },
-  removeItems: (path: string, toDelete: number[]) => () => {
+  removeItems: (path: string[], toDelete: number[]) => () => {
     dispatch(
       update(path, array => {
         toDelete
@@ -769,14 +769,14 @@ export const mapDispatchToArrayControlProps = (
 });
 
 export interface DispatchPropsOfMultiEnumControl {
-  addItem: (path: string, value: any) => void;
-  removeItem?: (path: string, toDelete: any) => void;
+  addItem: (path: string[], value: any) => void;
+  removeItem?: (path: string[], toDelete: any) => void;
 }
 
 export const mapDispatchToMultiEnumProps = (
   dispatch: Dispatch<CoreActions>
 ): DispatchPropsOfMultiEnumControl => ({
-  addItem: (path: string, value: any) => {
+  addItem: (path: string[], value: any) => {
     dispatch(
       update(path, data => {
         if (data === undefined || data === null) {
@@ -787,7 +787,7 @@ export const mapDispatchToMultiEnumProps = (
       })
     );
   },
-  removeItem: (path: string, toDelete: any) => {
+  removeItem: (path: string[], toDelete: any) => {
     dispatch(
       update(path, data => {
         const indexInData = data.indexOf(toDelete);
@@ -808,12 +808,12 @@ export interface ArrayControlProps
 export const layoutDefaultProps: {
   visible: boolean;
   enabled: boolean;
-  path: string;
+  path: string[];
   direction: 'row' | 'column';
 } = {
   visible: true,
   enabled: true,
-  path: '',
+  path: [],
   direction: 'column'
 };
 
@@ -915,7 +915,7 @@ export const controlDefaultProps = {
 
 export interface StatePropsOfCombinator extends OwnPropsOfControl {
   rootSchema: JsonSchema;
-  path: string;
+  path: string[];
   id: string;
   indexOfFittingSchema: number;
   uischemas: JsonFormsUISchemaRegistryEntry[];

--- a/packages/core/src/util/resolvers.ts
+++ b/packages/core/src/util/resolvers.ts
@@ -41,21 +41,19 @@ const isArraySchema = (schema: JsonSchema): boolean => {
   return schema.type === 'array' && schema.items !== undefined;
 };
 
-export const resolveData = (instance: any, dataPath: string): any => {
+export const resolveData = (instance: any, dataPath: string[]): any => {
   if (isEmpty(dataPath)) {
     return instance;
   }
-  const dataPathSegments = dataPath.split('.');
 
-  return dataPathSegments
-    .map(segment => decodeURIComponent(segment))
-    .reduce((curInstance, decodedSegment) => {
-      if (!curInstance || !curInstance.hasOwnProperty(decodedSegment)) {
-        return undefined;
-      }
+  // TODO: Replace with a `for` loop to improve performance (by breaking the loop on `undefined`)
+  return dataPath.reduce((curInstance, segment) => {
+    if (!curInstance?.hasOwnProperty(segment)) {
+      return undefined;
+    }
 
-      return curInstance[decodedSegment];
-    }, instance);
+    return curInstance[segment];
+  }, instance);
 };
 
 /**

--- a/packages/core/src/util/runtime.ts
+++ b/packages/core/src/util/runtime.ts
@@ -54,14 +54,14 @@ const isSchemaCondition = (
   condition: Condition
 ): condition is SchemaBasedCondition => has(condition, 'schema');
 
-const getConditionScope = (condition: Scopable, path: string): string => {
+const getConditionScope = (condition: Scopable, path: string[]): string[] => {
   return composeWithUi(condition, path);
 };
 
 const evaluateCondition = (
   data: any,
   condition: Condition,
-  path: string,
+  path: string[],
   ajv: Ajv
 ): boolean => {
   if (isAndCondition(condition)) {
@@ -89,7 +89,7 @@ const evaluateCondition = (
 const isRuleFulfilled = (
   uischema: UISchemaElement,
   data: any,
-  path: string,
+  path: string[],
   ajv: Ajv
 ): boolean => {
   const condition = uischema.rule.condition;
@@ -99,7 +99,7 @@ const isRuleFulfilled = (
 export const evalVisibility = (
   uischema: UISchemaElement,
   data: any,
-  path: string = undefined,
+  path: string[] = undefined,
   ajv: Ajv
 ): boolean => {
   const fulfilled = isRuleFulfilled(uischema, data, path, ajv);
@@ -118,7 +118,7 @@ export const evalVisibility = (
 export const evalEnablement = (
   uischema: UISchemaElement,
   data: any,
-  path: string = undefined,
+  path: string[] = undefined,
   ajv: Ajv
 ): boolean => {
   const fulfilled = isRuleFulfilled(uischema, data, path, ajv);
@@ -159,7 +159,7 @@ export const hasEnableRule = (uischema: UISchemaElement): boolean => {
 export const isVisible = (
   uischema: UISchemaElement,
   data: any,
-  path: string = undefined,
+  path: string[] = undefined,
   ajv: Ajv
 ): boolean => {
   if (uischema.rule) {
@@ -172,7 +172,7 @@ export const isVisible = (
 export const isEnabled = (
   uischema: UISchemaElement,
   data: any,
-  path: string = undefined,
+  path: string[] = undefined,
   ajv: Ajv
 ): boolean => {
   if (uischema.rule) {

--- a/packages/core/src/util/util.ts
+++ b/packages/core/src/util/util.ts
@@ -93,27 +93,27 @@ export const deriveTypes = (jsonSchema: JsonSchema): string[] => {
 };
 
 /**
-* Convenience wrapper around resolveData and resolveSchema.
-*/
+ * Convenience wrapper around resolveData and resolveSchema.
+ */
 export const Resolve: {
  schema(
    schema: JsonSchema,
    schemaPath: string,
    rootSchema?: JsonSchema
  ): JsonSchema;
- data(data: any, path: string): any;
+ data(data: any, path: string[]): any;
 } = {
  schema: resolveSchema,
  data: resolveData
 };
 
 // Paths --
-const fromScopable = (scopable: Scopable) =>
+const fromScopable = (scopable: Scopable) => // TODO: Where this is used?
  toDataPathSegments(scopable.scope).join('.');
 
 export const Paths = {
  compose: composePaths,
- fromScopable
+ fromScopable,
 };
 
 // Runtime --

--- a/packages/core/test/util/path.test.ts
+++ b/packages/core/test/util/path.test.ts
@@ -64,7 +64,7 @@ test('toDataPath use of keywords', t => {
   t.is(toDataPath('#/properties/properties'), 'properties');
 });
 test('toDataPath use of encoded paths', t => {
-  const fooBar = encodeURIComponent('foo.bar');
+  const fooBar = 'foo.bar';
   t.is(toDataPath(`#/properties/${fooBar}`), `${fooBar}`);
 });
 test('toDataPath relative with /', t => {

--- a/packages/core/test/util/renderer.test.ts
+++ b/packages/core/test/util/renderer.test.ts
@@ -168,7 +168,7 @@ test('mapStateToControlProps - visible via state with path from ownProps ', t =>
   };
   const ownProps = {
     uischema,
-    path: 'foo'
+    path: ['foo']
   };
   const state = {
     jsonforms: {
@@ -238,7 +238,7 @@ test('mapStateToControlProps - enabled via state with path from ownProps ', t =>
   const ownProps = {
     visible: true,
     uischema,
-    path: 'foo'
+    path: ['foo']
   };
   const state = {
     jsonforms: {

--- a/packages/material/src/additional/MaterialListWithDetailRenderer.tsx
+++ b/packages/material/src/additional/MaterialListWithDetailRenderer.tsx
@@ -64,8 +64,8 @@ export const MaterialListWithDetailRenderer = ({
 }: ArrayLayoutProps) => {
   const [selectedIndex, setSelectedIndex] = useState(undefined);
   const handleRemoveItem = useCallback(
-    (p: string, value: any) => () => {
-      removeItems(p, [value])();
+    (thePath: string[], value: any) => () => {
+      removeItems(thePath, [value])();
       if (selectedIndex === value) {
         setSelectedIndex(undefined);
       } else if (selectedIndex > value) {

--- a/packages/material/src/complex/CombinatorProperties.tsx
+++ b/packages/material/src/complex/CombinatorProperties.tsx
@@ -30,7 +30,7 @@ import omit from 'lodash/omit';
 interface CombinatorPropertiesProps {
   schema: JsonSchema;
   combinatorKeyword: 'oneOf' | 'anyOf';
-  path: string;
+  path: string[];
 }
 
 export const isLayout = (uischema: UISchemaElement): uischema is Layout =>

--- a/packages/material/src/complex/DeleteDialog.tsx
+++ b/packages/material/src/complex/DeleteDialog.tsx
@@ -40,7 +40,7 @@ export interface DeleteDialogProps {
 }
 
 export interface WithDeleteDialogSupport {
-  openDeleteDialog(path: string, data: number): void;
+  openDeleteDialog(path: string[], data: number): void;
 }
 
 export const DeleteDialog = React.memo(({ open, onClose, onConfirm, onCancel }: DeleteDialogProps) => {

--- a/packages/material/src/complex/MaterialArrayControlRenderer.tsx
+++ b/packages/material/src/complex/MaterialArrayControlRenderer.tsx
@@ -31,19 +31,20 @@ import { DeleteDialog } from './DeleteDialog';
 
 export const MaterialArrayControlRenderer = (props: ArrayLayoutProps) => {
   const [open, setOpen] = useState(false);
-  const [path, setPath] = useState(undefined);
+  const [path, setPath] = useState<string[]>(undefined);
   const [rowData, setRowData] = useState(undefined);
   const { removeItems, visible } = props;
 
-  const openDeleteDialog = useCallback((p: string, rowIndex: number) => {
+  const openDeleteDialog = useCallback((thePath: string[], rowIndex: number) => {
     setOpen(true);
-    setPath(p);
+    setPath(thePath);
     setRowData(rowIndex);
   }, [setOpen, setPath, setRowData]);
   const deleteCancel = useCallback(() => setOpen(false), [setOpen]);
   const deleteConfirm = useCallback(() => {
-    const p = path.substring(0, path.lastIndexOf(('.')));
-    removeItems(p, [rowData])();
+    const parentPath = [...path];
+    parentPath.pop();
+    removeItems(parentPath, [rowData])();
     setOpen(false);
   }, [setOpen, path, rowData]);
   const deleteClose = useCallback(() => setOpen(false), [setOpen]);

--- a/packages/material/src/complex/TableToolbar.tsx
+++ b/packages/material/src/complex/TableToolbar.tsx
@@ -42,12 +42,12 @@ export interface MaterialTableToolbarProps {
   numColumns: number;
   errors: string;
   label: string;
-  path: string;
+  path: string[];
   uischema: ControlElement;
   schema: JsonSchema;
   rootSchema: JsonSchema;
   enabled: boolean;
-  addItem(path: string, value: any): () => void;
+  addItem(path: string[], value: any): () => void;
 }
 
 const fixedCellSmall = {

--- a/packages/material/src/layouts/ArrayToolbar.tsx
+++ b/packages/material/src/layouts/ArrayToolbar.tsx
@@ -12,8 +12,8 @@ import ValidationIcon from '../complex/ValidationIcon';
 export interface ArrayLayoutToolbarProps {
   label: string;
   errors: string;
-  path: string;
-  addItem(path: string, data: any): () => void;
+  path: string[];
+  addItem(path: string[], data: any): () => void;
   createDefault(): any;
 }
 export const ArrayLayoutToolbar = React.memo(

--- a/packages/material/src/layouts/ExpandPanelRenderer.tsx
+++ b/packages/material/src/layouts/ExpandPanelRenderer.tsx
@@ -20,7 +20,8 @@ import {
   JsonFormsUISchemaRegistryEntry,
   getFirstPrimitiveProp,
   createId,
-  removeId
+  removeId,
+  stringifyPath,
 } from '@jsonforms/core';
 import {
   Accordion,
@@ -39,7 +40,7 @@ const iconStyle: any = { float: 'right' };
 
 interface OwnPropsOfExpandPanel {
   index: number;
-  path: string;
+  path: string[];
   uischema: ControlElement;
   schema: JsonSchema;
   expanded: boolean;
@@ -51,12 +52,12 @@ interface OwnPropsOfExpandPanel {
   enableMoveDown: boolean;
   config: any;
   childLabelProp?: string;
-  handleExpansion(panel: string): (event: any, expanded: boolean) => void;
+  handleExpansion(panel: string[]): (event: any, expanded: boolean) => void;
 }
 
 interface StatePropsOfExpandPanel extends OwnPropsOfExpandPanel {
   childLabel: string;
-  childPath: string;
+  childPath: string[];
   enableMoveUp: boolean;
   enableMoveDown: boolean;
 }
@@ -65,9 +66,9 @@ interface StatePropsOfExpandPanel extends OwnPropsOfExpandPanel {
  * Dispatch props of a table control
  */
 export interface DispatchPropsOfExpandPanel {
-  removeItems(path: string, toDelete: number[]): (event: any) => void;
-  moveUp(path: string, toMove: number): (event: any) => void;
-  moveDown(path: string, toMove: number): (event: any) => void;
+  removeItems(path: string[], toDelete: number[]): (event: any) => void;
+  moveUp(path: string[], toMove: number): (event: any) => void;
+  moveDown(path: string[], toMove: number): (event: any) => void;
 }
 
 export interface ExpandPanelProps
@@ -155,7 +156,8 @@ const ExpandPanelRendererComponent = (props: ExpandPanelProps) => {
                           style={iconStyle}
                           disabled={!enableMoveUp}
                           aria-label={`Move up`}
-                          size='large'>
+                          size='large'
+                        >
                           <ArrowUpward />
                         </IconButton>
                       </Grid>
@@ -165,7 +167,8 @@ const ExpandPanelRendererComponent = (props: ExpandPanelProps) => {
                           style={iconStyle}
                           disabled={!enableMoveDown}
                           aria-label={`Move down`}
-                          size='large'>
+                          size='large'
+                        >
                           <ArrowDownward />
                         </IconButton>
                       </Grid>
@@ -178,7 +181,8 @@ const ExpandPanelRendererComponent = (props: ExpandPanelProps) => {
                       onClick={removeItems(path, [index])}
                       style={iconStyle}
                       aria-label={`Delete`}
-                      size='large'>
+                      size='large'
+                    >
                       <DeleteIcon />
                     </IconButton>
                   </Grid>
@@ -193,7 +197,7 @@ const ExpandPanelRendererComponent = (props: ExpandPanelProps) => {
           schema={schema}
           uischema={foundUISchema}
           path={childPath}
-          key={childPath}
+          key={stringifyPath(childPath)}
           renderers={renderers}
           cells={cells}
         />
@@ -213,7 +217,7 @@ const ExpandPanelRenderer = React.memo(ExpandPanelRendererComponent);
 export const ctxDispatchToExpandPanelProps: (
   dispatch: Dispatch<ReducerAction<any>>
 ) => DispatchPropsOfExpandPanel = dispatch => ({
-  removeItems: useCallback((path: string, toDelete: number[]) => (event: any): void => {
+  removeItems: useCallback((path: string[], toDelete: number[]) => (event: any): void => {
     event.stopPropagation();
     dispatch(
       update(path, array => {
@@ -225,7 +229,7 @@ export const ctxDispatchToExpandPanelProps: (
       })
     );
   }, [dispatch]),
-  moveUp: useCallback((path: string, toMove: number) => (event: any): void => {
+  moveUp: useCallback((path: string[], toMove: number) => (event: any): void => {
     event.stopPropagation();
     dispatch(
       update(path, array => {
@@ -234,7 +238,7 @@ export const ctxDispatchToExpandPanelProps: (
       })
     );
   }, [dispatch]),
-  moveDown: useCallback((path: string, toMove: number) => (event: any): void => {
+  moveDown: useCallback((path: string[], toMove: number) => (event: any): void => {
     event.stopPropagation();
     dispatch(
       update(path, array => {

--- a/packages/material/src/layouts/MaterialArrayLayout.tsx
+++ b/packages/material/src/layouts/MaterialArrayLayout.tsx
@@ -23,27 +23,28 @@
   THE SOFTWARE.
 */
 import range from 'lodash/range';
-import React, {useState, useCallback} from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   ArrayLayoutProps,
   composePaths,
   computeLabel,
   createDefaultValue,
+  pathsAreEqual,
 } from '@jsonforms/core';
 import map from 'lodash/map';
 import { ArrayLayoutToolbar } from './ArrayToolbar';
 import ExpandPanelRenderer from './ExpandPanelRenderer';
 import merge from 'lodash/merge';
 
-const MaterialArrayLayoutComponent = (props: ArrayLayoutProps)=> {
-  const [expanded, setExpanded] = useState<string|boolean>(false);
+const MaterialArrayLayoutComponent = (props: ArrayLayoutProps) => {
+  const [expanded, setExpanded] = useState<string[]>(null);
   const innerCreateDefaultValue = useCallback(() => createDefaultValue(props.schema), [props.schema]);
-  const handleChange = useCallback((panel: string) => (_event: any, expandedPanel: boolean) => {
-    setExpanded(expandedPanel ? panel : false)
+  const handleChange = useCallback((panel: string[]) => (_event: any, expandedPanel: boolean) => {
+    setExpanded(expandedPanel ? panel : null);
   }, []);
-  const isExpanded = (index: number) => 
-    expanded === composePaths(props.path, `${index}`);
-  
+  const isExpanded = (index: number) =>
+    expanded ? pathsAreEqual(expanded, composePaths(props.path, `${index}`)) : false;
+
   const {
     data,
     path,

--- a/packages/material/src/layouts/MaterialArrayLayoutRenderer.tsx
+++ b/packages/material/src/layouts/MaterialArrayLayoutRenderer.tsx
@@ -50,7 +50,7 @@ export const MaterialArrayLayoutRenderer = ({
   uischemas,
   addItem
 }: ArrayLayoutProps) => {
-  const addItemCb = useCallback((p: string, value: any) => addItem(p, value), [
+  const addItemCb = useCallback((thePath: string[], value: any) => addItem(thePath, value), [
     addItem
   ]);
   return (

--- a/packages/material/src/util/datejs.ts
+++ b/packages/material/src/util/datejs.ts
@@ -5,8 +5,8 @@ import customParsing from 'dayjs/plugin/customParseFormat';
 dayjs.extend(customParsing);
 
 export const createOnChangeHandler = (
-  path: string,
-  handleChange: (path: string, value: any) => void,
+  path: string[],
+  handleChange: (path: string[], value: any) => void,
   saveFormat: string | undefined
 ) => (time: dayjs.Dayjs) => {
   if (!time) {

--- a/packages/material/src/util/debounce.ts
+++ b/packages/material/src/util/debounce.ts
@@ -23,11 +23,10 @@
   THE SOFTWARE.
 */
 import debounce from 'lodash/debounce';
-import { useState, useCallback, useEffect } from 'react'
-
+import { useCallback, useEffect, useState } from 'react';
 
 const eventToValue = (ev: any) => ev.target.value;
-export const useDebouncedChange = (handleChange: (path: string, value: any) => void, defaultValue: any, data: any, path: string, eventToValueFunction: (ev: any) => any = eventToValue, timeout = 300): [any, React.ChangeEventHandler, () => void] => {
+export const useDebouncedChange = (handleChange: (path: string[], value: any) => void, defaultValue: any, data: any, path: string[], eventToValueFunction: (ev: any) => any = eventToValue, timeout = 300): [any, React.ChangeEventHandler, () => void] => {
   const [input, setInput] = useState(data ?? defaultValue);
   useEffect(() => {
     setInput(data ?? defaultValue);

--- a/packages/material/src/util/layout.tsx
+++ b/packages/material/src/util/layout.tsx
@@ -40,7 +40,7 @@ import { Grid, Hidden } from '@mui/material';
 export const renderLayoutElements = (
   elements: UISchemaElement[],
   schema: JsonSchema,
-  path: string,
+  path: string[],
   enabled: boolean,
   renderers?: JsonFormsRendererRegistryEntry[],
   cells?: JsonFormsCellRendererRegistryEntry[]

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -95,7 +95,7 @@ const TestAndRender = React.memo(
   (props: {
     uischema: UISchemaElement;
     schema: JsonSchema;
-    path: string;
+    path: string[];
     enabled: boolean;
     renderers: JsonFormsRendererRegistryEntry[];
     cells: JsonFormsCellRendererRegistryEntry[];
@@ -144,18 +144,18 @@ const useJsonFormsDispatchRendererProps = (props: OwnPropsOfJsonFormsRenderer & 
   return {
     schema: props.schema || ctx.core.schema,
     uischema: props.uischema || ctx.core.uischema,
-    path: props.path || '',
+    path: props.path || [],
     enabled: props.enabled,
     rootSchema: ctx.core.schema,
     renderers: props.renderers || ctx.renderers,
     cells: props.cells || ctx.cells,
   };
-}
+};
 
 export const JsonFormsDispatch = React.memo(
   (props: OwnPropsOfJsonFormsRenderer & JsonFormsReactProps) => {
     const renderProps = useJsonFormsDispatchRendererProps(props);
-    return <JsonFormsDispatchRenderer {...renderProps} />
+    return <JsonFormsDispatchRenderer {...renderProps} />;
   }
 );
 

--- a/packages/react/test/renderers/JsonForms.test.tsx
+++ b/packages/react/test/renderers/JsonForms.test.tsx
@@ -43,6 +43,7 @@ import {
   registerCell,
   registerRenderer,
   schemaMatches,
+  stringifyPath,
   uiTypeIs,
   unregisterRenderer,
 } from '@jsonforms/core';
@@ -220,7 +221,7 @@ test('ids should be unique within the same form', () => {
         uischema={e}
         schema={fixture.schema}
         path={props.path}
-        key={`${props.path}-${idx}`}
+        key={`${stringifyPath(props.path)}-${idx}`}
       />
     ));
     return <div className='layout'>{children}</div>;
@@ -298,7 +299,7 @@ test('render schema with $ref', () => {
 
   const wrapper = mount(
     <JsonFormsDispatchRenderer
-      path={''}
+      path={[]}
       uischema={fixture.uischema}
       schema={schemaWithRef}
       renderers={renderers}
@@ -356,7 +357,7 @@ test.skip('updates schema with ref', () => {
 
   const wrapper = shallow(
     <JsonFormsDispatchRenderer
-      path={''}
+      path={[]}
       uischema={fixture.uischema}
       schema={fixture.schema}
       renderers={renderers}


### PR DESCRIPTION
Fix "dot-separated" paths by making paths type `string[]` (instead of `string`) for react (in these packages: **"core"**, **"react"** and **"material-renderers"**)

eclipsesource/jsonforms#1849
eclipsesource/jsonforms#1831