### PR TITLE
remove lodash startCase from label of checkboxes #1903

### DIFF
--- a/packages/material/src/complex/MaterialEnumArrayRenderer.tsx
+++ b/packages/material/src/complex/MaterialEnumArrayRenderer.tsx
@@ -22,7 +22,6 @@ import {
   FormHelperText,
   Hidden
 } from '@mui/material';
-import startCase from 'lodash/startCase';
 import isEmpty from 'lodash/isEmpty';
 import React from 'react';
 
@@ -68,7 +67,7 @@ export const MaterialEnumArrayRenderer = ({
                     {...otherProps}
                   />
                 }
-                label={startCase(option.label)}
+                label={option.label}
               />
             );
           })}

--- a/packages/material/test/renderers/MaterialEnumArrayRenderer.test.tsx
+++ b/packages/material/test/renderers/MaterialEnumArrayRenderer.test.tsx
@@ -113,7 +113,7 @@ describe('EnumArrayControl', () => {
     );
     const labels = wrapper.find('label');
     expect(labels.first().text()).toBe('My Title');
-    expect(labels.last().text()).toBe('Bar');
+    expect(labels.last().text()).toBe('bar');
   });
 
   test('oneOf items - updates data', (done) => {
@@ -176,9 +176,9 @@ describe('EnumArrayControl', () => {
       />
     );
     const labels = wrapper.find('label');
-    expect(labels.at(0).text()).toBe('A');
-    expect(labels.at(1).text()).toBe('B');
-    expect(labels.at(2).text()).toBe('C');
+    expect(labels.at(0).text()).toBe('a');
+    expect(labels.at(1).text()).toBe('b');
+    expect(labels.at(2).text()).toBe('c');
   });
 
   test('enum items - updates data', (done) => {


### PR DESCRIPTION
use of lodash startCase was changing the values of enum values used a labels. Removed function and import.