### PR TITLE
fix: remove @jsonforms/angular-test peerDependency

### DIFF
--- a/packages/angular-material/package.json
+++ b/packages/angular-material/package.json
@@ -71,7 +71,6 @@
     "@angular/platform-browser": "^15.0.0",
     "@angular/router": "^15.0.0",
     "@jsonforms/angular": "3.2.0-alpha.4",
-    "@jsonforms/angular-test": "^3.2.0-alpha.3",
     "@jsonforms/core": "3.2.0-alpha.4",
     "rxjs": "^6.6.0 || ^7.4.0"
   },


### PR DESCRIPTION
The @jsonforms/angular-material package specified
@jsonforms/angular-test as peerDependency. This is now removed.