### PR TITLE
[FIX-#2327] Revert deletion of hide css class in process of angular upgrade

### DIFF
--- a/packages/angular-material/src/library/other/master-detail/master.ts
+++ b/packages/angular-material/src/library/other/master-detail/master.ts
@@ -144,6 +144,9 @@ export const removeSchemaKeywords = (path: string) => {
         top: 0;
         right: 0;
       }
+      .hide {
+        display: none;
+      }
       .show {
         display: inline-block;
       }


### PR DESCRIPTION
Reverting back .`hide `css class, since delete button should be displayed only when an item is hovered and hidden and not all the time.