### PR TITLE
fix: matching required paths with slashes

### DIFF
--- a/packages/core/src/mappers/renderer.ts
+++ b/packages/core/src/mappers/renderer.ts
@@ -73,7 +73,7 @@ import {
   isVisible,
   Resolve,
   resolveSchema,
-  decode
+  decode,
 } from '../util';
 import {
   Translator,

--- a/packages/core/src/mappers/renderer.ts
+++ b/packages/core/src/mappers/renderer.ts
@@ -73,6 +73,7 @@ import {
   isVisible,
   Resolve,
   resolveSchema,
+  decode
 } from '../util';
 import {
   Translator,
@@ -114,7 +115,7 @@ const isRequired = (
   rootSchema: JsonSchema
 ): boolean => {
   const pathSegments = schemaPath.split('/');
-  const lastSegment = pathSegments[pathSegments.length - 1];
+  let lastSegment = pathSegments[pathSegments.length - 1];
   // Skip "properties", "items" etc. to resolve the parent
   const nextHigherSchemaSegments = pathSegments.slice(
     0,
@@ -126,6 +127,9 @@ const isRequired = (
     nextHigherSchemaPath,
     rootSchema
   );
+
+  // decode JSON Pointer escape sequences
+  lastSegment = decode(lastSegment);
 
   return (
     nextHigherSchema !== undefined &&

--- a/packages/core/src/mappers/renderer.ts
+++ b/packages/core/src/mappers/renderer.ts
@@ -115,7 +115,7 @@ const isRequired = (
   rootSchema: JsonSchema
 ): boolean => {
   const pathSegments = schemaPath.split('/');
-  let lastSegment = pathSegments[pathSegments.length - 1];
+  const lastSegment = decode(pathSegments[pathSegments.length - 1]);
   // Skip "properties", "items" etc. to resolve the parent
   const nextHigherSchemaSegments = pathSegments.slice(
     0,
@@ -127,9 +127,6 @@ const isRequired = (
     nextHigherSchemaPath,
     rootSchema
   );
-
-  // decode JSON Pointer escape sequences
-  lastSegment = decode(lastSegment);
 
   return (
     nextHigherSchema !== undefined &&

--- a/packages/core/test/mappers/renderer.test.ts
+++ b/packages/core/test/mappers/renderer.test.ts
@@ -1871,6 +1871,38 @@ test('mapStateToControlProps - i18n errors - custom keyword wins over all other 
   t.is(props.errors, 'this is my error custom error message');
 });
 
+test('mapStateToControlProps - required is calculated correctly from encoded JSON Pointer', (t) => {
+  const uischema: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/~1firstName',
+  };
+  const schema = {
+    type: 'object',
+    properties: {
+      '/firstName': { type: 'string' },
+    },
+    required: ['/firstName'],
+  };
+  const ownProps = {
+    visible: true,
+    uischema,
+    path: 'foo',
+    schema
+  };
+  const state = {
+    jsonforms: {
+      core: {
+        schema,
+        data: {},
+        uischema,
+        errors: [] as ErrorObject[],
+      },
+    },
+  };
+  const props = mapStateToControlProps(state, ownProps);
+  t.true(props.required === true);
+});
+
 test('mapStateToEnumControlProps - i18n - should not crash without i18n', (t) => {
   const ownProps = {
     uischema: coreUISchema,

--- a/packages/core/test/mappers/renderer.test.ts
+++ b/packages/core/test/mappers/renderer.test.ts
@@ -1887,7 +1887,7 @@ test('mapStateToControlProps - required is calculated correctly from encoded JSO
     visible: true,
     uischema,
     path: 'foo',
-    schema
+    schema,
   };
   const state = {
     jsonforms: {


### PR DESCRIPTION
In JSON Pointers two characters need to be escaped: '~' is converted to '~0' and '/' is converted to '~1'.
When JSON Paths contain one of these two characters, when trying to check whether those path are required, the `isRequired` function is used. That function compares the scoped path (which in this case is the encoded path with the converted symbols) with the closest `required` array (which contains the original unencoded path with either `~` or `/`).

Before checking the `required` array, we need to decode the scoped path so the comparison works properly.

Fixes https://github.com/eclipsesource/jsonforms/issues/2366