### PR TITLE
chore: use npm provenance

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,6 +24,7 @@ jobs:
   publish:
     permissions:
       contents: "write"
+      id-token: "write"
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v4"
@@ -81,6 +82,7 @@ jobs:
         run: "pnpm publish --recursive ${{  github.event.inputs.stable_release == 'true' && ' ' || '--tag next' }}"
         env:
           NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}"
+          NPM_CONFIG_PROVENANCE: "true"
 
       - name: "push"
         if: "github.event.inputs.skip_push == 'false'"


### PR DESCRIPTION
Configures the npm provenance mechanism for the Github release workflow.

The npm provenance assures consumers of JSON Forms that the libraries available on npmjs were actually produced by the JSON Forms project.

See https://docs.npmjs.com/generating-provenance-statements