### PR TITLE
Integrate external errors in form

### DIFF
--- a/packages/angular/src/jsonforms-root.component.ts
+++ b/packages/angular/src/jsonforms-root.component.ts
@@ -46,6 +46,7 @@ export class JsonForms implements OnChanges, OnInit {
     @Input() ajv: Ajv;
     @Input() config: any;
     @Input() i18n: JsonFormsI18nState;
+    @Input() additionalErrors: ErrorObject[];
     @Output() errors = new EventEmitter<ErrorObject[]>();
 
     private previousData:any;
@@ -64,7 +65,8 @@ export class JsonForms implements OnChanges, OnInit {
                 uischema: this.uischema,
                 schema: this.schema,
                 ajv: this.ajv,
-                validationMode: this.validationMode
+                validationMode: this.validationMode,
+                additionalErrors: this.additionalErrors
             },
             uischemas: this.uischemas,
             i18n: this.i18n,
@@ -128,14 +130,16 @@ export class JsonForms implements OnChanges, OnInit {
         const newValidationMode = changes.validationMode;
         const newAjv = changes.ajv;
         const newConfig = changes.config;
+        const newAdditionalErrors = changes.additionalErrors;
 
-        if (newData || newSchema || newUiSchema || newValidationMode || newAjv) {
+        if (newData || newSchema || newUiSchema || newValidationMode || newAjv || newAdditionalErrors) {
             this.jsonformsService.updateCoreState(
                 newData ? newData.currentValue : USE_STATE_VALUE,
                 newSchema ? newSchema.currentValue : USE_STATE_VALUE,
                 newUiSchema ? newUiSchema.currentValue : USE_STATE_VALUE,
                 newAjv ? newAjv.currentValue : USE_STATE_VALUE,
-                newValidationMode ? newValidationMode.currentValue : USE_STATE_VALUE
+                newValidationMode ? newValidationMode.currentValue : USE_STATE_VALUE,
+                newAdditionalErrors ? newAdditionalErrors.currentValue : USE_STATE_VALUE
             );
         }
 

--- a/packages/angular/src/jsonforms.service.ts
+++ b/packages/angular/src/jsonforms.service.ts
@@ -49,7 +49,7 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { JsonFormsBaseRenderer } from './base.renderer';
 
 import { cloneDeep } from 'lodash';
-import Ajv from 'ajv';
+import Ajv, { ErrorObject } from 'ajv';
 
 export const USE_STATE_VALUE = Symbol('Marker to use state value');
 export class JsonFormsAngularService {
@@ -57,7 +57,7 @@ export class JsonFormsAngularService {
     private _state: JsonFormsSubStates;
     private state: BehaviorSubject<JsonFormsState>;
 
-    init(initialState: JsonFormsSubStates = { core: { data: undefined, schema: undefined, uischema: undefined, validationMode: 'ValidateAndShow' } }) {
+    init(initialState: JsonFormsSubStates = { core: { data: undefined, schema: undefined, uischema: undefined, validationMode: 'ValidateAndShow', additionalErrors: undefined } }) {
         this._state = initialState;
         this._state.config = configReducer(undefined, setConfig(this._state.config));
         this._state.i18n = i18nReducer(this._state.i18n, updateI18n(this._state.i18n?.locale, this._state.i18n?.translate, this._state.i18n?.translateError));
@@ -209,15 +209,17 @@ export class JsonFormsAngularService {
         schema: JsonSchema | typeof USE_STATE_VALUE,
         uischema: UISchemaElement | typeof USE_STATE_VALUE,
         ajv: Ajv | typeof USE_STATE_VALUE,
-        validationMode: ValidationMode | typeof USE_STATE_VALUE
+        validationMode: ValidationMode | typeof USE_STATE_VALUE,
+        additionalErrors: ErrorObject[] | typeof USE_STATE_VALUE,
     ): void {
         const newData = data === USE_STATE_VALUE ? this._state.core.data : data;
         const newSchema = schema === USE_STATE_VALUE ? this._state.core.schema : schema ?? generateJsonSchema(newData);
         const newUischema = uischema === USE_STATE_VALUE ? this._state.core.uischema : uischema ?? generateDefaultUISchema(newSchema);
         const newAjv = ajv === USE_STATE_VALUE ? this._state.core.ajv : ajv;
         const newValidationMode = validationMode === USE_STATE_VALUE ? this._state.core.validationMode : validationMode;
+        const newAdditionalErrors = additionalErrors === USE_STATE_VALUE ? this._state.core.additionalErrors : additionalErrors;
         this.updateCore(
-            Actions.updateCore(newData, newSchema, newUischema, {ajv: newAjv, validationMode: newValidationMode})
+            Actions.updateCore(newData, newSchema, newUischema, {ajv: newAjv, validationMode: newValidationMode, additionalErrors: newAdditionalErrors})
         );
     }
 

--- a/packages/core/src/actions/actions.ts
+++ b/packages/core/src/actions/actions.ts
@@ -100,6 +100,7 @@ export interface UpdateCoreAction {
 export interface InitActionOptions {
   ajv?: AJV;
   validationMode?: ValidationMode;
+  additionalErrors?: ErrorObject[];
 }
 
 export interface SetValidationModeAction {

--- a/packages/examples/src/examples/additional-errors.ts
+++ b/packages/examples/src/examples/additional-errors.ts
@@ -1,3 +1,27 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2022 STMicroelectronics and others.
+  https://github.com/eclipsesource/jsonforms
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
 import { ErrorObject } from 'ajv';
 import { StateProps } from '../example';
 import { registerExamples } from '../register';

--- a/packages/examples/src/examples/additional-errors.ts
+++ b/packages/examples/src/examples/additional-errors.ts
@@ -1,0 +1,33 @@
+import { ErrorObject } from 'ajv';
+import { StateProps } from '../example';
+import { registerExamples } from '../register';
+import { schema, uischema, data } from './person'
+
+const additionalErrors: ErrorObject[] = [];
+
+const actions = [{
+    label: 'Add additional error', apply: (props: StateProps) => {
+        additionalErrors.push({
+            instancePath: '/personalData/age',
+            message:`New error #${additionalErrors.length +1 }`,
+            schemaPath: '',
+            keyword: '',
+            params: {}
+        });
+        return {
+            ...props,
+            additionalErrors: [...additionalErrors]
+        }
+    }
+}];
+
+registerExamples([
+    {
+        name: 'additional-errors',
+        label: 'Additional errors',
+        data,
+        schema,
+        uischema,
+        actions
+    }
+]);

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -76,6 +76,7 @@ import * as readonly from './examples/readonly';
 import * as bug_1779 from './examples/1779';
 import * as bug_1645 from './examples/1645';
 import * as conditionalSchemaComposition from './examples/conditional-schema-compositions';
+import * as additionalErrors from './examples/additional-errors';
 export * from './register';
 export * from './example';
 
@@ -136,5 +137,6 @@ export {
   readonly,
   bug_1779,
   bug_1645,
-  conditionalSchemaComposition
+  conditionalSchemaComposition,
+  additionalErrors
 };

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -24,7 +24,7 @@
 */
 import maxBy from 'lodash/maxBy';
 import React, { useMemo } from 'react';
-import Ajv from 'ajv';
+import Ajv, { ErrorObject } from 'ajv';
 import { UnknownRenderer } from './UnknownRenderer';
 import {
   createId,
@@ -185,6 +185,7 @@ export interface JsonFormsInitStateProps {
   readonly?: boolean;
   validationMode?: ValidationMode;
   i18n?: JsonFormsI18nState;
+  additionalErrors?: ErrorObject[];
 }
 
 export const JsonForms = (
@@ -202,7 +203,8 @@ export const JsonForms = (
     uischemas,
     readonly,
     validationMode,
-    i18n
+    i18n,
+    additionalErrors
   } = props;
   const schemaToUse = useMemo(
     () => (schema !== undefined ? schema : Generate.jsonSchema(data)),
@@ -222,7 +224,8 @@ export const JsonForms = (
           data,
           schema: schemaToUse,
           uischema: uischemaToUse,
-          validationMode: validationMode
+          validationMode: validationMode,
+          additionalErrors: additionalErrors
         },
         config,
         uischemas,

--- a/packages/react/src/JsonFormsContext.tsx
+++ b/packages/react/src/JsonFormsContext.tsx
@@ -78,6 +78,7 @@ const initialCoreState: JsonFormsCore = {
   schema: {},
   uischema: undefined,
   errors: [],
+  additionalErrors: [],
   validator: undefined,
   ajv: undefined,
 };
@@ -110,21 +111,21 @@ const useEffectAfterFirstRender = (
 };
 
 export const JsonFormsStateProvider = ({ children, initState, onChange }: any) => {
-  const { data, schema, uischema, ajv, validationMode } = initState.core;
+  const { data, schema, uischema, ajv, validationMode, additionalErrors } = initState.core;
   
   const [core, coreDispatch] = useReducer(
     coreReducer,
     undefined,
     () => coreReducer(
       initState.core,
-      Actions.init(data, schema, uischema, { ajv, validationMode })
+      Actions.init(data, schema, uischema, { ajv, validationMode, additionalErrors })
     )
   );
   useEffect(() => {
     coreDispatch(
-      Actions.updateCore(data, schema, uischema, { ajv, validationMode })
+      Actions.updateCore(data, schema, uischema, { ajv, validationMode, additionalErrors })
     );
-  }, [data, schema, uischema, ajv, validationMode]);
+  }, [data, schema, uischema, ajv, validationMode, additionalErrors]);
 
   const [config, configDispatch] = useReducer(
     configReducer,

--- a/packages/react/test/renderers/JsonForms.test.tsx
+++ b/packages/react/test/renderers/JsonForms.test.tsx
@@ -27,6 +27,7 @@ import { combineReducers, createStore } from 'redux';
 import { Provider } from 'react-redux';
 import type {
   ControlElement,
+  ControlProps,
   DispatchCellProps,
   JsonFormsState,
   JsonFormsStore,
@@ -988,4 +989,89 @@ test('JsonForms should update if data prop is updated', () => {
   wrapper.setProps({ data: { foo: 'Another name' } });
   wrapper.update();
   expect(wrapper.props().data.foo).toBe('Another name');
+});
+
+test('JsonForms should use additionalErrors if provided', () => {
+
+  const CustomRendererWithError: StatelessRenderer<ControlProps> = ({errors}) => { 
+    return (<h5>{errors}</h5>) 
+  };
+
+  const renderers = [
+    {
+      tester: () => 1000,
+      renderer: withJsonFormsControlProps(CustomRendererWithError)
+    }
+  ];
+  const additionalErrors = [{
+    instancePath: '',
+    dataPath: '',
+    schemaPath: '#/required',
+    keyword: 'required',
+    params: {
+      missingProperty: 'foo'
+    },
+    message: 'Lorem ipsum'
+  }];
+  const wrapper = mount(
+    <JsonForms
+      data={fixture.data}
+      uischema={fixture.uischema}
+      schema={fixture.schema}
+      renderers={renderers}
+      additionalErrors={additionalErrors}
+    />
+  );
+  expect(wrapper.find('h5').text()).toBe('Lorem ipsum');
+  wrapper.unmount();
+});
+
+test('JsonForms should use react to additionalErrors update', () => {
+
+  const CustomRendererWithError: StatelessRenderer<ControlProps> = ({ errors }) => {
+    return (<h5>{errors}</h5>)
+  };
+
+  const renderers = [
+    {
+      tester: () => 1000,
+      renderer: withJsonFormsControlProps(CustomRendererWithError)
+    }
+  ];
+  const additionalErrors = [{
+    instancePath: '',
+    dataPath: '',
+    schemaPath: '#/required',
+    keyword: 'required',
+    params: {
+      missingProperty: 'foo'
+    },
+    message: 'Lorem ipsum'
+  }];
+  const wrapper = mount(
+    <JsonForms
+      data={fixture.data}
+      uischema={fixture.uischema}
+      schema={fixture.schema}
+      renderers={renderers}
+      additionalErrors={additionalErrors}
+    />
+  );
+  expect(wrapper.find('h5').text()).toBe('Lorem ipsum');
+
+  wrapper.setProps({
+    additionalErrors: [{
+      instancePath: '',
+      dataPath: '',
+      schemaPath: '#/required',
+      keyword: 'required',
+      params: {
+        missingProperty: 'foo'
+      },
+      message: 'Foobar'
+    }]
+  });
+  wrapper.update();
+  expect(wrapper.find('h5').text()).toBe('Foobar');
+  wrapper.unmount();
 });

--- a/packages/vue/vue-vanilla/dev/components/App.vue
+++ b/packages/vue/vue-vanilla/dev/components/App.vue
@@ -5,6 +5,7 @@ import { vanillaRenderers, mergeStyles, defaultStyles } from '../../src';
 import '../../vanilla.css';
 import { get } from 'lodash';
 import { JsonFormsI18nState } from '@jsonforms/core';
+import { ErrorObject } from 'ajv';
 
 const schema = {
   properties: {
@@ -206,6 +207,7 @@ export default defineComponent({
   },
   data: function () {
     const i18n: Partial<JsonFormsI18nState> = { locale: 'en' };
+    const additionalErrors: ErrorObject[] = [];
     return {
       renderers: Object.freeze(vanillaRenderers),
       data: {
@@ -216,7 +218,8 @@ export default defineComponent({
       config: {
         hideRequiredAsterisk: true,
       },
-      i18n
+      i18n,
+      additionalErrors,
     };
   },
   methods: {
@@ -248,6 +251,18 @@ export default defineComponent({
     },
     switchAsterisk() {
       this.config.hideRequiredAsterisk = !this.config.hideRequiredAsterisk;
+    },
+    addAdditionalError() {
+      this.additionalErrors = [
+        ...this.additionalErrors,
+        {
+          instancePath: '/dateTime',
+          message: `New error #${this.additionalErrors.length + 1}`,
+          schemaPath: '',
+          keyword: '',
+          params: {},
+        },
+      ];
     },
     adaptData() {
       this.data.number = 10;
@@ -405,12 +420,14 @@ export default defineComponent({
         :renderers="renderers"
         :config="config"
         :i18n="i18n"
+        :additional-errors="additionalErrors"
         @change="onChange"
       />
       <button @click="setSchema">Set Schema</button>
       <button @click="switchAsterisk">Switch Asterisk</button>
       <button @click="adaptData">Adapt data</button>
       <button @click="adaptUiSchema">Adapt uischema</button>
+      <button @click="addAdditionalError">Add additional error</button>
     </div>
     <div class="data">
       <pre

--- a/packages/vue/vue/src/components/JsonForms.vue
+++ b/packages/vue/vue/src/components/JsonForms.vue
@@ -28,7 +28,7 @@ import {
 import { JsonFormsChangeEvent, MaybeReadonly } from '../types';
 import DispatchRenderer from './DispatchRenderer.vue';
 
-import Ajv from 'ajv';
+import Ajv, { ErrorObject } from 'ajv';
 
 const isObject = (elem: any): elem is Object => {
   return elem && typeof elem === 'object';
@@ -93,7 +93,12 @@ export default defineComponent({
       required: false,
       type: Object as PropType<JsonFormsI18nState>,
       default: undefined
-    }
+    },
+    additionalErrors: {
+      required: false,
+      type: Array as PropType<ErrorObject[]>,
+      default: () => []
+    },
   },
   data() {
     const generatorData = isObject(this.data) ? this.data : {};
@@ -110,6 +115,7 @@ export default defineComponent({
         Actions.init(this.data, schemaToUse, uischemaToUse, {
           validationMode: this.validationMode,
           ajv: this.ajv,
+          additionalErrors: this.additionalErrors
         })
       );
       return core;
@@ -166,6 +172,7 @@ export default defineComponent({
         Actions.updateCore(this.data, this.schemaToUse, this.uischemaToUse, {
           validationMode: this.validationMode,
           ajv: this.ajv,
+          additionalErrors: this.additionalErrors
         })
       );
     },
@@ -190,6 +197,7 @@ export default defineComponent({
         this.uischemaToUse,
         this.validationMode,
         this.ajv,
+        this.additionalErrors
       ];
     },
     eventToEmit(): JsonFormsChangeEvent {


### PR DESCRIPTION
Add support for specifying external errors via `additionalErrors:
ajv.ErrorObject[]` prop.

The additional errors are merged with the validation errors and are
supplied to the affected controls. The additional errors are not
affected by the validationMode like the validation errors are and it is
the responsability of the framework user to update the prop when
applicable (e.g. on ValidationMode changes).

Fixes #1926

Contributed on behalf of STMicroelectronics