### PR TITLE
Add vue-bootstrap

### DIFF
--- a/packages/vue-bootstrap/src/array/ArrayListElement.vue
+++ b/packages/vue-bootstrap/src/array/ArrayListElement.vue
@@ -1,0 +1,121 @@
+<template>
+  <div :class="toolbarClasses" @click="expandClicked">
+    <div>{{ label }}</div>
+    <div class="btn-group" role="group">
+      <button
+        :disabled="!moveUpEnabled"
+        class="btn btn-secondary"
+        type="button"
+        @click="moveUpClicked"
+      >
+        <i :class="styles.itemMoveUp ?? 'bi bi-arrow-up'"></i>
+      </button>
+      <button
+        :disabled="!moveDownEnabled"
+        class="btn btn-secondary"
+        type="button"
+        @click="moveDownClicked"
+      >
+        <i :class="styles.itemMoveDown ?? 'bi bi-arrow-down'"></i>
+      </button>
+      <button
+        :disabled="!deleteEnabled"
+        class="btn btn-secondary"
+        type="button"
+        @click="deleteClicked"
+      >
+        <i :class="styles.itemMoveDown ?? 'bi bi-x-lg'"></i>
+      </button>
+    </div>
+  </div>
+  <div :class="contentClasses">
+    <slot></slot>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue';
+import { classes, Styles } from '../styles';
+
+const listItem = defineComponent({
+  name: 'ArrayListElement',
+  props: {
+    initiallyExpanded: {
+      required: false,
+      type: Boolean,
+      default: false,
+    },
+    label: {
+      required: false,
+      type: String,
+      default: '',
+    },
+    moveUpEnabled: {
+      required: false,
+      type: Boolean,
+      default: true,
+    },
+    moveDownEnabled: {
+      required: false,
+      type: Boolean,
+      default: true,
+    },
+    moveUp: {
+      required: false,
+      type: Function,
+      default: undefined,
+    },
+    moveDown: {
+      required: false,
+      type: Function,
+      default: undefined,
+    },
+    deleteEnabled: {
+      required: false,
+      type: Boolean,
+      default: true,
+    },
+    delete: {
+      required: false,
+      type: Function,
+      default: undefined,
+    },
+    styles: {
+      required: true,
+      type: Object as PropType<Styles>,
+    },
+  },
+  data() {
+    return {
+      expanded: this.initiallyExpanded,
+    };
+  },
+  computed: {
+    contentClasses(): string {
+      return "";
+    },
+    toolbarClasses(): string {
+      return "";
+    },
+  },
+  methods: {
+    expandClicked(): void {
+      this.expanded = !this.expanded;
+    },
+    moveUpClicked(event: Event): void {
+      event.stopPropagation();
+      this.moveUp?.();
+    },
+    moveDownClicked(event: Event): void {
+      event.stopPropagation();
+      this.moveDown?.();
+    },
+    deleteClicked(event: Event): void {
+      event.stopPropagation();
+      this.delete?.();
+    },
+  },
+});
+
+export default listItem;
+</script>

--- a/packages/vue-bootstrap/src/array/ArrayListRenderer.vue
+++ b/packages/vue-bootstrap/src/array/ArrayListRenderer.vue
@@ -1,0 +1,130 @@
+<template>
+  <fieldset v-if="control.visible">
+    <legend>
+      <button
+        class="btn btn-secondary me-2"
+        type="button"
+        :disabled="
+          !control.enabled || (appliedOptions.restrict && maxItemsReached)
+        "
+        @click="addButtonClick"
+      >
+        <i :class="styles.addButton ?? 'bi bi-plus-lg'"></i>
+      </button>
+      <label class="form-label">
+        {{ control.label }}
+      </label>
+    </legend>
+    <div
+      v-for="(element, index) in control.data"
+      :key="`${control.path}-${index}`"
+      class="card m-1"
+    >
+      <div class="card-body">
+        <array-list-element
+          :move-up="moveUp(control.path, index)"
+          :move-up-enabled="control.enabled && index > 0"
+          :move-down="moveDown(control.path, index)"
+          :move-down-enabled="control.enabled && index < control.data.length - 1"
+          :delete-enabled="control.enabled && !minItemsReached"
+          :delete="removeItems(control.path, [index])"
+          :label="childLabelForIndex(index)"
+          :styles="styles"
+        >
+          <dispatch-renderer
+            :schema="control.schema"
+            :uischema="childUiSchema"
+            :path="composePaths(control.path, `${index}`)"
+            :enabled="control.enabled"
+            :renderers="control.renderers"
+            :cells="control.cells"
+          />
+        </array-list-element>
+      </div>
+    </div>
+    <div v-if="noData">
+      {{ control.translations.noDataMessage }}
+    </div>
+  </fieldset>
+</template>
+
+<script lang="ts">
+import {
+  composePaths,
+  createDefaultValue,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  ControlElement,
+  schemaTypeIs,
+  Resolve,
+  JsonSchema,
+} from '@jsonforms/core';
+import { defineComponent } from 'vue';
+import {
+  DispatchRenderer,
+  rendererProps,
+  useJsonFormsArrayControl,
+  RendererProps,
+} from '../../config/jsonforms';
+import { useVanillaArrayControl } from '../util';
+import ArrayListElement from './ArrayListElement.vue';
+
+const controlRenderer = defineComponent({
+  name: 'ArrayListRenderer',
+  components: {
+    ArrayListElement,
+    DispatchRenderer,
+  },
+  props: {
+    ...rendererProps<ControlElement>(),
+  },
+  setup(props: RendererProps<ControlElement>) {
+    return useVanillaArrayControl(useJsonFormsArrayControl(props));
+  },
+  computed: {
+    noData(): boolean {
+      return !this.control.data || this.control.data.length === 0;
+    },
+    arraySchema(): JsonSchema | undefined {
+      return Resolve.schema(
+        this.schema,
+        this.control.uischema.scope,
+        this.control.rootSchema
+      );
+    },
+    maxItemsReached(): boolean | undefined {
+      return (
+        this.arraySchema !== undefined &&
+        this.arraySchema.maxItems !== undefined &&
+        this.control.data !== undefined &&
+        this.control.data.length >= this.arraySchema.maxItems
+      );
+    },
+    minItemsReached(): boolean | undefined {
+      return (
+        this.arraySchema !== undefined &&
+        this.arraySchema.minItems !== undefined &&
+        this.control.data !== undefined &&
+        this.control.data.length <= this.arraySchema.minItems
+      );
+    },
+  },
+  methods: {
+    composePaths,
+    createDefaultValue,
+    addButtonClick() {
+      this.addItem(
+        this.control.path,
+        createDefaultValue(this.control.schema, this.control.rootSchema)
+      )();
+    },
+  },
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, schemaTypeIs('array')),
+};
+</script>

