### PR TITLE
feat(core/testers): add hasOption tester

### DIFF
--- a/packages/core/src/testers/testers.ts
+++ b/packages/core/src/testers/testers.ts
@@ -31,6 +31,7 @@ import isArray from 'lodash/isArray';
 import reduce from 'lodash/reduce';
 import toPairs from 'lodash/toPairs';
 import includes from 'lodash/includes';
+import isUndefined from 'lodash/isUndefined';
 import type {
   Categorization,
   ControlElement,
@@ -213,6 +214,24 @@ export const optionIs =
 
     const options = uischema.options;
     return !isEmpty(options) && options[optionName] === optionValue;
+  };
+
+/**
+ * Checks whether the given UI schema has an option with the given
+ * name. If no options property
+ * is set, returns false.
+ *
+ * @param {string} optionName the name of the option to check
+ */
+export const hasOption =
+  (optionName: string): Tester =>
+  (uischema: UISchemaElement): boolean => {
+    if (isEmpty(uischema)) {
+      return false;
+    }
+
+    const options = uischema.options;
+    return !isEmpty(options) && !isUndefined(options[optionName]);
   };
 
 /**

--- a/packages/core/src/testers/testers.ts
+++ b/packages/core/src/testers/testers.ts
@@ -218,8 +218,7 @@ export const optionIs =
 
 /**
  * Checks whether the given UI schema has an option with the given
- * name. If no options property
- * is set, returns false.
+ * name. If no options property is set, returns false.
  *
  * @param {string} optionName the name of the option to check
  */

--- a/packages/core/test/testers.test.ts
+++ b/packages/core/test/testers.test.ts
@@ -54,6 +54,7 @@ import {
   JsonSchema,
   LabelElement,
   UISchemaElement,
+  hasOption,
 } from '../src';
 
 const test = anyTest as TestInterface<{ uischema: ControlElement }>;
@@ -181,6 +182,30 @@ test('optionIs should return false for UI schema elements without options cell',
     scope: '#/properties/bar',
   };
   t.false(optionIs('answer', 42)(control, undefined, undefined));
+});
+
+test('hasOption should check for options', (t) => {
+  const control: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/bar',
+    options: {
+      answer: 42,
+    },
+  };
+  t.true(hasOption('answer')(control, undefined, undefined));
+});
+
+test('hasOption should not fail if uischema is undefined or null', (t) => {
+  const uischema: UISchemaElement = null;
+  t.false(hasOption('answer')(uischema, undefined, undefined));
+});
+
+test('hasOption should return false for UI schema elements without options cell', (t) => {
+  const control: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/bar',
+  };
+  t.false(hasOption('answer')(control, undefined, undefined));
 });
 
 test('schemaMatches should check type sub-schema of control via predicate', (t) => {


### PR DESCRIPTION
This PR adds a tester name `hasOption` allowing to check the presence of an option without specifying its value