### PR TITLE
fix: always hide React Material multi enum when not visible

### DIFF
--- a/packages/material-renderers/src/complex/MaterialEnumArrayRenderer.tsx
+++ b/packages/material-renderers/src/complex/MaterialEnumArrayRenderer.tsx
@@ -39,7 +39,7 @@ export const MaterialEnumArrayRenderer = ({
   ...otherProps
 }: ControlProps & OwnPropsOfEnum & DispatchPropsOfMultiEnumControl) => {
   return (
-    <Hidden xlUp={!visible}>
+    <Hidden xsUp={!visible}>
       <FormControl component='fieldset'>
         <FormGroup row>
           {options.map((option: any, index: number) => {


### PR DESCRIPTION
The 'Hidden' of the MaterialEnumArrayRenderer only applied from screen size 'xl' and larger. However it should always apply. This fix changes 'xlUp' to 'xsUp', therefore the control is hidden on all screen sizes.