--- a/packages/vue-bootstrap/src/array/index.ts
+++ b/packages/vue-bootstrap/src/array/index.ts
@@ -1,0 +1,5 @@
+export { default as ArrayListRenderer } from './ArrayListRenderer.vue';
+
+import { entry as arrayListRendererEntry } from './ArrayListRenderer.vue';
+
+export const arrayRenderers = [arrayListRendererEntry];

--- a/packages/vue-bootstrap/src/complex/ObjectRenderer.vue
+++ b/packages/vue-bootstrap/src/complex/ObjectRenderer.vue
@@ -1,0 +1,89 @@
+<template>
+  <div v-if="control.visible">
+    <dispatch-renderer
+      :visible="control.visible"
+      :enabled="control.enabled"
+      :schema="control.schema"
+      :uischema="detailUiSchema"
+      :path="control.path"
+      :renderers="control.renderers"
+      :cells="control.cells"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import {
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  ControlElement,
+  Generate,
+  GroupLayout,
+  UISchemaElement,
+  findUISchema,
+  isObjectControl,
+} from '@jsonforms/core';
+import { defineComponent } from 'vue';
+import {
+  DispatchRenderer,
+  rendererProps,
+  RendererProps,
+  useJsonFormsControlWithDetail,
+} from '../../config/jsonforms';
+import { useVanillaControl } from '../util';
+import { isEmpty } from 'lodash';
+
+const controlRenderer = defineComponent({
+  name: 'ObjectRenderer',
+  components: {
+    DispatchRenderer,
+  },
+  props: {
+    ...rendererProps<ControlElement>(),
+  },
+  setup(props: RendererProps<ControlElement>) {
+    const control = useVanillaControl(useJsonFormsControlWithDetail(props));
+    return {
+      ...control,
+      input: control,
+    };
+  },
+  computed: {
+    detailUiSchema(): UISchemaElement {
+      const uiSchemaGenerator = () => {
+        const uiSchema = Generate.uiSchema(
+          this.control.schema,
+          'Group',
+          undefined,
+          this.control.rootSchema
+        );
+        if (isEmpty(this.control.path)) {
+          uiSchema.type = 'VerticalLayout';
+        } else {
+          (uiSchema as GroupLayout).label = this.control.label;
+        }
+        return uiSchema;
+      };
+
+      const result = findUISchema(
+        this.control.uischemas,
+        this.control.schema,
+        this.control.uischema.scope,
+        this.control.path,
+        uiSchemaGenerator,
+        this.control.uischema,
+        this.control.rootSchema
+      );
+
+      return result;
+    },
+  },
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, isObjectControl),
+};
+</script>

--- a/packages/vue-bootstrap/src/complex/components/CombinatorProperties.vue
+++ b/packages/vue-bootstrap/src/complex/components/CombinatorProperties.vue
@@ -1,0 +1,74 @@
+<template>
+  <div v-if="isLayoutWithElements">
+    <dispatch-renderer
+      :schema="otherProps"
+      :path="path"
+      :uischema="foundUISchema"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { Generate, JsonSchema, Layout, UISchemaElement } from '@jsonforms/core';
+import omit from 'lodash/omit';
+import { PropType, defineComponent } from 'vue';
+import { DispatchRenderer } from '@jsonforms/vue';
+
+interface CombinatorProps {
+  schema: JsonSchema;
+  combinatorKeyword: 'oneOf' | 'anyOf' | 'allOf';
+  path: string;
+  rootSchema: JsonSchema;
+}
+
+export default defineComponent({
+  name: 'CombinatorProperties',
+  components: {
+    DispatchRenderer,
+  },
+  props: {
+    schema: {
+      type: Object as PropType<JsonSchema>,
+      required: true,
+    },
+    combinatorKeyword: {
+      type: String as PropType<'oneOf' | 'anyOf' | 'allOf'>,
+      required: true,
+    },
+    path: {
+      type: String,
+      required: true,
+    },
+    rootSchema: {
+      type: Object as PropType<JsonSchema>,
+      required: true,
+    },
+  },
+  setup(props: CombinatorProps) {
+    const otherProps: JsonSchema = omit(
+      props.schema,
+      props.combinatorKeyword
+    ) as JsonSchema;
+    const foundUISchema: UISchemaElement = Generate.uiSchema(
+      otherProps,
+      'VerticalLayout',
+      undefined,
+      props.rootSchema
+    );
+
+    const isLayout = (uischema: UISchemaElement): uischema is Layout =>
+      Object.prototype.hasOwnProperty.call(uischema, 'elements');
+
+    let isLayoutWithElements = false;
+    if (foundUISchema !== null && isLayout(foundUISchema)) {
+      isLayoutWithElements = foundUISchema.elements.length > 0;
+    }
+
+    return {
+      otherProps,
+      foundUISchema,
+      isLayoutWithElements,
+    };
+  },
+});
+</script>

