### PR TITLE
Disable vanilla array buttons when readonly

### DIFF
--- a/packages/examples/src/example.ts
+++ b/packages/examples/src/example.ts
@@ -41,6 +41,7 @@ export interface ExampleDescription {
   config?: any;
   actions?: { label: string; apply: (props: StateProps) => any }[];
   i18n?: JsonFormsI18nState;
+  readonly?: boolean;
 }
 
 export interface StateProps {
@@ -51,4 +52,5 @@ export interface StateProps {
   cells?: JsonFormsCellRendererRegistryEntry[];
   config?: any;
   uischemas?: JsonFormsUISchemaRegistryEntry[];
+  readonly?: boolean;
 }

--- a/packages/examples/src/examples/arrays-with-detail.ts
+++ b/packages/examples/src/examples/arrays-with-detail.ts
@@ -24,6 +24,7 @@
 */
 import { registerExamples } from '../register';
 import { personCoreSchema } from './person';
+import { StateProps } from '../example';
 
 export const schema = {
   type: 'object',
@@ -93,6 +94,15 @@ export const data = {
   ],
 };
 
+const actions = [
+  {
+    label: 'Toggle readonly',
+    apply: (props: StateProps) => {
+      return { ...props, readonly: !props.readonly };
+    }
+  }
+];
+
 registerExamples([
   {
     name: 'array-with-detail',
@@ -100,5 +110,6 @@ registerExamples([
     data,
     schema,
     uischema,
+    actions,
   },
 ]);

--- a/packages/examples/src/examples/arrays.ts
+++ b/packages/examples/src/examples/arrays.ts
@@ -123,6 +123,12 @@ const actions = [
       };
     },
   },
+  {
+    label: 'Toggle readonly',
+    apply: (props: StateProps) => {
+      return { ...props, readonly: !props.readonly };
+    }
+  }
 ];
 
 registerExamples([

--- a/packages/vanilla-renderers/src/complex/TableArrayControl.tsx
+++ b/packages/vanilla-renderers/src/complex/TableArrayControl.tsx
@@ -83,6 +83,7 @@ class TableArrayControl extends React.Component<
       getStyleAsClassName,
       childErrors,
       translations,
+      enabled,
     } = this.props;
 
     const controlElement = uischema as ControlElement;
@@ -112,6 +113,7 @@ class TableArrayControl extends React.Component<
           <label className={labelClass}>{label}</label>
           <button
             type='button'
+            disabled={!enabled}
             className={buttonClass}
             onClick={addItem(path, createDefaultValue(schema, rootSchema))}
           >
@@ -216,6 +218,7 @@ class TableArrayControl extends React.Component<
                     <td>
                       <button
                         type='button'
+                        disabled={!enabled}
                         aria-label={translations.removeAriaLabel}
                         onClick={() => {
                           if (

--- a/packages/vanilla-renderers/src/complex/array/ArrayControlRenderer.tsx
+++ b/packages/vanilla-renderers/src/complex/array/ArrayControlRenderer.tsx
@@ -58,6 +58,7 @@ export const ArrayControl = ({
   renderers,
   rootSchema,
   translations,
+  enabled,
 }: ArrayControlProps & VanillaRendererProps) => {
   const controlElement = uischema as ControlElement;
   const childUiSchema = useMemo(
@@ -98,6 +99,7 @@ export const ArrayControl = ({
         <button
           type='button'
           className={buttonClassAdd}
+          disabled={!enabled}
           onClick={addItem(path, createDefaultValue(schema, rootSchema))}
         >
           Add to {label}
@@ -121,6 +123,7 @@ export const ArrayControl = ({
                   <button
                     type='button'
                     className={buttonClassUp}
+                    disabled={!enabled}
                     aria-label={translations.upAriaLabel}
                     onClick={() => {
                       moveUp(path, index)();
@@ -131,6 +134,7 @@ export const ArrayControl = ({
                   <button
                     type='button'
                     className={buttonClassDown}
+                    disabled={!enabled}
                     aria-label={translations.downAriaLabel}
                     onClick={() => {
                       moveDown(path, index)();
@@ -141,6 +145,7 @@ export const ArrayControl = ({
                   <button
                     type='button'
                     className={buttonClassDelete}
+                    disabled={!enabled}
                     aria-label={translations.removeAriaLabel}
                     onClick={() => {
                       if (


### PR DESCRIPTION
This updates the vanilla array controls (`TableArrayControl` and `ArrayControlRenderer`) to disable the buttons (for adding/removing/moving items) when the control is set to readonly (otherwise the data can be updated while readonly).

To (manually) test this, I've updated the examples to support setting the `readonly` property of the `<JsonForms>`, and added toggle actions to a couple of the array examples. (Not sure if there's a better way to do this?)