### PR TITLE
(vue) add binding for one enum cell elements

### DIFF
--- a/packages/vue/vue/src/jsonFormsCompositions.ts
+++ b/packages/vue/vue/src/jsonFormsCompositions.ts
@@ -396,6 +396,22 @@ export const useJsonFormsEnumCell = (props: ControlProps) => {
 };
 
 /**
+ * Provides bindings for 'oneOf' enum cell elements. Cells are meant to show simple inputs,
+ * for example without error validation, within a larger structure like tables.
+ *
+ * Access bindings via the provided reactive 'cell' object.
+ * Dispatch changes via the provided `handleChange` method.
+ */
+export const useJsonFormsOneOfEnumCell = (props: ControlProps) => {
+  const { control, ...other } = useControl(
+      props,
+      mapStateToOneOfEnumControlProps,
+      mapDispatchToControlProps
+  );
+  return { cell: control, ...other };
+};
+
+/**
  * Provides bindings for a cell dispatcher. Cells are meant to show simple inputs,
  * for example without error validation, within a larger structure like tables.
  *

--- a/packages/vue/vue/src/jsonFormsCompositions.ts
+++ b/packages/vue/vue/src/jsonFormsCompositions.ts
@@ -27,6 +27,7 @@ import {
   JsonFormsCellRendererRegistryEntry,
   defaultMapStateToEnumCellProps,
   mapStateToDispatchCellProps,
+  mapStateToOneOfEnumCellProps,
   StatePropsOfJsonFormsRenderer,
   createId,
   removeId
@@ -405,7 +406,7 @@ export const useJsonFormsEnumCell = (props: ControlProps) => {
 export const useJsonFormsOneOfEnumCell = (props: ControlProps) => {
   const { control, ...other } = useControl(
       props,
-      mapStateToOneOfEnumControlProps,
+      mapStateToOneOfEnumCellProps,
       mapDispatchToControlProps
   );
   return { cell: control, ...other };


### PR DESCRIPTION
The control bindings for Vue where missing the one for cells with a `oneOf` schema; no `options` prop was generated. For control bindings this is present, this PR adds the binding for cells. If you have any feedback please let me know, I would like to contribute more in the future since we are investing in this project for our application that will soon be in production.