### PR TITLE
Use validationError classes defined in styles. This way this can be ovewriten by users

### DIFF
--- a/packages/vanilla/src/controls/RadioGroup.tsx
+++ b/packages/vanilla/src/controls/RadioGroup.tsx
@@ -58,7 +58,9 @@ export const RadioGroup = ({
   const radioInput = useMemo(() => findStyleAsClassName(contextStyles)('control.radio.input'), [contextStyles]);
   const radioLabel = useMemo(() => findStyleAsClassName(contextStyles)('control.radio.label'), [contextStyles]);
   const isValid = errors.length === 0;
-  const divClassNames = `validation  ${isValid ? classNames.description : 'validation_error' }`;
+  const divClassNames = [classNames.validation]
+    .concat(isValid ? classNames.description : classNames.validationError)
+    .join(' ');
   const appliedUiSchemaOptions = merge({}, config, uischema.options);
   const showDescription = !isDescriptionHidden(
     visible,


### PR DESCRIPTION
# What? 
This one is pretty easy. In text inputs errors can be styled. 

### Example in my code
![image](https://user-images.githubusercontent.com/49499/148811423-4469715a-630b-4d88-8121-42d36979b79b.png)


But Radio buttons have a hardcoded string so is not possible. 

### Solution 
Just use the prop we have for this clase