### PR TITLE
ci: Update publish workflow pnpm setup action to v4

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,11 +42,11 @@ jobs:
           node-version: "18"
           registry-url: "https://registry.npmjs.org"
 
-      - uses: "pnpm/action-setup@v2.2.4"
-        name: "Install pnpm"
-        id: "pnpm-install"
+      - uses: pnpm/action-setup@v4.0.0
+        name: Install pnpm
+        id: pnpm-install
         with:
-          version: "8"
+          version: 8
           run_install: false
 
       - name: "Install Packages"


### PR DESCRIPTION
This aligns it with the ci workflow