### PR TITLE
Recognize arrays with union type items as nested object arrays again

### DIFF
--- a/packages/core/src/testers/testers.ts
+++ b/packages/core/src/testers/testers.ts
@@ -466,6 +466,9 @@ export const isObjectArrayWithNesting = (
         if (val.$ref !== undefined) {
           return false;
         }
+        if (val.anyOf || val.oneOf) {
+          return true;
+        }
         if (hasType(val, 'object')) {
           objectDepth++;
           if (objectDepth === 2) {

--- a/packages/core/test/testers.test.ts
+++ b/packages/core/test/testers.test.ts
@@ -773,6 +773,58 @@ test('tester isObjectArrayWithNesting', t => {
     }
   };
 
+  const nestedSchemaWithAnyOf = {
+    type: "array",
+    items: {
+      anyOf: [
+        {
+          type: "object",
+          properties: {
+            value: {
+              type: "string"
+            }
+          },
+          required: ["value"]
+        },
+        {
+          type: "object",
+          properties: {
+            value: {
+              type: "number"
+            }
+          },
+          required: ["value"]
+        }
+      ]
+    }
+  };
+
+  const nestedSchemaWithOneOf = {
+    type: "array",
+    items: {
+      oneOf: [
+        {
+          type: "object",
+          properties: {
+            value: {
+              type: "string"
+            }
+          },
+          required: ["value"]
+        },
+        {
+          type: "object",
+          properties: {
+            value: {
+              type: "number"
+            }
+          },
+          required: ["value"]
+        }
+      ]
+    }
+  };
+
   const uischemaOptions: {
     generate: ControlElement;
     default: ControlElement;
@@ -822,6 +874,9 @@ test('tester isObjectArrayWithNesting', t => {
   t.false(isObjectArrayWithNesting(uischemaOptions.default, schema, undefined));
   t.true(isObjectArrayWithNesting(uischemaOptions.generate, schema, undefined));
   t.true(isObjectArrayWithNesting(uischemaOptions.inline, schema, undefined));
+
+  t.true(isObjectArrayWithNesting(uischema, nestedSchemaWithAnyOf, undefined));
+  t.true(isObjectArrayWithNesting(uischema, nestedSchemaWithOneOf, undefined));
 });
 
 test('tester schemaSubPathMatches', t => {

--- a/packages/examples/src/examples/1996.ts
+++ b/packages/examples/src/examples/1996.ts
@@ -1,0 +1,102 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2022 EclipseSource
+  https://github.com/eclipsesource/jsonforms
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the 'Software'), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import { registerExamples } from '../register';
+import { ControlElement } from '@jsonforms/core';
+
+export const schemaAnyOf = {
+  type: "array",
+  items: {
+    anyOf: [
+      {
+        type: "object",
+        properties: {
+          value: {
+            type: "string"
+          }
+        },
+        required: ["value"]
+      },
+      {
+        type: "object",
+        properties: {
+          value: {
+            type: "number"
+          }
+        },
+        required: ["value"]
+      }
+    ]
+  }
+};
+
+export const schemaOneOf = {
+  type: "array",
+  items: {
+    oneOf: [
+      {
+        type: "object",
+        properties: {
+          value: {
+            type: "string"
+          }
+        },
+        required: ["value"]
+      },
+      {
+        type: "object",
+        properties: {
+          value: {
+            type: "number"
+          }
+        },
+        required: ["value"]
+      }
+    ]
+  }
+};
+
+export const uischema: ControlElement = {
+  type: 'Control',
+  scope: '#'
+};
+
+export const data: any[] = [];
+
+registerExamples([
+  {
+    name: '1996_anyOf',
+    label: 'Issue 1996 - array with anyOf items',
+    data,
+    schema: schemaAnyOf,
+    uischema
+  },
+  {
+    name: '1996_oneOf',
+    label: 'Issue 1996 - array with oneOf items',
+    data,
+    schema: schemaOneOf,
+    uischema
+  }
+]);

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -61,6 +61,7 @@ import * as listWithDetailRegistered from './examples/list-with-detail-registere
 import * as object from './examples/object';
 import * as i18n from './examples/i18n';
 import * as issue_1948 from './examples/1948';
+import * as issue_1996 from './examples/1996';
 import * as issue_1169 from './examples/1169';
 import * as issue_1220 from './examples/1220';
 import * as issue_1253 from './examples/1253';
@@ -86,6 +87,7 @@ import * as ifThenElse from './examples/if_then_else';
 
 export {
   issue_1948,
+  issue_1996,
   defaultExample,
   allOf,
   anyOf,


### PR DESCRIPTION
Adapts the `isObjectArrayWithNesting` tester to return true for an array that has an `anyOf` or `oneOf` as its items definition.
This was already the case earlier. Thus, this is not a new behavior but fixes a regression.

Fix #1996