### PR TITLE
Debounce emitted events in React

### DIFF
--- a/packages/material/test/renderers/MaterialArrayLayout.test.tsx
+++ b/packages/material/test/renderers/MaterialArrayLayout.test.tsx
@@ -306,7 +306,7 @@ describe('Material array layout', () => {
         .find({ 'aria-label': 'Move down' }).length
     ).toBe(1);
   });
-  it('should move item up if up button is presses', () => {
+  it('should move item up if up button is presses', (done) => {
     const onChangeData: any = {
       data: undefined
     };
@@ -331,19 +331,23 @@ describe('Material array layout', () => {
       .find('button')
       .find({ 'aria-label': 'Move up' });
     upButton.simulate('click');
-    expect(onChangeData.data).toEqual([
-      {
-        message: 'Yolo',
-        message2: 'Yolo 2'
-      },
-      {
-        message: 'El Barto was here',
-        message2: 'El Barto was here 2',
-        done: true
-      }
-    ]);
+    // events are debounced for some time, so let's wait
+    setTimeout(() => {
+      expect(onChangeData.data).toEqual([
+        {
+          message: 'Yolo',
+          message2: 'Yolo 2'
+        },
+        {
+          message: 'El Barto was here',
+          message2: 'El Barto was here 2',
+          done: true
+        }
+      ]);
+      done();
+    }, 50);
   });
-  it('shoud move item down if down button is pressed', () => {
+  it('should move item down if down button is pressed', (done) => {
     const onChangeData: any = {
       data: undefined
     };
@@ -368,17 +372,20 @@ describe('Material array layout', () => {
       .find('button')
       .find({ 'aria-label': 'Move down' });
     upButton.simulate('click');
-    expect(onChangeData.data).toEqual([
-      {
-        message: 'Yolo',
-        message2: 'Yolo 2'
-      },
-      {
-        message: 'El Barto was here',
-        message2: 'El Barto was here 2',
-        done: true
-      }
-    ]);
+    // events are debounced for some time, so let's wait
+    setTimeout(() => {
+      expect(onChangeData.data).toEqual([
+        {
+          message: 'Yolo',
+          message2: 'Yolo 2'
+        },
+        {
+          message: 'El Barto was here',
+          message2: 'El Barto was here 2',
+          done: true
+        }
+      ]); done();
+    }, 50);
   });
   it('should have up button disabled for first element', () => {
     wrapper = mount(

--- a/packages/material/test/renderers/MaterialEnumArrayRenderer.test.tsx
+++ b/packages/material/test/renderers/MaterialEnumArrayRenderer.test.tsx
@@ -116,8 +116,8 @@ describe('EnumArrayControl', () => {
     expect(labels.last().text()).toBe('Bar');
   });
 
-  test('oneOf items - updates data', () => {
-    let myData = undefined;
+  test('oneOf items - updates data', (done) => {
+    let myData: any = undefined;
     wrapper = mount(
       <JsonForms
         schema={oneOfSchema}
@@ -131,7 +131,11 @@ describe('EnumArrayControl', () => {
     );
     const input = wrapper.find('input').first();
     input.simulate('change', { target: { checked: true } });
-    expect(myData).toStrictEqual(['foo']);
+    // events are debounced for some time, so let's wait
+    setTimeout(() => {
+      expect(myData).toStrictEqual(['foo']);
+      done();
+    }, 50);
   });
 
   test('enum items - renders', () => {
@@ -177,8 +181,8 @@ describe('EnumArrayControl', () => {
     expect(labels.at(2).text()).toBe('C');
   });
 
-  test('enum items - updates data', () => {
-    let myData = undefined;
+  test('enum items - updates data', (done) => {
+    let myData: any = undefined;
     wrapper = mount(
       <JsonForms
         schema={enumSchema}
@@ -192,6 +196,10 @@ describe('EnumArrayControl', () => {
     );
     const input = wrapper.find('input').first();
     input.simulate('change', { target: { checked: true } });
-    expect(myData).toStrictEqual(['a']);
+    // events are debounced for some time, so let's wait
+    setTimeout(() => {
+      expect(myData).toStrictEqual(['a']);
+      done();
+    }, 50);
   });
 });

--- a/packages/react/src/JsonFormsContext.tsx
+++ b/packages/react/src/JsonFormsContext.tsx
@@ -90,8 +90,6 @@ export const JsonFormsContext = React.createContext<JsonFormsStateContext>({
   renderers: []
 });
 
-type EmittedEventsCache = { timestamp: number; event: any }[];
-
 /**
  * Hook similar to `useEffect` with the difference that the effect
  * is only executed from the second call onwards.
@@ -167,36 +165,8 @@ export const JsonFormsStateProvider = ({ children, initState, onChange }: any) =
     onChangeRef.current = onChange;
   }, [onChange]);
 
-  /**
-   * We keep recently emitted events in a cache to not emit them again in case they were already sent very
-   * recently. This is used to prevent endless rerendering loops in cases where the user triggers changes
-   * very very quickly, for example via Chrome form autofill. As the incoming data is only checked against
-   * the current data in the state, these events might loop A -> B -> A -> B ... when the user
-   * feeds the updated data back to JSON Forms in between the updates. Not emitting them again
-   * prevents the loop.
-   */
-  const emittedEventsCache = useRef<EmittedEventsCache>([]);
   useEffect(() => {
-    if (!onChangeRef.current) {
-      return;
-    }
-    if (emittedEventsCache.current.length > 0) {
-      // clear cache in case it's outdated
-      if (Date.now() - emittedEventsCache.current[emittedEventsCache.current.length - 1].timestamp > 300) {
-        emittedEventsCache.current.length = 0;
-      }
-      // Don't emit again when data was recently emitted
-      if (emittedEventsCache.current.find(previouslyEmitted => previouslyEmitted.event.data === core.data) !== undefined) {
-        return;
-      }
-    }
-    const newEvent = { data: core.data, errors: core.errors };
-    // Maximum size of the cache
-    if (emittedEventsCache.current.length > 100) {
-      emittedEventsCache.current.shift();
-    }
-    emittedEventsCache.current.push({ timestamp: Date.now(), event: newEvent });
-    onChangeRef.current(newEvent);
+    onChangeRef.current?.({ data: core.data, errors: core.errors });
   }, [core.data, core.errors]);
 
   return (

--- a/packages/react/test/renderers/JsonForms.test.tsx
+++ b/packages/react/test/renderers/JsonForms.test.tsx
@@ -865,7 +865,7 @@ test('JsonForms should not crash with undefined uischemas', () => {
   );
 });
 
-test('JsonForms should call onChange handler with new data', () => {
+test('JsonForms should call onChange handler with new data', (done) => {
   const onChangeHandler = jest.fn();
   const TestInputRenderer = withJsonFormsControlProps(props => (
     <input onChange={ev => props.handleChange('foo', ev.target.value)} />
@@ -893,13 +893,18 @@ test('JsonForms should call onChange handler with new data', () => {
     }
   });
 
-  const calls = onChangeHandler.mock.calls;
-  const lastCallParameter = calls[calls.length - 1][0];
-  expect(lastCallParameter.data).toEqual({ foo: 'Test Value' });
-  expect(lastCallParameter.errors).toEqual([]);
+  // events are debounced for some time, so let's wait
+  setTimeout(() => {
+    const calls = onChangeHandler.mock.calls;
+    const lastCallParameter = calls[calls.length - 1][0];
+    expect(lastCallParameter.data).toEqual({ foo: 'Test Value' });
+    expect(lastCallParameter.errors).toEqual([]);
+    done();
+  }, 50);
+  
 });
 
-test('JsonForms should call onChange handler with errors', () => {
+test('JsonForms should call onChange handler with errors', (done) => {
   const onChangeHandler = jest.fn();
   const TestInputRenderer = withJsonFormsControlProps(props => (
     <input onChange={ev => props.handleChange('foo', ev.target.value)} />
@@ -938,11 +943,16 @@ test('JsonForms should call onChange handler with errors', () => {
     }
   });
 
-  const calls = onChangeHandler.mock.calls;
-  const lastCallParameter = calls[calls.length - 1][0];
-  expect(lastCallParameter.data).toEqual({ foo: 'xyz' });
-  expect(lastCallParameter.errors.length).toEqual(1);
-  expect(lastCallParameter.errors[0].keyword).toEqual('minLength');
+  // events are debounced for some time, so let's wait
+  setTimeout(() => {
+    const calls = onChangeHandler.mock.calls;
+    const lastCallParameter = calls[calls.length - 1][0];
+    expect(lastCallParameter.data).toEqual({ foo: 'xyz' });
+    expect(lastCallParameter.errors.length).toEqual(1);
+    expect(lastCallParameter.errors[0].keyword).toEqual('minLength');
+    done();
+  }, 50);
+
 });
 
 test('JsonForms should update if data prop is updated', () => {


### PR DESCRIPTION
There are some use cases in which a large amount of independent changes are
performed in an extremely low amount of time, potentially leading to data
loss or endless rerendering loops when using the React bindings.

An example for such a use case is Chrome auto-fill which can cause JSON Forms
to emit multiple change events before the parent component is rerendered. If
the parent component feeds the emitted data back to JSON Forms then it will
hand over not the latest data, but the previouslys emitted data first. JSON
Forms recognizes that this is not the very recent data and will validate,
rerender and emit a change event again, leading to the problematic behavior.

To handle these edge cases in which many change events are sent in an
extremely short amount of time we debounce them over a short amount of time.
We debounce the emitted events instead of the incoming data as we don't know
anything about the amount of work performed (and therefore time passed) on the
emitted data.