--- a/packages/vue-bootstrap/src/complex/index.ts
+++ b/packages/vue-bootstrap/src/complex/index.ts
@@ -1,0 +1,7 @@
+export { default as ObjectRenderer } from './ObjectRenderer.vue';
+export { default as OneOfRenderer } from './OneOfRenderer.vue';
+
+import { entry as objectRendererEntry } from './ObjectRenderer.vue';
+import { entry as oneOfRendererEntry } from './OneOfRenderer.vue';
+
+export const complexRenderers = [objectRendererEntry, oneOfRendererEntry];

--- a/packages/vue-bootstrap/src/controls/BooleanControlRenderer.vue
+++ b/packages/vue-bootstrap/src/controls/BooleanControlRenderer.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="form-check">
+      <input
+        :id="control.id + '-input'"
+        type="checkbox"
+        class="form-check-input"
+        :checked="!!control.data"
+        :disabled="!control.enabled"
+        :autofocus="appliedOptions.focus"
+        :placeholder="appliedOptions.placeholder"
+        @change="onChange"
+        @focus="isFocused = true"
+        @blur="isFocused = false"
+      />
+    <label
+      class="form-label"
+      v-bind="controlWrapper"
+      :for="control.id + '-input'"
+      :styles="styles"
+      :is-focused="isFocused"
+      :applied-options="appliedOptions"
+    >{{control.label}}</label>
+  </div>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isBooleanControl,
+} from '@jsonforms/core';
+import { defineComponent } from 'vue';
+import {
+  rendererProps,
+  useJsonFormsControl,
+  RendererProps,
+} from '../../config/jsonforms';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'BooleanControlRenderer',
+  components: {
+    ControlWrapper,
+  },
+  props: {
+    ...rendererProps<ControlElement>(),
+  },
+  setup(props: RendererProps<ControlElement>) {
+    return useVanillaControl(
+      useJsonFormsControl(props),
+      (target) => target.checked
+    );
+  },
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(1, isBooleanControl),
+};
+</script>

--- a/packages/vue-bootstrap/src/controls/ControlWrapper.vue
+++ b/packages/vue-bootstrap/src/controls/ControlWrapper.vue
@@ -1,0 +1,77 @@
+<template>
+  <div v-if="visible" :id="id" class="mb-3">
+    <label :for="id + '-input'" :class="['form-label', { 'required': required }]">
+      {{ label }}
+    </label>
+    <slot></slot>
+    <div :class="errors ? 'text-danger' : 'text-body-secondary'">
+      {{ errors ? errors : showDescription ? description : null }}
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { isDescriptionHidden } from '@jsonforms/core';
+import { defineComponent, PropType } from 'vue';
+import { Styles } from '../styles';
+import { Options } from '../util';
+
+export default defineComponent({
+  name: 'ControlWrapper',
+  props: {
+    id: {
+      required: true,
+      type: String,
+    },
+    description: {
+      required: false as const,
+      type: String,
+      default: undefined,
+    },
+    errors: {
+      required: false as const,
+      type: String,
+      default: undefined,
+    },
+    label: {
+      required: false as const,
+      type: String,
+      default: undefined,
+    },
+    appliedOptions: {
+      required: false as const,
+      type: Object as PropType<Options>,
+      default: undefined,
+    },
+    visible: {
+      required: false as const,
+      type: Boolean,
+      default: true,
+    },
+    required: {
+      required: false as const,
+      type: Boolean,
+      default: false,
+    },
+    isFocused: {
+      required: false as const,
+      type: Boolean,
+      default: false,
+    },
+    styles: {
+      required: true,
+      type: Object as PropType<Styles>,
+    },
+  },
+  computed: {
+    showDescription(): boolean {
+      return !isDescriptionHidden(
+        this.visible,
+        this.description,
+        true,
+        !!this.appliedOptions?.showUnfocusedDescription
+      );
+    },
+  },
+});
+</script>

--- a/packages/vue-bootstrap/src/controls/DateControlRenderer.vue
+++ b/packages/vue-bootstrap/src/controls/DateControlRenderer.vue
@@ -1,0 +1,61 @@
+<template>
+  <control-wrapper
+    v-bind="controlWrapper"
+    :styles="styles"
+    :is-focused="isFocused"
+    :applied-options="appliedOptions"
+  >
+    <input
+      :id="control.id + '-input'"
+      type="date"
+      class="form-control"
+      :value="control.data"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      :placeholder="appliedOptions.placeholder"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    />
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isDateControl,
+} from '@jsonforms/core';
+import { defineComponent } from 'vue';
+import {
+  rendererProps,
+  useJsonFormsControl,
+  RendererProps,
+} from '../../config/jsonforms';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'DateControlRenderer',
+  components: {
+    ControlWrapper,
+  },
+  props: {
+    ...rendererProps<ControlElement>(),
+  },
+  setup(props: RendererProps<ControlElement>) {
+    return useVanillaControl(
+      useJsonFormsControl(props),
+      (target) => target.value || undefined
+    );
+  },
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, isDateControl),
+};
+</script>

