### PR TITLE
fix(core): Generate UI Schema with Type Null

### DIFF
--- a/packages/core/src/generators/uischema.ts
+++ b/packages/core/src/generators/uischema.ts
@@ -191,6 +191,8 @@ const generateUISchema = (
     /* falls through */
     case 'integer':
     /* falls through */
+    case 'null':
+    /* falls through */
     case 'boolean': {
       const controlObject: ControlElement = createControlElement(currentRef);
       schemaElements.push(controlObject);


### PR DESCRIPTION
Previously, the default UI schema generation function threw error when encountering data containing a null value. With this commit, a control with type null will be generated, that can be used in custom renderers.

Closes #2207