### PR TITLE
feat: added select control renderer for enums and oneOf

### DIFF
--- a/packages/angular-material/example/app/app.component.ts
+++ b/packages/angular-material/example/app/app.component.ts
@@ -58,7 +58,9 @@ const itemTester: UISchemaTester = (_schema, schemaPath, _path) => {
   selector: 'app-root',
   template: `
     <h1>Angular Material Examples</h1>
-    Data: {{ selectedExample.data | json }}
+    <p>Data: {{ selectedExample.data | json }}</p>
+    <p>Schema: {{ selectedExample.schema | json }}</p>
+    <p>UI Schema: {{ selectedExample.uischema | json }}</p>
     <div>
       Example:
       <select (change)="onChange($event)">

--- a/packages/angular-material/src/library/controls/select.renderer.ts
+++ b/packages/angular-material/src/library/controls/select.renderer.ts
@@ -1,0 +1,195 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnInit,
+} from '@angular/core';
+import { MatSelectChange } from '@angular/material/select';
+import { JsonFormsAngularService, JsonFormsControl } from '@jsonforms/angular';
+import {
+  Actions,
+  composeWithUi,
+  ControlElement,
+  OwnPropsOfControl,
+  RankedTester,
+  rankWith,
+  or,
+  and,
+  optionIs,
+  isEnumControl,
+  isOneOfEnumControl,
+  JsonSchema,
+  resolveSchema,
+  uiTypeIs,
+  schemaSubPathMatches,
+  hasType,
+  schemaMatches,
+} from '@jsonforms/core';
+
+@Component({
+  selector: 'SelectControlRenderer',
+  template: `
+    <mat-form-field [ngStyle]="{ display: hidden ? 'none' : '' }">
+      <mat-label>{{ label }}</mat-label>
+      <mat-select
+        (selectionChange)="onSelect($event)"
+        [id]="id"
+        [formControl]="form"
+        [multiple]="multiple"
+        (focus)="focused = true"
+        (focusout)="focused = false"
+      >
+        <mat-option *ngIf="!multiple"> <i>None</i> </mat-option>
+        <mat-option
+          *ngFor="let option of optionElements"
+          [value]="option.const"
+          [disabled]="option.disabled ? true : false"
+        >
+          {{ option.label }}
+        </mat-option>
+      </mat-select>
+      <mat-hint *ngIf="shouldShowUnfocusedDescription() || focused">{{
+        description
+      }}</mat-hint>
+      <mat-error>{{ error }}</mat-error>
+    </mat-form-field>
+  `,
+  styles: [
+    `
+      :host {
+        display: flex;
+        flex-direction: row;
+      }
+      mat-form-field {
+        flex: 1 1 auto;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SelectControlRenderer extends JsonFormsControl implements OnInit {
+  @Input() options: OptionOfSelect[];
+  multiple = false;
+  optionElements: OptionOfSelect[] = [];
+  focused = false;
+  constructor(jsonformsService: JsonFormsAngularService) {
+    super(jsonformsService);
+  }
+  getEventValue = (event: any) => event.target.value || undefined;
+
+  ngOnInit() {
+    super.ngOnInit();
+    let scope: JsonSchema = this.scopedSchema;
+
+    /* allow multiple selections for array type control */
+    if (scope.items) {
+      this.multiple = true;
+      /* change scope to items of the array */
+      scope = scope.items as JsonSchema;
+    }
+    console.log(scope);
+
+    if (this.options) {
+      this.optionElements = this.options;
+    } else {
+      /* Used for enum types */
+      if (scope.enum) {
+        this.optionElements = scope.enum.map((el) => {
+          return { const: el, label: el };
+        });
+      }
+      /* Used for oneOf types */
+      if (scope.oneOf) {
+        this.optionElements = scope.oneOf.map((el) => {
+          return {
+            const: el.const,
+            label: el.title ? el.title : el.const,
+            // disabled: el.readOnly ? true : false,
+          };
+        });
+      }
+    }
+  }
+
+  onSelect(ev: MatSelectChange) {
+    const path = composeWithUi(this.uischema as ControlElement, this.path);
+    this.jsonFormsService.updateCore(Actions.update(path, () => ev.value));
+    this.triggerValidation();
+  }
+
+  protected getOwnProps(): OwnPropsOfSelect {
+    return {
+      ...super.getOwnProps(),
+      options: this.options,
+    };
+  }
+}
+
+const hasOneOfItems = (schema: JsonSchema): boolean =>
+  schema.oneOf !== undefined &&
+  schema.oneOf.length > 0 &&
+  (schema.oneOf as JsonSchema[]).every((entry: JsonSchema) => {
+    return entry.const !== undefined;
+  });
+
+const hasEnumItems = (schema: JsonSchema): boolean =>
+  schema.type === 'string' && schema.enum !== undefined;
+
+export const SelectControlRendererTester: RankedTester = rankWith(
+  5,
+  /* Can be used for simple Enums or OneOf, autocomplete functionallity needs autocomplete.rederer */
+  or(
+    and(or(isEnumControl, isOneOfEnumControl), optionIs('autocomplete', false)),
+    and(
+      uiTypeIs('Control'),
+      and(
+        schemaMatches(
+          (schema) =>
+            hasType(schema, 'array') &&
+            !Array.isArray(schema.items) &&
+            schema.uniqueItems === true
+        ),
+        schemaSubPathMatches('items', (schema, rootSchema) => {
+          const resolvedSchema = schema.$ref
+            ? resolveSchema(rootSchema, schema.$ref, rootSchema)
+            : schema;
+          return hasOneOfItems(resolvedSchema) || hasEnumItems(resolvedSchema);
+        })
+      )
+    )
+  )
+);
+
+interface OptionOfSelect {
+  const: string;
+  label?: string;
+  disabled?: boolean;
+}
+
+interface OwnPropsOfSelect extends OwnPropsOfControl {
+  options: OptionOfSelect[];
+}

--- a/packages/angular-material/src/library/index.ts
+++ b/packages/angular-material/src/library/index.ts
@@ -46,6 +46,10 @@ import {
   RangeControlRendererTester,
 } from './controls/range.renderer';
 import {
+  SelectControlRenderer,
+  SelectControlRendererTester,
+} from './controls/select.renderer';
+import {
   DateControlRenderer,
   DateControlRendererTester,
 } from './controls/date.renderer';
@@ -104,6 +108,7 @@ export const angularMaterialRenderers: {
   { tester: TextAreaRendererTester, renderer: TextAreaRenderer },
   { tester: NumberControlRendererTester, renderer: NumberControlRenderer },
   { tester: RangeControlRendererTester, renderer: RangeControlRenderer },
+  { tester: SelectControlRendererTester, renderer: SelectControlRenderer },
   { tester: DateControlRendererTester, renderer: DateControlRenderer },
   { tester: ToggleControlRendererTester, renderer: ToggleControlRenderer },
   { tester: enumControlTester, renderer: AutocompleteControlRenderer },

--- a/packages/angular-material/src/library/module.ts
+++ b/packages/angular-material/src/library/module.ts
@@ -50,6 +50,7 @@ import { BooleanControlRenderer } from './controls/boolean.renderer';
 import { DateControlRenderer } from './controls/date.renderer';
 import { NumberControlRenderer } from './controls/number.renderer';
 import { RangeControlRenderer } from './controls/range.renderer';
+import { SelectControlRenderer } from './controls/select.renderer';
 import { TextAreaRenderer } from './controls/textarea.renderer';
 import { TextControlRenderer } from './controls/text.renderer';
 import { ToggleControlRenderer } from './controls/toggle.renderer';
@@ -96,6 +97,7 @@ import { LayoutChildrenRenderPropsPipe } from './layouts';
     TextControlRenderer,
     NumberControlRenderer,
     RangeControlRenderer,
+    SelectControlRenderer,
     DateControlRenderer,
     ToggleControlRenderer,
     VerticalLayoutRenderer,

--- a/packages/examples/src/examples/enum-multi.ts
+++ b/packages/examples/src/examples/enum-multi.ts
@@ -58,7 +58,21 @@ export const uischema = {
     },
     {
       type: 'Control',
+      scope: '#/properties/oneOfMultiEnum',
+      options: {
+        autocomplete: false,
+      },
+    },
+    {
+      type: 'Control',
       scope: '#/properties/multiEnum',
+    },
+    {
+      type: 'Control',
+      scope: '#/properties/multiEnum',
+      options: {
+        autocomplete: false,
+      },
     },
   ],
 };


### PR DESCRIPTION
Added `<mat-select>` control for enum and oneOf types. Enable multi-selection for array type. Not sure if RankedTester ist properly defined, could need help with that.