### PR TITLE
array translatins for vanilla, angular-material and vue

### DIFF
--- a/packages/angular-material/src/layouts/array-layout.renderer.ts
+++ b/packages/angular-material/src/layouts/array-layout.renderer.ts
@@ -31,6 +31,7 @@ import {
 import { JsonFormsAngularService, JsonFormsAbstractControl } from '@jsonforms/angular';
 import {
   ArrayLayoutProps,
+  ArrayTranslations,
   createDefaultValue,
   findUISchema,
   isObjectArrayWithNesting,
@@ -68,15 +69,15 @@ import {
         <span fxFlex></span>
         <button
           mat-button
-          matTooltip="{{ this.addTooltip }}"
+          matTooltip="{{ translations.addTooltip }}"
           [disabled]="!isEnabled()"
           (click)="add()"
-          attr.aria-label="{{ this.addAriaLabel }}"
+          attr.aria-label="{{ translations.addAriaLabel }}"
         >
           <mat-icon>add</mat-icon>
         </button>
       </div>
-      <p *ngIf="noData">{{ this.noDataMessage }}</p>
+      <p *ngIf="noData">{{ translations.noDataMessage }}</p>
       <div
         *ngFor="
           let item of [].constructor(data);
@@ -97,8 +98,8 @@ import {
               mat-button
               [disabled]="first"
               (click)="up(idx)"
-              attr.aria-label="{{ this.upAriaLabel }}"
-              matTooltip="{{ this.upTooltip }}"
+              attr.aria-label="{{ translations.upAriaLabel }}"
+              matTooltip="{{ translations.up }}"
               matTooltipPosition="right"
             >
               <mat-icon>arrow_upward</mat-icon>
@@ -109,8 +110,8 @@ import {
               mat-button
               [disabled]="last"
               (click)="down(idx)"
-              attr.aria-label="{{ this.downAriaLabel }}"
-              matTooltip="{{ this.downTooltip }}"
+              attr.aria-label="{{ translations.downAriaLabel }}"
+              matTooltip="{{ translations.down }}"
               matTooltipPosition="right"
             >
               <mat-icon>arrow_downward</mat-icon>
@@ -119,8 +120,8 @@ import {
               mat-button
               color="warn"
               (click)="remove(idx)"
-              attr.aria-label="{{ this.removeAriaLabel }}"
-              matTooltip="{{ this.removeTooltip }}"
+              attr.aria-label="{{ translations.removeAriaLabel }}"
+              matTooltip="{{ translations.removeTooltip }}"
               matTooltipPosition="right"
             >
               <mat-icon>delete</mat-icon>
@@ -148,16 +149,8 @@ import {
 export class ArrayLayoutRenderer
   extends JsonFormsAbstractControl<StatePropsOfArrayLayout>
   implements OnInit, OnDestroy {
-  addTooltip: string;
-  addAriaLabel: string;
-  noDataMessage: string;
-  removeTooltip: string;
-  removeAriaLabel: string;
-  upTooltip: string;
-  upAriaLabel: string;
-  downTooltip: string;
-  downAriaLabel:string;
   noData: boolean;
+  translations: ArrayTranslations;
   addItem: (path: string, value: any) => () => void;
   moveItemUp: (path: string, index: number) => () => void;
   moveItemDown: (path: string, index: number) => () => void;
@@ -196,15 +189,9 @@ export class ArrayLayoutRenderer
     this.removeItems = removeItems;
   }
   mapAdditionalProps(props: ArrayLayoutProps) {
+    this.translations = props.translations;
     this.noData = !props.data || props.data === 0;
     this.uischemas = props.uischemas;
-    this.addTooltip = `Add to ${this.label}`;
-    this.addAriaLabel = `Add to ${this.label} button`;
-    this.upAriaLabel = `Move ${this.label} up`;
-    this.downAriaLabel = `Move ${this.label} down`;
-    this.removeTooltip = `Delete`;
-    this.removeAriaLabel = `Delete button`;
-    this.noDataMessage = `No data`;
   }
   getProps(index: number): OwnPropsOfRenderer {
     const uischema = findUISchema(

--- a/packages/angular-material/src/other/master-detail/master.ts
+++ b/packages/angular-material/src/other/master-detail/master.ts
@@ -31,6 +31,7 @@ import {
 } from '@jsonforms/angular';
 import {
   ArrayControlProps,
+  ArrayTranslations,
   ControlElement,
   createDefaultValue,
   decode,
@@ -64,7 +65,7 @@ export const removeSchemaKeywords = (path: string) => {
       <mat-sidenav mode="side" opened>
         <mat-nav-list>
           <mat-list-item *ngIf="masterItems.length === 0"
-            >No items</mat-list-item
+            >{{ translations.noDataMessage }}</mat-list-item
           >
           <mat-list-item
             *ngFor="
@@ -96,7 +97,7 @@ export const removeSchemaKeywords = (path: string) => {
           (click)="onAddClick()"
           *ngIf="isEnabled()"
         >
-          <mat-icon aria-label="Add item to list">add</mat-icon>
+          <mat-icon [attr.aria-label]="translations.addAriaLabel">add</mat-icon>
         </button>
       </mat-sidenav>
       <mat-sidenav-content class="content">
@@ -149,6 +150,7 @@ export class MasterListComponent extends JsonFormsArrayControl {
   removeItems: (path: string, toDelete: number[]) => () => void;
   propsPath: string;
   highlightedIdx: number;
+  translations: ArrayTranslations;
 
   constructor(jsonformsService: JsonFormsAngularService, private changeDetectorRef: ChangeDetectorRef) {
     super(jsonformsService);
@@ -187,6 +189,8 @@ export class MasterListComponent extends JsonFormsArrayControl {
     if (!this.isEnabled()) {
       setReadonly(detailUISchema);
     }
+
+    this.translations=props.translations;
 
     const masterItems = (data || []).map((d: any, index: number) => {
       const labelRefInstancePath = controlElement.options?.labelRef && removeSchemaKeywords(

--- a/packages/angular-material/src/other/table.renderer.ts
+++ b/packages/angular-material/src/other/table.renderer.ts
@@ -30,6 +30,7 @@ import {
 } from '@jsonforms/angular';
 import {
   ArrayControlProps,
+  ArrayTranslations,
   ControlElement, createDefaultValue,
   deriveTypes,
   encode,
@@ -57,7 +58,7 @@ import {
       <ng-container matColumnDef="action">
         <tr>
           <th mat-header-cell *matHeaderCellDef>
-            <button mat-button color="primary" (click)="add()" [disabled]="!isEnabled()" matTooltip="Add"><mat-icon>add</mat-icon></button>
+            <button mat-button color="primary" (click)="add()" [disabled]="!isEnabled()" [matTooltip]="translations.addTooltip"><mat-icon>add</mat-icon></button>
           </th>
         </tr>
         <tr>
@@ -68,7 +69,7 @@ import {
               mat-button
               [disabled]="first"
               (click)="up(i)"
-              matTooltip="Move item up"
+              [matTooltip]="translations.upAriaLabel"
               matTooltipPosition="right"
               >
               <mat-icon>arrow_upward</mat-icon>
@@ -79,7 +80,7 @@ import {
               mat-button
               [disabled]="last"
               (click)="down(i)"
-              matTooltip="Move item down"
+              [matTooltip]="translations.downAriaLabel"
               matTooltipPosition="right"
             >
               <mat-icon>arrow_downward</mat-icon>
@@ -90,7 +91,7 @@ import {
                 (click)="remove(i)"
                 [disabled]="!isEnabled()"
                 matTooltipPosition="right"
-                matTooltip="Delete"
+                [matTooltip]="translations.removeTooltip"
             >
               <mat-icon>delete</mat-icon>
             </button>
@@ -126,6 +127,7 @@ export class TableRenderer extends JsonFormsArrayControl {
   moveItemUp: (path: string, index: number) => () => void;
   moveItemDown: (path: string, index: number) => () => void;
   removeItems: (path: string, toDelete: number[]) => () => void;
+  translations: ArrayTranslations;
 
   constructor(jsonformsService: JsonFormsAngularService) {
     super(jsonformsService);
@@ -139,6 +141,7 @@ export class TableRenderer extends JsonFormsArrayControl {
     if (this.isEnabled()) {
       this.displayedColumns.push('action');
     }
+    this.translations = props.translations;
   }
   getProps(index: number, props: OwnPropsOfRenderer): OwnPropsOfRenderer {
     const rowPath = Paths.compose(props.path, `${index}`);

--- a/packages/angular-material/test/master-detail.spec.ts
+++ b/packages/angular-material/test/master-detail.spec.ts
@@ -41,6 +41,7 @@ import { MasterListComponent } from '../src/other/master-detail/master';
 import { JsonFormsDetailComponent } from '../src/other/master-detail/detail';
 import { getJsonFormsService, setupMockStore } from '@jsonforms/angular-test';
 import { Actions } from '@jsonforms/core';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 describe('Master detail', () => {
   let fixture: ComponentFixture<MasterListComponent>;
@@ -114,7 +115,8 @@ describe('Master detail', () => {
         MatIconModule,
         MatButtonModule,
         FlexLayoutModule,
-        NoopAnimationsModule
+        NoopAnimationsModule,
+        MatTooltipModule
       ],
       providers: [JsonFormsAngularService]
     })

--- a/packages/angular-material/test/table-control.spec.ts
+++ b/packages/angular-material/test/table-control.spec.ts
@@ -42,6 +42,7 @@ import {
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { setupMockStore } from '@jsonforms/angular-test';
 import { createTesterContext } from './util';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 const uischema1: ControlElement = { type: 'Control', scope: '#' };
 const uischema2: ControlElement = {
@@ -127,7 +128,8 @@ describe('Table', () => {
         MatInputModule,
         ReactiveFormsModule,
         FlexLayoutModule,
-        MatTableModule
+        MatTableModule,
+        MatTooltipModule,
       ],
       providers: [JsonFormsAngularService]
     })

--- a/packages/core/src/i18n/arrayTranslations.ts
+++ b/packages/core/src/i18n/arrayTranslations.ts
@@ -15,7 +15,9 @@ export enum ArrayTranslationEnum{
     deleteDialogTitle = 'deleteDialogTitle',
     deleteDialogMessage = 'deleteDialogMessage',
     deleteDialogAccept = 'deleteDialogAccept',
-    deleteDialogDecline = 'deleteDialogDecline'
+    deleteDialogDecline = 'deleteDialogDecline',
+    up = 'up',
+    down = 'down'
 }
 
 export type ArrayTranslations = {
@@ -24,13 +26,15 @@ export type ArrayTranslations = {
 
 export const arrayDefaultTranslations: ArrayDefaultTranslation[] = [
     {key: ArrayTranslationEnum.addTooltip, default: (input) => input?`Add to ${input}`:'Add'},
-    {key: ArrayTranslationEnum.addAriaLabel, default: (input) => input?`Add to ${input}`:'Add'},
+    {key: ArrayTranslationEnum.addAriaLabel, default: (input) => input?`Add to ${input} button`:'Add button'},
     {key: ArrayTranslationEnum.removeTooltip, default: () => 'Delete'},
-    {key: ArrayTranslationEnum.upAriaLabel, default: (input) => `Move ${input} up`},
-    {key: ArrayTranslationEnum.downAriaLabel, default: (input) => `Move ${input} down`},
     {key: ArrayTranslationEnum.removeAriaLabel, default: () => 'Delete button'},
-    {key: ArrayTranslationEnum.noDataMessage, default: () => 'No Data'},
-    {key: ArrayTranslationEnum.noSelection, default: () => 'No Selection'},
+    {key: ArrayTranslationEnum.upAriaLabel, default: () => `Move item up`},
+    {key: ArrayTranslationEnum.up, default: () => 'Up'},
+    {key: ArrayTranslationEnum.down, default: () => 'Down'},
+    {key: ArrayTranslationEnum.downAriaLabel, default: () => `Move item down`},
+    {key: ArrayTranslationEnum.noDataMessage, default: () => 'No data'},
+    {key: ArrayTranslationEnum.noSelection, default: () => 'No selection'},
     {key: ArrayTranslationEnum.deleteDialogTitle, default: () => 'Confirm Deletion'},
     {key: ArrayTranslationEnum.deleteDialogMessage, default: () => 'Are you sure you want to delete the selected entry?'},
     {key: ArrayTranslationEnum.deleteDialogAccept, default: () => 'Yes'},

--- a/packages/core/src/util/renderer.ts
+++ b/packages/core/src/util/renderer.ts
@@ -652,6 +652,7 @@ export interface OwnPropsOfMasterListItem {
   schema: JsonSchema;
   handleSelect(index: number): () => void;
   removeItem(path: string, value: number): () => void;
+  translations: ArrayTranslations;
 }
 
 export interface StatePropsOfMasterItem extends OwnPropsOfMasterListItem {
@@ -686,6 +687,7 @@ export interface ControlWithDetailProps
  */
 export interface StatePropsOfArrayControl
   extends StatePropsOfControlWithDetail {
+  translations: ArrayTranslations;
   childErrors?: ErrorObject[];
 }
 
@@ -700,23 +702,25 @@ export const mapStateToArrayControlProps = (
   state: JsonFormsState,
   ownProps: OwnPropsOfControl
 ): StatePropsOfArrayControl => {
-  const { path, schema, uischema, ...props } = mapStateToControlWithDetailProps(
+  const { path, schema, uischema, i18nKeyPrefix, label, ...props } = mapStateToControlWithDetailProps(
     state,
     ownProps
   );
 
   const resolvedSchema = Resolve.schema(schema, 'items', props.rootSchema);
   const childErrors = getSubErrorsAt(path, resolvedSchema)(state);
-
+  const t = getTranslator()(state);
 
   return {
     ...props,
+    label,
     path,
     uischema,
     schema: resolvedSchema,
     childErrors,
     renderers: ownProps.renderers || getRenderers(state),
     cells: ownProps.cells || getCells(state),
+    translations: getArrayTranslations(t,arrayDefaultTranslations,i18nKeyPrefix, label)
   };
 };
 

--- a/packages/material-renderers/src/additional/ListWithDetailMasterItem.tsx
+++ b/packages/material-renderers/src/additional/ListWithDetailMasterItem.tsx
@@ -35,7 +35,7 @@ import {
 import DeleteIcon from '@mui/icons-material/Delete';
 import React from 'react';
 
-const ListWithDetailMasterItem = ({ index, childLabel, selected, handleSelect, removeItem, path }: StatePropsOfMasterItem) => {
+const ListWithDetailMasterItem = ({ index, childLabel, selected, handleSelect, removeItem, path, translations }: StatePropsOfMasterItem) => {
     return (
         <ListItem
             button
@@ -47,7 +47,7 @@ const ListWithDetailMasterItem = ({ index, childLabel, selected, handleSelect, r
             </ListItemAvatar>
             <ListItemText primary={childLabel} />
             <ListItemSecondaryAction>
-                <IconButton aria-label='Delete' onClick={removeItem(path, index)} size='large'>
+                <IconButton aria-label={translations.removeAriaLabel} onClick={removeItem(path, index)} size='large'>
                     <DeleteIcon />
                 </IconButton>
             </ListItemSecondaryAction>

--- a/packages/material-renderers/src/additional/MaterialListWithDetailRenderer.tsx
+++ b/packages/material-renderers/src/additional/MaterialListWithDetailRenderer.tsx
@@ -130,6 +130,7 @@ export const MaterialListWithDetailRenderer = ({
                   removeItem={handleRemoveItem}
                   selected={selectedIndex === index}
                   key={index}
+                  translations={translations}
                 />
               ))
             ) : (

--- a/packages/material-renderers/src/complex/MaterialTableControl.tsx
+++ b/packages/material-renderers/src/complex/MaterialTableControl.tsx
@@ -260,9 +260,10 @@ interface NonEmptyRowProps {
   enabled: boolean;
   cells?: JsonFormsCellRendererRegistryEntry[];
   path: string;
+  translations: ArrayTranslations
 }
 
-const NonEmptyRowComponent = 
+const NonEmptyRowComponent =
   ({
     childPath,
     schema,
@@ -275,7 +276,8 @@ const NonEmptyRowComponent =
     showSortButtons,
     enabled,
     cells,
-    path
+    path,
+    translations
   }: NonEmptyRowProps & WithDeleteDialogSupport) => {
     const moveUp = useMemo(() => moveUpCreator(path, rowIndex),[moveUpCreator, path, rowIndex]);
     const moveDown = useMemo(() => moveDownCreator(path, rowIndex),[moveDownCreator, path, rowIndex]);
@@ -295,13 +297,13 @@ const NonEmptyRowComponent =
               {showSortButtons ? (
                 <Fragment>
                   <Grid item>
-                    <IconButton aria-label={`Move up`} onClick={moveUp} disabled={!enableUp} size='large'>
+                    <IconButton aria-label={translations.upAriaLabel} onClick={moveUp} disabled={!enableUp} size='large'>
                       <ArrowUpward />
                     </IconButton>
                   </Grid>
                   <Grid item>
                     <IconButton
-                      aria-label={`Move down`}
+                      aria-label={translations.downAriaLabel}
                       onClick={moveDown}
                       disabled={!enableDown}
                       size='large'>
@@ -312,7 +314,7 @@ const NonEmptyRowComponent =
               ) : null}
               <Grid item>
                 <IconButton
-                  aria-label={`Delete`}
+                  aria-label={translations.removeAriaLabel}
                   onClick={() => openDeleteDialog(childPath, rowIndex)}
                   size='large'>
                   <DeleteIcon />
@@ -378,6 +380,7 @@ const TableRows = ({
             enabled={enabled}
             cells={cells}
             path={path}
+            translations={translations}
           />
         );
       })}

--- a/packages/material-renderers/src/complex/TableToolbar.tsx
+++ b/packages/material-renderers/src/complex/TableToolbar.tsx
@@ -99,7 +99,7 @@ const TableToolbar = React.memo(
             placement='bottom'
           >
             <IconButton
-              aria-label={translations.addTooltip}
+              aria-label={translations.addAriaLabel}
               onClick={addItem(path, createDefaultValue(schema))}
               size='large'>
               <AddIcon />

--- a/packages/material-renderers/src/layouts/ArrayToolbar.tsx
+++ b/packages/material-renderers/src/layouts/ArrayToolbar.tsx
@@ -46,7 +46,7 @@ export const ArrayLayoutToolbar = React.memo(
                   placement='bottom'
                 >
                   <IconButton
-                    aria-label={translations.addTooltip}
+                    aria-label={translations.addAriaLabel}
                     onClick={addItem(path, createDefault())}
                     size='large'>
                     <AddIcon />

--- a/packages/material-renderers/src/layouts/ExpandPanelRenderer.tsx
+++ b/packages/material-renderers/src/layouts/ExpandPanelRenderer.tsx
@@ -20,7 +20,8 @@ import {
   JsonFormsUISchemaRegistryEntry,
   getFirstPrimitiveProp,
   createId,
-  removeId
+  removeId,
+  ArrayTranslations
 } from '@jsonforms/core';
 import {
   Accordion,
@@ -53,6 +54,7 @@ interface OwnPropsOfExpandPanel {
   config: any;
   childLabelProp?: string;
   handleExpansion(panel: string): (event: any, expanded: boolean) => void;
+  translations: ArrayTranslations;
 }
 
 interface StatePropsOfExpandPanel extends OwnPropsOfExpandPanel {
@@ -103,7 +105,8 @@ const ExpandPanelRendererComponent = (props: ExpandPanelProps) => {
     uischemas,
     renderers,
     cells,
-    config
+    config,
+    translations
   } = props;
 
   const foundUISchema = useMemo(
@@ -157,7 +160,7 @@ const ExpandPanelRendererComponent = (props: ExpandPanelProps) => {
                           onClick={moveUp(path, index)}
                           style={iconStyle}
                           disabled={!enableMoveUp}
-                          aria-label={`Move up`}
+                          aria-label={translations.upAriaLabel}
                           size='large'>
                           <ArrowUpward />
                         </IconButton>
@@ -167,7 +170,7 @@ const ExpandPanelRendererComponent = (props: ExpandPanelProps) => {
                           onClick={moveDown(path, index)}
                           style={iconStyle}
                           disabled={!enableMoveDown}
-                          aria-label={`Move down`}
+                          aria-label={translations.downAriaLabel}
                           size='large'>
                           <ArrowDownward />
                         </IconButton>
@@ -180,7 +183,7 @@ const ExpandPanelRendererComponent = (props: ExpandPanelProps) => {
                     <IconButton
                       onClick={removeItems(path, [index])}
                       style={iconStyle}
-                      aria-label={`Delete`}
+                      aria-label={translations.removeAriaLabel}
                       size='large'>
                       <DeleteIcon />
                     </IconButton>

--- a/packages/material-renderers/src/layouts/MaterialArrayLayout.tsx
+++ b/packages/material-renderers/src/layouts/MaterialArrayLayout.tsx
@@ -102,6 +102,7 @@ const MaterialArrayLayoutComponent = (props: ArrayLayoutProps)=> {
                 config={config}
                 childLabelProp={appliedUiSchemaOptions.elementLabelProp}
                 uischemas={uischemas}
+                translations={translations}
               />
             );
           })

--- a/packages/material-renderers/test/renderers/MaterialArrayControl.test.tsx
+++ b/packages/material-renderers/test/renderers/MaterialArrayControl.test.tsx
@@ -487,11 +487,11 @@ describe('Material array control', () => {
     );
     // up button
     expect(
-      wrapper.find('button').find({ 'aria-label': 'Move up' }).length
+      wrapper.find('button').find({ 'aria-label': 'Move item up' }).length
     ).toBe(1);
     // down button
     expect(
-      wrapper.find('button').find({ 'aria-label': 'Move down' }).length
+      wrapper.find('button').find({ 'aria-label': 'Move item down' }).length
     ).toBe(1);
   });
   it('should be able to move item down if down button is clicked', () => {
@@ -517,7 +517,7 @@ describe('Material array control', () => {
       .find('tr')
       .at(1)
       .find('button')
-      .find({ 'aria-label': 'Move down' });
+      .find({ 'aria-label': 'Move item down' });
     downButton.simulate('click');
     expect(onChangeData.data).toEqual({
       test: ['baz', 'foo', 'bar']
@@ -546,7 +546,7 @@ describe('Material array control', () => {
       .find('tr')
       .at(3)
       .find('button')
-      .find({ 'aria-label': 'Move up' });
+      .find({ 'aria-label': 'Move item up' });
     upButton.simulate('click');
     expect(onChangeData.data).toEqual({
       test: ['foo', 'bar', 'baz']
@@ -567,7 +567,7 @@ describe('Material array control', () => {
       .find('tr')
       .at(1)
       .find('button')
-      .find({ 'aria-label': 'Move up' });
+      .find({ 'aria-label': 'Move item up' });
     expect(upButton.is('[disabled]')).toBe(true);
   });
 
@@ -627,7 +627,7 @@ describe('Material array control', () => {
       .find('tr')
       .at(3)
       .find('button')
-      .find({ 'aria-label': 'Move down' });
+      .find({ 'aria-label': 'Move item down' });
     expect(downButton.is('[disabled]')).toBe(true);
   });
 });

--- a/packages/material-renderers/test/renderers/MaterialArrayLayout.test.tsx
+++ b/packages/material-renderers/test/renderers/MaterialArrayLayout.test.tsx
@@ -322,7 +322,7 @@ describe('Material array layout', () => {
         .find('Memo(ExpandPanelRendererComponent)')
         .at(0)
         .find('button')
-        .find({ 'aria-label': 'Move up' }).length
+        .find({ 'aria-label': 'Move item up' }).length
     ).toBe(1);
     // down button
     expect(
@@ -330,7 +330,7 @@ describe('Material array layout', () => {
         .find('Memo(ExpandPanelRendererComponent)')
         .at(0)
         .find('button')
-        .find({ 'aria-label': 'Move down' }).length
+        .find({ 'aria-label': 'Move item down' }).length
     ).toBe(1);
   });
   it('should render sort buttons if showSortButtons is true in config', () => {
@@ -352,7 +352,7 @@ describe('Material array layout', () => {
         .find('Memo(ExpandPanelRendererComponent)')
         .at(0)
         .find('button')
-        .find({ 'aria-label': 'Move up' }).length
+        .find({ 'aria-label': 'Move item up' }).length
     ).toBe(1);
     // down button
     expect(
@@ -360,7 +360,7 @@ describe('Material array layout', () => {
         .find('Memo(ExpandPanelRendererComponent)')
         .at(0)
         .find('button')
-        .find({ 'aria-label': 'Move down' }).length
+        .find({ 'aria-label': 'Move item down' }).length
     ).toBe(1);
   });
   it('should move item up if up button is presses', (done) => {
@@ -387,7 +387,7 @@ describe('Material array layout', () => {
       .find('Memo(ExpandPanelRendererComponent)')
       .at(1)
       .find('button')
-      .find({ 'aria-label': 'Move up' });
+      .find({ 'aria-label': 'Move item up' });
     upButton.simulate('click');
     // events are debounced for some time, so let's wait
     setTimeout(() => {
@@ -428,7 +428,7 @@ describe('Material array layout', () => {
       .find('Memo(ExpandPanelRendererComponent)')
       .at(0)
       .find('button')
-      .find({ 'aria-label': 'Move down' });
+      .find({ 'aria-label': 'Move item down' });
     upButton.simulate('click');
     // events are debounced for some time, so let's wait
     setTimeout(() => {
@@ -462,7 +462,7 @@ describe('Material array layout', () => {
       .find('Memo(ExpandPanelRendererComponent)')
       .at(0)
       .find('button')
-      .find({ 'aria-label': 'Move up' });
+      .find({ 'aria-label': 'Move item up' });
     expect(upButton.is('[disabled]')).toBe(true);
   });
   it('should have down button disabled for last element', () => {
@@ -482,7 +482,7 @@ describe('Material array layout', () => {
       .find('Memo(ExpandPanelRendererComponent)')
       .at(1)
       .find('button')
-      .find({ 'aria-label': 'Move down' });
+      .find({ 'aria-label': 'Move item down' });
     expect(downButton.is('[disabled]')).toBe(true);
   });
 

--- a/packages/vanilla-renderers/src/complex/TableArrayControl.tsx
+++ b/packages/vanilla-renderers/src/complex/TableArrayControl.tsx
@@ -46,7 +46,7 @@ import { DispatchCell, withJsonFormsArrayControlProps } from '@jsonforms/react';
 import { withVanillaControlProps } from '../util';
 import type { VanillaRendererProps } from '../index';
 
-const { createLabelDescriptionFrom, convertToValidClassName } = Helpers;
+const { convertToValidClassName } = Helpers;
 
 const { or, isObjectArrayControl, isPrimitiveArrayControl, rankWith } = Test;
 
@@ -79,7 +79,8 @@ class TableArrayControl extends React.Component<ArrayControlProps & VanillaRende
       errors,
       label,
       getStyleAsClassName,
-      childErrors
+      childErrors,
+      translations
     } = this.props;
 
     const controlElement = uischema as ControlElement;
@@ -96,7 +97,6 @@ class TableArrayControl extends React.Component<ArrayControlProps & VanillaRende
       label: false,
       scope: schema.type === 'object' ? `#/properties/${key}` : '#'
     });
-    const labelObject = createLabelDescriptionFrom(controlElement, schema);
     const isValid = errors.length === 0;
     const divClassNames = [validationClass]
       .concat(isValid ? '' : getStyleAsClassName('array.table.validation.error'))
@@ -110,7 +110,7 @@ class TableArrayControl extends React.Component<ArrayControlProps & VanillaRende
             className={buttonClass}
             onClick={addItem(path, createDefaultValue(schema))}
           >
-            Add to {labelObject.text}
+            {translations.addTooltip}
           </button>
         </header>
         <div className={divClassNames}>
@@ -135,7 +135,7 @@ class TableArrayControl extends React.Component<ArrayControlProps & VanillaRende
           <tbody>
             {!data || !Array.isArray(data) || data.length === 0 ? (
               <tr>
-                <td>No data</td>
+                <td>{translations.noDataMessage}</td>
               </tr>
             ) : (
                 data.map((_child, index) => {
@@ -205,14 +205,14 @@ class TableArrayControl extends React.Component<ArrayControlProps & VanillaRende
                       </td>
                       <td>
                         <button
-                          aria-label={`Delete`}
+                          aria-label={translations.removeAriaLabel}
                           onClick={() => {
-                            if (window.confirm('Are you sure you wish to delete this item?')) {
+                            if (window.confirm(translations.deleteDialogMessage)) {
                               this.confirmDelete(childPath, index);
                             }
                           }}
                         >
-                          Delete
+                          {translations.removeTooltip}
                         </button>
                       </td>
                     </tr>

--- a/packages/vanilla-renderers/src/complex/array/ArrayControlRenderer.tsx
+++ b/packages/vanilla-renderers/src/complex/array/ArrayControlRenderer.tsx
@@ -46,7 +46,8 @@ export const ArrayControl = ({
   uischemas,
   getStyleAsClassName,
   renderers,
-  rootSchema
+  rootSchema,
+  translations
 }: ArrayControlProps & VanillaRendererProps) => {
 	
   const controlElement = uischema as ControlElement;
@@ -99,30 +100,30 @@ export const ArrayControl = ({
                 <div className={childControlsClass}>
                   <button
                     className={buttonClassUp}
-              	    aria-label={`Up`}
+              	    aria-label={translations.upAriaLabel}
                     onClick={() => {
                       moveUp(path,index)();
-                  }}>Up</button>
+                  }}>{translations.up}</button>
                   <button
                     className={buttonClassDown}
-                    aria-label={`Down`}
+                    aria-label={translations.downAriaLabel}
                     onClick={() => {
                       moveDown(path,index)();
-                  }}>Down</button>
+                  }}>{translations.down}</button>
                   <button
                     className={buttonClassDelete}
-                    aria-label={`Delete`}
+                    aria-label={translations.removeAriaLabel}
                     onClick={() => {
                       if (window.confirm('Are you sure you wish to delete this item?')) {
                         removeItems(path,[index])();
                       }
-                  }}>Delete</button>
+                  }}>{translations.removeTooltip}</button>
                 </div>
               </div>
             );
           })
         ) : (
-            <p>No data</p>
+            <p>{translations.noDataMessage}</p>
         )}
       </div>
     </div>
@@ -147,7 +148,8 @@ export const ArrayControlRenderer =
         id,
         visible,
         enabled,
-        errors
+        errors,
+        translations
     }: ArrayControlProps & VanillaRendererProps) => {
         const controlElement = uischema as ControlElement;
         const labelDescription = Helpers.createLabelDescriptionFrom(controlElement, schema);
@@ -184,6 +186,7 @@ export const ArrayControlRenderer =
                 visible={visible}
                 enabled={enabled}
                 getStyle={getStyle}
+                translations={translations}
             />
         );
     };

--- a/packages/vanilla-renderers/test/renderers/TableArrayControl.test.tsx
+++ b/packages/vanilla-renderers/test/renderers/TableArrayControl.test.tsx
@@ -286,7 +286,7 @@ describe('Table array control', () => {
 
     const button = legendChildren.item(1);
     expect(button.tagName).toBe('BUTTON');
-    expect(button.textContent).toBe('Add to Test');
+    expect(button.textContent).toBe('Add');
 
     const table = wrapper.find('table').getDOMNode();
     const tableChildren = table.children;

--- a/packages/vue/vue-vanilla/src/array/ArrayListRenderer.vue
+++ b/packages/vue/vue-vanilla/src/array/ArrayListRenderer.vue
@@ -37,7 +37,7 @@
       </array-list-element>
     </div>
     <div v-if="noData" :class="styles.arrayList.noData">
-      No data
+      {{control.translations.noDataMessage}}
     </div>
   </fieldset>
 </template>


### PR DESCRIPTION
Add translation-options for array-control elements for the vanilla, angular-material and vue renderers.

closes #1826