### PR TITLE
Export all unwrapped React Material renderers

### DIFF
--- a/packages/material-renderers/src/additional/index.ts
+++ b/packages/material-renderers/src/additional/index.ts
@@ -25,8 +25,16 @@
 import MaterialLabelRenderer, {
   materialLabelRendererTester,
 } from './MaterialLabelRenderer';
-export { MaterialLabelRenderer, materialLabelRendererTester };
+
 import MaterialListWithDetailRenderer, {
   materialListWithDetailTester,
 } from './MaterialListWithDetailRenderer';
-export { MaterialListWithDetailRenderer, materialListWithDetailTester };
+
+export {
+  MaterialLabelRenderer,
+  materialLabelRendererTester,
+  MaterialListWithDetailRenderer,
+  materialListWithDetailTester,
+};
+
+export * from './ListWithDetailMasterItem';

--- a/packages/material-renderers/src/additional/unwrapped.ts
+++ b/packages/material-renderers/src/additional/unwrapped.ts
@@ -22,45 +22,11 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import type { StatePropsOfMasterItem } from '@jsonforms/core';
-import { withJsonFormsMasterListItemProps } from '@jsonforms/react';
-import {
-  Avatar,
-  IconButton,
-  ListItem,
-  ListItemAvatar,
-  ListItemSecondaryAction,
-  ListItemText,
-} from '@mui/material';
-import DeleteIcon from '@mui/icons-material/Delete';
-import React from 'react';
+import { MaterialLabelRenderer } from './MaterialLabelRenderer';
 
-export const ListWithDetailMasterItem = ({
-  index,
-  childLabel,
-  selected,
-  handleSelect,
-  removeItem,
-  path,
-  translations,
-}: StatePropsOfMasterItem) => {
-  return (
-    <ListItem button selected={selected} onClick={handleSelect(index)}>
-      <ListItemAvatar>
-        <Avatar aria-label='Index'>{index + 1}</Avatar>
-      </ListItemAvatar>
-      <ListItemText primary={childLabel} />
-      <ListItemSecondaryAction>
-        <IconButton
-          aria-label={translations.removeAriaLabel}
-          onClick={removeItem(path, index)}
-          size='large'
-        >
-          <DeleteIcon />
-        </IconButton>
-      </ListItemSecondaryAction>
-    </ListItem>
-  );
+import { MaterialListWithDetailRenderer } from './MaterialListWithDetailRenderer';
+
+export const UnwrappedAdditional = {
+  MaterialLabelRenderer,
+  MaterialListWithDetailRenderer,
 };
-
-export default withJsonFormsMasterListItemProps(ListWithDetailMasterItem);

--- a/packages/material-renderers/src/complex/CombinatorProperties.tsx
+++ b/packages/material-renderers/src/complex/CombinatorProperties.tsx
@@ -23,7 +23,12 @@
   THE SOFTWARE.
 */
 import React from 'react';
-import { Generate, JsonSchema, Layout, UISchemaElement } from '@jsonforms/core';
+import {
+  Generate,
+  JsonSchema,
+  UISchemaElement,
+  isLayout,
+} from '@jsonforms/core';
 import { JsonFormsDispatch } from '@jsonforms/react';
 import omit from 'lodash/omit';
 
@@ -32,9 +37,6 @@ interface CombinatorPropertiesProps {
   combinatorKeyword: 'oneOf' | 'anyOf';
   path: string;
 }
-
-export const isLayout = (uischema: UISchemaElement): uischema is Layout =>
-  uischema.hasOwnProperty('elements');
 
 export class CombinatorProperties extends React.Component<
   CombinatorPropertiesProps,

--- a/packages/material-renderers/src/complex/MaterialArrayControlRenderer.tsx
+++ b/packages/material-renderers/src/complex/MaterialArrayControlRenderer.tsx
@@ -23,7 +23,14 @@
   THE SOFTWARE.
 */
 import React, { useCallback, useState } from 'react';
-import { ArrayLayoutProps } from '@jsonforms/core';
+import {
+  ArrayLayoutProps,
+  RankedTester,
+  isObjectArrayControl,
+  isPrimitiveArrayControl,
+  or,
+  rankWith,
+} from '@jsonforms/core';
 import { withJsonFormsArrayLayoutProps } from '@jsonforms/react';
 import { MaterialTableControl } from './MaterialTableControl';
 import { Hidden } from '@mui/material';
@@ -67,5 +74,10 @@ export const MaterialArrayControlRenderer = (props: ArrayLayoutProps) => {
     </Hidden>
   );
 };
