### PR TITLE
dev: reverse push and publish operations

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -77,15 +77,15 @@ jobs:
           git add -A && git commit --amend --no-edit
           git tag v${{ github.event.inputs.next_version }} -f
 
+      - name: "push"
+        if: "github.event.inputs.skip_push == 'false'"
+        run: |
+          git push
+          git push origin v${{ github.event.inputs.next_version }}
+
       - name: "Publish to npm"
         if: "github.event.inputs.skip_publish == 'false'"
         run: "pnpm publish --recursive ${{  github.event.inputs.stable_release == 'true' && ' ' || '--tag next' }}"
         env:
           NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}"
           NPM_CONFIG_PROVENANCE: "true"
-
-      - name: "push"
-        if: "github.event.inputs.skip_push == 'false'"
-        run: |
-          git push
-          git push origin v${{ github.event.inputs.next_version }}


### PR DESCRIPTION
In the publish workflow we first pushed the release to npm and then pushed the commit to Github. If there was any error during pushing, the published release would point to a non-existing commit. Therefore these operations are now reversed so that this can not happen.