### PR TITLE
Properly determine UI Schemas

### DIFF
--- a/packages/angular-material/src/layouts/array-layout.renderer.ts
+++ b/packages/angular-material/src/layouts/array-layout.renderer.ts
@@ -172,7 +172,8 @@ export class ArrayLayoutRenderer
       this.uischema.scope,
       this.propsPath,
       undefined,
-      this.uischema
+      this.uischema,
+      this.rootSchema
     );
     if (this.isEnabled()) {
       unsetReadonly(uischema);

--- a/packages/angular-material/src/other/master-detail/master.ts
+++ b/packages/angular-material/src/other/master-detail/master.ts
@@ -179,7 +179,8 @@ export class MasterListComponent extends JsonFormsArrayControl {
         `${controlElement.scope}/items`,
         props.path,
         'VerticalLayout',
-        controlElement
+        controlElement,
+        props.rootSchema
       );
 
     const masterItems = (data || []).map((d: any, index: number) => {

--- a/packages/angular-material/src/other/object.renderer.ts
+++ b/packages/angular-material/src/other/object.renderer.ts
@@ -63,9 +63,11 @@ export class ObjectControlRenderer extends JsonFormsControlWithDetail {
     this.detailUiSchema = findUISchema(
       props.uischemas,
       props.schema,
-      undefined,
+      props.uischema.scope,
       props.path,
-      'Group'
+      'Group',
+      props.uischema,
+      props.rootSchema
     );
     if (isEmpty(props.path)) {
       this.detailUiSchema.type = 'VerticalLayout';

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -894,7 +894,10 @@ export const mapStateToJsonFormsRendererProps = (
         state.jsonforms.uischemas,
         ownProps.schema,
         undefined,
-        ownProps.path
+        ownProps.path,
+        undefined,
+        undefined,
+        state.jsonforms.core.schema
       );
     } else {
       uischema = getUiSchema(state);

--- a/packages/material/src/additional/MaterialListWithDetailRenderer.tsx
+++ b/packages/material/src/additional/MaterialListWithDetailRenderer.tsx
@@ -60,7 +60,8 @@ export const MaterialListWithDetailRenderer = ({
   data,
   renderers,
   cells,
-  config
+  config,
+  rootSchema
 }: ArrayLayoutProps) => {
   const [selectedIndex, setSelectedIndex] = useState(undefined);
   const handleRemoveItem = useCallback(
@@ -90,9 +91,10 @@ export const MaterialListWithDetailRenderer = ({
         uischema.scope,
         path,
         undefined,
-        uischema
+        uischema,
+        rootSchema
       ),
-    [uischemas, schema, uischema.scope, path, uischema]
+    [uischemas, schema, uischema.scope, path, uischema, rootSchema]
   );
   const appliedUiSchemaOptions = merge({}, config, uischema.options);
 

--- a/packages/vanilla/src/complex/array/ArrayControl.tsx
+++ b/packages/vanilla/src/complex/array/ArrayControl.tsx
@@ -37,11 +37,12 @@ export const ArrayControl = ({
   addItem,
   uischema,
   uischemas,
-  renderers
+  renderers,
+  rootSchema
 }: ArrayControlProps & VanillaRendererProps) => {
   const childUiSchema = useMemo(
-    () => findUISchema(uischemas, schema, uischema.scope, path),
-    [uischemas, schema, uischema.scope, path]
+    () => findUISchema(uischemas, schema, uischema.scope, path, undefined, uischema, rootSchema),
+    [uischemas, schema, uischema.scope, path, uischema, rootSchema]
   );
   return (
     <div className={classNames.wrapper}>

--- a/packages/vue/vue-vanilla/src/util/composition.ts
+++ b/packages/vue/vue-vanilla/src/util/composition.ts
@@ -90,7 +90,10 @@ export const useVanillaArrayControl = <I extends { control: any }>(
       input.control.value.uischemas,
       input.control.value.schema,
       input.control.value.uischema.scope,
-      input.control.value.path
+      input.control.value.path,
+      undefined,
+      input.control.value.uischema,
+      input.control.value.rootSchema
     )
   );
 


### PR DESCRIPTION
Always hand over as many parameters as applicable to the "findUISchema" utility. This
makes sure that all available options are considered in all cases. For example this fixes
an issue in the Vue bindings in which "options.detail" UI Schemas were ignored.