### PR TITLE
BUGFIX: Orphaned labels on single select dropdown

### DIFF
--- a/packages/material-renderers/src/mui-controls/MuiAutocomplete.tsx
+++ b/packages/material-renderers/src/mui-controls/MuiAutocomplete.tsx
@@ -129,7 +129,7 @@ export const MuiAutocomplete = (
               autoFocus={appliedUiSchemaOptions.focus}
               disabled={!enabled}
               {...params}
-              id={id + '-input'}
+              id={id}
               required={
                 required && !appliedUiSchemaOptions.hideRequiredAsterisk
               }


### PR DESCRIPTION
Removed "-input" from id on input so that the label and input are associated correctly.  Will fix issue #2198 