### PR TITLE
Enable ESLint no-prototype-builtins rule and fix errors

### DIFF
--- a/packages/angular-material/.eslintrc.js
+++ b/packages/angular-material/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
     '@angular-eslint/directive-class-suffix': 'off',
     '@angular-eslint/no-conflicting-lifecycle': 'warn',
     '@typescript-eslint/no-explicit-any': 'off',
-    'no-prototype-builtins': 'off',
     // Base rule must be disabled to avoid incorrect errors
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': [

--- a/packages/angular-test/.eslintrc.js
+++ b/packages/angular-test/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
     '@angular-eslint/directive-class-suffix': 'off',
     '@angular-eslint/no-conflicting-lifecycle': 'warn',
     '@typescript-eslint/no-explicit-any': 'off',
-    'no-prototype-builtins': 'off',
     // Base rule must be disabled to avoid incorrect errors
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': [

--- a/packages/angular/.eslintrc.js
+++ b/packages/angular/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
     '@angular-eslint/directive-class-suffix': 'off',
     '@angular-eslint/no-conflicting-lifecycle': 'warn',
     '@typescript-eslint/no-explicit-any': 'off',
-    'no-prototype-builtins': 'off',
     // Base rule must be disabled to avoid incorrect errors
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': [

--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -21,7 +21,6 @@ module.exports = {
       },
     ],
     '@typescript-eslint/no-explicit-any': 'off',
-    'no-prototype-builtins': 'off',
     // Base rule must be disabled to avoid incorrect errors
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': [

