### PR TITLE
Remove enableIvy option

### DIFF
--- a/packages/angular-material/tsconfig.json
+++ b/packages/angular-material/tsconfig.json
@@ -10,7 +10,6 @@
   "angularCompilerOptions": {
     "strictMetadataEmit": true,
     "generateCodeForLibraries": false,
-    "skipTemplateCodegen": true,
-    "enableIvy": false
+    "skipTemplateCodegen": true
   }
 }

--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -10,7 +10,6 @@
   "angularCompilerOptions": {
     "strictMetadataEmit": true,
     "generateCodeForLibraries": false,
-    "skipTemplateCodegen": true,
-    "enableIvy": false
+    "skipTemplateCodegen": true
   }
 }


### PR DESCRIPTION
Solution for this bug, that is preventing the angular compiler from using the Ivy engine

https://github.com/eclipsesource/jsonforms/issues/2116