### PR TITLE
Add release CI with changelog generator

### DIFF
--- a/.github/config/changelog.json
+++ b/.github/config/changelog.json
@@ -1,0 +1,8 @@
+{
+  "sort": "DESC",
+  "pr_template": "- [${{LABELS}}] ${{TITLE}} (#${{NUMBER}})",
+  "template": "${{UNCATEGORIZED}}",
+  "ignore_labels": [
+    "dependencies"
+  ]
+}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,8 @@ jobs:
     if: | 
       startsWith(github.ref, 'refs/tags/v') &&
       !contains(github.ref, 'alpha') &&
-      !contains(github.ref, 'beta')
+      !contains(github.ref, 'beta') &&
+      !contains(github.ref, 'rc')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: 'Release'
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Create Changelog
+        id: create_changelog
+        uses: mikepenz/release-changelog-builder-action@v2
+        with:
+          configuration: ./.github/config/changelog.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: ${{ steps.create_changelog.outputs.changelog }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   release:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: | 
+      startsWith(github.ref, 'refs/tags/v') &&
+      !contains(github.ref, 'alpha') &&
+      !contains(github.ref, 'beta')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Add github action, that creates a changelog automatically on every release.

Example changelog (packages are missing for most PRs, since the they don't have any labels yet):
https://github.com/TheZoker/jsonforms/releases/tag/v3.0.0

Note: It id recommended, that every PR since the last release is tagged with the fitting lable. So for changes in the core, the PR should get the label `core` and so on...
This will lead to the desired output of: "[core] PR Title (#pr number)"