--- a/packages/vue-bootstrap/src/controls/DateTimeControlRenderer.vue
+++ b/packages/vue-bootstrap/src/controls/DateTimeControlRenderer.vue
@@ -1,0 +1,69 @@
+<template>
+  <control-wrapper
+    v-bind="controlWrapper"
+    :styles="styles"
+    :is-focused="isFocused"
+    :applied-options="appliedOptions"
+  >
+    <input
+      :id="control.id + '-input'"
+      type="datetime-local"
+      class="form-control"
+      :value="dataTime"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      :placeholder="appliedOptions.placeholder"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    />
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isDateTimeControl,
+} from '@jsonforms/core';
+import { defineComponent } from 'vue';
+import {
+  rendererProps,
+  useJsonFormsControl,
+  RendererProps,
+} from '../../config/jsonforms';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const toISOString = (inputDateTime: string) => {
+  return inputDateTime === '' ? undefined : inputDateTime + ':00.000Z';
+};
+
+const controlRenderer = defineComponent({
+  name: 'DatetimeControlRenderer',
+  components: {
+    ControlWrapper,
+  },
+  props: {
+    ...rendererProps<ControlElement>(),
+  },
+  setup(props: RendererProps<ControlElement>) {
+    return useVanillaControl(useJsonFormsControl(props), (target) =>
+      toISOString(target.value)
+    );
+  },
+  computed: {
+    dataTime(): string {
+      return (this.control.data ?? '').substr(0, 16);
+    },
+  },
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, isDateTimeControl),
+};
+</script>

--- a/packages/vue-bootstrap/src/controls/EnumControlRenderer.vue
+++ b/packages/vue-bootstrap/src/controls/EnumControlRenderer.vue
@@ -1,0 +1,66 @@
+<template>
+  <control-wrapper
+    v-bind="controlWrapper"
+    :styles="styles"
+    :is-focused="isFocused"
+    :applied-options="appliedOptions"
+  >
+    <select
+      :id="control.id + '-select'"
+      class="form-select"
+      :value="control.data"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    >
+      <option key="empty" value="" />
+      <option
+        v-for="optionElement in control.options"
+        :key="optionElement.value"
+        :value="optionElement.value"
+        :label="optionElement.label"
+      ></option>
+    </select>
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isEnumControl,
+} from '@jsonforms/core';
+import { defineComponent } from 'vue';
+import {
+  rendererProps,
+  useJsonFormsEnumControl,
+  RendererProps,
+} from '../../config/jsonforms';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'EnumControlRenderer',
+  components: {
+    ControlWrapper,
+  },
+  props: {
+    ...rendererProps<ControlElement>(),
+  },
+  setup(props: RendererProps<ControlElement>) {
+    return useVanillaControl(useJsonFormsEnumControl(props), (target) =>
+      target.selectedIndex === 0 ? undefined : target.value
+    );
+  },
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, isEnumControl),
+};
+</script>

--- a/packages/vue-bootstrap/src/controls/EnumOneOfControlRenderer.vue
+++ b/packages/vue-bootstrap/src/controls/EnumOneOfControlRenderer.vue
@@ -1,0 +1,66 @@
+<template>
+  <control-wrapper
+    v-bind="controlWrapper"
+    :styles="styles"
+    :is-focused="isFocused"
+    :applied-options="appliedOptions"
+  >
+    <select
+      :id="control.id + '-input'"
+      class="form-select"
+      :value="control.data"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    >
+      <option key="empty" value="" />
+      <option
+        v-for="optionElement in control.options"
+        :key="optionElement.value"
+        :value="optionElement.value"
+        :label="optionElement.label"
+      ></option>
+    </select>
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isOneOfEnumControl,
+} from '@jsonforms/core';
+import { defineComponent } from 'vue';
+import {
+  rendererProps,
+  useJsonFormsOneOfEnumControl,
+  RendererProps,
+} from '../../config/jsonforms';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'EnumOneofControlRenderer',
+  components: {
+    ControlWrapper,
+  },
+  props: {
+    ...rendererProps<ControlElement>(),
+  },
+  setup(props: RendererProps<ControlElement>) {
+    return useVanillaControl(useJsonFormsOneOfEnumControl(props), (target) =>
+      target.selectedIndex === 0 ? undefined : target.value
+    );
+  },
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(5, isOneOfEnumControl),
+};
+</script>

