### PR TITLE
(core, testers) allow other additional types besides 'string' when testing for format

### DIFF
--- a/packages/core/src/testers/testers.ts
+++ b/packages/core/src/testers/testers.ts
@@ -142,7 +142,7 @@ export const formatIs = (expectedFormat: string): Tester =>
     schema =>
       !isEmpty(schema) &&
       schema.format === expectedFormat &&
-      schema.type === 'string'
+      hasType(schema, 'string')
   );
 
 /**


### PR DESCRIPTION
I came across an issue where I have the following schema:

```
{
  "type": [ "string", "null"],
  "default": null,
  "format": "date"
}
```
As far as I know this is valid JSON schema, and is not really an edge case: a date field might be allowed a NULL value (maybe I am wrong here).

Currently the `isDateControl` and `isDateTimeControl` do not work here because they `formatIs` tests for `schema.type === 'string'`. This is replaced with `hasType(schema,  'string')` so the format is recognized correctly when other types are allowed (such as null) as well.