### PR TITLE
Control React Material radio group

### DIFF
--- a/packages/material/src/controls/MaterialRadioGroup.tsx
+++ b/packages/material/src/controls/MaterialRadioGroup.tsx
@@ -90,7 +90,7 @@ export const MaterialRadioGroup = (props: ControlProps & OwnPropsOfEnum) => {
         </FormLabel>
 
         <RadioGroup
-          value={props.data}
+          value={props.data ?? ''}
           onChange={onChange}
           row={true}
         >


### PR DESCRIPTION
Make sure that the React Material radio group is always rendered in controlled mode by
handing over an empty string in case no value exists. This fixes an issue in which the
control changed its mode once the user selects a value.

Fixes #2007 