### PR TITLE
Update Angular packages

### DIFF
--- a/packages/angular-material/package.json
+++ b/packages/angular-material/package.json
@@ -54,20 +54,19 @@
     ]
   },
   "peerDependencies": {
-    "@angular/animations": "^12.0.0",
-    "@angular/cdk": "^12.0.0",
-    "@angular/common": "^12.0.0",
-    "@angular/core": "^12.0.0",
-    "@angular/flex-layout": "^12.0.0-beta",
-    "@angular/forms": "^12.0.0",
-    "@angular/material": "^12.0.0",
-    "@angular/platform-browser": "^12.0.0",
-    "@angular/router": "^12.0.0",
+    "@angular/animations": "^12.0.0 || ^13.0.0",
+    "@angular/cdk": "^12.0.0 || ^13.0.0",
+    "@angular/common": "^12.0.0 || ^13.0.0",
+    "@angular/core": "^12.0.0 || ^13.0.0",
+    "@angular/flex-layout": "^12.0.0-beta || ^13.0.0-beta",
+    "@angular/forms": "^12.0.0 || ^13.0.0",
+    "@angular/material": "^12.0.0 || ^13.0.0",
+    "@angular/platform-browser": "^12.0.0 || ^13.0.0",
+    "@angular/router": "^12.0.0 || ^13.0.0",
     "@jsonforms/angular": "^3.0.0-beta.0",
     "@jsonforms/core": "^3.0.0-beta.0",
     "core-js": "^2.5.3",
-    "rxjs": "^6.4.0",
-    "zone.js": "^0.10.2"
+    "rxjs": "^6.4.0"
   },
   "dependencies": {
     "hammerjs": "2.0.8"
@@ -116,6 +115,6 @@
     "webpack": "^4.41.2",
     "webpack-cli": "^3.2.1",
     "webpack-dev-server": "^3.9.0",
-    "zone.js": "^0.10.2"
+    "zone.js": "^0.11.4"
   }
 }

--- a/packages/angular-material/src/other/label.renderer.ts
+++ b/packages/angular-material/src/other/label.renderer.ts
@@ -40,7 +40,7 @@ import {
 } from '@jsonforms/core';
 import { Subscription } from 'rxjs';
 
-const mapStateToProps = (
+export const mapStateToLabelProps = (
   state: JsonFormsState,
   ownProps: OwnPropsOfRenderer
 ) => {
@@ -77,7 +77,7 @@ export class LabelRenderer extends JsonFormsBaseRenderer<LabelElement> {
       labelElement.text;
     this.subscription = this.jsonFormsService.$state.subscribe({
       next: (state: JsonFormsState) => {
-        const props = mapStateToProps(state, this.getOwnProps());
+        const props = mapStateToLabelProps(state, this.getOwnProps());
         this.visible = props.visible;
       }
     });

--- a/packages/angular-material/src/other/table.renderer.ts
+++ b/packages/angular-material/src/other/table.renderer.ts
@@ -155,7 +155,7 @@ interface ColumnDescription {
   props: OwnPropsOfRenderer;
 }
 
-const controlWithoutLabel = (scope: string): ControlElement => ({
+export const controlWithoutLabel = (scope: string): ControlElement => ({
   type: 'Control',
   scope: scope,
   label: false

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -30,7 +30,7 @@
     "customization"
   ],
   "main": "./lib/cjs/index.js",
-  "esm": "./lib/esm/index.js",
+  "module": "./lib/esm/index.js",
   "typings": "./lib/esm/index.d.ts",
   "scripts": {
     "build": "ngc && ngc -p tsconfig.cjs.json",
@@ -61,8 +61,8 @@
     ]
   },
   "peerDependencies": {
-    "@angular/core": "^12.0.0",
-    "@angular/forms": "^12.0.0",
+    "@angular/core": "^12.0.0 || ^13.0.0",
+    "@angular/forms": "^12.0.0 || ^13.0.0",
     "@jsonforms/core": "^3.0.0-beta.0",
     "rxjs": "^6.4.0"
   },

--- a/packages/angular/src/jsonforms-root.component.ts
+++ b/packages/angular/src/jsonforms-root.component.ts
@@ -52,6 +52,7 @@ export class JsonForms implements OnChanges, OnInit {
     private previousErrors:ErrorObject[];
 
     private initialized = false;
+    oldI18N: JsonFormsI18nState;
 
     constructor(private jsonformsService: JsonFormsAngularService) {
     }
@@ -83,15 +84,33 @@ export class JsonForms implements OnChanges, OnInit {
                 this.errors.emit(errors);
             }
         });
+        this.oldI18N = this.i18n;
         this.initialized = true;
     }
 
     ngDoCheck(): void {
         // we can't use ngOnChanges as then nested i18n changes will not be detected
         // the update will result in a no-op when the parameters did not change
-        this.jsonformsService.updateI18n(
-            Actions.updateI18n(this.i18n?.locale, this.i18n?.translate, this.i18n?.translateError)
-        );
+        if (
+          this.oldI18N?.locale !== this.i18n?.locale ||
+          this.oldI18N?.translate !== this.i18n?.translate ||
+          this.oldI18N?.translateError !== this.i18n?.translateError
+        ) {
+          this.jsonformsService.updateI18n(
+            Actions.updateI18n(
+              this.oldI18N?.locale === this.i18n?.locale
+                ? this.jsonformsService.getState().jsonforms.i18n.locale
+                : this.i18n?.locale,
+              this.oldI18N?.translate === this.i18n?.translate
+                ? this.jsonformsService.getState().jsonforms.i18n.translate
+                : this.i18n?.translate,
+              this.oldI18N?.translateError === this.i18n?.translateError
+                ? this.jsonformsService.getState().jsonforms.i18n.translateError
+                : this.i18n?.translateError
+            )
+          );
+          this.oldI18N = this.i18n;
+        }
     }
 
     // tslint:disable-next-line: cyclomatic-complexity


### PR DESCRIPTION
- Fixes the module declaration in @jsonforms/angular so the ESM
  build can be picked up reliably
- Exports all functions used in Angular components to avoid
  name clashes by the ngc transpiler
- Removes the redundant zonejs peer dependency
- Indicate compatibility with Angular 13
- Adapts i18n change detection to allow updating i18n via the
  JsonFormsAngularService independent from the root component
  props