+
+export const materialArrayControlTester: RankedTester = rankWith(
+  3,
+  or(isObjectArrayControl, isPrimitiveArrayControl)
+);
 
 export default withJsonFormsArrayLayoutProps(MaterialArrayControlRenderer);

--- a/packages/material-renderers/src/complex/index.ts
+++ b/packages/material-renderers/src/complex/index.ts
@@ -22,42 +22,45 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import {
-  isObjectArrayControl,
-  isPrimitiveArrayControl,
-  or,
-  RankedTester,
-  rankWith,
-} from '@jsonforms/core';
-import MaterialArrayControlRenderer from './MaterialArrayControlRenderer';
-import MaterialObjectRenderer, {
-  materialObjectControlTester,
-} from './MaterialObjectRenderer';
 import MaterialAllOfRenderer, {
   materialAllOfControlTester,
 } from './MaterialAllOfRenderer';
 import MaterialAnyOfRenderer, {
   materialAnyOfControlTester,
 } from './MaterialAnyOfRenderer';
-import MaterialOneOfRenderer, {
-  materialOneOfControlTester,
-} from './MaterialOneOfRenderer';
+import MaterialArrayControlRenderer, {
+  materialArrayControlTester,
+} from './MaterialArrayControlRenderer';
 import MaterialEnumArrayRenderer, {
   materialEnumArrayRendererTester,
 } from './MaterialEnumArrayRenderer';
+import MaterialObjectRenderer, {
+  materialObjectControlTester,
+} from './MaterialObjectRenderer';
+import MaterialOneOfRenderer, {
+  materialOneOfControlTester,
+} from './MaterialOneOfRenderer';
 
-export const materialArrayControlTester: RankedTester = rankWith(
-  3,
-  or(isObjectArrayControl, isPrimitiveArrayControl)
-);
-export { MaterialArrayControlRenderer };
-export { MaterialObjectRenderer };
-export { MaterialAllOfRenderer };
-export { MaterialAnyOfRenderer };
-export { MaterialOneOfRenderer };
-export { MaterialEnumArrayRenderer };
-export { materialObjectControlTester };
-export { materialAllOfControlTester };
-export { materialAnyOfControlTester };
-export { materialOneOfControlTester };
-export { materialEnumArrayRendererTester };
+export {
+  materialAllOfControlTester,
+  MaterialAllOfRenderer,
+  materialAnyOfControlTester,
+  MaterialAnyOfRenderer,
+  materialArrayControlTester,
+  MaterialArrayControlRenderer,
+  materialEnumArrayRendererTester,
+  MaterialEnumArrayRenderer,
+  materialObjectControlTester,
+  MaterialObjectRenderer,
+  materialOneOfControlTester,
+  MaterialOneOfRenderer,
+};
+
+export * from './CombinatorProperties';
+export * from './DeleteDialog';
+export * from './MaterialTableControl';
+export * from './TableToolbar';
+export * from './ValidationIcon';
+
+import NoBorderTableCell from './NoBorderTableCell';
+export { NoBorderTableCell };

