### PR TITLE
react-material: Allow material ui ^6 as peer dependency

### DIFF
--- a/packages/material-renderers/package.json
+++ b/packages/material-renderers/package.json
@@ -88,8 +88,8 @@
     "@emotion/styled": "^11.3.0",
     "@jsonforms/core": "3.4.0-alpha.3",
     "@jsonforms/react": "3.4.0-alpha.3",
-    "@mui/icons-material": "^5.11.16",
-    "@mui/material": "^5.13.0",
+    "@mui/icons-material": "^5.11.16 || ^6.0.0",
+    "@mui/material": "^5.13.0 || ^6.0.0",
     "@mui/x-date-pickers": "^6.0.0 || ^7.0.0",
     "react": "^16.12.0 || ^17.0.0 || ^18.0.0"
   },


### PR DESCRIPTION
fixes #2375

When trying this out locally, pnpm complained that @mui/x-date-pickers 7.7.1 wants peer @mui/material@^5.15.14: found 6.1.0 .
However, in the example app, the date pickers seemed to work fine. Thus, I don't think this is an issue.