### PR TITLE
Vanilla TextCell password

### DIFF
--- a/packages/vanilla-renderers/src/cells/TextCell.tsx
+++ b/packages/vanilla-renderers/src/cells/TextCell.tsx
@@ -50,7 +50,7 @@ export const TextCell = (props: CellProps & VanillaRendererProps) => {
   const appliedUiSchemaOptions = merge({}, config, uischema.options);
   return (
     <input
-      type='text'
+      type={appliedUiSchemaOptions.type ? appliedUiSchemaOptions.type : 'text'}
       value={data || ''}
       onChange={(ev) =>
         handleChange(path, ev.target.value === '' ? undefined : ev.target.value)

--- a/packages/vanilla-renderers/src/cells/TextCell.tsx
+++ b/packages/vanilla-renderers/src/cells/TextCell.tsx
@@ -50,11 +50,9 @@ export const TextCell = (props: CellProps & VanillaRendererProps) => {
   const appliedUiSchemaOptions = merge({}, config, uischema.options);
   return (
     <input
-      
       type={
         appliedUiSchemaOptions.format ? appliedUiSchemaOptions.format : 'text'
       }
-      
       value={data || ''}
       onChange={(ev) =>
         handleChange(path, ev.target.value === '' ? undefined : ev.target.value)

--- a/packages/vanilla-renderers/src/cells/TextCell.tsx
+++ b/packages/vanilla-renderers/src/cells/TextCell.tsx
@@ -50,7 +50,7 @@ export const TextCell = (props: CellProps & VanillaRendererProps) => {
   const appliedUiSchemaOptions = merge({}, config, uischema.options);
   return (
     <input
-      type={appliedUiSchemaOptions.type ? appliedUiSchemaOptions.type : 'text'}
+      type={appliedUiSchemaOptions.format ? appliedUiSchemaOptions.format : 'text'}
       value={data || ''}
       onChange={(ev) =>
         handleChange(path, ev.target.value === '' ? undefined : ev.target.value)

--- a/packages/vanilla-renderers/src/cells/TextCell.tsx
+++ b/packages/vanilla-renderers/src/cells/TextCell.tsx
@@ -50,7 +50,9 @@ export const TextCell = (props: CellProps & VanillaRendererProps) => {
   const appliedUiSchemaOptions = merge({}, config, uischema.options);
   return (
     <input
+      
       type={appliedUiSchemaOptions.format ? appliedUiSchemaOptions.format : 'text'}
+      
       value={data || ''}
       onChange={(ev) =>
         handleChange(path, ev.target.value === '' ? undefined : ev.target.value)

--- a/packages/vanilla-renderers/src/cells/TextCell.tsx
+++ b/packages/vanilla-renderers/src/cells/TextCell.tsx
@@ -51,7 +51,9 @@ export const TextCell = (props: CellProps & VanillaRendererProps) => {
   return (
     <input
       
-      type={appliedUiSchemaOptions.format ? appliedUiSchemaOptions.format : 'text'}
+      type={
+        appliedUiSchemaOptions.format ? appliedUiSchemaOptions.format : 'text'
+      }
       
       value={data || ''}
       onChange={(ev) =>

--- a/packages/vanilla-renderers/test/renderers/TextCell.test.tsx
+++ b/packages/vanilla-renderers/test/renderers/TextCell.test.tsx
@@ -614,7 +614,7 @@ describe('Text cell', () => {
       type: 'Control',
       scope: '#/properties/name',
       options: {
-        type: 'password',
+        format: 'password',
       },
     };
     const core = initCore(fixture.schema, uischema, fixture.data);

--- a/packages/vanilla-renderers/test/renderers/TextCell.test.tsx
+++ b/packages/vanilla-renderers/test/renderers/TextCell.test.tsx
@@ -593,4 +593,37 @@ describe('Text cell', () => {
     expect(input.maxLength).toBe(defaultMaxLength);
     expect(input.size).toBe(defaultSize);
   });
+
+  test('default type is text', () => {
+    const uischema: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/name'
+    };
+    const core = initCore(fixture.schema, uischema, fixture.data);
+    wrapper = mount(
+      <JsonFormsStateProvider initState={{ core }}>
+        <TextCell schema={fixture.schema} uischema={uischema} path='name' />
+      </JsonFormsStateProvider>
+    );
+    const input = wrapper.find('input').getDOMNode() as HTMLInputElement;
+    expect(input.type).toBe('text');
+  });
+
+  test('change type to password', () => {
+    const uischema: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/name',
+      options: {
+        type: 'password',
+      },
+    };
+    const core = initCore(fixture.schema, uischema, fixture.data);
+    wrapper = mount(
+      <JsonFormsStateProvider initState={{ core }}>
+        <TextCell schema={fixture.schema} uischema={uischema} path='name' />
+      </JsonFormsStateProvider>
+    );
+    const input = wrapper.find('input').getDOMNode() as HTMLInputElement;
+    expect(input.type).toBe('password');
+  });
 });

--- a/packages/vanilla-renderers/test/renderers/TextCell.test.tsx
+++ b/packages/vanilla-renderers/test/renderers/TextCell.test.tsx
@@ -597,7 +597,7 @@ describe('Text cell', () => {
   test('default type is text', () => {
     const uischema: ControlElement = {
       type: 'Control',
-      scope: '#/properties/name'
+      scope: '#/properties/name',
     };
     const core = initCore(fixture.schema, uischema, fixture.data);
     wrapper = mount(


### PR DESCRIPTION
The input type for a TextCell in the vanilla-renderers was 'text' and could not be changed.

This change keeps the default 'text' type but allows the type to be changed via an option "type"

`"options": {
              "format": "password"
            }`

See also:
https://jsonforms.discourse.group/t/input-type-with-vanilla-renderers/272