### PR TITLE
(core) Categorization interface does not have a 'label' property

### DIFF
--- a/packages/core/src/models/uischema.ts
+++ b/packages/core/src/models/uischema.ts
@@ -256,7 +256,7 @@ export interface Category extends Layout, Labeled {
  * A child element may either be itself a Categorization or a Category, hence
  * the categorization element can be used to represent recursive structures like trees.
  */
-export interface Categorization extends UISchemaElement, Labeled {
+export interface Categorization extends UISchemaElement {
   type: 'Categorization';
   /**
    * The child elements of this categorization which are either of type


### PR DESCRIPTION
I may be missing something but I think the `Categorization` interface should not extend `Labeled`; the top level element of a Category layout (`type: "Categorization"`) does not have a label, [the example JSON in the docs](https://jsonforms.io/docs/uischema/layouts#categorization) confirms this.