### PR TITLE
Migrate material date- and time pickers from mui/lab to mui/x-date-pickers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1671,57 +1671,12 @@
       "resolved": "https://registry.npmjs.org/@date-io/core/-/core-1.3.13.tgz",
       "integrity": "sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA=="
     },
-    "@date-io/date-fns": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-2.11.0.tgz",
-      "integrity": "sha512-mPQ71plBeFrArvBSHtjWMHXA89IUbZ6kuo2dsjlRC/1uNOybo91spIb+wTu03NxKTl8ut07s0jJ9svF71afpRg==",
-      "requires": {
-        "@date-io/core": "^2.11.0"
-      },
-      "dependencies": {
-        "@date-io/core": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/@date-io/core/-/core-2.11.0.tgz",
-          "integrity": "sha512-DvPBnNoeuLaoSJZaxgpu54qzRhRKjSYVyQjhznTFrllKuDpm0sDFjHo6lvNLCM/cfMx2gb2PM2zY2kc9C8nmuw=="
-        }
-      }
-    },
     "@date-io/dayjs": {
       "version": "1.3.13",
       "resolved": "https://registry.npmjs.org/@date-io/dayjs/-/dayjs-1.3.13.tgz",
       "integrity": "sha512-nD39xWYwQjDMIdpUzHIcADHxY9m1hm1DpOaRn3bc2rBdgmwQC0PfW0WYaHyGGP/6LEzEguINRbHuotMhf+T9Sg==",
       "requires": {
         "@date-io/core": "^1.3.13"
-      }
-    },
-    "@date-io/luxon": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@date-io/luxon/-/luxon-2.11.1.tgz",
-      "integrity": "sha512-JUXo01kdPQxLORxqdENrgdUhooKgDUggsNRSdi2BcUhASIY2KGwwWXu8ikVHHGkw+DUF4FOEKGfkQd0RHSvX6g==",
-      "requires": {
-        "@date-io/core": "^2.11.0"
-      },
-      "dependencies": {
-        "@date-io/core": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/@date-io/core/-/core-2.11.0.tgz",
-          "integrity": "sha512-DvPBnNoeuLaoSJZaxgpu54qzRhRKjSYVyQjhznTFrllKuDpm0sDFjHo6lvNLCM/cfMx2gb2PM2zY2kc9C8nmuw=="
-        }
-      }
-    },
-    "@date-io/moment": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@date-io/moment/-/moment-2.11.0.tgz",
-      "integrity": "sha512-QSL+83qezQ9Ty0dtFgAkk6eC0GMl/lgYfDajeVUDB3zVA2A038hzczRLBg29ifnBGhQMPABxuOafgWwhDjlarg==",
-      "requires": {
-        "@date-io/core": "^2.11.0"
-      },
-      "dependencies": {
-        "@date-io/core": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/@date-io/core/-/core-2.11.0.tgz",
-          "integrity": "sha512-DvPBnNoeuLaoSJZaxgpu54qzRhRKjSYVyQjhznTFrllKuDpm0sDFjHo6lvNLCM/cfMx2gb2PM2zY2kc9C8nmuw=="
-        }
       }
     },
     "@emotion/babel-plugin": {
@@ -4403,46 +4358,6 @@
         "@babel/runtime": "^7.16.3"
       }
     },
-    "@mui/lab": {
-      "version": "5.0.0-alpha.61",
-      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.61.tgz",
-      "integrity": "sha512-bLWTj8CR/C+HKOtrJVbAa0AYXGAdjZzQlwOQgvdw1YWNo3HQi+ers9BirDoqzP+j+t+0zh/YM2ZchFsc8KTGTA==",
-      "requires": {
-        "@babel/runtime": "^7.16.3",
-        "@date-io/date-fns": "^2.11.0",
-        "@date-io/dayjs": "^2.11.0",
-        "@date-io/luxon": "^2.11.1",
-        "@date-io/moment": "^2.11.0",
-        "@mui/base": "5.0.0-alpha.61",
-        "@mui/system": "^5.2.5",
-        "@mui/utils": "^5.2.3",
-        "clsx": "^1.1.1",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2",
-        "react-transition-group": "^4.4.2",
-        "rifm": "^0.12.1"
-      },
-      "dependencies": {
-        "@date-io/core": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/@date-io/core/-/core-2.11.0.tgz",
-          "integrity": "sha512-DvPBnNoeuLaoSJZaxgpu54qzRhRKjSYVyQjhznTFrllKuDpm0sDFjHo6lvNLCM/cfMx2gb2PM2zY2kc9C8nmuw=="
-        },
-        "@date-io/dayjs": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/@date-io/dayjs/-/dayjs-2.11.0.tgz",
-          "integrity": "sha512-w67vRK56NZJIKhJM/CrNbfnIcuMvR3ApfxzNZiCZ5w29sxgBDeKuX4M+P7A9r5HXOMGcsOcpgaoTDINNGkdpGQ==",
-          "requires": {
-            "@date-io/core": "^2.11.0"
-          }
-        },
-        "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-        }
-      }
-    },
     "@mui/material": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.2.5.tgz",
