### PR TITLE
Add special className to style boolean cells (checkbox) in Vanilla package

### DIFF
--- a/packages/vanilla/src/cells/BooleanCell.tsx
+++ b/packages/vanilla/src/cells/BooleanCell.tsx
@@ -1,19 +1,19 @@
 /*
   The MIT License
-  
+
   Copyright (c) 2017-2019 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
-  
+
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
-  
+
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
-  
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,7 +32,7 @@ import {
 import { withJsonFormsCellProps } from '@jsonforms/react';
 import { StatelessComponent } from 'react';
 import { VanillaRendererProps } from '../index';
-import { withVanillaCellProps } from '../util/index';
+import { withVanillaBooleanCellProps } from '../util/index';
 
 export const BooleanCell: StatelessComponent<CellProps> =
   (props: CellProps & VanillaRendererProps) => {
@@ -59,4 +59,4 @@ export const BooleanCell: StatelessComponent<CellProps> =
  */
 export const booleanCellTester: RankedTester = rankWith(2, isBooleanControl);
 
-export default withJsonFormsCellProps(withVanillaCellProps(BooleanCell));
+export default withJsonFormsCellProps(withVanillaBooleanCellProps(BooleanCell));

--- a/packages/vanilla/src/styles/styles.ts
+++ b/packages/vanilla/src/styles/styles.ts
@@ -54,6 +54,10 @@ export const vanillaStyles: StyleDef[] = [
     classNames: ['select']
   },
   {
+    name: 'control.checkbox',
+    classNames: ['checkbox']
+  },
+  {
     name: 'control.radio',
     classNames: ['radio']
   },

--- a/packages/vanilla/src/util/index.tsx
+++ b/packages/vanilla/src/util/index.tsx
@@ -209,3 +209,7 @@ export const withVanillaEnumCellProps = withVanillaCellPropsForType(
   'control.select'
 );
 
+export const withVanillaBooleanCellProps = withVanillaCellPropsForType(
+  'control.checkbox'
+);
+

--- a/packages/vanilla/test/renderers/BooleanCell.test.tsx
+++ b/packages/vanilla/test/renderers/BooleanCell.test.tsx
@@ -55,6 +55,10 @@ const fixture = {
       classNames: ['control']
     },
     {
+      name: 'control.checkbox',
+      classNames: ['checkbox']
+    },
+    {
       name: 'control.validation',
       classNames: ['validation']
     }
@@ -240,7 +244,7 @@ describe('Boolean cell', () => {
       </JsonFormsStateProvider>
     );
     const input = wrapper.find('input');
-    expect(input.hasClass('input')).toBe(true);
+    expect(input.hasClass('checkbox')).toBe(true);
     expect(input.hasClass('validate')).toBe(true);
     expect(input.hasClass('valid')).toBe(true);
   });
@@ -380,5 +384,16 @@ describe('Boolean cell', () => {
     );
     const input = wrapper.find('input').getDOMNode() as HTMLInputElement;
     expect(input.disabled).toBe(false);
+  });
+
+  test('with checkbox className', () => {
+    const core = initCore(fixture.schema, fixture.uischema, fixture.data);
+    wrapper = mount(
+      <JsonFormsStateProvider initState={{ renderers: vanillaRenderers, core }}>
+        <BooleanCell schema={fixture.schema} uischema={fixture.uischema} path='foo' />
+      </JsonFormsStateProvider>
+    );
+    const input = wrapper.find('input').getDOMNode() as HTMLInputElement;
+    expect(input.classList.contains('checkbox')).toBe(true);
   });
 });


### PR DESCRIPTION
# What?
Hi I was using the lib and I noticed Vanilla React has the same styles for `input type='text'` and `input type='checkbox'`. Would be possible to have different styles? This way is easier to style it

## Order
Also noticed when is a checkbox boolean the position is the same as with `type=text`
Now:
``` html
<label>My label</label>
<input type='checkbox' />
``` 
Wouldn't be better to put the cell inside the label? 

``` html
<label>
  <input type='checkbox' />
  <div>My label</div>
</label>
```
I think is a common practice for checkboxes 

Changing the order checkbox can look like this
![image](https://user-images.githubusercontent.com/49499/148931360-f44f7e9f-7b85-4e6f-89a4-dbcdf772a56d.png)


Thanks! 