### PR TITLE
angular-material: Fix unfocused description display for number renderer

### DIFF
--- a/packages/angular-material/src/controls/number.renderer.ts
+++ b/packages/angular-material/src/controls/number.renderer.ts
@@ -51,7 +51,7 @@ import merge from 'lodash/merge';
         (focus)="focused = true"
         (focusout)="focused = false"
       />
-      <mat-hint *ngIf="shouldShowUnfocusedDescription()" || focused>{{
+      <mat-hint *ngIf="shouldShowUnfocusedDescription() || focused">{{
         description
       }}</mat-hint>
       <mat-error>{{ error }}</mat-error>


### PR DESCRIPTION
The template had a bug closing the ngIf that checks whether the description is shown too early. This lead to a DOMException and the description to never be shown.

Fix #2166