### PR TITLE
Do not filter out errors for oneOf enums

### DIFF
--- a/packages/core/src/testers/testers.ts
+++ b/packages/core/src/testers/testers.ts
@@ -37,7 +37,12 @@ import type {
   JsonSchema,
   UISchemaElement,
 } from '../models';
-import { deriveTypes, hasType, resolveSchema } from '../util';
+import {
+  deriveTypes,
+  hasType,
+  isOneOfEnumSchema,
+  resolveSchema,
+} from '../util';
 
 /**
  * Constant that indicates that a tester is not capable of handling
@@ -353,11 +358,7 @@ export const isEnumControl = and(
  */
 export const isOneOfEnumControl = and(
   uiTypeIs('Control'),
-  schemaMatches(
-    (schema) =>
-      schema.hasOwnProperty('oneOf') &&
-      (schema.oneOf as JsonSchema[]).every((s) => s.const !== undefined)
-  )
+  schemaMatches((schema) => isOneOfEnumSchema(schema))
 );
 
 /**
@@ -517,7 +518,7 @@ export const isObjectArrayWithNesting = (
           if (val.anyOf || val.allOf) {
             return true;
           }
-          if (val.oneOf && !isOneOfEnumControl(uischema, val, context)) {
+          if (val.oneOf && !isOneOfEnumSchema(val)) {
             return true;
           }
           if (hasType(val, 'object')) {

--- a/packages/core/src/util/schema.ts
+++ b/packages/core/src/util/schema.ts
@@ -24,6 +24,7 @@
 */
 
 import find from 'lodash/find';
+import { JsonSchema } from '../models';
 
 export const getFirstPrimitiveProp = (schema: any) => {
   if (schema.properties) {
@@ -38,3 +39,11 @@ export const getFirstPrimitiveProp = (schema: any) => {
   }
   return undefined;
 };
+
+/**
+ * Tests whether the schema has an enum based on oneOf.
+ */
+export const isOneOfEnumSchema = (schema: JsonSchema) =>
+  schema?.hasOwnProperty('oneOf') &&
+  schema?.oneOf &&
+  (schema.oneOf as JsonSchema[]).every((s) => s.const !== undefined);

--- a/packages/examples/src/examples/arrays.ts
+++ b/packages/examples/src/examples/arrays.ts
@@ -45,6 +45,10 @@ export const schema = {
             type: 'string',
             const: 'foo',
           },
+          oneOfEnum: {
+            type: 'string',
+            oneOf: [{ const: 'foo' }, { const: 'bar' }],
+          },
         },
       },
     },
@@ -95,6 +99,7 @@ export const data = {
     {
       date: new Date().toISOString().substr(0, 10),
       message: 'Get ready for booohay',
+      oneOfEnum: 'test',
     },
   ],
 };

--- a/packages/examples/src/examples/enum.ts
+++ b/packages/examples/src/examples/enum.ts
@@ -35,6 +35,10 @@ export const schema = {
       type: 'string',
       enum: ['foo', 'bar'],
     },
+    enumWithError: {
+      type: 'string',
+      enum: ['foo', 'bar'],
+    },
     oneOfEnum: {
       type: 'string',
       oneOf: [
@@ -44,6 +48,14 @@ export const schema = {
       ],
     },
     oneOfEnumSet: {
+      type: 'string',
+      oneOf: [
+        { const: 'foo', title: 'Foo' },
+        { const: 'bar', title: 'Bar' },
+        { const: 'foobar', title: 'FooBar' },
+      ],
+    },
+    oneOfEnumWithError: {
       type: 'string',
       oneOf: [
         { const: 'foo', title: 'Foo' },
@@ -90,6 +102,10 @@ export const uischema = {
             autocomplete: false,
           },
         },
+        {
+          type: 'Control',
+          scope: '#/properties/enumWithError',
+        },
       ],
     },
     {
@@ -118,12 +134,21 @@ export const uischema = {
             autocomplete: false,
           },
         },
+        {
+          type: 'Control',
+          scope: '#/properties/oneOfEnumWithError',
+        },
       ],
     },
   ],
 };
 
-export const data = { plainEnumSet: 'foo', oneOfEnumSet: 'bar' };
+export const data = {
+  plainEnumSet: 'foo',
+  enumWithError: 'bogus',
+  oneOfEnumSet: 'bar',
+  oneOfEnumWithError: 'bogus',
+};
 
 registerExamples([
   {


### PR DESCRIPTION
The `errorsAt` function, used to filter the errors that belong to a control, ignores the errors AJV produces for oneOf schemas. Most of these errors should not be shown in the UI (e.g. when the oneOf property
does not match exactly one subschema), however the errors produced directly for oneOf enums are an exception.

Validation errors for oneOf enum controls are valid and should be shown in the UI.


Contributed on behalf of STMicroelectronics

### How to test in the UI:

- the `enums` example now displays sample controls with errors - [preview](https://deploy-preview-2133--jsonforms-examples.netlify.app/react-material/#enum)
- the `arrays` example now displays an item with a oneOf enum with errors - [preview](https://deploy-preview-2133--jsonforms-examples.netlify.app/react-material/#array)