### PR TITLE
Add a failWhenUndefined option to the SchemaBasedCondition

### DIFF
--- a/packages/core/src/models/uischema.ts
+++ b/packages/core/src/models/uischema.ts
@@ -135,6 +135,19 @@ export interface LeafCondition extends Condition, Scoped {
 
 export interface SchemaBasedCondition extends Condition, Scoped {
   schema: JsonSchema;
+
+  /**
+   * When the scope resolves to undefined and `failWhenUndefined` is set to `true`, the condition
+   * will fail. Therefore the reverse effect will be applied.
+   *
+   * Background:
+   * Most JSON Schemas will successfully validate against `undefined` data. Specifying that a
+   * condition shall fail when data is `undefined` requires to lift the scope to being able to use
+   * JSON Schema's `required`.
+   *
+   * Using `failWhenUndefined` allows to more conveniently express this condition.
+   */
+  failWhenUndefined?: boolean;
 }
 
 /**

--- a/packages/core/src/util/runtime.ts
+++ b/packages/core/src/util/runtime.ts
@@ -79,6 +79,9 @@ const evaluateCondition = (
     return value === condition.expectedValue;
   } else if (isSchemaCondition(condition)) {
     const value = resolveData(data, getConditionScope(condition, path));
+    if (condition.failWhenUndefined && value === undefined) {
+      return false;
+    }
     return ajv.validate(condition.schema, value) as boolean;
   } else {
     // unknown condition

--- a/packages/core/test/util/runtime.test.ts
+++ b/packages/core/test/util/runtime.test.ts
@@ -552,6 +552,59 @@ test('evalEnablement disable invalid case based on schema condition', (t) => {
   );
 });
 
+test('evalEnablement fail on failWhenUndefined', (t) => {
+  const condition: SchemaBasedCondition = {
+    scope: '#/properties/ruleValue',
+    schema: {
+      enum: ['bar', 'baz'],
+    },
+  };
+  const failConditionTrue: SchemaBasedCondition = {
+    ...condition,
+    failWhenUndefined: true,
+  };
+  const failConditionFalse: SchemaBasedCondition = {
+    ...condition,
+    failWhenUndefined: false,
+  };
+
+  const uischema: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/value',
+    rule: {
+      effect: RuleEffect.DISABLE,
+      condition: failConditionTrue,
+    },
+  };
+  const failConditionTrueUischema: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/value',
+    rule: {
+      effect: RuleEffect.DISABLE,
+      condition: failConditionTrue,
+    },
+  };
+  const failConditionFalseUischema: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/value',
+    rule: {
+      effect: RuleEffect.DISABLE,
+      condition: failConditionFalse,
+    },
+  };
+  const data = {
+    value: 'foo',
+  };
+  t.is(
+    evalEnablement(failConditionTrueUischema, data, undefined, createAjv()),
+    true
+  );
+  t.is(
+    evalEnablement(failConditionFalseUischema, data, undefined, createAjv()),
+    evalEnablement(uischema, data, undefined, createAjv())
+  );
+});
+
 test('isInherentlyEnabled disabled globally', (t) => {
   t.false(
     isInherentlyEnabled(


### PR DESCRIPTION
This PR adds an option to mark the scope of a rule condition as required.

The original proposed solution was to add:
`whenUndefined: 'fail' | 'success'`
but after understanding the problem a bit better I think the main problem is that you can't define the condition scope as required and adding this option keeps it a bit closer to JSONSchema.

I added a comment about my interpretation about whats happening in the code. Let me know what you think, I might be wrong about it and AJV just does something weird... I also still like `whenUndefined` since it might actually be more user friendly.

Original discussion:
https://jsonforms.discourse.group/t/no-rule-validation-for-array-contains-value-when-array-undefined/1308/7