### PR TITLE
Fix vanilla ArrayControl `addItem` function

### DIFF
--- a/packages/core/src/testers/testers.ts
+++ b/packages/core/src/testers/testers.ts
@@ -445,10 +445,7 @@ export const isObjectArrayWithNesting = (
   }
   const schemaPath = (uischema as ControlElement).scope;
   const resolvedSchema = resolveSchema(schema, schemaPath, rootSchema ?? schema);
-  const wantedNestingByType: { [key: string]: number } = {
-    object: 2,
-    array: 1
-  };
+  let objectDepth = 0;
   if (resolvedSchema !== undefined && resolvedSchema.items !== undefined) {
     // check if nested arrays
     if (
@@ -459,16 +456,16 @@ export const isObjectArrayWithNesting = (
         if (val.$ref !== undefined) {
           return false;
         }
-        // we don't support multiple types
-        if (typeof val.type !== 'string') {
+        if (hasType(val, 'object')) {
+          objectDepth++;
+          if (objectDepth === 2) {
+            return true;
+          }
+        }
+        if (hasType(val, 'array')) {
           return true;
         }
-        const typeCount = wantedNestingByType[val.type];
-        if (typeCount === undefined) {
-          return false;
-        }
-        wantedNestingByType[val.type] = typeCount - 1;
-        return wantedNestingByType[val.type] === 0;
+        return false;
       }, rootSchema)
     ) {
       return true;

--- a/packages/examples/src/examples/1948.ts
+++ b/packages/examples/src/examples/1948.ts
@@ -1,0 +1,87 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2022 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the 'Software'), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import { registerExamples } from '../register';
+import { UISchemaElement } from '@jsonforms/core';
+
+export const schema = {
+  type: 'object',
+  definitions: {
+    import: {
+      title: 'Import',
+      type: 'object',
+      properties: {
+        eClass: {
+          const: 'http://my_schema/1.0.0#//Import'
+        },
+        document: {
+          type: 'string'
+        },
+        package: {
+          type: 'string'
+        },
+        prefix: {
+          type: 'string'
+        }
+      }
+    }
+  },
+  properties: {
+    import: {
+      type: 'array',
+      items: {
+        $ref: '#/definitions/import'
+      }
+    }
+  }
+};
+
+export const uischema: UISchemaElement = undefined;
+
+export const data = {
+  import: [
+    {
+      document: 'Document1',
+      package: 'Package1',
+      prefix: 'Prefix'
+    }
+  ]
+};
+
+registerExamples([
+  {
+    name: '1948_with',
+    label: 'Issue 1948 with schema',
+    data,
+    schema,
+    uischema
+  },
+  {
+    name: '1948_without',
+    label: 'Issue 1948 w/o schema',
+    data,
+    schema: undefined,
+    uischema
+  }
+]);

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -59,6 +59,7 @@ import * as listWithDetail from './examples/list-with-detail';
 import * as listWithDetailRegistered from './examples/list-with-detail-registered';
 import * as object from './examples/object';
 import * as i18n from './examples/i18n';
+import * as issue_1948 from './examples/1948';
 import * as issue_1169 from './examples/1169';
 import * as issue_1220 from './examples/1220';
 import * as issue_1253 from './examples/1253';
@@ -83,6 +84,7 @@ export * from './example';
 import * as ifThenElse from './examples/if_then_else';
 
 export {
+  issue_1948,
   defaultExample,
   allOf,
   anyOf,

--- a/packages/vanilla/src/complex/array/ArrayControl.tsx
+++ b/packages/vanilla/src/complex/array/ArrayControl.tsx
@@ -50,7 +50,7 @@ export const ArrayControl = ({
         <legend>
           <button
             className={classNames.button}
-            onClick={() => addItem(path, createDefaultValue(schema))}
+            onClick={addItem(path, createDefaultValue(schema))}
           >
             +
           </button>

--- a/packages/vanilla/src/complex/array/index.ts
+++ b/packages/vanilla/src/complex/array/index.ts
@@ -33,7 +33,7 @@ import { ArrayControl } from './ArrayControl';
 export { ArrayControl, ArrayControlRenderer };
 
 export const arrayControlTester: RankedTester = rankWith(
-  2,
+  4,
   isObjectArrayWithNesting
 );
 


### PR DESCRIPTION
The vanilla ArrayControl was wrapping the `addItem` in a function,
whereas the `addItem` function is already wrapped. So the `onClick`
can directly be bound to `addItem`.

Fixes #1948