### PR TITLE
Improve Translator type

### DIFF
--- a/packages/core/src/i18n/i18nTypes.ts
+++ b/packages/core/src/i18n/i18nTypes.ts
@@ -4,6 +4,7 @@ import { JsonSchema, UISchemaElement } from '../models';
 export type Translator = {
     (id: string, defaultMessage: string, values?: any): string;
     (id: string, defaultMessage: undefined, values?: any): string | undefined;
+    (id: string, defaultMessage?: string, values?: any): string | undefined;
 }
 
 export type ErrorTranslator = (error: ErrorObject, translate: Translator, uischema?: UISchemaElement) => string;


### PR DESCRIPTION
The Translator type is an overloaded function. While the current type considers the 'defaultMessage' to be either 'string' or 'undefined' it does not handle the case where it could be 'string | undefined' while the implementation obviously handles this fine.

This change adds this additional case to the 'Translator' type and optionalizes the 'defaultMessage' parameter. This allows a more convenient use of this type by adopters.