### PR TITLE
Disable auto select in MuiAutocomplete control

### DIFF
--- a/packages/material-renderers/src/mui-controls/MuiAutocomplete.tsx
+++ b/packages/material-renderers/src/mui-controls/MuiAutocomplete.tsx
@@ -113,7 +113,6 @@ export const MuiAutocomplete = (
           setInputValue(newInputValue);
         }}
         autoHighlight
-        autoSelect
         autoComplete
         fullWidth
         options={options}


### PR DESCRIPTION
The MUI Autoselect control currently has a weird behavior, which can easily lead to accidential selections or selection changes, when the user just wants to "light dismiss" the dropdown. See issue #2232.

This PR fixes the irritating behavior by removing the "autoSelect" property.