--- a/packages/core/src/generators/schema.ts
+++ b/packages/core/src/generators/schema.ts
@@ -38,7 +38,7 @@ const distinct = (
 
   return properties.filter((item) => {
     const discriminatorValue = discriminator(item);
-    if (known.hasOwnProperty(discriminatorValue)) {
+    if (Object.prototype.hasOwnProperty.call(known, discriminatorValue)) {
       return false;
     } else {
       known[discriminatorValue] = true;
@@ -155,13 +155,17 @@ export const generateJsonSchema = (
     (optionName: string): boolean | string[] => {
       switch (optionName) {
         case ADDITIONAL_PROPERTIES:
-          if (options.hasOwnProperty(ADDITIONAL_PROPERTIES)) {
+          if (
+            Object.prototype.hasOwnProperty.call(options, ADDITIONAL_PROPERTIES)
+          ) {
             return options[ADDITIONAL_PROPERTIES];
           }
 
           return true;
         case REQUIRED_PROPERTIES:
-          if (options.hasOwnProperty(REQUIRED_PROPERTIES)) {
+          if (
+            Object.prototype.hasOwnProperty.call(options, REQUIRED_PROPERTIES)
+          ) {
             return options[REQUIRED_PROPERTIES](props);
           }
 

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -90,7 +90,10 @@ const initState: JsonFormsCore = {
 };
 
 const reuseAjvForSchema = (ajv: Ajv, schema: JsonSchema): Ajv => {
-  if (schema.hasOwnProperty('id') || schema.hasOwnProperty('$id')) {
+  if (
+    Object.prototype.hasOwnProperty.call(schema, 'id') ||
+    Object.prototype.hasOwnProperty.call(schema, '$id')
+  ) {
     ajv.removeSchema(schema);
   }
   return ajv;

--- a/packages/core/src/testers/testers.ts
+++ b/packages/core/src/testers/testers.ts
@@ -325,17 +325,23 @@ export const isObjectControl = and(uiTypeIs('Control'), schemaTypeIs('object'));
 
 export const isAllOfControl = and(
   uiTypeIs('Control'),
-  schemaMatches((schema) => schema.hasOwnProperty('allOf'))
+  schemaMatches((schema) =>
+    Object.prototype.hasOwnProperty.call(schema, 'allOf')
+  )
 );
 
 export const isAnyOfControl = and(
   uiTypeIs('Control'),
-  schemaMatches((schema) => schema.hasOwnProperty('anyOf'))
+  schemaMatches((schema) =>
+    Object.prototype.hasOwnProperty.call(schema, 'anyOf')
+  )
 );
 
 export const isOneOfControl = and(
   uiTypeIs('Control'),
-  schemaMatches((schema) => schema.hasOwnProperty('oneOf'))
+  schemaMatches((schema) =>
+    Object.prototype.hasOwnProperty.call(schema, 'oneOf')
+  )
 );
 
 /**
@@ -346,8 +352,12 @@ export const isOneOfControl = and(
 export const isEnumControl = and(
   uiTypeIs('Control'),
   or(
-    schemaMatches((schema) => schema.hasOwnProperty('enum')),
-    schemaMatches((schema) => schema.hasOwnProperty('const'))
+    schemaMatches((schema) =>
+      Object.prototype.hasOwnProperty.call(schema, 'enum')
+    ),
+    schemaMatches((schema) =>
+      Object.prototype.hasOwnProperty.call(schema, 'const')
+    )
   )
 );
 
@@ -592,9 +602,9 @@ export const isRangeControl = and(
   or(schemaTypeIs('number'), schemaTypeIs('integer')),
   schemaMatches(
     (schema) =>
-      schema.hasOwnProperty('maximum') &&
-      schema.hasOwnProperty('minimum') &&
-      schema.hasOwnProperty('default')
+      Object.prototype.hasOwnProperty.call(schema, 'maximum') &&
+      Object.prototype.hasOwnProperty.call(schema, 'minimum') &&
+      Object.prototype.hasOwnProperty.call(schema, 'default')
   ),
   optionIs('slider', true)
 );

--- a/packages/core/src/util/resolvers.ts
+++ b/packages/core/src/util/resolvers.ts
@@ -49,7 +49,10 @@ export const resolveData = (instance: any, dataPath: string): any => {
   const dataPathSegments = dataPath.split('.');
 
   return dataPathSegments.reduce((curInstance, decodedSegment) => {
-    if (!curInstance || !curInstance.hasOwnProperty(decodedSegment)) {
+    if (
+      !curInstance ||
+      !Object.prototype.hasOwnProperty.call(curInstance, decodedSegment)
+    ) {
       return undefined;
     }
 

--- a/packages/core/src/util/schema.ts
+++ b/packages/core/src/util/schema.ts
@@ -44,6 +44,7 @@ export const getFirstPrimitiveProp = (schema: any) => {
  * Tests whether the schema has an enum based on oneOf.
  */
 export const isOneOfEnumSchema = (schema: JsonSchema) =>
-  schema?.hasOwnProperty('oneOf') &&
-  schema?.oneOf &&
+  !!schema &&
+  Object.prototype.hasOwnProperty.call(schema, 'oneOf') &&
+  schema.oneOf &&
   (schema.oneOf as JsonSchema[]).every((s) => s.const !== undefined);

--- a/packages/examples-react/.eslintrc.js
+++ b/packages/examples-react/.eslintrc.js
@@ -20,7 +20,6 @@ module.exports = {
   ],
   rules: {
     '@typescript-eslint/no-explicit-any': 'off',
-    'no-prototype-builtins': 'off',
     // Base rule must be disabled to avoid incorrect errors
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': [

--- a/packages/examples/.eslintrc.js
+++ b/packages/examples/.eslintrc.js
@@ -14,7 +14,6 @@ module.exports = {
   ],
   rules: {
     '@typescript-eslint/no-explicit-any': 'off',
-    'no-prototype-builtins': 'off',
     // Base rule must be disabled to avoid incorrect errors
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': [

--- a/packages/material-renderers/.eslintrc.js
+++ b/packages/material-renderers/.eslintrc.js
@@ -20,7 +20,6 @@ module.exports = {
   ],
   rules: {
     '@typescript-eslint/no-explicit-any': 'off',
-    'no-prototype-builtins': 'off',
     'import/no-named-as-default': 'off',
     // Base rule must be disabled to avoid incorrect errors
     'no-unused-vars': 'off',

--- a/packages/material-renderers/src/controls/MaterialAnyOfStringOrEnumControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialAnyOfStringOrEnumControl.tsx
@@ -133,7 +133,9 @@ const hasEnumAndText = (schemas: JsonSchema[]) => {
 const simpleAnyOf = and(
   uiTypeIs('Control'),
   schemaMatches(
-    (schema) => schema.hasOwnProperty('anyOf') && hasEnumAndText(schema.anyOf)
+    (schema) =>
+      Object.prototype.hasOwnProperty.call(schema, 'anyOf') &&
+      hasEnumAndText(schema.anyOf)
   )
 );
 export const materialAnyOfStringOrEnumControlTester: RankedTester = rankWith(

--- a/packages/react/.eslintrc.js
+++ b/packages/react/.eslintrc.js
@@ -20,7 +20,6 @@ module.exports = {
   ],
   rules: {
     '@typescript-eslint/no-explicit-any': 'off',
-    'no-prototype-builtins': 'off',
     // Base rule must be disabled to avoid incorrect errors
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': [

--- a/packages/vanilla-renderers/.eslintrc.js
+++ b/packages/vanilla-renderers/.eslintrc.js
@@ -20,7 +20,6 @@ module.exports = {
   ],
   rules: {
     '@typescript-eslint/no-explicit-any': 'off',
-    'no-prototype-builtins': 'off',
     'import/no-named-as-default': 'off',
     // Base rule must be disabled to avoid incorrect errors
     'no-unused-vars': 'off',

--- a/packages/vue/vue-vanilla/.eslintrc.js
+++ b/packages/vue/vue-vanilla/.eslintrc.js
@@ -21,7 +21,6 @@ module.exports = {
   ],
   rules: {
     '@typescript-eslint/no-explicit-any': 'off',
-    'no-prototype-builtins': 'off',
     // Base rule must be disabled to avoid incorrect errors
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': [

--- a/packages/vue/vue/.eslintrc.js
+++ b/packages/vue/vue/.eslintrc.js
@@ -21,7 +21,6 @@ module.exports = {
   ],
   rules: {
     '@typescript-eslint/no-explicit-any': 'off',
-    'no-prototype-builtins': 'off',
     // Base rule must be disabled to avoid incorrect errors
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': [


### PR DESCRIPTION
Use `Object.prototype.<method>.call(<object>, <property>)` syntax instead of directly calling the methods on the objects. This is the suggested fix in the [rule documentation](https://eslint.org/docs/latest/rules/no-prototype-builtins).

Part of #2131