--- a/packages/vue-bootstrap/src/controls/IntegerControlRenderer.vue
+++ b/packages/vue-bootstrap/src/controls/IntegerControlRenderer.vue
@@ -1,0 +1,61 @@
+<template>
+  <control-wrapper
+    v-bind="controlWrapper"
+    :styles="styles"
+    :is-focused="isFocused"
+    :applied-options="appliedOptions"
+  >
+    <input
+      :id="control.id + '-input'"
+      type="number"
+      :step="1"
+      class="form-control"
+      :value="control.data"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      :placeholder="appliedOptions.placeholder"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    />
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isIntegerControl,
+} from '@jsonforms/core';
+import { defineComponent } from 'vue';
+import {
+  rendererProps,
+  useJsonFormsControl,
+  RendererProps,
+} from '../../config/jsonforms';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'IntegerControlRenderer',
+  components: {
+    ControlWrapper,
+  },
+  props: {
+    ...rendererProps<ControlElement>(),
+  },
+  setup(props: RendererProps<ControlElement>) {
+    return useVanillaControl(useJsonFormsControl(props), (target) =>
+      target.value === '' ? undefined : parseInt(target.value, 10)
+    );
+  },
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(1, isIntegerControl),
+};
+</script>

--- a/packages/vue-bootstrap/src/controls/MultiStringControlRenderer.vue
+++ b/packages/vue-bootstrap/src/controls/MultiStringControlRenderer.vue
@@ -1,0 +1,62 @@
+<template>
+  <control-wrapper
+    v-bind="controlWrapper"
+    :styles="styles"
+    :is-focused="isFocused"
+    :applied-options="appliedOptions"
+  >
+    <textarea
+      :id="control.id + '-input'"
+      class="form-control"
+      :value="control.data"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      :placeholder="appliedOptions.placeholder"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    />
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isStringControl,
+  isMultiLineControl,
+  and,
+} from '@jsonforms/core';
+import { defineComponent } from 'vue';
+import {
+  rendererProps,
+  useJsonFormsControl,
+  RendererProps,
+} from '../../config/jsonforms';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'MultiStringControlRenderer',
+  components: {
+    ControlWrapper,
+  },
+  props: {
+    ...rendererProps<ControlElement>(),
+  },
+  setup(props: RendererProps<ControlElement>) {
+    return useVanillaControl(
+      useJsonFormsControl(props),
+      (target) => target.value || undefined
+    );
+  },
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, and(isStringControl, isMultiLineControl)),
+};
+</script>

--- a/packages/vue-bootstrap/src/controls/NumberControlRenderer.vue
+++ b/packages/vue-bootstrap/src/controls/NumberControlRenderer.vue
@@ -1,0 +1,67 @@
+<template>
+  <control-wrapper
+    v-bind="controlWrapper"
+    :styles="styles"
+    :is-focused="isFocused"
+    :applied-options="appliedOptions"
+  >
+    <input
+      :id="control.id + '-input'"
+      type="number"
+      :step="step"
+      class="form-control"
+      :value="control.data"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      :placeholder="appliedOptions.placeholder"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    />
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isNumberControl,
+} from '@jsonforms/core';
+import { defineComponent } from 'vue';
+import {
+  rendererProps,
+  useJsonFormsControl,
+  RendererProps,
+} from '../../config/jsonforms';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'NumberControlRenderer',
+  components: {
+    ControlWrapper,
+  },
+  props: {
+    ...rendererProps<ControlElement>(),
+  },
+  setup(props: RendererProps<ControlElement>) {
+    return useVanillaControl(useJsonFormsControl(props), (target) =>
+      target.value === '' ? undefined : Number(target.value)
+    );
+  },
+  computed: {
+    step(): number {
+      const options: any = this.appliedOptions;
+      return options.step ?? 0.1;
+    },
+  },
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(1, isNumberControl),
+};
+</script>

--- a/packages/vue-bootstrap/src/controls/StringControlRenderer.vue
+++ b/packages/vue-bootstrap/src/controls/StringControlRenderer.vue
@@ -1,0 +1,60 @@
+<template>
+  <control-wrapper
+    v-bind="controlWrapper"
+    :styles="styles"
+    :is-focused="isFocused"
+    :applied-options="appliedOptions"
+  >
+    <input
+      :id="control.id + '-input'"
+      class="form-control"
+      :value="control.data"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      :placeholder="appliedOptions.placeholder"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    />
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isStringControl,
+} from '@jsonforms/core';
+import { defineComponent } from 'vue';
+import {
+  rendererProps,
+  useJsonFormsControl,
+  RendererProps,
+} from '../../config/jsonforms';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'StringControlRenderer',
+  components: {
+    ControlWrapper,
+  },
+  props: {
+    ...rendererProps<ControlElement>(),
+  },
+  setup(props: RendererProps<ControlElement>) {
+    return useVanillaControl(
+      useJsonFormsControl(props),
+      (target) => target.value || undefined
+    );
+  },
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(1, isStringControl),
+};
+</script>

--- a/packages/vue-bootstrap/src/controls/TimeControlRenderer.vue
+++ b/packages/vue-bootstrap/src/controls/TimeControlRenderer.vue
@@ -1,0 +1,61 @@
+<template>
+  <control-wrapper
+    v-bind="controlWrapper"
+    :styles="styles"
+    :is-focused="isFocused"
+    :applied-options="appliedOptions"
+  >
+    <input
+      :id="control.id + '-input'"
+      type="time"
+      class="form-control"
+      :value="control.data"
+      :disabled="!control.enabled"
+      :autofocus="appliedOptions.focus"
+      :placeholder="appliedOptions.placeholder"
+      @change="onChange"
+      @focus="isFocused = true"
+      @blur="isFocused = false"
+    />
+  </control-wrapper>
+</template>
+
+<script lang="ts">
+import {
+  ControlElement,
+  JsonFormsRendererRegistryEntry,
+  rankWith,
+  isTimeControl,
+} from '@jsonforms/core';
+import { defineComponent } from 'vue';
+import {
+  rendererProps,
+  useJsonFormsControl,
+  RendererProps,
+} from '../../config/jsonforms';
+import { default as ControlWrapper } from './ControlWrapper.vue';
+import { useVanillaControl } from '../util';
+
+const controlRenderer = defineComponent({
+  name: 'TimeControlRenderer',
+  components: {
+    ControlWrapper,
+  },
+  props: {
+    ...rendererProps<ControlElement>(),
+  },
+  setup(props: RendererProps<ControlElement>) {
+    return useVanillaControl(
+      useJsonFormsControl(props),
+      (target) => target.value || undefined
+    );
+  },
+});
+
+export default controlRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, isTimeControl),
+};
+</script>