--- a/packages/material-renderers/src/complex/unwrapped.ts
+++ b/packages/material-renderers/src/complex/unwrapped.ts
@@ -1,19 +1,19 @@
 /*
   The MIT License
-
+  
   Copyright (c) 2017-2019 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
-
+  
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
-
+  
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
-
+  
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,45 +22,18 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import type { StatePropsOfMasterItem } from '@jsonforms/core';
-import { withJsonFormsMasterListItemProps } from '@jsonforms/react';
-import {
-  Avatar,
-  IconButton,
-  ListItem,
-  ListItemAvatar,
-  ListItemSecondaryAction,
-  ListItemText,
-} from '@mui/material';
-import DeleteIcon from '@mui/icons-material/Delete';
-import React from 'react';
+import { MaterialAllOfRenderer } from './MaterialAllOfRenderer';
+import { MaterialAnyOfRenderer } from './MaterialAnyOfRenderer';
+import { MaterialArrayControlRenderer } from './MaterialArrayControlRenderer';
+import { MaterialEnumArrayRenderer } from './MaterialEnumArrayRenderer';
+import { MaterialObjectRenderer } from './MaterialObjectRenderer';
+import { MaterialOneOfRenderer } from './MaterialOneOfRenderer';
 
-export const ListWithDetailMasterItem = ({
-  index,
-  childLabel,
-  selected,
-  handleSelect,
-  removeItem,
-  path,
-  translations,
-}: StatePropsOfMasterItem) => {
-  return (
-    <ListItem button selected={selected} onClick={handleSelect(index)}>
-      <ListItemAvatar>
-        <Avatar aria-label='Index'>{index + 1}</Avatar>
-      </ListItemAvatar>
-      <ListItemText primary={childLabel} />
-      <ListItemSecondaryAction>
-        <IconButton
-          aria-label={translations.removeAriaLabel}
-          onClick={removeItem(path, index)}
-          size='large'
-        >
-          <DeleteIcon />
-        </IconButton>
-      </ListItemSecondaryAction>
-    </ListItem>
-  );
+export const UnwrappedComplex = {
+  MaterialAllOfRenderer,
+  MaterialAnyOfRenderer,
+  MaterialArrayControlRenderer,
+  MaterialEnumArrayRenderer,
+  MaterialObjectRenderer,
+  MaterialOneOfRenderer,
 };
-
-export default withJsonFormsMasterListItemProps(ListWithDetailMasterItem);

--- a/packages/material-renderers/src/controls/index.ts
+++ b/packages/material-renderers/src/controls/index.ts
@@ -22,119 +22,83 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
+import MaterialAnyOfStringOrEnumControl, {
+  materialAnyOfStringOrEnumControlTester,
+} from './MaterialAnyOfStringOrEnumControl';
 import MaterialBooleanControl, {
   materialBooleanControlTester,
-  MaterialBooleanControl as MaterialBooleanControlUnwrapped,
 } from './MaterialBooleanControl';
 import MaterialBooleanToggleControl, {
   materialBooleanToggleControlTester,
-  MaterialBooleanToggleControl as MaterialBooleanToggleControlUnwrapped,
 } from './MaterialBooleanToggleControl';
-import MaterialEnumControl, {
-  materialEnumControlTester,
-  MaterialEnumControl as MaterialEnumControlUnwrapped,
-} from './MaterialEnumControl';
-import MaterialNativeControl, {
-  materialNativeControlTester,
-  MaterialNativeControl as MaterialNativeControlUnwrapped,
-} from './MaterialNativeControl';
 import MaterialDateControl, {
   materialDateControlTester,
-  MaterialDateControl as MaterialDateControlUnwrapped,
 } from './MaterialDateControl';
 import MaterialDateTimeControl, {
   materialDateTimeControlTester,
-  MaterialDateTimeControl as MaterialDateTimeControlUnwrapped,
 } from './MaterialDateTimeControl';
-import MaterialTimeControl, {
-  materialTimeControlTester,
-  MaterialTimeControl as MaterialTimeControlUnwrapped,
-} from './MaterialTimeControl';
-import MaterialSliderControl, {
-  materialSliderControlTester,
-  MaterialSliderControl as MaterialSliderControlUnwrapped,
-} from './MaterialSliderControl';
-import MaterialRadioGroupControl, {
-  materialRadioGroupControlTester,
-  MaterialRadioGroupControl as MaterialRadioGroupControlUnwrapped,
-} from './MaterialRadioGroupControl';
+import MaterialEnumControl, {
+  materialEnumControlTester,
+} from './MaterialEnumControl';
 import MaterialIntegerControl, {
   materialIntegerControlTester,
-  MaterialIntegerControl as MaterialIntegerControlUnwrapped,
 } from './MaterialIntegerControl';
+import MaterialNativeControl, {
+  materialNativeControlTester,
+} from './MaterialNativeControl';
 import MaterialNumberControl, {
   materialNumberControlTester,
-  MaterialNumberControl as MaterialNumberControlUnwrapped,
 } from './MaterialNumberControl';
-import MaterialTextControl, {
-  materialTextControlTester,
-  MaterialTextControl as MaterialTextControlUnwrapped,
-} from './MaterialTextControl';
-
-import MaterialAnyOfStringOrEnumControl, {
-  materialAnyOfStringOrEnumControlTester,
-  MaterialAnyOfStringOrEnumControl as MaterialAnyOfStringOrEnumControlUnwrapped,
-} from './MaterialAnyOfStringOrEnumControl';
-
 import MaterialOneOfEnumControl, {
   materialOneOfEnumControlTester,
-  MaterialOneOfEnumControl as MaterialOneOfEnumControlUnwrapped,
 } from './MaterialOneOfEnumControl';
-
 import MaterialOneOfRadioGroupControl, {
   materialOneOfRadioGroupControlTester,
-  MaterialOneOfRadioGroupControl as MaterialOneOfRadioGroupControlUnwrapped,
 } from './MaterialOneOfRadioGroupControl';
-
-export const Unwrapped = {
-  MaterialBooleanControl: MaterialBooleanControlUnwrapped,
-  MaterialBooleanToggleControl: MaterialBooleanToggleControlUnwrapped,
-  MaterialEnumControl: MaterialEnumControlUnwrapped,
-  MaterialNativeControl: MaterialNativeControlUnwrapped,
-  MaterialDateControl: MaterialDateControlUnwrapped,
-  MaterialDateTimeControl: MaterialDateTimeControlUnwrapped,
-  MaterialTimeControl: MaterialTimeControlUnwrapped,
-  MaterialSliderControl: MaterialSliderControlUnwrapped,
-  MaterialRadioGroupControl: MaterialRadioGroupControlUnwrapped,
-  MaterialIntegerControl: MaterialIntegerControlUnwrapped,
-  MaterialNumberControl: MaterialNumberControlUnwrapped,
-  MaterialTextControl: MaterialTextControlUnwrapped,
-  MaterialAnyOfStringOrEnumControl: MaterialAnyOfStringOrEnumControlUnwrapped,
-  MaterialOneOfEnumControl: MaterialOneOfEnumControlUnwrapped,
-  MaterialOneOfRadioGroupControl: MaterialOneOfRadioGroupControlUnwrapped,
-};
+import MaterialRadioGroupControl, {
+  materialRadioGroupControlTester,
+} from './MaterialRadioGroupControl';
+import MaterialSliderControl, {
+  materialSliderControlTester,
+} from './MaterialSliderControl';
+import MaterialTextControl, {
+  materialTextControlTester,
+} from './MaterialTextControl';
+import MaterialTimeControl, {
+  materialTimeControlTester,
+} from './MaterialTimeControl';
 
 export {
+  MaterialAnyOfStringOrEnumControl,
+  materialAnyOfStringOrEnumControlTester,
   MaterialBooleanControl,
   materialBooleanControlTester,
   MaterialBooleanToggleControl,
   materialBooleanToggleControlTester,
-  MaterialEnumControl,
-  materialEnumControlTester,
-  MaterialNativeControl,
-  materialNativeControlTester,
   MaterialDateControl,
   materialDateControlTester,
   MaterialDateTimeControl,
   materialDateTimeControlTester,
-  MaterialTimeControl,
-  materialTimeControlTester,
-  MaterialSliderControl,
-  materialSliderControlTester,
-  MaterialRadioGroupControl,
-  materialRadioGroupControlTester,
+  MaterialEnumControl,
+  materialEnumControlTester,
   MaterialIntegerControl,
   materialIntegerControlTester,
+  MaterialNativeControl,
+  materialNativeControlTester,
   MaterialNumberControl,
   materialNumberControlTester,
-  MaterialTextControl,
-  materialTextControlTester,
-  MaterialAnyOfStringOrEnumControl,
-  materialAnyOfStringOrEnumControlTester,
   MaterialOneOfEnumControl,
   materialOneOfEnumControlTester,
   MaterialOneOfRadioGroupControl,
   materialOneOfRadioGroupControlTester,
+  MaterialRadioGroupControl,
+  materialRadioGroupControlTester,
+  MaterialSliderControl,
+  materialSliderControlTester,
+  MaterialTextControl,
+  materialTextControlTester,
+  MaterialTimeControl,
+  materialTimeControlTester,
 };
 
 export * from './MaterialInputControl';

--- a/packages/material-renderers/src/controls/unwrapped.ts
+++ b/packages/material-renderers/src/controls/unwrapped.ts
@@ -1,0 +1,57 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import { MaterialAnyOfStringOrEnumControl } from './MaterialAnyOfStringOrEnumControl';
+import { MaterialBooleanControl } from './MaterialBooleanControl';
+import { MaterialBooleanToggleControl } from './MaterialBooleanToggleControl';
+import { MaterialDateControl } from './MaterialDateControl';
+import { MaterialDateTimeControl } from './MaterialDateTimeControl';
+import { MaterialEnumControl } from './MaterialEnumControl';
+import { MaterialIntegerControl } from './MaterialIntegerControl';
+import { MaterialNativeControl } from './MaterialNativeControl';
+import { MaterialNumberControl } from './MaterialNumberControl';
+import { MaterialOneOfEnumControl } from './MaterialOneOfEnumControl';
+import { MaterialOneOfRadioGroupControl } from './MaterialOneOfRadioGroupControl';
+import { MaterialRadioGroupControl } from './MaterialRadioGroupControl';
+import { MaterialSliderControl } from './MaterialSliderControl';
+import { MaterialTextControl } from './MaterialTextControl';
+import { MaterialTimeControl } from './MaterialTimeControl';
+
+export const UnwrappedControls = {
+  MaterialAnyOfStringOrEnumControl,
+  MaterialBooleanControl,
+  MaterialBooleanToggleControl,
+  MaterialDateControl,
+  MaterialDateTimeControl,
+  MaterialEnumControl,
+  MaterialIntegerControl,
+  MaterialNativeControl,
+  MaterialNumberControl,
+  MaterialOneOfEnumControl,
+  MaterialOneOfRadioGroupControl,
+  MaterialSliderControl,
+  MaterialRadioGroupControl,
+  MaterialTextControl,
+  MaterialTimeControl,
+};

--- a/packages/material-renderers/src/index.ts
+++ b/packages/material-renderers/src/index.ts
@@ -116,10 +116,11 @@ import MaterialCategorizationStepperLayout, {
   materialCategorizationStepperTester,
 } from './layouts/MaterialCategorizationStepperLayout';
 
+export * from './additional';
+export * from './cells';
 export * from './complex';
 export * from './controls';
 export * from './layouts';
-export * from './cells';
 export * from './mui-controls';
 export * from './util';
 
@@ -203,3 +204,15 @@ export const materialCells: JsonFormsCellRendererRegistryEntry[] = [
   { tester: materialTextCellTester, cell: MaterialTextCell },
   { tester: materialTimeCellTester, cell: MaterialTimeCell },
 ];
+
+import { UnwrappedAdditional } from './additional/unwrapped';
+import { UnwrappedComplex } from './complex/unwrapped';
+import { UnwrappedControls } from './controls/unwrapped';
+import { UnwrappedLayouts } from './layouts/unwrapped';
+
+export const Unwrapped = {
+  ...UnwrappedAdditional,
+  ...UnwrappedComplex,
+  ...UnwrappedControls,
+  ...UnwrappedLayouts,
+};

--- a/packages/material-renderers/src/layouts/ExpandPanelRenderer.tsx
+++ b/packages/material-renderers/src/layouts/ExpandPanelRenderer.tsx
@@ -223,7 +223,7 @@ const ExpandPanelRendererComponent = (props: ExpandPanelProps) => {
   );
 };
 
-const ExpandPanelRenderer = React.memo(ExpandPanelRendererComponent);
+export const ExpandPanelRenderer = React.memo(ExpandPanelRendererComponent);
 
 /**
  * Maps state to dispatch properties of an expand pandel control.

--- a/packages/material-renderers/src/layouts/index.ts
+++ b/packages/material-renderers/src/layouts/index.ts
@@ -22,6 +22,11 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
+import ExpandPanelRenderer, {
+  ctxDispatchToExpandPanelProps,
+  withContextToExpandPanelProps,
+  withJsonFormsExpandPanelProps,
+} from './ExpandPanelRenderer';
 import MaterialGroupLayout, {
   materialGroupTester,
 } from './MaterialGroupLayout';
@@ -39,8 +44,12 @@ import MaterialArrayLayout, {
 } from './MaterialArrayLayoutRenderer';
 
 export {
-  materialArrayLayoutTester,
+  ExpandPanelRenderer,
+  ctxDispatchToExpandPanelProps,
+  withContextToExpandPanelProps,
+  withJsonFormsExpandPanelProps,
   MaterialArrayLayout,
+  materialArrayLayoutTester,
   MaterialCategorizationLayout,
   materialCategorizationTester,
   MaterialGroupLayout,
@@ -50,3 +59,5 @@ export {
   MaterialVerticalLayout,
   materialVerticalLayoutTester,
 };
+
+export * from './ArrayToolbar';

--- a/packages/material-renderers/src/layouts/unwrapped.ts
+++ b/packages/material-renderers/src/layouts/unwrapped.ts
@@ -1,19 +1,19 @@
 /*
   The MIT License
-
+  
   Copyright (c) 2017-2019 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
-
+  
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
-
+  
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
-
+  
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,45 +22,20 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import type { StatePropsOfMasterItem } from '@jsonforms/core';
-import { withJsonFormsMasterListItemProps } from '@jsonforms/react';
-import {
-  Avatar,
-  IconButton,
-  ListItem,
-  ListItemAvatar,
-  ListItemSecondaryAction,
-  ListItemText,
-} from '@mui/material';
-import DeleteIcon from '@mui/icons-material/Delete';
-import React from 'react';
+import { ExpandPanelRenderer as ExpandPanelRendererUnwrapped } from './ExpandPanelRenderer';
+import { MaterializedGroupLayoutRenderer } from './MaterialGroupLayout';
+import { MaterialHorizontalLayoutRenderer } from './MaterialHorizontalLayout';
+import { MaterialVerticalLayoutRenderer } from './MaterialVerticalLayout';
+import { MaterialCategorizationLayoutRenderer } from './MaterialCategorizationLayout';
+import { MaterialArrayLayoutRenderer } from './MaterialArrayLayoutRenderer';
 
-export const ListWithDetailMasterItem = ({
-  index,
-  childLabel,
-  selected,
-  handleSelect,
-  removeItem,
-  path,
-  translations,
-}: StatePropsOfMasterItem) => {
-  return (
-    <ListItem button selected={selected} onClick={handleSelect(index)}>
-      <ListItemAvatar>
-        <Avatar aria-label='Index'>{index + 1}</Avatar>
-      </ListItemAvatar>
-      <ListItemText primary={childLabel} />
-      <ListItemSecondaryAction>
-        <IconButton
-          aria-label={translations.removeAriaLabel}
-          onClick={removeItem(path, index)}
-          size='large'
-        >
-          <DeleteIcon />
-        </IconButton>
-      </ListItemSecondaryAction>
-    </ListItem>
-  );
+export const UnwrappedLayouts = {
+  ExpandPanelRenderer: ExpandPanelRendererUnwrapped,
+  MaterialArrayLayout: MaterialArrayLayoutRenderer,
+  MaterialCategorizationLayout: MaterialCategorizationLayoutRenderer,
+  MaterialGroupLayout: MaterializedGroupLayoutRenderer,
+  MaterialHorizontalLayout: MaterialHorizontalLayoutRenderer,
+  MaterialVerticalLayout: MaterialVerticalLayoutRenderer,
 };
 
-export default withJsonFormsMasterListItemProps(ListWithDetailMasterItem);
+export * from './ArrayToolbar';

--- a/packages/material-renderers/src/mui-controls/index.ts
+++ b/packages/material-renderers/src/mui-controls/index.ts
@@ -22,10 +22,12 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
+export * from './MuiAutocomplete';
 export * from './MuiCheckbox';
-export * from './MuiSelect';
 export * from './MuiInputInteger';
 export * from './MuiInputNumber';
 export * from './MuiInputNumberFormat';
 export * from './MuiInputText';
 export * from './MuiInputTime';
+export * from './MuiSelect';
+export * from './MuiToggle';


### PR DESCRIPTION
Previously only the control renderers were made available unwrapped. Now all unwrapped React Material renderers are exported.

Implements #1687

Contributed on behalf of STMicroelectronics