### PR TITLE
Adapt README URLs  to renamed vanilla and material renderers folders

### DIFF
--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -8,7 +8,7 @@ JSON Forms eliminates the tedious task of writing fully-featured forms by hand b
 
 This is the examples package which demonstrates how to integrate JSON Forms with your application.
 
-You can use the examples with any renderer set you want, for example the [Material Renderers](https://github.com/eclipsesource/jsonforms/tree/master/packages/material) or the [Angular Renderers](https://github.com/eclipsesource/jsonforms/tree/master/packages/angular-material).
+You can use the examples with any renderer set you want, for example the [Material Renderers](https://github.com/eclipsesource/jsonforms/tree/master/packages/material-renderers) or the [Angular Renderers](https://github.com/eclipsesource/jsonforms/tree/master/packages/angular-material).
 
 Check <https://www.npmjs.com/search?q=%40jsonforms> for all published JSON Forms packages.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -8,7 +8,7 @@ JSON Forms eliminates the tedious task of writing fully-featured forms by hand b
 
 This is the JSON Forms React package which provides the necessary bindings for React. It uses [JSON Forms Core](https://github.com/eclipsesource/jsonforms/blob/master/packages/core).
 
-You can combine the react package with any react-based renderer set you want, for example the [Material Renderers](https://github.com/eclipsesource/jsonforms/tree/master/packages/material) or the [Vanilla Renderers](https://github.com/eclipsesource/jsonforms/tree/master/packages/vanilla).
+You can combine the react package with any react-based renderer set you want, for example the [Material Renderers](https://github.com/eclipsesource/jsonforms/tree/master/packages/material-renderers) or the [Vanilla Renderers](https://github.com/eclipsesource/jsonforms/tree/master/packages/vanilla-renderers).
 
 See the official [documentation](https://jsonforms.io/) and the JSON Forms React [seed repository](https://github.com/eclipsesource/jsonforms-react-seed) for examples on how to integrate JSON Forms with your application.
 

--- a/packages/vanilla-renderers/README.md
+++ b/packages/vanilla-renderers/README.md
@@ -14,7 +14,7 @@ See the official [documentation](https://jsonforms.io/docs/integrations/react/) 
 
 Check <https://www.npmjs.com/search?q=%40jsonforms> for all published JSONForms packages.
 
-If you want to customize styling, have a look at our [styles guide](https://github.com/eclipsesource/jsonforms/blob/master/packages/vanilla/Styles.md).
+If you want to customize styling, have a look at our [styles guide](https://github.com/eclipsesource/jsonforms/blob/master/packages/vanilla-renderers/Styles.md).
 
 ### Quick start
 


### PR DESCRIPTION
Related to https://github.com/eclipsesource/jsonforms/issues/1036