### PR TITLE
fix(material): Resolve refs in object renderer

### DIFF
--- a/packages/angular-material/src/other/object.renderer.ts
+++ b/packages/angular-material/src/other/object.renderer.ts
@@ -73,7 +73,12 @@ export class ObjectControlRenderer extends JsonFormsControlWithDetail {
         delete newSchema.oneOf;
         delete newSchema.anyOf;
         delete newSchema.allOf;
-        return Generate.uiSchema(newSchema, 'Group');
+        return Generate.uiSchema(
+          newSchema,
+          'Group',
+          undefined,
+          this.rootSchema
+        );
       },
       props.uischema,
       props.rootSchema

--- a/packages/core/src/reducers/reducers.ts
+++ b/packages/core/src/reducers/reducers.ts
@@ -77,7 +77,7 @@ export const findUISchema = (
           return fallback();
         }
         // force generation of uischema
-        return Generate.uiSchema(schema, fallback);
+        return Generate.uiSchema(schema, fallback, undefined, rootSchema);
       }
     } else if (typeof control.options.detail === 'object') {
       // check if detail is a valid uischema

--- a/packages/material-renderers/src/complex/CombinatorProperties.tsx
+++ b/packages/material-renderers/src/complex/CombinatorProperties.tsx
@@ -36,6 +36,7 @@ interface CombinatorPropertiesProps {
   schema: JsonSchema;
   combinatorKeyword: 'oneOf' | 'anyOf';
   path: string;
+  rootSchema: JsonSchema;
 }
 
 export class CombinatorProperties extends React.Component<
@@ -45,7 +46,7 @@ export class CombinatorProperties extends React.Component<
   {}
 > {
   render() {
-    const { schema, combinatorKeyword, path } = this.props;
+    const { schema, combinatorKeyword, path, rootSchema } = this.props;
 
     const otherProps: JsonSchema = omit(
       schema,
@@ -53,7 +54,9 @@ export class CombinatorProperties extends React.Component<
     ) as JsonSchema;
     const foundUISchema: UISchemaElement = Generate.uiSchema(
       otherProps,
-      'VerticalLayout'
+      'VerticalLayout',
+      undefined,
+      rootSchema
     );
     let isLayoutWithElements = false;
     if (foundUISchema !== null && isLayout(foundUISchema)) {

--- a/packages/material-renderers/src/complex/MaterialAnyOfRenderer.tsx
+++ b/packages/material-renderers/src/complex/MaterialAnyOfRenderer.tsx
@@ -104,6 +104,7 @@ export const MaterialAnyOfRenderer = ({
         schema={schema}
         combinatorKeyword={anyOf}
         path={path}
+        rootSchema={rootSchema}
       />
       <Tabs value={selectedAnyOf} onChange={handleTabChange}>
         {anyOfRenderInfos.map((anyOfRenderInfo) => (

--- a/packages/material-renderers/src/complex/MaterialObjectRenderer.tsx
+++ b/packages/material-renderers/src/complex/MaterialObjectRenderer.tsx
@@ -56,8 +56,11 @@ export const MaterialObjectRenderer = ({
         path,
         () =>
           isEmpty(path)
-            ? Generate.uiSchema(schema, 'VerticalLayout')
-            : { ...Generate.uiSchema(schema, 'Group'), label },
+            ? Generate.uiSchema(schema, 'VerticalLayout', undefined, rootSchema)
+            : {
+                ...Generate.uiSchema(schema, 'Group', undefined, rootSchema),
+                label,
+              },
         uischema,
         rootSchema
       ),

--- a/packages/material-renderers/src/complex/MaterialOneOfRenderer.tsx
+++ b/packages/material-renderers/src/complex/MaterialOneOfRenderer.tsx
@@ -106,6 +106,7 @@ export const MaterialOneOfRenderer = ({
         schema={schema}
         combinatorKeyword={'oneOf'}
         path={path}
+        rootSchema={rootSchema}
       />
       <Tabs value={selectedIndex} onChange={handleTabChange}>
         {oneOfRenderInfos.map((oneOfRenderInfo) => (

--- a/packages/react/src/JsonForms.tsx
+++ b/packages/react/src/JsonForms.tsx
@@ -210,7 +210,9 @@ export const JsonForms = (
   );
   const uischemaToUse = useMemo(
     () =>
-      typeof uischema === 'object' ? uischema : Generate.uiSchema(schemaToUse),
+      typeof uischema === 'object'
+        ? uischema
+        : Generate.uiSchema(schemaToUse, undefined, undefined, schemaToUse),
     [uischema, schemaToUse]
   );
 

--- a/packages/vue-vanilla/src/complex/ObjectRenderer.vue
+++ b/packages/vue-vanilla/src/complex/ObjectRenderer.vue
@@ -51,7 +51,12 @@ const controlRenderer = defineComponent({
   computed: {
     detailUiSchema(): UISchemaElement {
       const uiSchemaGenerator = () => {
-        const uiSchema = Generate.uiSchema(this.control.schema, 'Group');
+        const uiSchema = Generate.uiSchema(
+          this.control.schema,
+          'Group',
+          undefined,
+          this.control.rootSchema
+        );
         if (isEmpty(this.control.path)) {
           uiSchema.type = 'VerticalLayout';
         } else {

--- a/packages/vue-vanilla/src/complex/components/CombinatorProperties.vue
+++ b/packages/vue-vanilla/src/complex/components/CombinatorProperties.vue
@@ -18,6 +18,7 @@ interface CombinatorProps {
   schema: JsonSchema;
   combinatorKeyword: 'oneOf' | 'anyOf' | 'allOf';
   path: string;
+  rootSchema: JsonSchema;
 }
 
 export default defineComponent({
@@ -38,6 +39,10 @@ export default defineComponent({
       type: String,
       required: true,
     },
+    rootSchema: {
+      type: Object as PropType<JsonSchema>,
+      required: true,
+    },
   },
   setup(props: CombinatorProps) {
     const otherProps: JsonSchema = omit(
@@ -46,7 +51,9 @@ export default defineComponent({
     ) as JsonSchema;
     const foundUISchema: UISchemaElement = Generate.uiSchema(
       otherProps,
-      'VerticalLayout'
+      'VerticalLayout',
+      undefined,
+      props.rootSchema
     );
 
     const isLayout = (uischema: UISchemaElement): uischema is Layout =>

--- a/packages/vue/src/components/JsonForms.vue
+++ b/packages/vue/src/components/JsonForms.vue
@@ -114,8 +114,11 @@ export default defineComponent({
   data() {
     const dataToUse = this.data;
     const generatorData = isObject(dataToUse) ? dataToUse : {};
-    const schemaToUse = this.schema ?? Generate.jsonSchema(generatorData);
-    const uischemaToUse = this.uischema ?? Generate.uiSchema(schemaToUse);
+    const schemaToUse: JsonSchema =
+      this.schema ?? Generate.jsonSchema(generatorData);
+    const uischemaToUse =
+      this.uischema ??
+      Generate.uiSchema(schemaToUse, undefined, undefined, schemaToUse);
     const initCore = (): JsonFormsCore => {
       const initialCore = {
         data: dataToUse,
@@ -177,11 +180,23 @@ export default defineComponent({
       const generatorData = isObject(this.data) ? this.data : {};
       this.schemaToUse = newSchema ?? Generate.jsonSchema(generatorData);
       if (!this.uischema) {
-        this.uischemaToUse = Generate.uiSchema(this.schemaToUse);
+        this.uischemaToUse = Generate.uiSchema(
+          this.schemaToUse,
+          undefined,
+          undefined,
+          this.schemaToUse
+        );
       }
     },
     uischema(newUischema) {
-      this.uischemaToUse = newUischema ?? Generate.uiSchema(this.schemaToUse);
+      this.uischemaToUse =
+        newUischema ??
+        Generate.uiSchema(
+          this.schemaToUse,
+          undefined,
+          undefined,
+          this.schemaToUse
+        );
     },
     data(newData) {
       this.dataToUse = newData;


### PR DESCRIPTION
Previously, UI schemas generated in the Material object renderer were incomplete because not all refs could be resolved.

Closes #2187