### PR TITLE
Describe milestones in README

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
 
 jobs:
   ci:

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ The project roadmap can be found in [ROADMAP.md](./ROADMAP.md).
 Issues are sorted in one the following milestones that indicate when their implementation is planned.
 Independently of the assigned milestone, contributions are always accepted and appreciated.
 
-- [3.4](https://github.com/eclipsesource/jsonforms/milestone/57): Issues which we plan to implement for the upcoming 3.4 release.
-- [4.0](https://github.com/eclipsesource/jsonforms/milestone/55): Issue which we plan to implement for the next major release 4.0. This is the next planned version after the 3.4. release.
-- [4.x](https://github.com/eclipsesource/jsonforms/milestone/58): Issues which are concrete candidates for one of the next versions after the 4.0 release.
+- A milestone for the next minor version. Issues planned to be implemented for the next release.
+- A milestone for the next major version. Issues planned to be implemented for the next major release.
+- A `.x` milestone. Issues which are concrete candidates for one of the next versions.
 - [next](https://github.com/eclipsesource/jsonforms/milestone/37): Issues which we would like to tackle soonish in one of the upcoming versions. However, they are not yet planned for a specific version.
 - [Backlog](https://github.com/eclipsesource/jsonforms/milestone/2): Issues which are interesting in some form but we don't plan to do ourselves in the foreseeable future. Still these might become part of JSON Forms via a community contribution or by prioritization of a paying customer.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ In addition, EclipseSource also offers [professional support](https://jsonforms.
 
 See our [migration guide](https://github.com/eclipsesource/jsonforms/blob/master/MIGRATION.md) when updating JSON Forms.
 
+## Roadmap & Milestones
+
+The project roadmap can be found in [ROADMAP.md](./ROADMAP.md).
+
+Issues are sorted in one the following milestones that indicate when their implementation is planned.
+Independently of the assigned milestone, contributions are always accepted and appreciated.
+
+- [3.4](https://github.com/eclipsesource/jsonforms/milestone/57): Issues which we plan to implement for the upcoming 3.4 release.
+- [4.0](https://github.com/eclipsesource/jsonforms/milestone/55): Issue which we plan to implement for the next major release 4.0. This is the next planned version after the 3.4. release.
+- [4.x](https://github.com/eclipsesource/jsonforms/milestone/58): Issues which are concrete candidates for one of the next versions after the 4.0 release.
+- [next](https://github.com/eclipsesource/jsonforms/milestone/37): Issues which we would like to tackle soonish in one of the upcoming versions. However, they are not yet planned for a specific version.
+- [Backlog](https://github.com/eclipsesource/jsonforms/milestone/2): Issues which are interesting in some form but we don't plan to do ourselves in the foreseeable future. Still these might become part of JSON Forms via a community contribution or by prioritization of a paying customer.
+
 ## Developers Documentation
 
 ### First time setup


### PR DESCRIPTION
I closed the 3.x milestone as we plan 4.0. after 3.4. All open issues from 3.x were moved to 4.x