### PR TITLE
vue-vanilla: Show required asterisk in example app

### DIFF
--- a/packages/vue-vanilla/dev/components/App.vue
+++ b/packages/vue-vanilla/dev/components/App.vue
@@ -34,9 +34,6 @@ export default defineComponent({
       renderers: Object.freeze(vanillaRenderers),
       currentExampleName: examples[0].name,
       examples,
-      config: {
-        hideRequiredAsterisk: true,
-      },
       i18n,
       additionalErrors,
     };


### PR DESCRIPTION
The vue vanilla example app globally disabled showing the required asterisk. This makes it impossible to observe the asterisk's behavior in the example app.