### PR TITLE
React Vanilla enum renderer removes empty data

### DIFF
--- a/packages/vanilla/src/cells/EnumCell.tsx
+++ b/packages/vanilla/src/cells/EnumCell.tsx
@@ -43,7 +43,7 @@ export const EnumCell = (props: EnumCellProps & VanillaRendererProps) => {
       disabled={!enabled}
       autoFocus={uischema.options && uischema.options.focus}
       value={data || ''}
-      onChange={ev => handleChange(path, ev.target.value)}
+      onChange={ev => handleChange(path, ev.target.selectedIndex === 0 ? undefined : ev.target.value)}
     >
       {
         [<option value='' key={'empty'} />]

--- a/packages/vanilla/test/renderers/EnumCell.test.tsx
+++ b/packages/vanilla/test/renderers/EnumCell.test.tsx
@@ -188,6 +188,27 @@ describe('Enum cell', () => {
     expect(onChangeData.data.foo).toBe('b');
   });
 
+  test('empty selection should lead to data deletion', () => {
+    const onChangeData: any = {
+      data: undefined
+    };
+    const core = initCore(fixture.schema, fixture.uischema, fixture.data);
+    wrapper = mount(
+      <JsonFormsStateProvider initState={{ core }}>
+        <TestEmitter
+          onChange={({ data }) => {
+            onChangeData.data = data;
+          }}
+        />
+        <EnumCell schema={fixture.schema} uischema={fixture.uischema} path='foo' />
+      </JsonFormsStateProvider>
+    );
+    expect(onChangeData.data.foo).toBe('a');
+    const select = wrapper.find('select');
+    select.simulate('change', { target: { selectedIndex: 0 } });
+    expect(onChangeData.data.foo).toBe(undefined);
+  });
+
   test('update via action', () => {
     const data = { 'foo': 'b' };
     const core = initCore(fixture.schema, fixture.uischema, data);


### PR DESCRIPTION
Instead of the empty string the React Vanilla enum renderer will now hand over
'undefined' to handleChange and therefore delete the corresponding attribute.

Fixes #1959 