--- a/packages/vue-bootstrap/src/controls/index.ts
+++ b/packages/vue-bootstrap/src/controls/index.ts
@@ -1,0 +1,35 @@
+export { default as ControlWrapper } from './ControlWrapper.vue';
+export { default as StringControlRenderer } from './StringControlRenderer.vue';
+export { default as MultiStringControlRenderer } from './MultiStringControlRenderer.vue';
+export { default as NumberControlRenderer } from './NumberControlRenderer.vue';
+export { default as IntegerControlRenderer } from './IntegerControlRenderer.vue';
+export { default as EnumControlRenderer } from './EnumControlRenderer.vue';
+export { default as oneOfEnumControlRenderer } from './EnumOneOfControlRenderer.vue';
+export { default as DateControlRenderer } from './DateControlRenderer.vue';
+export { default as DateTimeControlRenderer } from './DateTimeControlRenderer.vue';
+export { default as TimeControlRenderer } from './TimeControlRenderer.vue';
+export { default as BooleanControlRenderer } from './BooleanControlRenderer.vue';
+
+import { entry as stringControlRendererEntry } from './StringControlRenderer.vue';
+import { entry as multiStringControlRendererEntry } from './MultiStringControlRenderer.vue';
+import { entry as numberControlRendererEntry } from './NumberControlRenderer.vue';
+import { entry as integerControlRendererEntry } from './IntegerControlRenderer.vue';
+import { entry as enumControlRendererEntry } from './EnumControlRenderer.vue';
+import { entry as oneOfEnumControlRendererEntry } from './EnumOneOfControlRenderer.vue';
+import { entry as dateControlRendererEntry } from './DateControlRenderer.vue';
+import { entry as dateTimeControlRendererEntry } from './DateTimeControlRenderer.vue';
+import { entry as timeControlRendererEntry } from './TimeControlRenderer.vue';
+import { entry as booleanControlRendererEntry } from './BooleanControlRenderer.vue';
+
+export const controlRenderers = [
+  stringControlRendererEntry,
+  multiStringControlRendererEntry,
+  numberControlRendererEntry,
+  integerControlRendererEntry,
+  enumControlRendererEntry,
+  oneOfEnumControlRendererEntry,
+  dateControlRendererEntry,
+  dateTimeControlRendererEntry,
+  timeControlRendererEntry,
+  booleanControlRendererEntry,
+];

--- a/packages/vue-bootstrap/src/index.ts
+++ b/packages/vue-bootstrap/src/index.ts
@@ -1,0 +1,7 @@
+export * from './array';
+export * from './controls';
+export * from './layouts';
+export * from './renderers';
+export * from './styles';
+export * from './util';
+export * from './label';

--- a/packages/vue-bootstrap/src/label/LabelRenderer.vue
+++ b/packages/vue-bootstrap/src/label/LabelRenderer.vue
@@ -1,0 +1,38 @@
+<template>
+  <label v-if="label.visible" class="form-label">
+    {{ label.text }}
+  </label>
+</template>
+
+<script lang="ts">
+import {
+  JsonFormsRendererRegistryEntry,
+  LabelElement,
+  rankWith,
+  uiTypeIs,
+} from '@jsonforms/core';
+import { defineComponent } from 'vue';
+import {
+  rendererProps,
+  RendererProps,
+  useJsonFormsLabel,
+} from '../../config/jsonforms';
+import { useVanillaLabel } from '../util';
+
+const labelRenderer = defineComponent({
+  name: 'LabelRenderer',
+  props: {
+    ...rendererProps<LabelElement>(),
+  },
+  setup(props: RendererProps<LabelElement>) {
+    return useVanillaLabel(useJsonFormsLabel(props));
+  },
+});
+
+export default labelRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: labelRenderer,
+  tester: rankWith(1, uiTypeIs('Label')),
+};
+</script>

--- a/packages/vue-bootstrap/src/label/index.ts
+++ b/packages/vue-bootstrap/src/label/index.ts
@@ -1,0 +1,5 @@
+export { default as LabelRenderer } from './LabelRenderer.vue';
+
+import { entry as labelRendererEntry } from './LabelRenderer.vue';
+
+export const labelRenderers = [labelRendererEntry];

