### PR TITLE
Fix/datepicker validation

### DIFF
--- a/packages/core/src/util/defaultDateFormat.ts
+++ b/packages/core/src/util/defaultDateFormat.ts
@@ -1,7 +1,7 @@
 /*
   The MIT License
   
-  Copyright (c) 2017-2019 EclipseSource Munich
+  Copyright (c) 2023-2023 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
   
   Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -23,19 +23,6 @@
   THE SOFTWARE.
 */
 
-export * from './array';
-export * from './cell';
-export * from './combinators';
-export * from './Formatted';
-export * from './ids';
-export * from './label';
-export * from './path';
-export * from './renderer';
-export * from './resolvers';
-export * from './runtime';
-export * from './schema';
-export * from './type';
-export * from './uischema';
-export * from './util';
-export * from './validator';
-export * from './defaultDateFormat';
+export const defaultDateFormat = 'YYYY-MM-DD';
+export const defaultTimeFormat = 'HH:mm:ss';
+export const defaultDateTimeFormat = 'YYYY-MM-DDTHH:mm:ss.sssZ';

--- a/packages/examples/src/examples/dates.ts
+++ b/packages/examples/src/examples/dates.ts
@@ -129,12 +129,12 @@ export const uischema = {
 export const data = {
   schemaBased: {
     date: new Date().toISOString().substr(0, 10),
-    time: '13:37',
+    time: '13:37:00',
     datetime: new Date().toISOString(),
   },
   uiSchemaBased: {
     date: new Date().toISOString().substr(0, 10),
-    time: '13:37',
+    time: '13:37:00',
     datetime: '1999/12/11 10:05 am',
   },
 };

--- a/packages/material-renderers/package.json
+++ b/packages/material-renderers/package.json
@@ -59,7 +59,8 @@
     },
     "testEnvironment": "jsdom",
     "testMatch": [
-      "**/test/**/*.test.tsx"
+      "**/test/**/*.test.tsx",
+      "**/test/**.test.ts"
     ],
     "testPathIgnorePatterns": [
       "/node_modules/",

--- a/packages/material-renderers/src/controls/MaterialTimeControl.tsx
+++ b/packages/material-renderers/src/controls/MaterialTimeControl.tsx
@@ -22,7 +22,7 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import merge from 'lodash/merge';
 import {
   ControlProps,
@@ -30,12 +30,18 @@ import {
   isDescriptionHidden,
   RankedTester,
   rankWith,
+  defaultTimeFormat,
 } from '@jsonforms/core';
 import { withJsonFormsControlProps } from '@jsonforms/react';
 import { FormHelperText, Hidden } from '@mui/material';
 import { TimePicker, LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { createOnChangeHandler, getData, useFocus } from '../util';
+import {
+  createOnBlurHandler,
+  createOnChangeHandler,
+  getData,
+  useFocus,
+} from '../util';
 
 export const MaterialTimeControl = (props: ControlProps) => {
   const [focused, onFocus, onBlur] = useFocus();
@@ -56,6 +62,8 @@ export const MaterialTimeControl = (props: ControlProps) => {
   const appliedUiSchemaOptions = merge({}, config, uischema.options);
   const isValid = errors.length === 0;
 
+  const [key, setKey] = useState<number>(0);
+
   const showDescription = !isDescriptionHidden(
     visible,
     description,
@@ -64,7 +72,7 @@ export const MaterialTimeControl = (props: ControlProps) => {
   );
 
   const format = appliedUiSchemaOptions.timeFormat ?? 'HH:mm';
-  const saveFormat = appliedUiSchemaOptions.timeSaveFormat ?? 'HH:mm:ss';
+  const saveFormat = appliedUiSchemaOptions.timeSaveFormat ?? defaultTimeFormat;
 
   const views = appliedUiSchemaOptions.views ?? ['hours', 'minutes'];
 
@@ -75,19 +83,35 @@ export const MaterialTimeControl = (props: ControlProps) => {
     : null;
   const secondFormHelperText = showDescription && !isValid ? errors : null;
 
+  const updateChild = useCallback(() => setKey((key) => key + 1), []);
+
   const onChange = useMemo(
     () => createOnChangeHandler(path, handleChange, saveFormat),
     [path, handleChange, saveFormat]
   );
 
+  const onBlurHandler = useMemo(
+    () =>
+      createOnBlurHandler(
+        path,
+        handleChange,
+        format,
+        saveFormat,
+        updateChild,
+        onBlur
+      ),
+    [path, handleChange, format, saveFormat, updateChild]
+  );
   const value = getData(data, saveFormat);
+
   return (
     <Hidden xsUp={!visible}>
       <LocalizationProvider dateAdapter={AdapterDayjs}>
         <TimePicker
+          key={key}
           label={label}
           value={value}
-          onChange={onChange}
+          onAccept={onChange}
           format={format}
           ampm={!!appliedUiSchemaOptions.ampm}
           views={views}
@@ -111,7 +135,7 @@ export const MaterialTimeControl = (props: ControlProps) => {
               },
               InputLabelProps: data ? { shrink: true } : undefined,
               onFocus: onFocus,
-              onBlur: onBlur,
+              onBlur: onBlurHandler,
             },
           }}
         />

--- a/packages/material-renderers/src/util/datejs.tsx
+++ b/packages/material-renderers/src/util/datejs.tsx
@@ -8,16 +8,55 @@ export const createOnChangeHandler =
   (
     path: string,
     handleChange: (path: string, value: any) => void,
-    saveFormat: string | undefined
+    saveFormat: string
   ) =>
-  (time: dayjs.Dayjs) => {
-    if (!time) {
+  (value: dayjs.Dayjs) => {
+    if (!value) {
       handleChange(path, undefined);
-      return;
+    } else if (value.toString() !== 'Invalid Date') {
+      const formatedDate = formatDate(value, saveFormat);
+      handleChange(path, formatedDate);
     }
-    const result = dayjs(time).format(saveFormat);
-    handleChange(path, result);
   };
+
+export const createOnBlurHandler =
+  (
+    path: string,
+    handleChange: (path: string, value: any) => void,
+    format: string,
+    saveFormat: string,
+    rerenderChild: () => void,
+    onBlur: () => void
+  ) =>
+  (e: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement, Element>) => {
+    const date = dayjs(e.target.value, format);
+    const formatedDate = formatDate(date, saveFormat);
+    if (formatedDate.toString() === 'Invalid Date') {
+      handleChange(path, undefined);
+      rerenderChild();
+    } else {
+      handleChange(path, formatedDate);
+    }
+    onBlur();
+  };
+
+export const formatDate = (date: dayjs.Dayjs, saveFormat: string) => {
+  let formatedDate = date.format(saveFormat);
+  // Workaround to address a bug in Dayjs, neglecting leading 0 (https://github.com/iamkun/dayjs/issues/1849)
+  const indexOfYear = saveFormat.indexOf('YYYY');
+  if (date.year() < 1000 && indexOfYear !== -1) {
+    const stringUpToYear = formatedDate.slice(0, indexOfYear);
+    const stringFromYear = formatedDate.slice(indexOfYear);
+    if (date.year() >= 100) {
+      formatedDate = [stringUpToYear, 0, stringFromYear].join('');
+    } else if (date.year() >= 10) {
+      formatedDate = [stringUpToYear, 0, 0, stringFromYear].join('');
+    } else if (date.year() >= 1) {
+      formatedDate = [stringUpToYear, 0, 0, 0, stringFromYear].join('');
+    }
+  }
+  return formatedDate;
+};
 
 export const getData = (
   data: any,

--- a/packages/material-renderers/test/datejs.test.ts
+++ b/packages/material-renderers/test/datejs.test.ts
@@ -1,19 +1,19 @@
 /*
   The MIT License
-  
-  Copyright (c) 2017-2019 EclipseSource Munich
+
+  Copyright (c) 2024-2024 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
-  
+
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
-  
+
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
-  
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,20 +22,31 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
+import dayjs from 'dayjs';
+import { formatDate } from '../src/util/datejs';
 
-export * from './array';
-export * from './cell';
-export * from './combinators';
-export * from './Formatted';
-export * from './ids';
-export * from './label';
-export * from './path';
-export * from './renderer';
-export * from './resolvers';
-export * from './runtime';
-export * from './schema';
-export * from './type';
-export * from './uischema';
-export * from './util';
-export * from './validator';
-export * from './defaultDateFormat';
+describe('Date Util tester', () => {
+  test('format default', () => {
+    const date = dayjs('2024-01-01');
+    const actual = formatDate(date, 'YYYY-MM-DD');
+    expect(actual).toBe('2024-01-01');
+  });
+
+  test('format year < 1000', () => {
+    const date = dayjs('999-01-01');
+    const actual = formatDate(date, 'YYYY-MM-DD');
+    expect(actual).toBe('0999-01-01');
+  });
+
+  test('format 100 < year < 1000', () => {
+    const date = dayjs(new Date('0099-01-01'));
+    const actual = formatDate(date, 'YYYY-MM-DD');
+    expect(actual).toBe('0099-01-01');
+  });
+
+  test('format 10 < year < 100', () => {
+    const date = dayjs(new Date('0019-01-01'));
+    const actual = formatDate(date, 'YYYY-MM-DD');
+    expect(actual).toBe('0019-01-01');
+  });
+});

--- a/packages/material-renderers/test/renderers/MaterialDateControl.test.tsx
+++ b/packages/material-renderers/test/renderers/MaterialDateControl.test.tsx
@@ -225,7 +225,7 @@ describe('Material date control', () => {
     );
     const input = wrapper.find('input').first();
     (input.getDOMNode() as HTMLInputElement).value = '1961-04-12';
-    input.simulate('change', input);
+    input.simulate('blur', input);
     expect(onChangeData.data.foo).toBe('1961-04-12');
   });
 
@@ -421,7 +421,7 @@ describe('Material date control', () => {
     expect(input.props().value).toBe('1980/06');
 
     (input.getDOMNode() as HTMLInputElement).value = '1961/04';
-    input.simulate('change', input);
+    input.simulate('blur', input);
     expect(onChangeData.data.foo).toBe('04---1961');
   });
 });

--- a/packages/material-renderers/test/renderers/MaterialDateTimeControl.test.tsx
+++ b/packages/material-renderers/test/renderers/MaterialDateTimeControl.test.tsx
@@ -24,7 +24,11 @@
 */
 import './MatchMediaMock';
 import React from 'react';
-import { ControlElement, NOT_APPLICABLE } from '@jsonforms/core';
+import {
+  ControlElement,
+  defaultDateTimeFormat,
+  NOT_APPLICABLE,
+} from '@jsonforms/core';
 import MaterialDateTimeControl, {
   materialDateTimeControlTester,
 } from '../../src/controls/MaterialDateTimeControl';
@@ -38,7 +42,7 @@ import { initCore, TestEmitter } from './util';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-const data = { foo: dayjs('1980-04-04 13:37').format() };
+const data = { foo: dayjs('1980-04-04 13:37').format(defaultDateTimeFormat) };
 const schema = {
   type: 'object',
   properties: {
@@ -228,8 +232,10 @@ describe('Material date time control', () => {
     );
     const input = wrapper.find('input').first();
     (input.getDOMNode() as HTMLInputElement).value = '1961-12-12 20:15';
-    input.simulate('change', input);
-    expect(onChangeData.data.foo).toBe(dayjs('1961-12-12 20:15').format());
+    input.simulate('blur', input);
+    expect(onChangeData.data.foo).toBe(
+      dayjs('1961-12-12 20:15').format(defaultDateTimeFormat)
+    );
   });
 
   it('should update via action', () => {
@@ -241,7 +247,10 @@ describe('Material date time control', () => {
         <MaterialDateTimeControl schema={schema} uischema={uischema} />
       </JsonFormsStateProvider>
     );
-    core.data = { ...core.data, foo: dayjs('1961-12-04 20:15').format() };
+    core.data = {
+      ...core.data,
+      foo: dayjs('1961-12-04 20:15').format(defaultDateTimeFormat),
+    };
     wrapper.setProps({ initState: { renderers: materialRenderers, core } });
     wrapper.update();
     const input = wrapper.find('input').first();
@@ -427,7 +436,7 @@ describe('Material date time control', () => {
     expect(input.props().value).toBe('23-04-80 01:37:pm');
 
     (input.getDOMNode() as HTMLInputElement).value = '10-12-05 11:22:am';
-    input.simulate('change', input);
+    input.simulate('blur', input);
     expect(onChangeData.data.foo).toBe('2005/12/10 11:22 am');
   });
 });

--- a/packages/material-renderers/test/renderers/MaterialTimeControl.test.tsx
+++ b/packages/material-renderers/test/renderers/MaterialTimeControl.test.tsx
@@ -225,8 +225,8 @@ describe('Material time control', () => {
     );
     const input = wrapper.find('input').first();
     (input.getDOMNode() as HTMLInputElement).value = '08:40';
-    input.simulate('change', input);
-    expect(onChangeData.data.foo).toBe('08:40:05');
+    input.simulate('blur', input);
+    expect(onChangeData.data.foo).toBe('08:40:00');
   });
 
   it('should update via action', () => {
@@ -421,7 +421,7 @@ describe('Material time control', () => {
     expect(input.props().value).toBe('02-13');
 
     (input.getDOMNode() as HTMLInputElement).value = '12-01';
-    input.simulate('change', input);
+    input.simulate('blur', input);
     expect(onChangeData.data.foo).toBe('1//12 am');
   });
 });


### PR DESCRIPTION
Previously, data wasn't cleared when the input field was emptied.
This commit will set the value to 'undefined' when the input is empty or
invalid upon blurring. During editing, the data is only updated when the
current input is valid.

Closes #2183