### PR TITLE
Add default views for material date/time controls

### DIFF
--- a/packages/material/src/controls/MaterialDateControl.tsx
+++ b/packages/material/src/controls/MaterialDateControl.tsx
@@ -68,6 +68,8 @@ export const MaterialDateControl = (props: ControlProps)=> {
   const format = appliedUiSchemaOptions.dateFormat ?? 'YYYY-MM-DD';
   const saveFormat = appliedUiSchemaOptions.dateSaveFormat ?? 'YYYY-MM-DD';
 
+  const views = appliedUiSchemaOptions.views ?? ['year', 'day'];
+
   const firstFormHelperText = showDescription
     ? description
     : !isValid
@@ -90,7 +92,7 @@ export const MaterialDateControl = (props: ControlProps)=> {
           onChange={onChange}
           inputFormat={format}
           disableMaskedInput
-          views={appliedUiSchemaOptions.views}
+          views={views}
           disabled={!enabled}
           cancelText={appliedUiSchemaOptions.cancelLabel}
           clearText={appliedUiSchemaOptions.clearLabel}

--- a/packages/material/src/controls/MaterialDateTimeControl.tsx
+++ b/packages/material/src/controls/MaterialDateTimeControl.tsx
@@ -69,6 +69,8 @@ export const MaterialDateTimeControl = (props: ControlProps) => {
   const format = appliedUiSchemaOptions.dateTimeFormat ?? 'YYYY-MM-DD HH:mm';
   const saveFormat = appliedUiSchemaOptions.dateTimeSaveFormat ?? undefined;
 
+  const views = appliedUiSchemaOptions.views ?? ['year', 'day', 'hours', 'minutes'];
+
   const firstFormHelperText = showDescription
     ? description
     : !isValid
@@ -93,7 +95,7 @@ export const MaterialDateTimeControl = (props: ControlProps) => {
           inputFormat={format}
           disableMaskedInput
           ampm={!!appliedUiSchemaOptions.ampm}
-          views={appliedUiSchemaOptions.views}
+          views={views}
           disabled={!enabled}
           cancelText={appliedUiSchemaOptions.cancelLabel}
           clearText={appliedUiSchemaOptions.clearLabel}

--- a/packages/material/src/controls/MaterialTimeControl.tsx
+++ b/packages/material/src/controls/MaterialTimeControl.tsx
@@ -67,7 +67,9 @@ export const MaterialTimeControl = (props: ControlProps) => {
   );
 
   const format = appliedUiSchemaOptions.timeFormat ?? 'HH:mm';
-    const saveFormat = appliedUiSchemaOptions.timeSaveFormat ?? 'HH:mm:ss';
+  const saveFormat = appliedUiSchemaOptions.timeSaveFormat ?? 'HH:mm:ss';
+
+  const views = appliedUiSchemaOptions.views ?? ['hours', 'minutes'];
 
   const firstFormHelperText = showDescription
     ? description
@@ -93,7 +95,7 @@ export const MaterialTimeControl = (props: ControlProps) => {
           inputFormat={format}
           disableMaskedInput
           ampm={!!appliedUiSchemaOptions.ampm}
-          views={appliedUiSchemaOptions.views}
+          views={views}
           disabled={!enabled}
           cancelText={appliedUiSchemaOptions.cancelLabel}
           clearText={appliedUiSchemaOptions.clearLabel}


### PR DESCRIPTION
When no views to show for date and/or time controls are specified in the UI Schema, explicitly hand in the default ones.

This ensures consitent behavior if the internal default of the material controls changes and avoids type errors on undefined views arrays.