### PR TITLE
Update and fix dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,11 +2,13 @@
 
 # [Choice] Node.js version: 16
 ARG VARIANT="16"
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:1-${VARIANT}
 
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+# Install chromium and point the CHROME_BIN environment variable to it
+# This allows running angular-material's tests in the dev container
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get -y install --no-install-recommends chromium
+ENV CHROME_BIN=/usr/bin/chromium
 
 # [Optional] Uncomment if you want to install an additional version of node using nvm
 # ARG EXTRA_NODE_VERSION=10

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ As an alternative to the first time setup, you can use the provided [VS Code dev
 - Wait until the container is built and loaded
 - First time setup and an initial build of all packages has been executed in the container
 
+**Note:** If you have installed dependencies before opening the remote container, its initialization might fail.
+In this case, you can try to clean the repository with `git clean -dfx`. Beware that this removes all untracked files!
+
 ### Build & Testing
 
 - Build (all packages): `pnpm run build`


### PR DESCRIPTION
- Update base image to version 1.x
- Install chromium to enable running angular-material tests in the container
- Extend README with hint to clean repo in case initialization fails

Fix #2149