@@ -4525,6 +4440,126 @@
           "version": "17.0.2",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
           "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+        }
+      }
+    },
+    "@mui/x-date-pickers": {
+      "version": "5.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-5.0.0-beta.5.tgz",
+      "integrity": "sha512-pCVNSHuAcndEJACVS/v2AKBSXemqmhzVvOdsPS9hOIOzGSYawrbCEuhI9+o0/NR/pFLz+JcIYrnVV/Zx8f2ZEw==",
+      "requires": {
+        "@babel/runtime": "^7.18.6",
+        "@date-io/core": "^2.14.0",
+        "@date-io/date-fns": "^2.14.0",
+        "@date-io/dayjs": "^2.14.0",
+        "@date-io/luxon": "^2.14.0",
+        "@date-io/moment": "^2.14.0",
+        "@mui/utils": "^5.4.1",
+        "@types/react-transition-group": "^4.4.5",
+        "clsx": "^1.2.1",
+        "prop-types": "^15.7.2",
+        "react-transition-group": "^4.4.2",
+        "rifm": "^0.12.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.18.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+          "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@date-io/core": {
+          "version": "2.15.0",
+          "resolved": "https://registry.npmjs.org/@date-io/core/-/core-2.15.0.tgz",
+          "integrity": "sha512-3CRvQUEK7aF87NUOwcTtmJ2Rc1kN0D4jFQUfRoanuAnE4o5HzHx4E2YenjaKjSPWeZYiWG6ZhDomx5hp1AaCJA=="
+        },
+        "@date-io/date-fns": {
+          "version": "2.15.0",
+          "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-2.15.0.tgz",
+          "integrity": "sha512-hkVeLm0jijHS2F9YVQcf0LSlD55w9xPvvIfuxDE0XWNXOTcRAAhqw2aqOxyeGbmHxc5U4HqyPZaqs9tfeTsomQ==",
+          "requires": {
+            "@date-io/core": "^2.15.0"
+          }
+        },
+        "@date-io/dayjs": {
+          "version": "2.15.0",
+          "resolved": "https://registry.npmjs.org/@date-io/dayjs/-/dayjs-2.15.0.tgz",
+          "integrity": "sha512-wgYzwaXr9KxkHNYxrOb1t8fYLfAdjIf0Q86qdVCwANObcvyGcPBm0uFtpPK7ApeE4DJUlbuG0IX75TtO+uITwQ==",
+          "requires": {
+            "@date-io/core": "^2.15.0"
+          }
+        },
+        "@date-io/luxon": {
+          "version": "2.15.0",
+          "resolved": "https://registry.npmjs.org/@date-io/luxon/-/luxon-2.15.0.tgz",
+          "integrity": "sha512-CxTRCo5AM96ainnYaTpe1NS9GiA78SIgXBScgeAresCS20AvMcOd5XKerDj+y/KLhbSQbU6WUDqG9QcsrImXyQ==",
+          "requires": {
+            "@date-io/core": "^2.15.0"
+          }
+        },
+        "@date-io/moment": {
+          "version": "2.15.0",
+          "resolved": "https://registry.npmjs.org/@date-io/moment/-/moment-2.15.0.tgz",
+          "integrity": "sha512-AcYBjl3EnEGsByaM5ir644CKbhgJsgc1iWFa9EXfdb4fQexxOC8oCdPAurK2ZDTwg62odyyKa/05YE7ElYh5ag==",
+          "requires": {
+            "@date-io/core": "^2.15.0"
+          }
+        },
+        "@mui/utils": {
+          "version": "5.9.3",
+          "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.9.3.tgz",
+          "integrity": "sha512-l0N5bcrenE9hnwZ/jPecpIRqsDFHkPXoFUcmkgysaJwVZzJ3yQkGXB47eqmXX5yyGrSc6HksbbqXEaUya+siew==",
+          "requires": {
+            "@babel/runtime": "^7.17.2",
+            "@types/prop-types": "^15.7.5",
+            "@types/react-is": "^16.7.1 || ^17.0.0",
+            "prop-types": "^15.8.1",
+            "react-is": "^18.2.0"
+          },
+          "dependencies": {
+            "prop-types": {
+              "version": "15.8.1",
+              "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+              "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+              "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.13.1"
+              },
+              "dependencies": {
+                "react-is": {
+                  "version": "16.13.1",
+                  "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+                  "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+                }
+              }
+            }
+          }
+        },
+        "@types/prop-types": {
+          "version": "15.7.5",
+          "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+          "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+        },
+        "@types/react-transition-group": {
+          "version": "4.4.5",
+          "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
+          "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
+          "requires": {
+            "@types/react": "*"
+          }
+        },
+        "clsx": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+          "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+        },
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         }
       }
     },

