### PR TITLE
chore: update migration guide and readmes

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -43,7 +43,7 @@ const theme = createTheme({
 When using JSON Forms 3.2 your Angular application now needs to target Angular 16 or 17.
 Some refactorings, especially in Angular Material, were necessary to accomplish this.
 
-Use JSON Forms 3.1 if need to stay in Angular 14.
+Use JSON Forms 3.1 if you need to stay on Angular 14.
 
 > [!NOTE]
 > Angular 15 is only supported by the JSON Forms prerelease `3.2.0-alpha.4`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,7 +2,7 @@
 
 ## Migrating to JSON Forms 3.2
 
-### Material Renderers using Outlined Inputs
+### React Material Renderers using Outlined Inputs
 
 JSON Forms now uses the `outlined` input variant as the default, aligning with the default style of Material UI since version 5.
 If you would like to use the `standard` input variant, as was default in previous versions of JSON Forms, then this can be accomplished using the Material UI `ThemeProvider`:
@@ -37,6 +37,16 @@ const theme = createTheme({
   <JsonForms {...props} />
 </ThemeProvider>;
 ```
+
+### Angular support now targets Angular 16 and Angular 17
+
+When using JSON Forms 3.2 your Angular application now needs to target Angular 16 or 17.
+Some refactorings, especially in Angular Material, were necessary to accomplish this.
+
+Use JSON Forms 3.1 if need to stay in Angular 14.
+
+> [!NOTE]
+> Angular 15 is only supported by the JSON Forms prerelease `3.2.0-alpha.4`.
 
 ## Migrating to JSON Forms 3.0
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -40,7 +40,7 @@ const theme = createTheme({
 
 ### Angular support now targets Angular 16 and Angular 17
 
-When using JSON Forms 3.2 your Angular application now needs to target Angular 16 or 17.
+When using JSON Forms 3.2, your Angular application now needs to target Angular 16 or 17.
 Some refactorings, especially in Angular Material, were necessary to accomplish this.
 
 Use JSON Forms 3.1 if you need to stay on Angular 14.

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -32,7 +32,8 @@ Optional props:
 - `uischemas: JsonFormsUiSchemaEntry[]` - registry for dynamic ui schema dispatching
 - `validationMode: 'ValidateAndShow' | 'ValidateAndHide' | 'NoValidation'` - the validation mode for the form
 - `ajv: AJV` - custom Ajv instance for the form
-- `locale` - string, for example for formatting numbers
+- `middleware: Middleware` - can be used to hook into the form-wide data management.
+- `i18n: JsonFormsI18nState` - can be used to internationalize the rendered form.
 - `dataChange` - event emitter which is called on each data change, containing the updated data and the validation result.
 - `errors` - event emitter which is called with all validations errors.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -18,15 +18,9 @@ The following seeds are available:
 - [Angular Seed](https://github.com/eclipsesource/jsonforms-angular-seed)
 - [Vue Seed](https://github.com/eclipsesource/jsonforms-vue-seed)
 
-See the official [documentation](https://jsonforms.io/) and the [Example Package](https://github.com/eclipsesource/jsonforms/blob/master/packages/examples) on how to integrate JSON Forms with your application.
+See the official [documentation](https://jsonforms.io/) for more information.
 
 Check <https://www.npmjs.com/search?q=%40jsonforms> for all published JSON Forms packages.
-
-## Upgrading to JSON Forms 3.0
-
-With version 3.0 of JSON Forms we removed `json-schema-ref-parser` from the core package.
-This change only affects users of the React variant (Vue and Angular are not affected) and even for React only a few users will need to adjust their code.
-To avoid issues and for more information, please have a look at our [migration guide](https://github.com/eclipsesource/jsonforms/blob/master/MIGRATION.md).
 
 ## License
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -33,7 +33,9 @@ Optional props:
 - `uischemas: JsonFormsUiSchemaEntry[]` - registry for dynamic ui schema dispatching
 - `validationMode: 'ValidateAndShow' | 'ValidateAndHide' | 'NoValidation'` - the validation mode for the form
 - `ajv: AJV` - custom Ajv instance for the form
-- `onChange` - callback which is called on each data change, containing the updated data and the validation result.
+- `middleware: Middleware` - can be used to hook into the form-wide data management.
+- `i18n: JsonFormsI18nState` - can be used to internationalize the rendered form.
+- `onChange` - callback which is called initially and on each data change, containing the updated data and the validation result.
 
 Example:
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -31,6 +31,8 @@ Optional props:
 - `uischemas: JsonFormsUiSchemaEntry[]` - registry for dynamic ui schema dispatching
 - `validationMode: 'ValidateAndShow' | 'ValidateAndHide' | 'NoValidation'` - the validation mode for the form
 - `ajv: AJV` - custom Ajv instance for the form
+- `middleware: Middleware` - can be used to hook into the form-wide data management.
+- `i18n: JsonFormsI18nState` - can be used to internationalize the rendered form.
 
 Events:
 


### PR DESCRIPTION
- remove the 3.0 migration warning from @jsonforms/core
- add more information to migration guide in regards to Angular 16/17
- update JSON Forms component props information in all binding readmes