### PR TITLE
Show description or tooltip on boolean controls

### DIFF
--- a/packages/examples/src/examples/control-options.ts
+++ b/packages/examples/src/examples/control-options.ts
@@ -31,7 +31,8 @@ export const schema = {
         type: 'string'
       },
       boolean: {
-        type: 'boolean'
+        type: 'boolean',
+        description: 'Boolean description as a tooltip'
       },
       number: {
         type: 'number'

--- a/packages/material-renderers/src/controls/MaterialBooleanControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialBooleanControl.tsx
@@ -23,15 +23,17 @@
   THE SOFTWARE.
 */
 import isEmpty from 'lodash/isEmpty';
+import merge from 'lodash/merge';
 import React from 'react';
 import {
   isBooleanControl,
   RankedTester,
   rankWith,
-  ControlProps
+  ControlProps,
+  isDescriptionHidden
 } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
-import { FormControlLabel, Hidden } from '@mui/material';
+import { FormControlLabel, FormHelperText, Tooltip, Hidden } from '@mui/material';
 import { MuiCheckbox } from '../mui-controls/MuiCheckbox';
 
 export const MaterialBooleanControl = ({
@@ -46,30 +48,64 @@ export const MaterialBooleanControl = ({
   handleChange,
   errors,
   path,
-  config
+  config,
+  description
 }: ControlProps) => {
+
+  const isValid = errors.length === 0;
+  const appliedUiSchemaOptions = merge({}, config, uischema.options);
+
+  const showDescription = !isDescriptionHidden(
+    visible,
+    description,
+    false,
+    appliedUiSchemaOptions.showUnfocusedDescription
+  );
+
+  const showTooltip = !showDescription && !isDescriptionHidden(
+    visible,
+    description,
+    true,
+    true
+  );
+
+  const firstFormHelperText = showDescription
+    ? description
+    : !isValid
+    ? errors
+    : null;
+  const secondFormHelperText = showDescription && !isValid ? errors : null;
+
   return (
     <Hidden xsUp={!visible}>
-      <FormControlLabel
-        label={label}
-        id={id}
-        control={
-          <MuiCheckbox
-            id={`${id}-input`}
-            isValid={isEmpty(errors)}
-            data={data}
-            enabled={enabled}
-            visible={visible}
-            path={path}
-            uischema={uischema}
-            schema={schema}
-            rootSchema={rootSchema}
-            handleChange={handleChange}
-            errors={errors}
-            config={config}
-          />
-        }
-      />
+      <Tooltip title={(showTooltip) ? description : ''}>
+        <FormControlLabel
+          label={label}
+          id={id}
+          control={
+            <MuiCheckbox
+              id={`${id}-input`}
+              isValid={isEmpty(errors)}
+              data={data}
+              enabled={enabled}
+              visible={visible}
+              path={path}
+              uischema={uischema}
+              schema={schema}
+              rootSchema={rootSchema}
+              handleChange={handleChange}
+              errors={errors}
+              config={config}
+            />
+          }
+        />
+      </Tooltip>
+      <FormHelperText error={!isValid && !showDescription}>
+        {firstFormHelperText}
+      </FormHelperText>
+      <FormHelperText error={!isValid}>
+        {secondFormHelperText}
+      </FormHelperText>
     </Hidden>
   );
 };

--- a/packages/material-renderers/src/controls/MaterialBooleanControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialBooleanControl.tsx
@@ -58,6 +58,9 @@ export const MaterialBooleanControl = ({
   const showDescription = !isDescriptionHidden(
     visible,
     description,
+    // Checkboxes do not receive focus until they are used, so
+    // we cannot rely on focus as criteria for showing descriptions.
+    // So we pass "false" to treat it as unfocused.
     false,
     appliedUiSchemaOptions.showUnfocusedDescription
   );
@@ -65,7 +68,11 @@ export const MaterialBooleanControl = ({
   const showTooltip = !showDescription && !isDescriptionHidden(
     visible,
     description,
+    // Tooltips have their own focus handlers, so we do not need to rely
+    // on focus state here. So we pass 'true' to treat it as focused.
     true,
+    // We also pass true here for showUnfocusedDescription since it should
+    // render regardless of that setting.
     true
   );
 


### PR DESCRIPTION
The intended behavior here is that if a boolean control has a description, then it will appear as a tooltip. However if showUnfocusedDescription is true, then the description appears below as text. I tried to copy as much code from existing components as possible, but I'm happy to make any changes as needed.