### PR TITLE
Set `type` of `<button>`s in vanilla array renderer

### DIFF
--- a/packages/vanilla-renderers/src/complex/TableArrayControl.tsx
+++ b/packages/vanilla-renderers/src/complex/TableArrayControl.tsx
@@ -111,6 +111,7 @@ class TableArrayControl extends React.Component<
         <header>
           <label className={labelClass}>{label}</label>
           <button
+            type='button'
             className={buttonClass}
             onClick={addItem(path, createDefaultValue(schema, rootSchema))}
           >
@@ -214,6 +215,7 @@ class TableArrayControl extends React.Component<
                     </td>
                     <td>
                       <button
+                        type='button'
                         aria-label={translations.removeAriaLabel}
                         onClick={() => {
                           if (

--- a/packages/vanilla-renderers/src/complex/array/ArrayControlRenderer.tsx
+++ b/packages/vanilla-renderers/src/complex/array/ArrayControlRenderer.tsx
@@ -96,7 +96,7 @@ export const ArrayControl = ({
       <header>
         <label className={labelClass}>{label}</label>
         <button
-          type="button"
+          type='button'
           className={buttonClassAdd}
           onClick={addItem(path, createDefaultValue(schema, rootSchema))}
         >
@@ -119,7 +119,7 @@ export const ArrayControl = ({
                 />
                 <div className={childControlsClass}>
                   <button
-                    type="button"
+                    type='button'
                     className={buttonClassUp}
                     aria-label={translations.upAriaLabel}
                     onClick={() => {
@@ -129,7 +129,7 @@ export const ArrayControl = ({
                     {translations.up}
                   </button>
                   <button
-                    type="button"
+                    type='button'
                     className={buttonClassDown}
                     aria-label={translations.downAriaLabel}
                     onClick={() => {
@@ -139,7 +139,7 @@ export const ArrayControl = ({
                     {translations.down}
                   </button>
                   <button
-                    type="button"
+                    type='button'
                     className={buttonClassDelete}
                     aria-label={translations.removeAriaLabel}
                     onClick={() => {

--- a/packages/vanilla-renderers/src/complex/array/ArrayControlRenderer.tsx
+++ b/packages/vanilla-renderers/src/complex/array/ArrayControlRenderer.tsx
@@ -96,6 +96,7 @@ export const ArrayControl = ({
       <header>
         <label className={labelClass}>{label}</label>
         <button
+          type="button"
           className={buttonClassAdd}
           onClick={addItem(path, createDefaultValue(schema, rootSchema))}
         >
@@ -118,6 +119,7 @@ export const ArrayControl = ({
                 />
                 <div className={childControlsClass}>
                   <button
+                    type="button"
                     className={buttonClassUp}
                     aria-label={translations.upAriaLabel}
                     onClick={() => {
@@ -127,6 +129,7 @@ export const ArrayControl = ({
                     {translations.up}
                   </button>
                   <button
+                    type="button"
                     className={buttonClassDown}
                     aria-label={translations.downAriaLabel}
                     onClick={() => {
@@ -136,6 +139,7 @@ export const ArrayControl = ({
                     {translations.down}
                   </button>
                   <button
+                    type="button"
                     className={buttonClassDelete}
                     aria-label={translations.removeAriaLabel}
                     onClick={() => {


### PR DESCRIPTION
This updates the `<button>`s in the vanilla array renderer to set the `type` to `"button"`. This allows a `<JsonForms>` to be contained within a `<form>` without these buttons triggering a submit of the form.

I believe this is fixing the same issue as #1731, but for the vanilla renderers.