### PR TITLE
fix(core): Disable schema caching in AJV instance

### DIFF
--- a/packages/core/src/util/validator.ts
+++ b/packages/core/src/util/validator.ts
@@ -31,6 +31,7 @@ export const createAjv = (options?: Options) => {
     allErrors: true,
     verbose: true,
     strict: false,
+    addUsedSchema: false,
     ...options,
   });
   addFormats(ajv);


### PR DESCRIPTION
Set the 'addUsedSchema' option to false during AJV instantiation to prevent schema caching by default. This resolves issues where updating a schema that contains an ID leads to duplicate ID errors in AJV.

Closes #2071