### PR TITLE
Add Interface for config of Jsonforms-Angular

### DIFF
--- a/packages/angular/src/config.ts
+++ b/packages/angular/src/config.ts
@@ -1,0 +1,7 @@
+export interface Config {
+    hideRequiredAsterisk?: boolean,
+    readonly?: boolean,
+    restrict?: boolean,
+    trim?: boolean;
+    showUnfocusedDescription?: boolean
+}

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -31,3 +31,4 @@ export * from './unknown.component';
 export * from './jsonforms.service';
 export * from './jsonforms-root.component';
 export * from './abstract-control';
+export * from './config';

--- a/packages/angular/src/jsonforms-root.component.ts
+++ b/packages/angular/src/jsonforms-root.component.ts
@@ -28,6 +28,7 @@ import {
 import { Actions, JsonFormsI18nState, JsonFormsRendererRegistryEntry, JsonSchema, UISchemaElement, UISchemaTester, ValidationMode } from '@jsonforms/core';
 import Ajv, { ErrorObject } from 'ajv';
 import { JsonFormsAngularService, USE_STATE_VALUE } from './jsonforms.service';
+import { Config } from './config';
 @Component({
     selector: 'jsonforms',
     template: '<jsonforms-outlet></jsonforms-outlet>',
@@ -44,7 +45,7 @@ export class JsonForms implements OnChanges, OnInit {
     @Input() readonly: boolean;
     @Input() validationMode: ValidationMode;
     @Input() ajv: Ajv;
-    @Input() config: any;
+    @Input() config: Config;
     @Input() i18n: JsonFormsI18nState;
     @Input() additionalErrors: ErrorObject[];
     @Output() errors = new EventEmitter<ErrorObject[]>();


### PR DESCRIPTION
Add Interface for Jsonforms-Config, instead of 'any' Datatype. This applies only for the Angular-Version.