--- a/packages/vue-bootstrap/src/layouts/GroupRenderer.vue
+++ b/packages/vue-bootstrap/src/layouts/GroupRenderer.vue
@@ -1,0 +1,59 @@
+<template>
+  <div v-if="layout.visible" class="card mb-3">
+    <div class="card-body">
+      <h5 class="card-title">{{ layout.label }}</h5>
+      <div
+        v-for="(element, index) in layout.uischema.elements"
+        :key="`${layout.path}-${index}`"
+      >
+        <dispatch-renderer
+          :schema="layout.schema"
+          :uischema="element"
+          :path="layout.path"
+          :enabled="layout.enabled"
+          :renderers="layout.renderers"
+          :cells="layout.cells"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import {
+  JsonFormsRendererRegistryEntry,
+  Layout,
+  rankWith,
+  and,
+  isLayout,
+  uiTypeIs,
+} from '@jsonforms/core';
+import { defineComponent } from 'vue';
+import {
+  DispatchRenderer,
+  rendererProps,
+  useJsonFormsLayout,
+  RendererProps,
+} from '../../config/jsonforms';
+import { useVanillaLayout } from '../util';
+
+const layoutRenderer = defineComponent({
+  name: 'GroupRenderer',
+  components: {
+    DispatchRenderer,
+  },
+  props: {
+    ...rendererProps<Layout>(),
+  },
+  setup(props: RendererProps<Layout>) {
+    return useVanillaLayout(useJsonFormsLayout(props));
+  },
+});
+
+export default layoutRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: layoutRenderer,
+  tester: rankWith(2, and(isLayout, uiTypeIs('Group'))),
+};
+</script>

--- a/packages/vue-bootstrap/src/layouts/LayoutRenderer.vue
+++ b/packages/vue-bootstrap/src/layouts/LayoutRenderer.vue
@@ -1,0 +1,55 @@
+<template>
+  <div v-if="layout.visible" class="row">
+    <div
+      v-for="(element, index) in layout.uischema.elements"
+      :key="`${layout.path}-${index}`"
+      :class="[layout.direction === 'row' ? 'col-sm' : 'col-12']"
+    >
+      <dispatch-renderer
+        :schema="layout.schema"
+        :uischema="element"
+        :path="layout.path"
+        :enabled="layout.enabled"
+        :renderers="layout.renderers"
+        :cells="layout.cells"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import {
+  isLayout,
+  JsonFormsRendererRegistryEntry,
+  Layout,
+  rankWith,
+} from '@jsonforms/core';
+import { defineComponent } from 'vue';
+import {
+  DispatchRenderer,
+  rendererProps,
+  useJsonFormsLayout,
+  RendererProps,
+} from '../../config/jsonforms';
+import { useVanillaLayout } from '../util';
+
+const layoutRenderer = defineComponent({
+  name: 'LayoutRenderer',
+  components: {
+    DispatchRenderer,
+  },
+  props: {
+    ...rendererProps<Layout>(),
+  },
+  setup(props: RendererProps<Layout>) {
+    return useVanillaLayout(useJsonFormsLayout(props));
+  },
+});
+
+export default layoutRenderer;
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: layoutRenderer,
+  tester: rankWith(1, isLayout),
+};
+</script>

--- a/packages/vue-bootstrap/src/layouts/index.ts
+++ b/packages/vue-bootstrap/src/layouts/index.ts
@@ -1,0 +1,7 @@
+export { default as LayoutRenderer } from './LayoutRenderer.vue';
+export { default as GroupRenderer } from './GroupRenderer.vue';
+
+import { entry as layoutRendererEntry } from './LayoutRenderer.vue';
+import { entry as groupRendererEntry } from './GroupRenderer.vue';
+
+export const layoutRenderers = [layoutRendererEntry, groupRendererEntry];

--- a/packages/vue-bootstrap/src/renderers.ts
+++ b/packages/vue-bootstrap/src/renderers.ts
@@ -1,0 +1,11 @@
+import { arrayRenderers } from './array';
+import { controlRenderers } from './controls';
+import { labelRenderers } from './label';
+import { layoutRenderers } from './layouts';
+
+export const bootstrapRenderers = [
+  ...controlRenderers,
+  ...layoutRenderers,
+  ...arrayRenderers,
+  ...labelRenderers,
+];

--- a/packages/vue-bootstrap/src/styles/defaultStyles.ts
+++ b/packages/vue-bootstrap/src/styles/defaultStyles.ts
@@ -1,0 +1,8 @@
+import { Styles } from './styles';
+
+export const defaultStyles: Styles = {
+  addButton: undefined,
+  itemMoveUp: undefined,
+  itemMoveDown: undefined,
+  itemDelete: undefined,
+};

--- a/packages/vue-bootstrap/src/styles/index.ts
+++ b/packages/vue-bootstrap/src/styles/index.ts
@@ -1,0 +1,2 @@
+export * from './styles';
+export * from './defaultStyles';

--- a/packages/vue-bootstrap/src/styles/styles.ts
+++ b/packages/vue-bootstrap/src/styles/styles.ts
@@ -1,0 +1,31 @@
+import { UISchemaElement } from '@jsonforms/core';
+import { inject } from 'vue';
+import merge from 'lodash/merge';
+import { defaultStyles } from './defaultStyles';
+
+const createEmptyStyles = (): Styles => ({
+});
+
+export interface Styles {
+  addButton?: string;
+  itemMoveUp?: string;
+  itemMoveDown?: string;
+  itemDelete?: string;
+}
+
+export const useStyles = (element?: UISchemaElement) => {
+  const userStyles = inject('styles', defaultStyles);
+  if (!element?.options?.styles) {
+    return userStyles;
+  }
+  const styles = createEmptyStyles();
+  if (userStyles) {
+    merge(styles, userStyles);
+  } else {
+    merge(styles, defaultStyles);
+  }
+  if (element?.options?.styles) {
+    merge(styles, element.options.styles);
+  }
+  return styles;
+};