--- a/packages/material/package.json
+++ b/packages/material/package.json
@@ -79,8 +79,8 @@
     "@jsonforms/core": "3.0.0-rc.0",
     "@jsonforms/react": "3.0.0-rc.0",
     "@mui/icons-material": "^5.0.0",
-    "@mui/lab": "^5.0.0-alpha.54",
-    "@mui/material": "^5.0.0"
+    "@mui/material": "^5.0.0",
+    "@mui/x-date-pickers": "^5.0.0-beta.5"
   },
   "devDependencies": {
     "@emotion/react": "^11.5.0",
@@ -88,8 +88,8 @@
     "@jsonforms/core": "^3.0.0-rc.0",
     "@jsonforms/react": "^3.0.0-rc.0",
     "@mui/icons-material": "^5.2.0",
-    "@mui/lab": "^5.0.0-alpha.58",
     "@mui/material": "^5.2.2",
+    "@mui/x-date-pickers": "^5.0.0-beta.5",
     "@types/enzyme": "^3.10.3",
     "@types/react-dom": "^17.0.9",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.3",

--- a/packages/material/src/controls/MaterialDateControl.tsx
+++ b/packages/material/src/controls/MaterialDateControl.tsx
@@ -36,8 +36,8 @@ import { FormHelperText, Hidden } from '@mui/material';
 import {
   DatePicker,
   LocalizationProvider 
-} from '@mui/lab';
-import AdapterDayjs from '@mui/lab/AdapterDayjs';
+} from '@mui/x-date-pickers';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import {
   createOnChangeHandler,
   getData,
@@ -96,15 +96,16 @@ export const MaterialDateControl = (props: ControlProps)=> {
         <DatePicker
           label={label}
           value={value}
-          clearable
           onChange={onChange}
           inputFormat={format}
           disableMaskedInput
           views={views}
           disabled={!enabled}
-          cancelText={appliedUiSchemaOptions.cancelLabel}
-          clearText={appliedUiSchemaOptions.clearLabel}
-          okText={appliedUiSchemaOptions.okLabel}
+          componentsProps={{
+            actionBar: {
+              actions: (variant) => (variant === 'desktop' ? [] : ['clear', 'cancel', 'accept'])
+            }
+          }}
           renderInput={params => (
             <ResettableTextField 
               {...params}

--- a/packages/material/src/controls/MaterialDateTimeControl.tsx
+++ b/packages/material/src/controls/MaterialDateTimeControl.tsx
@@ -36,8 +36,8 @@ import { FormHelperText, Hidden } from '@mui/material';
 import {
   DateTimePicker,
   LocalizationProvider 
-} from '@mui/lab';
-import AdapterDayjs from '@mui/lab/AdapterDayjs';
+} from '@mui/x-date-pickers';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import {
   createOnChangeHandler,
   getData,
@@ -98,16 +98,17 @@ export const MaterialDateTimeControl = (props: ControlProps) => {
         <DateTimePicker
           label={label}
           value={value}
-          clearable
           onChange={onChange}
           inputFormat={format}
           disableMaskedInput
           ampm={!!appliedUiSchemaOptions.ampm}
           views={views}
           disabled={!enabled}
-          cancelText={appliedUiSchemaOptions.cancelLabel}
-          clearText={appliedUiSchemaOptions.clearLabel}
-          okText={appliedUiSchemaOptions.okLabel}
+          componentsProps={{
+            actionBar: {
+              actions: (variant) => (variant === 'desktop' ? [] : ['clear', 'cancel', 'accept'])
+            }
+          }}
           renderInput={params => (
             <ResettableTextField 
               {...params}
@@ -129,7 +130,8 @@ export const MaterialDateTimeControl = (props: ControlProps) => {
               onBlur={onBlur}
               variant={'standard'}
             />
-          )}
+          )
+          }
         />
         <FormHelperText error={!isValid && !showDescription}>
           {firstFormHelperText}

--- a/packages/material/src/controls/MaterialTimeControl.tsx
+++ b/packages/material/src/controls/MaterialTimeControl.tsx
@@ -36,8 +36,8 @@ import { FormHelperText, Hidden } from '@mui/material';
 import {
   TimePicker,
   LocalizationProvider 
-} from '@mui/lab';
-import AdapterDayjs from '@mui/lab/AdapterDayjs';
+} from '@mui/x-date-pickers';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import {
   createOnChangeHandler,
   getData,
@@ -98,16 +98,17 @@ export const MaterialTimeControl = (props: ControlProps) => {
         <TimePicker
           label={label}
           value={value}
-          clearable
           onChange={onChange}
           inputFormat={format}
           disableMaskedInput
           ampm={!!appliedUiSchemaOptions.ampm}
           views={views}
           disabled={!enabled}
-          cancelText={appliedUiSchemaOptions.cancelLabel}
-          clearText={appliedUiSchemaOptions.clearLabel}
-          okText={appliedUiSchemaOptions.okLabel}
+          componentsProps={{
+            actionBar: {
+              actions: (variant) => (variant === 'desktop' ? [] : ['clear', 'cancel', 'accept'])
+            }
+          }}
           renderInput={params => (
             <ResettableTextField 
               {...params}

--- a/packages/material/test/renderers/MaterialDateTimeControl.test.tsx
+++ b/packages/material/test/renderers/MaterialDateTimeControl.test.tsx
@@ -209,10 +209,10 @@ describe('Material date time control', () => {
       </JsonFormsStateProvider>
     );
     const input = wrapper.find('input').first();
-    (input.getDOMNode() as HTMLInputElement).value ='1961-12-94 20:15'; 
+    (input.getDOMNode() as HTMLInputElement).value ='1961-12-12 20:15'; 
     input.simulate('change', input);
     expect(onChangeData.data.foo).toBe(
-      dayjs('1961-12-94 20:15').format()
+      dayjs('1961-12-12 20:15').format()
     );
   });
 

--- a/packages/material/test/renderers/MaterialTimeControl.test.tsx
+++ b/packages/material/test/renderers/MaterialTimeControl.test.tsx
@@ -377,7 +377,7 @@ describe('Material time control', () => {
     const input = wrapper.find('input').first();
     expect(input.props().value).toBe('02-13');
 
-    (input.getDOMNode() as HTMLInputElement).value = '12:01';
+    (input.getDOMNode() as HTMLInputElement).value = '12-01';
     input.simulate('change', input);
     expect(onChangeData.data.foo).toBe('1//12 am');
   });


### PR DESCRIPTION
Date pickers failed with recent versions of @mui/lab.
Furthermore, they have officially been moved to @mui/x-date-pickers.
See https://mui.com/blog/lab-date-pickers-to-mui-x/

* Add @mui/x-date-picker peer and dev dependency to the material renderer package
* Remove @mui/lab peer and dev dependency from the material renderer package.
  It was only used for the date and time pickers
* Adapt two unit tests to actually use valid inputs.
* Adapt date and time picker action configuration to new API.
  * Keep the clear button on mobile devices
  * No action buttons on desktop devices (as before)
  * Action button labels (for mobile devices) can no longer be configured via ui schema option due to missing API

Fix #1998 

# UI differences for mobile devices
Notable differences:

- clear button are no longer left aligned
- button texts are no longer adaptable. This might be addable again in a follow up by providing a custom toolbar. See [here](https://github.com/mui/mui-x/blob/master/CHANGELOG.md#muix-date-pickersv500-alpha4--muix-date-pickers-prov500-alpha4) as a starting point.

## Now
![image](https://user-images.githubusercontent.com/6959840/185435959-6a11e68a-795a-4e3c-a479-463ae646d5d6.png)
![image](https://user-images.githubusercontent.com/6959840/185435977-b481f858-7f66-43ca-ba98-a787b1f60b8f.png)
![image](https://user-images.githubusercontent.com/6959840/185435987-5b4f4fc7-f02c-4def-9e0e-7eabf3186634.png)
## Before
![image](https://user-images.githubusercontent.com/6959840/185435852-679f11fa-a22e-4284-b51b-3b61076a5d17.png)
![image](https://user-images.githubusercontent.com/6959840/185435877-52192edc-b403-44ee-b7ef-9c11fb465a0d.png)
![image](https://user-images.githubusercontent.com/6959840/185435895-038cc91f-e993-4839-abee-12e35104bdcf.png)