--- a/packages/vue-bootstrap/src/util/composition.ts
+++ b/packages/vue-bootstrap/src/util/composition.ts
@@ -1,0 +1,139 @@
+import { useStyles } from '../styles';
+import { computed, ref } from 'vue';
+import merge from 'lodash/merge';
+import cloneDeep from 'lodash/cloneDeep';
+import {
+  composePaths,
+  findUISchema,
+  getFirstPrimitiveProp,
+  Resolve,
+} from '@jsonforms/core';
+
+/**
+ * Adds styles, isFocused, appliedOptions and onChange
+ */
+export const useVanillaControl = <
+  I extends { control: any; handleChange: any }
+>(
+  input: I,
+  adaptTarget: (target: any) => any = (v) => v.value
+) => {
+  const appliedOptions = computed(() =>
+    merge(
+      {},
+      cloneDeep(input.control.value.config),
+      cloneDeep(input.control.value.uischema.options)
+    )
+  );
+
+  const isFocused = ref(false);
+  const onChange = (event: Event) => {
+    input.handleChange(input.control.value.path, adaptTarget(event.target));
+  };
+
+  const controlWrapper = computed(() => {
+    const { id, description, errors, label, visible, required } =
+      input.control.value;
+    return { id, description, errors, label, visible, required };
+  });
+
+  return {
+    ...input,
+    styles: useStyles(input.control.value.uischema),
+    isFocused,
+    appliedOptions,
+    controlWrapper,
+    onChange,
+  };
+};
+
+/**
+ * Adds styles and appliedOptions
+ */
+export const useVanillaLayout = <I extends { layout: any }>(input: I) => {
+  const appliedOptions = computed(() =>
+    merge(
+      {},
+      cloneDeep(input.layout.value.config),
+      cloneDeep(input.layout.value.uischema.options)
+    )
+  );
+  return {
+    ...input,
+    styles: useStyles(input.layout.value.uischema),
+    appliedOptions,
+  };
+};
+
+/**
+ * Adds styles and appliedOptions
+ */
+export const useVanillaLabel = <I extends { label: any }>(input: I) => {
+  const appliedOptions = computed(() =>
+    merge(
+      {},
+      cloneDeep(input.label.value.config),
+      cloneDeep(input.label.value.uischema.options)
+    )
+  );
+  return {
+    ...input,
+    styles: useStyles(input.label.value.uischema),
+    appliedOptions,
+  };
+};
+
+/**
+ * Adds styles, appliedOptions and childUiSchema
+ */
+export const useVanillaArrayControl = <I extends { control: any }>(
+  input: I
+) => {
+  const appliedOptions = computed(() =>
+    merge(
+      {},
+      cloneDeep(input.control.value.config),
+      cloneDeep(input.control.value.uischema.options)
+    )
+  );
+
+  const childUiSchema = computed(() =>
+    findUISchema(
+      input.control.value.uischemas,
+      input.control.value.schema,
+      input.control.value.uischema.scope,
+      input.control.value.path,
+      undefined,
+      input.control.value.uischema,
+      input.control.value.rootSchema
+    )
+  );
+
+  const childLabelForIndex = (index: number) => {
+    const childLabelProp =
+      input.control.value.uischema.options?.childLabelProp ??
+      getFirstPrimitiveProp(input.control.value.schema);
+    if (!childLabelProp) {
+      return `${index}`;
+    }
+    const labelValue = Resolve.data(
+      input.control.value.data,
+      composePaths(`${index}`, childLabelProp)
+    );
+    if (
+      labelValue === undefined ||
+      labelValue === null ||
+      Number.isNaN(labelValue)
+    ) {
+      return '';
+    }
+    return `${labelValue}`;
+  };
+  return {
+    ...input,
+    styles: useStyles(input.control.value.uischema),
+    appliedOptions,
+    childUiSchema,
+    childLabelForIndex,
+  };
+};

--- a/packages/vue-bootstrap/src/util/index.ts
+++ b/packages/vue-bootstrap/src/util/index.ts
@@ -1,0 +1,2 @@
+export * from './options';
+export * from './composition';

--- a/packages/vue-bootstrap/src/util/options.ts
+++ b/packages/vue-bootstrap/src/util/options.ts
@@ -1,0 +1,6 @@
+export interface Options {
+  showUnfocusedDescription?: boolean;
+  hideRequiredAsterisk?: boolean;
+  focus?: boolean;
+  step?: number;
+}

--- a/packages/vue-bootstrap/style.css
+++ b/packages/vue-bootstrap/style.css
@@ -1,0 +1,5 @@
+label.required::after {
+  color: var(--bs-red);
+  padding-left: 5px;
+  content: "*"
+}


### PR DESCRIPTION
This PR adds a renderer for Vue that uses Bootstrap.

It is derived from `vue-vanilla` so it only supports what is supported by that package which is not as full fledged as the Material Design renderer for the React package.

It requires an icon set, by default it assumes that will be [Bootstrap Icons](https://icons.getbootstrap.com/) so it requires you to include that, however if you rather use some other icon set such as [Font Awesome](https://fontawesome.com/) or any other you can do that by overriding some properties using a `provide` (just like the `vue-vanilla` does for CSS classes).