### PR TITLE
vue-vuetify: Extract control entries and fix usage instructions

### DIFF
--- a/packages/vue-vuetify/README.md
+++ b/packages/vue-vuetify/README.md
@@ -36,9 +36,8 @@ Use the `json-forms` component for each form you want to render and hand over th
 ```vue
 <script>
 import { JsonForms } from '@jsonforms/vue';
+import { extendedVuetifyRenderers } from '@jsonforms/vue-vuetify';
 import { markRaw } from 'vue';
-
-const { extendedVuetifyRenderers } = await import('@jsonforms/vue-vuetify');
 
 const renderers = markRaw([
   ...extendedVuetifyRenderers,

--- a/packages/vue-vuetify/src/additional/LabelRenderer.entry.ts
+++ b/packages/vue-vuetify/src/additional/LabelRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  rankWith,
+  uiTypeIs,
+  type JsonFormsRendererRegistryEntry,
+} from '@jsonforms/core';
+import labelRenderer from './LabelRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: labelRenderer,
+  tester: rankWith(1, uiTypeIs('Label')),
+};

--- a/packages/vue-vuetify/src/additional/LabelRenderer.vue
+++ b/packages/vue-vuetify/src/additional/LabelRenderer.vue
@@ -9,12 +9,7 @@
 </template>
 
 <script lang="ts">
-import {
-  rankWith,
-  uiTypeIs,
-  type JsonFormsRendererRegistryEntry,
-  type LabelElement,
-} from '@jsonforms/core';
+import { type LabelElement } from '@jsonforms/core';
 import {
   rendererProps,
   useJsonFormsLabel,
@@ -38,9 +33,4 @@ const labelRenderer = defineComponent({
 });
 
 export default labelRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: labelRenderer,
-  tester: rankWith(1, uiTypeIs('Label')),
-};
 </script>

--- a/packages/vue-vuetify/src/additional/ListWithDetailRenderer.entry.ts
+++ b/packages/vue-vuetify/src/additional/ListWithDetailRenderer.entry.ts
@@ -1,0 +1,13 @@
+import {
+  and,
+  isObjectArray,
+  rankWith,
+  uiTypeIs,
+  type JsonFormsRendererRegistryEntry,
+} from '@jsonforms/core';
+import controlRenderer from './ListWithDetailRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(4, and(uiTypeIs('ListWithDetail'), isObjectArray)),
+};

--- a/packages/vue-vuetify/src/additional/ListWithDetailRenderer.vue
+++ b/packages/vue-vuetify/src/additional/ListWithDetailRenderer.vue
@@ -318,11 +318,6 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(4, and(uiTypeIs('ListWithDetail'), isObjectArray)),
-};
 </script>
 
 <style scoped>

--- a/packages/vue-vuetify/src/additional/index.ts
+++ b/packages/vue-vuetify/src/additional/index.ts
@@ -1,8 +1,8 @@
 export { default as LabelRenderer } from './LabelRenderer.vue';
 export { default as ListWithDetailRenderer } from './ListWithDetailRenderer.vue';
 
-import { entry as labelRendererEntry } from './LabelRenderer.vue';
-import { entry as listWithDetailRendererEntry } from './ListWithDetailRenderer.vue';
+import { entry as labelRendererEntry } from './LabelRenderer.entry';
+import { entry as listWithDetailRendererEntry } from './ListWithDetailRenderer.entry';
 
 export const additionalRenderers = [
   labelRendererEntry,

--- a/packages/vue-vuetify/src/complex/AllOfRenderer.entry.ts
+++ b/packages/vue-vuetify/src/complex/AllOfRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  isAllOfControl,
+  rankWith,
+  type JsonFormsRendererRegistryEntry,
+} from '@jsonforms/core';
+import controlRenderer from './AllOfRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(3, isAllOfControl),
+};

--- a/packages/vue-vuetify/src/complex/AllOfRenderer.vue
+++ b/packages/vue-vuetify/src/complex/AllOfRenderer.vue
@@ -36,11 +36,8 @@
 import {
   createCombinatorRenderInfos,
   findMatchingUISchema,
-  isAllOfControl,
-  rankWith,
   type CombinatorSubSchemaRenderInfo,
   type ControlElement,
-  type JsonFormsRendererRegistryEntry,
   type UISchemaElement,
 } from '@jsonforms/core';
 import {
@@ -90,9 +87,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(3, isAllOfControl),
-};
 </script>

--- a/packages/vue-vuetify/src/complex/AnyOfRenderer.entry.ts
+++ b/packages/vue-vuetify/src/complex/AnyOfRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  isAnyOfControl,
+  rankWith,
+  type JsonFormsRendererRegistryEntry,
+} from '@jsonforms/core';
+import controlRenderer from './AnyOfRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(3, isAnyOfControl),
+};

--- a/packages/vue-vuetify/src/complex/AnyOfRenderer.vue
+++ b/packages/vue-vuetify/src/complex/AnyOfRenderer.vue
@@ -39,9 +39,6 @@ import {
   type CombinatorSubSchemaRenderInfo,
   type ControlElement,
   createCombinatorRenderInfos,
-  isAnyOfControl,
-  type JsonFormsRendererRegistryEntry,
-  rankWith,
 } from '@jsonforms/core';
 import {
   DispatchRenderer,
@@ -94,9 +91,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(3, isAnyOfControl),
-};
 </script>

--- a/packages/vue-vuetify/src/complex/ArrayControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/complex/ArrayControlRenderer.entry.ts
@@ -1,0 +1,13 @@
+import {
+  isObjectArrayControl,
+  isPrimitiveArrayControl,
+  or,
+  rankWith,
+  type JsonFormsRendererRegistryEntry,
+} from '@jsonforms/core';
+import controlRenderer from './ArrayControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(3, or(isObjectArrayControl, isPrimitiveArrayControl)),
+};

--- a/packages/vue-vuetify/src/complex/ArrayControlRenderer.vue
+++ b/packages/vue-vuetify/src/complex/ArrayControlRenderer.vue
@@ -181,12 +181,7 @@ import {
   Resolve,
   composePaths,
   createDefaultValue,
-  isObjectArrayControl,
-  isPrimitiveArrayControl,
-  or,
-  rankWith,
   type ControlElement,
-  type JsonFormsRendererRegistryEntry,
   type JsonSchema,
 } from '@jsonforms/core';
 import {
@@ -303,11 +298,6 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(3, or(isObjectArrayControl, isPrimitiveArrayControl)),
-};
 </script>
 
 <style scoped>

--- a/packages/vue-vuetify/src/complex/EnumArrayRenderer.entry.ts
+++ b/packages/vue-vuetify/src/complex/EnumArrayRenderer.entry.ts
@@ -1,0 +1,42 @@
+import {
+  and,
+  hasType,
+  rankWith,
+  schemaMatches,
+  schemaSubPathMatches,
+  uiTypeIs,
+  type JsonFormsRendererRegistryEntry,
+  type JsonSchema,
+} from '@jsonforms/core';
+import controlRenderer from './EnumArrayRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(
+    5,
+    and(
+      uiTypeIs('Control'),
+      and(
+        schemaMatches(
+          (schema) =>
+            hasType(schema, 'array') &&
+            !Array.isArray(schema.items) &&
+            schema.uniqueItems === true,
+        ),
+        schemaSubPathMatches('items', (schema) => {
+          return hasOneOfItems(schema) || hasEnumItems(schema);
+        }),
+      ),
+    ),
+  ),
+};
+
+const hasOneOfItems = (schema: JsonSchema): boolean =>
+  schema.oneOf !== undefined &&
+  schema.oneOf.length > 0 &&
+  (schema.oneOf as JsonSchema[]).every((entry: JsonSchema) => {
+    return entry.const !== undefined;
+  });
+
+const hasEnumItems = (schema: JsonSchema): boolean =>
+  schema.type === 'string' && schema.enum !== undefined;

--- a/packages/vue-vuetify/src/complex/EnumArrayRenderer.vue
+++ b/packages/vue-vuetify/src/complex/EnumArrayRenderer.vue
@@ -19,18 +19,7 @@
 </template>
 
 <script lang="ts">
-import {
-  and,
-  type ControlElement,
-  hasType,
-  type JsonFormsRendererRegistryEntry,
-  type JsonSchema,
-  rankWith,
-  schemaMatches,
-  schemaSubPathMatches,
-  uiTypeIs,
-  composePaths,
-} from '@jsonforms/core';
+import { type ControlElement, composePaths } from '@jsonforms/core';
 import { VCheckbox, VContainer, VRow, VCol } from 'vuetify/components';
 import {
   rendererProps,
@@ -71,35 +60,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-const hasOneOfItems = (schema: JsonSchema): boolean =>
-  schema.oneOf !== undefined &&
-  schema.oneOf.length > 0 &&
-  (schema.oneOf as JsonSchema[]).every((entry: JsonSchema) => {
-    return entry.const !== undefined;
-  });
-
-const hasEnumItems = (schema: JsonSchema): boolean =>
-  schema.type === 'string' && schema.enum !== undefined;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(
-    5,
-    and(
-      uiTypeIs('Control'),
-      and(
-        schemaMatches(
-          (schema) =>
-            hasType(schema, 'array') &&
-            !Array.isArray(schema.items) &&
-            schema.uniqueItems === true,
-        ),
-        schemaSubPathMatches('items', (schema) => {
-          return hasOneOfItems(schema) || hasEnumItems(schema);
-        }),
-      ),
-    ),
-  ),
-};
 </script>

--- a/packages/vue-vuetify/src/complex/ObjectRenderer.entry.ts
+++ b/packages/vue-vuetify/src/complex/ObjectRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  isObjectControl,
+  rankWith,
+  type JsonFormsRendererRegistryEntry,
+} from '@jsonforms/core';
+import controlRenderer from './ObjectRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, isObjectControl),
+};

--- a/packages/vue-vuetify/src/complex/ObjectRenderer.vue
+++ b/packages/vue-vuetify/src/complex/ObjectRenderer.vue
@@ -111,9 +111,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(2, isObjectControl),
-};
 </script>

--- a/packages/vue-vuetify/src/complex/OneOfRenderer.entry.ts
+++ b/packages/vue-vuetify/src/complex/OneOfRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  isOneOfControl,
+  rankWith,
+  type JsonFormsRendererRegistryEntry,
+} from '@jsonforms/core';
+import controlRenderer from './OneOfRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(3, isOneOfControl),
+};

--- a/packages/vue-vuetify/src/complex/OneOfRenderer.vue
+++ b/packages/vue-vuetify/src/complex/OneOfRenderer.vue
@@ -80,9 +80,6 @@ import {
   type ControlElement,
   createCombinatorRenderInfos,
   createDefaultValue,
-  isOneOfControl,
-  type JsonFormsRendererRegistryEntry,
-  rankWith,
 } from '@jsonforms/core';
 import {
   DispatchRenderer,
@@ -213,9 +210,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(3, isOneOfControl),
-};
 </script>

--- a/packages/vue-vuetify/src/complex/OneOfTabRenderer.entry.ts
+++ b/packages/vue-vuetify/src/complex/OneOfTabRenderer.entry.ts
@@ -1,0 +1,13 @@
+import {
+  and,
+  isOneOfControl,
+  optionIs,
+  rankWith,
+  type JsonFormsRendererRegistryEntry,
+} from '@jsonforms/core';
+import controlRenderer from './OneOfTabRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(4, and(isOneOfControl, optionIs('variant', 'tab'))),
+};

--- a/packages/vue-vuetify/src/complex/OneOfTabRenderer.vue
+++ b/packages/vue-vuetify/src/complex/OneOfTabRenderer.vue
@@ -59,15 +59,10 @@
 
 <script lang="ts">
 import {
-  and,
   type CombinatorSubSchemaRenderInfo,
   type ControlElement,
   createCombinatorRenderInfos,
   createDefaultValue,
-  isOneOfControl,
-  type JsonFormsRendererRegistryEntry,
-  optionIs,
-  rankWith,
 } from '@jsonforms/core';
 import {
   DispatchRenderer,
@@ -187,9 +182,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(4, and(isOneOfControl, optionIs('variant', 'tab'))),
-};
 </script>

--- a/packages/vue-vuetify/src/complex/index.ts
+++ b/packages/vue-vuetify/src/complex/index.ts
@@ -6,13 +6,13 @@ export { default as ObjectRenderer } from './ObjectRenderer.vue';
 export { default as OneOfRenderer } from './OneOfRenderer.vue';
 export { default as OneOfTabRenderer } from './OneOfTabRenderer.vue';
 
-import { entry as allOfRendererEntry } from './AllOfRenderer.vue';
-import { entry as anyOfRendererEntry } from './AnyOfRenderer.vue';
-import { entry as arrayControlRendererEntry } from './ArrayControlRenderer.vue';
-import { entry as enumArrayRendererEntry } from './EnumArrayRenderer.vue';
-import { entry as objectRendererEntry } from './ObjectRenderer.vue';
-import { entry as oneOfRendererEntry } from './OneOfRenderer.vue';
-import { entry as oneOfTabRendererEntry } from './OneOfTabRenderer.vue';
+import { entry as allOfRendererEntry } from './AllOfRenderer.entry';
+import { entry as anyOfRendererEntry } from './AnyOfRenderer.entry';
+import { entry as arrayControlRendererEntry } from './ArrayControlRenderer.entry';
+import { entry as enumArrayRendererEntry } from './EnumArrayRenderer.entry';
+import { entry as objectRendererEntry } from './ObjectRenderer.entry';
+import { entry as oneOfRendererEntry } from './OneOfRenderer.entry';
+import { entry as oneOfTabRendererEntry } from './OneOfTabRenderer.entry';
 
 export const complexRenderers = [
   allOfRendererEntry,

--- a/packages/vue-vuetify/src/controls/AnyOfStringOrEnumControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/controls/AnyOfStringOrEnumControlRenderer.entry.ts
@@ -1,0 +1,40 @@
+import {
+  and,
+  rankWith,
+  schemaMatches,
+  uiTypeIs,
+  type JsonFormsRendererRegistryEntry,
+  type JsonSchema,
+} from '@jsonforms/core';
+import controlRenderer from './AnyOfStringOrEnumControlRenderer.vue';
+
+const findEnumSchema = (schemas: JsonSchema[]) =>
+  schemas.find(
+    (s) =>
+      s.enum !== undefined && (s.type === 'string' || s.type === undefined),
+  );
+const findTextSchema = (schemas: JsonSchema[]) =>
+  schemas.find((s) => s.type === 'string' && s.enum === undefined);
+
+const hasEnumAndText = (schemas: JsonSchema[]): boolean => {
+  // idea: map to type,enum and check that all types are string and at least one item is of type enum,
+  const enumSchema = findEnumSchema(schemas);
+  const stringSchema = findTextSchema(schemas);
+  const remainingSchemas = schemas.filter(
+    (s) => s !== enumSchema || s !== stringSchema,
+  );
+  const wrongType = remainingSchemas.find((s) => s.type && s.type !== 'string');
+  return !!enumSchema && !!stringSchema && !wrongType;
+};
+
+const simpleAnyOf = and(
+  uiTypeIs('Control'),
+  schemaMatches(
+    (schema) => Array.isArray(schema.anyOf) && hasEnumAndText(schema.anyOf),
+  ),
+);
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(5, simpleAnyOf),
+};

--- a/packages/vue-vuetify/src/controls/AnyOfStringOrEnumControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/AnyOfStringOrEnumControlRenderer.vue
@@ -37,15 +37,7 @@
 </template>
 
 <script lang="ts">
-import {
-  and,
-  rankWith,
-  schemaMatches,
-  uiTypeIs,
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-  type JsonSchema,
-} from '@jsonforms/core';
+import { type ControlElement, type JsonSchema } from '@jsonforms/core';
 import {
   rendererProps,
   useJsonFormsControl,
@@ -91,28 +83,4 @@ const findEnumSchema = (schemas: JsonSchema[]) =>
     (s) =>
       s.enum !== undefined && (s.type === 'string' || s.type === undefined),
   );
-const findTextSchema = (schemas: JsonSchema[]) =>
-  schemas.find((s) => s.type === 'string' && s.enum === undefined);
-
-const hasEnumAndText = (schemas: JsonSchema[]): boolean => {
-  // idea: map to type,enum and check that all types are string and at least one item is of type enum,
-  const enumSchema = findEnumSchema(schemas);
-  const stringSchema = findTextSchema(schemas);
-  const remainingSchemas = schemas.filter(
-    (s) => s !== enumSchema || s !== stringSchema,
-  );
-  const wrongType = remainingSchemas.find((s) => s.type && s.type !== 'string');
-  return !!enumSchema && !!stringSchema && !wrongType;
-};
-const simpleAnyOf = and(
-  uiTypeIs('Control'),
-  schemaMatches(
-    (schema) => Array.isArray(schema.anyOf) && hasEnumAndText(schema.anyOf),
-  ),
-);
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(5, simpleAnyOf),
-};
 </script>

--- a/packages/vue-vuetify/src/controls/BooleanControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/controls/BooleanControlRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  type JsonFormsRendererRegistryEntry,
+  rankWith,
+  isBooleanControl,
+} from '@jsonforms/core';
+import controlRenderer from './BooleanControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(1, isBooleanControl),
+};

--- a/packages/vue-vuetify/src/controls/BooleanControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/BooleanControlRenderer.vue
@@ -27,12 +27,7 @@
 </template>
 
 <script lang="ts">
-import {
-  isBooleanControl,
-  rankWith,
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-} from '@jsonforms/core';
+import { type ControlElement } from '@jsonforms/core';
 import {
   rendererProps,
   useJsonFormsControl,
@@ -58,9 +53,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(1, isBooleanControl),
-};
 </script>

--- a/packages/vue-vuetify/src/controls/BooleanToggleControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/controls/BooleanToggleControlRenderer.entry.ts
@@ -1,0 +1,13 @@
+import {
+  type JsonFormsRendererRegistryEntry,
+  rankWith,
+  and,
+  isBooleanControl,
+  optionIs,
+} from '@jsonforms/core';
+import controlRenderer from './BooleanToggleControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(3, and(isBooleanControl, optionIs('toggle', true))),
+};

--- a/packages/vue-vuetify/src/controls/BooleanToggleControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/BooleanToggleControlRenderer.vue
@@ -30,14 +30,7 @@
 </template>
 
 <script lang="ts">
-import {
-  and,
-  isBooleanControl,
-  optionIs,
-  rankWith,
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-} from '@jsonforms/core';
+import { type ControlElement } from '@jsonforms/core';
 import {
   rendererProps,
   useJsonFormsControl,
@@ -63,9 +56,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(3, and(isBooleanControl, optionIs('toggle', true))),
-};
 </script>

--- a/packages/vue-vuetify/src/controls/DateControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/controls/DateControlRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  type JsonFormsRendererRegistryEntry,
+  rankWith,
+  isDateControl,
+} from '@jsonforms/core';
+import controlRenderer from './DateControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, isDateControl),
+};

--- a/packages/vue-vuetify/src/controls/DateControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/DateControlRenderer.vue
@@ -77,13 +77,7 @@
 </template>
 
 <script lang="ts">
-import {
-  isDateControl,
-  rankWith,
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-  type JsonSchema,
-} from '@jsonforms/core';
+import { type ControlElement, type JsonSchema } from '@jsonforms/core';
 import { computed, defineComponent, ref, unref } from 'vue';
 
 import {
@@ -149,9 +143,9 @@ const controlRenderer = defineComponent({
     const dateFormat = computed<string>(
       () =>
         typeof control.appliedOptions.value.dateFormat == 'string'
-          ? expandLocaleFormat(control.appliedOptions.value.dateFormat) ??
-            control.appliedOptions.value.dateFormat
-          : expandLocaleFormat('L') ?? 'YYYY-MM-DD', // by default try to use localized default if unavailable then YYYY-MM-DD
+          ? (expandLocaleFormat(control.appliedOptions.value.dateFormat) ??
+            control.appliedOptions.value.dateFormat)
+          : (expandLocaleFormat('L') ?? 'YYYY-MM-DD'), // by default try to use localized default if unavailable then YYYY-MM-DD
     );
 
     const useMask = control.appliedOptions.value.mask !== false;
@@ -323,9 +317,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(2, isDateControl),
-};
 </script>

--- a/packages/vue-vuetify/src/controls/DateTimeControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/controls/DateTimeControlRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  type JsonFormsRendererRegistryEntry,
+  rankWith,
+  isDateTimeControl,
+} from '@jsonforms/core';
+import controlRenderer from './DateTimeControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, isDateTimeControl),
+};

--- a/packages/vue-vuetify/src/controls/DateTimeControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/DateTimeControlRenderer.vue
@@ -175,13 +175,7 @@
 </template>
 
 <script lang="ts">
-import {
-  isDateTimeControl,
-  rankWith,
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-  type JsonSchema,
-} from '@jsonforms/core';
+import { type ControlElement, type JsonSchema } from '@jsonforms/core';
 import {
   rendererProps,
   useJsonFormsControl,
@@ -276,9 +270,9 @@ const controlRenderer = defineComponent({
 
     const dateTimeFormat = computed<string>(() =>
       typeof control.appliedOptions.value.dateTimeFormat == 'string'
-        ? expandLocaleFormat(control.appliedOptions.value.dateTimeFormat) ??
-          control.appliedOptions.value.dateTimeFormat
-        : expandLocaleFormat('L LT') ?? 'YYYY-MM-DD H:mm',
+        ? (expandLocaleFormat(control.appliedOptions.value.dateTimeFormat) ??
+          control.appliedOptions.value.dateTimeFormat)
+        : (expandLocaleFormat('L LT') ?? 'YYYY-MM-DD H:mm'),
     );
 
     const useMask = control.appliedOptions.value.mask !== false;
@@ -592,11 +586,6 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(2, isDateTimeControl),
-};
 </script>
 
 <style lang="scss" scoped>

--- a/packages/vue-vuetify/src/controls/EnumControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/controls/EnumControlRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  type JsonFormsRendererRegistryEntry,
+  rankWith,
+  isEnumControl,
+} from '@jsonforms/core';
+import controlRenderer from './EnumControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, isEnumControl),
+};

--- a/packages/vue-vuetify/src/controls/EnumControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/EnumControlRenderer.vue
@@ -31,12 +31,7 @@
 </template>
 
 <script lang="ts">
-import {
-  isEnumControl,
-  rankWith,
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-} from '@jsonforms/core';
+import { type ControlElement } from '@jsonforms/core';
 import {
   rendererProps,
   useJsonFormsEnumControl,
@@ -68,9 +63,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(2, isEnumControl),
-};
 </script>

--- a/packages/vue-vuetify/src/controls/IntegerControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/controls/IntegerControlRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  type JsonFormsRendererRegistryEntry,
+  rankWith,
+  isIntegerControl,
+} from '@jsonforms/core';
+import controlRenderer from './IntegerControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(1, isIntegerControl),
+};

--- a/packages/vue-vuetify/src/controls/IntegerControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/IntegerControlRenderer.vue
@@ -29,12 +29,7 @@
 </template>
 
 <script lang="ts">
-import {
-  isIntegerControl,
-  rankWith,
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-} from '@jsonforms/core';
+import { type ControlElement } from '@jsonforms/core';
 import {
   rendererProps,
   useJsonFormsControl,
@@ -118,9 +113,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(1, isIntegerControl),
-};
 </script>

--- a/packages/vue-vuetify/src/controls/MultiStringControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/controls/MultiStringControlRenderer.entry.ts
@@ -1,0 +1,13 @@
+import {
+  type JsonFormsRendererRegistryEntry,
+  rankWith,
+  and,
+  isStringControl,
+  isMultiLineControl,
+} from '@jsonforms/core';
+import controlRenderer from './MultiStringControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, and(isStringControl, isMultiLineControl)),
+};

--- a/packages/vue-vuetify/src/controls/MultiStringControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/MultiStringControlRenderer.vue
@@ -37,14 +37,7 @@
 </template>
 
 <script lang="ts">
-import {
-  and,
-  isMultiLineControl,
-  isStringControl,
-  rankWith,
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-} from '@jsonforms/core';
+import { type ControlElement } from '@jsonforms/core';
 import {
   rendererProps,
   useJsonFormsControl,
@@ -78,9 +71,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(2, and(isStringControl, isMultiLineControl)),
-};
 </script>

--- a/packages/vue-vuetify/src/controls/NumberControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/controls/NumberControlRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  type JsonFormsRendererRegistryEntry,
+  rankWith,
+  isNumberControl,
+} from '@jsonforms/core';
+import controlRenderer from './NumberControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(1, isNumberControl),
+};

--- a/packages/vue-vuetify/src/controls/NumberControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/NumberControlRenderer.vue
@@ -29,12 +29,7 @@
 </template>
 
 <script lang="ts">
-import {
-  isNumberControl,
-  rankWith,
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-} from '@jsonforms/core';
+import { type ControlElement } from '@jsonforms/core';
 import {
   rendererProps,
   useJsonFormsControl,
@@ -129,9 +124,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(1, isNumberControl),
-};
 </script>

--- a/packages/vue-vuetify/src/controls/OneOfEnumControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/controls/OneOfEnumControlRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  type JsonFormsRendererRegistryEntry,
+  rankWith,
+  isOneOfEnumControl,
+} from '@jsonforms/core';
+import controlRenderer from './OneOfEnumControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(5, isOneOfEnumControl),
+};

--- a/packages/vue-vuetify/src/controls/OneOfEnumControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/OneOfEnumControlRenderer.vue
@@ -31,12 +31,7 @@
 </template>
 
 <script lang="ts">
-import {
-  isOneOfEnumControl,
-  rankWith,
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-} from '@jsonforms/core';
+import { type ControlElement } from '@jsonforms/core';
 import {
   rendererProps,
   useJsonFormsOneOfEnumControl,
@@ -68,9 +63,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(5, isOneOfEnumControl),
-};
 </script>

--- a/packages/vue-vuetify/src/controls/OneOfRadioGroupControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/controls/OneOfRadioGroupControlRenderer.entry.ts
@@ -1,0 +1,13 @@
+import {
+  type JsonFormsRendererRegistryEntry,
+  rankWith,
+  and,
+  isOneOfEnumControl,
+  optionIs,
+} from '@jsonforms/core';
+import controlRenderer from './OneOfRadioGroupControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(20, and(isOneOfEnumControl, optionIs('format', 'radio'))),
+};

--- a/packages/vue-vuetify/src/controls/OneOfRadioGroupControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/OneOfRadioGroupControlRenderer.vue
@@ -36,14 +36,7 @@
 </template>
 
 <script lang="ts">
-import {
-  and,
-  isOneOfEnumControl,
-  optionIs,
-  rankWith,
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-} from '@jsonforms/core';
+import { type ControlElement } from '@jsonforms/core';
 import {
   rendererProps,
   useJsonFormsOneOfEnumControl,
@@ -71,9 +64,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(20, and(isOneOfEnumControl, optionIs('format', 'radio'))),
-};
 </script>

--- a/packages/vue-vuetify/src/controls/PasswordControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/controls/PasswordControlRenderer.entry.ts
@@ -1,0 +1,13 @@
+import {
+  type JsonFormsRendererRegistryEntry,
+  rankWith,
+  and,
+  isStringControl,
+  formatIs,
+} from '@jsonforms/core';
+import controlRenderer from './PasswordControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, and(isStringControl, formatIs('password'))),
+};

--- a/packages/vue-vuetify/src/controls/PasswordControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/PasswordControlRenderer.vue
@@ -41,14 +41,7 @@
 </template>
 
 <script lang="ts">
-import {
-  and,
-  formatIs,
-  isStringControl,
-  rankWith,
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-} from '@jsonforms/core';
+import { type ControlElement } from '@jsonforms/core';
 import {
   rendererProps,
   useJsonFormsControl,
@@ -85,9 +78,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(2, and(isStringControl, formatIs('password'))),
-};
 </script>

--- a/packages/vue-vuetify/src/controls/RadioGroupControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/controls/RadioGroupControlRenderer.entry.ts
@@ -1,0 +1,13 @@
+import {
+  type JsonFormsRendererRegistryEntry,
+  rankWith,
+  and,
+  isEnumControl,
+  optionIs,
+} from '@jsonforms/core';
+import controlRenderer from './RadioGroupControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(20, and(isEnumControl, optionIs('format', 'radio'))),
+};

--- a/packages/vue-vuetify/src/controls/RadioGroupControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/RadioGroupControlRenderer.vue
@@ -36,14 +36,7 @@
 </template>
 
 <script lang="ts">
-import {
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-  rankWith,
-  isEnumControl,
-  optionIs,
-  and,
-} from '@jsonforms/core';
+import { type ControlElement } from '@jsonforms/core';
 import { defineComponent } from 'vue';
 import {
   rendererProps,
@@ -71,9 +64,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(20, and(isEnumControl, optionIs('format', 'radio'))),
-};
 </script>

--- a/packages/vue-vuetify/src/controls/SliderControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/controls/SliderControlRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  type JsonFormsRendererRegistryEntry,
+  rankWith,
+  isRangeControl,
+} from '@jsonforms/core';
+import controlRenderer from './SliderControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(4, isRangeControl),
+};

--- a/packages/vue-vuetify/src/controls/SliderControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/SliderControlRenderer.vue
@@ -30,12 +30,7 @@
 </template>
 
 <script lang="ts">
-import {
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-  rankWith,
-  isRangeControl,
-} from '@jsonforms/core';
+import { type ControlElement } from '@jsonforms/core';
 import { defineComponent } from 'vue';
 import {
   rendererProps,
@@ -63,9 +58,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(4, isRangeControl),
-};
 </script>

--- a/packages/vue-vuetify/src/controls/StringControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/controls/StringControlRenderer.entry.ts
@@ -1,0 +1,10 @@
+import {
+  isStringControl,
+  rankWith,
+  type JsonFormsRendererRegistryEntry,
+} from '@jsonforms/core';
+import controlRenderer from './StringControlRenderer.vue';
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(1, isStringControl),
+};

--- a/packages/vue-vuetify/src/controls/StringControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/StringControlRenderer.vue
@@ -67,12 +67,7 @@
 </template>
 
 <script lang="ts">
-import {
-  isStringControl,
-  rankWith,
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-} from '@jsonforms/core';
+import { type ControlElement } from '@jsonforms/core';
 import {
   rendererProps,
   useJsonFormsControl,
@@ -125,9 +120,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(1, isStringControl),
-};
 </script>

--- a/packages/vue-vuetify/src/controls/StringMaskControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/controls/StringMaskControlRenderer.entry.ts
@@ -1,0 +1,13 @@
+import {
+  type JsonFormsRendererRegistryEntry,
+  rankWith,
+  and,
+  isStringControl,
+  hasOption,
+} from '@jsonforms/core';
+import controlRenderer from './StringMaskControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, and(isStringControl, hasOption('mask'))),
+};

--- a/packages/vue-vuetify/src/controls/StringMaskControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/StringMaskControlRenderer.vue
@@ -38,11 +38,7 @@
 
 <script lang="ts">
 import {
-  and,
   type ControlElement,
-  isStringControl,
-  type JsonFormsRendererRegistryEntry,
-  rankWith,
   type Tester,
   type UISchemaElement,
 } from '@jsonforms/core';
@@ -206,9 +202,4 @@ const hasOption =
       false
     );
   };
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(2, and(isStringControl, hasOption('mask'))),
-};
 </script>

--- a/packages/vue-vuetify/src/controls/TimeControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/controls/TimeControlRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  type JsonFormsRendererRegistryEntry,
+  rankWith,
+  isTimeControl,
+} from '@jsonforms/core';
+import controlRenderer from './TimeControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(2, isTimeControl),
+};

--- a/packages/vue-vuetify/src/controls/TimeControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/TimeControlRenderer.vue
@@ -80,13 +80,7 @@
 </template>
 
 <script lang="ts">
-import {
-  isTimeControl,
-  rankWith,
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-  type JsonSchema,
-} from '@jsonforms/core';
+import { type ControlElement, type JsonSchema } from '@jsonforms/core';
 import {
   rendererProps,
   useJsonFormsControl,
@@ -164,9 +158,9 @@ const controlRenderer = defineComponent({
     const timeFormat = computed(
       () =>
         typeof control.appliedOptions.value.timeFormat == 'string'
-          ? expandLocaleFormat(control.appliedOptions.value.timeFormat) ??
-            control.appliedOptions.value.timeFormat
-          : expandLocaleFormat('LT') ?? 'H:mm', // by default try to use localized default if unavailable then H:mm,
+          ? (expandLocaleFormat(control.appliedOptions.value.timeFormat) ??
+            control.appliedOptions.value.timeFormat)
+          : (expandLocaleFormat('LT') ?? 'H:mm'), // by default try to use localized default if unavailable then H:mm,
     );
 
     const useMask = control.appliedOptions.value.mask !== false;
@@ -374,9 +368,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(2, isTimeControl),
-};
 </script>

--- a/packages/vue-vuetify/src/controls/index.ts
+++ b/packages/vue-vuetify/src/controls/index.ts
@@ -20,23 +20,23 @@ export { default as StringControlRenderer } from './StringControlRenderer.vue';
 export { default as StringMaskControlRenderer } from './StringMaskControlRenderer.vue';
 export { default as TimeControlRenderer } from './TimeControlRenderer.vue';
 
-import { entry as anyOfStringOrEnumControlRendererEntry } from './AnyOfStringOrEnumControlRenderer.vue';
-import { entry as booleanControlRendererEntry } from './BooleanControlRenderer.vue';
-import { entry as booleanToggleControlRendererEntry } from './BooleanToggleControlRenderer.vue';
-import { entry as dateControlRendererEntry } from './DateControlRenderer.vue';
-import { entry as dateTimeControlRendererEntry } from './DateTimeControlRenderer.vue';
-import { entry as enumControlRendererEntry } from './EnumControlRenderer.vue';
-import { entry as integerControlRendererEntry } from './IntegerControlRenderer.vue';
-import { entry as multiStringControlRendererEntry } from './MultiStringControlRenderer.vue';
-import { entry as numberControlRendererEntry } from './NumberControlRenderer.vue';
-import { entry as oneOfEnumControlRendererEntry } from './OneOfEnumControlRenderer.vue';
-import { entry as oneOfRadioGroupControlRendererEntry } from './OneOfRadioGroupControlRenderer.vue';
-import { entry as passwordControlRendererEntry } from './PasswordControlRenderer.vue';
-import { entry as radioGroupControlRendererEntry } from './RadioGroupControlRenderer.vue';
-import { entry as sliderControlRendererEntry } from './SliderControlRenderer.vue';
-import { entry as stringControlRendererEntry } from './StringControlRenderer.vue';
-import { entry as stringMaskControlRendererEntry } from './StringMaskControlRenderer.vue';
-import { entry as timeControlRendererEntry } from './TimeControlRenderer.vue';
+import { entry as anyOfStringOrEnumControlRendererEntry } from './AnyOfStringOrEnumControlRenderer.entry';
+import { entry as booleanControlRendererEntry } from './BooleanControlRenderer.entry';
+import { entry as booleanToggleControlRendererEntry } from './BooleanToggleControlRenderer.entry';
+import { entry as dateControlRendererEntry } from './DateControlRenderer.entry';
+import { entry as dateTimeControlRendererEntry } from './DateTimeControlRenderer.entry';
+import { entry as enumControlRendererEntry } from './EnumControlRenderer.entry';
+import { entry as integerControlRendererEntry } from './IntegerControlRenderer.entry';
+import { entry as multiStringControlRendererEntry } from './MultiStringControlRenderer.entry';
+import { entry as numberControlRendererEntry } from './NumberControlRenderer.entry';
+import { entry as oneOfEnumControlRendererEntry } from './OneOfEnumControlRenderer.entry';
+import { entry as oneOfRadioGroupControlRendererEntry } from './OneOfRadioGroupControlRenderer.entry';
+import { entry as passwordControlRendererEntry } from './PasswordControlRenderer.entry';
+import { entry as radioGroupControlRendererEntry } from './RadioGroupControlRenderer.entry';
+import { entry as sliderControlRendererEntry } from './SliderControlRenderer.entry';
+import { entry as stringControlRendererEntry } from './StringControlRenderer.entry';
+import { entry as stringMaskControlRendererEntry } from './StringMaskControlRenderer.entry';
+import { entry as timeControlRendererEntry } from './TimeControlRenderer.entry';
 
 export const controlRenderers = [
   anyOfStringOrEnumControlRendererEntry,

--- a/packages/vue-vuetify/src/extended/AutocompleteEnumControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/extended/AutocompleteEnumControlRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  isEnumControl,
+  rankWith,
+  type JsonFormsRendererRegistryEntry,
+} from '@jsonforms/core';
+import controlRenderer from './AutocompleteEnumControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(10, isEnumControl),
+};

--- a/packages/vue-vuetify/src/extended/AutocompleteEnumControlRenderer.vue
+++ b/packages/vue-vuetify/src/extended/AutocompleteEnumControlRenderer.vue
@@ -55,12 +55,7 @@
 </template>
 
 <script lang="ts">
-import {
-  isEnumControl,
-  rankWith,
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-} from '@jsonforms/core';
+import { type ControlElement } from '@jsonforms/core';
 import {
   rendererProps,
   useJsonFormsEnumControl,
@@ -95,9 +90,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(10, isEnumControl),
-};
 </script>

--- a/packages/vue-vuetify/src/extended/AutocompleteOneOfEnumControlRenderer.entry.ts
+++ b/packages/vue-vuetify/src/extended/AutocompleteOneOfEnumControlRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  isOneOfEnumControl,
+  rankWith,
+  type JsonFormsRendererRegistryEntry,
+} from '@jsonforms/core';
+import controlRenderer from './AutocompleteOneOfEnumControlRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(10, isOneOfEnumControl),
+};

--- a/packages/vue-vuetify/src/extended/AutocompleteOneOfEnumControlRenderer.vue
+++ b/packages/vue-vuetify/src/extended/AutocompleteOneOfEnumControlRenderer.vue
@@ -55,12 +55,7 @@
 </template>
 
 <script lang="ts">
-import {
-  isOneOfEnumControl,
-  rankWith,
-  type ControlElement,
-  type JsonFormsRendererRegistryEntry,
-} from '@jsonforms/core';
+import { type ControlElement } from '@jsonforms/core';
 import {
   rendererProps,
   useJsonFormsOneOfEnumControl,
@@ -95,9 +90,4 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(10, isOneOfEnumControl),
-};
 </script>

--- a/packages/vue-vuetify/src/extended/index.ts
+++ b/packages/vue-vuetify/src/extended/index.ts
@@ -1,8 +1,8 @@
 export { default as AutocompleteEnumControlRenderer } from './AutocompleteEnumControlRenderer.vue';
 export { default as AutocompleteOneOfEnumControlRenderer } from './AutocompleteOneOfEnumControlRenderer.vue';
 
-import { entry as autocompleteEnumControlRendererEntry } from './AutocompleteEnumControlRenderer.vue';
-import { entry as autocompleteOneOfEnumControlRendererEntry } from './AutocompleteOneOfEnumControlRenderer.vue';
+import { entry as autocompleteEnumControlRendererEntry } from './AutocompleteEnumControlRenderer.entry';
+import { entry as autocompleteOneOfEnumControlRendererEntry } from './AutocompleteOneOfEnumControlRenderer.entry';
 
 export const extendedRenderers = [
   autocompleteEnumControlRendererEntry,

--- a/packages/vue-vuetify/src/layouts/ArrayLayoutRenderer.entry.ts
+++ b/packages/vue-vuetify/src/layouts/ArrayLayoutRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  isObjectArrayWithNesting,
+  rankWith,
+  type JsonFormsRendererRegistryEntry,
+} from '@jsonforms/core';
+import controlRenderer from './ArrayLayoutRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: controlRenderer,
+  tester: rankWith(4, isObjectArrayWithNesting),
+};

--- a/packages/vue-vuetify/src/layouts/ArrayLayoutRenderer.vue
+++ b/packages/vue-vuetify/src/layouts/ArrayLayoutRenderer.vue
@@ -255,10 +255,7 @@ import {
   createDefaultValue,
   findUISchema,
   getControlPath,
-  isObjectArrayWithNesting,
-  rankWith,
   type ControlElement,
-  type JsonFormsRendererRegistryEntry,
   type JsonSchema,
   type UISchemaElement,
 } from '@jsonforms/core';
@@ -421,11 +418,6 @@ const controlRenderer = defineComponent({
 });
 
 export default controlRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(4, isObjectArrayWithNesting),
-};
 </script>
 
 <style scoped>

--- a/packages/vue-vuetify/src/layouts/CategorizationRenderer.entry.ts
+++ b/packages/vue-vuetify/src/layouts/CategorizationRenderer.entry.ts
@@ -1,0 +1,13 @@
+import {
+  and,
+  categorizationHasCategory,
+  isCategorization,
+  rankWith,
+  type JsonFormsRendererRegistryEntry,
+} from '@jsonforms/core';
+import layoutRenderer from './CategorizationRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: layoutRenderer,
+  tester: rankWith(2, and(isCategorization, categorizationHasCategory)),
+};

--- a/packages/vue-vuetify/src/layouts/CategorizationRenderer.vue
+++ b/packages/vue-vuetify/src/layouts/CategorizationRenderer.vue
@@ -134,11 +134,6 @@ const layoutRenderer = defineComponent({
 });
 
 export default layoutRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: layoutRenderer,
-  tester: rankWith(2, and(isCategorization, categorizationHasCategory)),
-};
 </script>
 
 <style scoped>

--- a/packages/vue-vuetify/src/layouts/CategorizationStepperRenderer.entry.ts
+++ b/packages/vue-vuetify/src/layouts/CategorizationStepperRenderer.entry.ts
@@ -1,0 +1,21 @@
+import {
+  and,
+  categorizationHasCategory,
+  isCategorization,
+  optionIs,
+  rankWith,
+  type JsonFormsRendererRegistryEntry,
+} from '@jsonforms/core';
+import layoutRenderer from './CategorizationStepperRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: layoutRenderer,
+  tester: rankWith(
+    3,
+    and(
+      isCategorization,
+      categorizationHasCategory,
+      optionIs('variant', 'stepper'),
+    ),
+  ),
+};

--- a/packages/vue-vuetify/src/layouts/CategorizationStepperRenderer.vue
+++ b/packages/vue-vuetify/src/layouts/CategorizationStepperRenderer.vue
@@ -78,15 +78,7 @@
 </template>
 
 <script lang="ts">
-import {
-  and,
-  categorizationHasCategory,
-  isCategorization,
-  optionIs,
-  rankWith,
-  type JsonFormsRendererRegistryEntry,
-  type Layout,
-} from '@jsonforms/core';
+import { type Layout } from '@jsonforms/core';
 import {
   DispatchRenderer,
   rendererProps,
@@ -149,16 +141,4 @@ const layoutRenderer = defineComponent({
 });
 
 export default layoutRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: layoutRenderer,
-  tester: rankWith(
-    3,
-    and(
-      isCategorization,
-      categorizationHasCategory,
-      optionIs('variant', 'stepper'),
-    ),
-  ),
-};
 </script>

--- a/packages/vue-vuetify/src/layouts/GroupRenderer.entry.ts
+++ b/packages/vue-vuetify/src/layouts/GroupRenderer.entry.ts
@@ -1,0 +1,13 @@
+import {
+  type JsonFormsRendererRegistryEntry,
+  rankWith,
+  and,
+  isLayout,
+  uiTypeIs,
+} from '@jsonforms/core';
+import layoutRenderer from './GroupRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: layoutRenderer,
+  tester: rankWith(2, and(isLayout, uiTypeIs('Group'))),
+};

--- a/packages/vue-vuetify/src/layouts/GroupRenderer.vue
+++ b/packages/vue-vuetify/src/layouts/GroupRenderer.vue
@@ -32,14 +32,7 @@
 </template>
 
 <script lang="ts">
-import {
-  and,
-  isLayout,
-  rankWith,
-  uiTypeIs,
-  type JsonFormsRendererRegistryEntry,
-  type Layout,
-} from '@jsonforms/core';
+import { type Layout } from '@jsonforms/core';
 import {
   DispatchRenderer,
   rendererProps,
@@ -85,11 +78,6 @@ const layoutRenderer = defineComponent({
 });
 
 export default layoutRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: layoutRenderer,
-  tester: rankWith(2, and(isLayout, uiTypeIs('Group'))),
-};
 </script>
 
 <!-- Default styles for the 'nested' feature -->

--- a/packages/vue-vuetify/src/layouts/HorizontalLayoutRenderer.entry.ts
+++ b/packages/vue-vuetify/src/layouts/HorizontalLayoutRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  rankWith,
+  uiTypeIs,
+  type JsonFormsRendererRegistryEntry,
+} from '@jsonforms/core';
+import layoutRenderer from './HorizontalLayoutRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: layoutRenderer,
+  tester: rankWith(2, uiTypeIs('HorizontalLayout')),
+};

--- a/packages/vue-vuetify/src/layouts/HorizontalLayoutRenderer.vue
+++ b/packages/vue-vuetify/src/layouts/HorizontalLayoutRenderer.vue
@@ -26,12 +26,7 @@
 </template>
 
 <script lang="ts">
-import {
-  rankWith,
-  uiTypeIs,
-  type JsonFormsRendererRegistryEntry,
-  type Layout,
-} from '@jsonforms/core';
+import { type Layout } from '@jsonforms/core';
 import {
   DispatchRenderer,
   rendererProps,
@@ -113,9 +108,4 @@ const layoutRenderer = defineComponent({
 });
 
 export default layoutRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: layoutRenderer,
-  tester: rankWith(2, uiTypeIs('HorizontalLayout')),
-};
 </script>

--- a/packages/vue-vuetify/src/layouts/VerticalLayoutRenderer.entry.ts
+++ b/packages/vue-vuetify/src/layouts/VerticalLayoutRenderer.entry.ts
@@ -1,0 +1,11 @@
+import {
+  rankWith,
+  uiTypeIs,
+  type JsonFormsRendererRegistryEntry,
+} from '@jsonforms/core';
+import layoutRenderer from './VerticalLayoutRenderer.vue';
+
+export const entry: JsonFormsRendererRegistryEntry = {
+  renderer: layoutRenderer,
+  tester: rankWith(2, uiTypeIs('VerticalLayout')),
+};

--- a/packages/vue-vuetify/src/layouts/VerticalLayoutRenderer.vue
+++ b/packages/vue-vuetify/src/layouts/VerticalLayoutRenderer.vue
@@ -29,12 +29,7 @@
 </template>
 
 <script lang="ts">
-import {
-  rankWith,
-  uiTypeIs,
-  type JsonFormsRendererRegistryEntry,
-  type Layout,
-} from '@jsonforms/core';
+import { type Layout } from '@jsonforms/core';
 import {
   DispatchRenderer,
   rendererProps,
@@ -62,9 +57,4 @@ const layoutRenderer = defineComponent({
 });
 
 export default layoutRenderer;
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: layoutRenderer,
-  tester: rankWith(2, uiTypeIs('VerticalLayout')),
-};
 </script>

--- a/packages/vue-vuetify/src/layouts/index.ts
+++ b/packages/vue-vuetify/src/layouts/index.ts
@@ -4,12 +4,12 @@ import {
   type JsonFormsRendererRegistryEntry,
 } from '@jsonforms/core';
 
-import { entry as arrayLayoutRendererEntry } from './ArrayLayoutRenderer.vue';
-import { entry as categorizationRendererEntry } from './CategorizationRenderer.vue';
-import { entry as categorizationStepperRendererEntry } from './CategorizationStepperRenderer.vue';
-import { entry as groupRendererEntry } from './GroupRenderer.vue';
-import { entry as horizontalLayoutRendererEntry } from './HorizontalLayoutRenderer.vue';
-import { entry as verticalLayoutRendererEntry } from './VerticalLayoutRenderer.vue';
+import { entry as arrayLayoutRendererEntry } from './ArrayLayoutRenderer.entry';
+import { entry as categorizationRendererEntry } from './CategorizationRenderer.entry';
+import { entry as categorizationStepperRendererEntry } from './CategorizationStepperRenderer.entry';
+import { entry as groupRendererEntry } from './GroupRenderer.entry';
+import { entry as horizontalLayoutRendererEntry } from './HorizontalLayoutRenderer.entry';
+import { entry as verticalLayoutRendererEntry } from './VerticalLayoutRenderer.entry';
 
 import { default as VerticalLayoutRenderer } from './VerticalLayoutRenderer.vue';
 export { default as ArrayLayoutRenderer } from './ArrayLayoutRenderer.vue';

--- a/packages/vue-vuetify/tests/unit/additional/LabelRenderer.spec.ts
+++ b/packages/vue-vuetify/tests/unit/additional/LabelRenderer.spec.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { clearAllIds } from '@jsonforms/core';
-import LabelRenderer, {
-  entry as labelRendererEntry,
-} from '../../../src/additional/LabelRenderer.vue';
+import LabelRenderer from '../../../src/additional/LabelRenderer.vue';
+import { entry as labelRendererEntry } from '../../../src/additional/LabelRenderer.entry';
 import { mountJsonForms } from '../util';
 
 describe('LabelRenderer.vue', () => {

--- a/packages/vue-vuetify/tests/unit/additional/ListWithDetailRenderer.spec.ts
+++ b/packages/vue-vuetify/tests/unit/additional/ListWithDetailRenderer.spec.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { clearAllIds, type Translator } from '@jsonforms/core';
-import ListWithDetailRenderer, {
-  entry as listWithDetailRendererEntry,
-} from '../../../src/additional/ListWithDetailRenderer.vue';
+import ListWithDetailRenderer from '../../../src/additional/ListWithDetailRenderer.vue';
+import { entry as listWithDetailRendererEntry } from '../../../src/additional/ListWithDetailRenderer.entry';
 import { mountJsonForms } from '../util';
 
 describe('ListWithDetailRenderer.vue', () => {

--- a/packages/vue-vuetify/tests/unit/complex/ArrayControlRenderer.spec.ts
+++ b/packages/vue-vuetify/tests/unit/complex/ArrayControlRenderer.spec.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { clearAllIds, type Translator } from '@jsonforms/core';
-import ArrayControlRenderer, {
-  entry as arrayControlRendererEntry,
-} from '../../../src/complex/ArrayControlRenderer.vue';
+import ArrayControlRenderer from '../../../src/complex/ArrayControlRenderer.vue';
+import { entry as arrayControlRendererEntry } from '../../../src/complex/ArrayControlRenderer.entry';
 import { mountJsonForms } from '../util';
 
 describe('ArrayControlRenderer.vue', () => {

--- a/packages/vue-vuetify/tests/unit/complex/OneOfRenderer.spec.ts
+++ b/packages/vue-vuetify/tests/unit/complex/OneOfRenderer.spec.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { clearAllIds, type Translator } from '@jsonforms/core';
-import OneOfControlRenderer, {
-  entry as oneOfControlRendererEntry,
-} from '../../../src/complex/OneOfRenderer.vue';
+import OneOfControlRenderer from '../../../src/complex/OneOfRenderer.vue';
+import { entry as oneOfControlRendererEntry } from '../../../src/complex/OneOfRenderer.entry';
 import { mountJsonForms } from '../util';
 
 describe('OneOfRenderer.vue', () => {

--- a/packages/vue-vuetify/tests/unit/controls/BooleanControlRenderer.spec.ts
+++ b/packages/vue-vuetify/tests/unit/controls/BooleanControlRenderer.spec.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { clearAllIds } from '@jsonforms/core';
-import BooleanControlRenderer, {
-  entry as booleanControlRendererEntry,
-} from '../../../src/controls/BooleanControlRenderer.vue';
+import BooleanControlRenderer from '../../../src/controls/BooleanControlRenderer.vue';
+import { entry as booleanControlRendererEntry } from '../../../src/controls/BooleanControlRenderer.entry';
 import { mountJsonForms } from '../util';
 
 describe('BooleanControlRenderer.vue', () => {

--- a/packages/vue-vuetify/tests/unit/controls/DateControlRenderer.spec.ts
+++ b/packages/vue-vuetify/tests/unit/controls/DateControlRenderer.spec.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { clearAllIds } from '@jsonforms/core';
-import DateControlRenderer, {
-  entry as dateControlRendererEntry,
-} from '../../../src/controls/DateControlRenderer.vue';
+import DateControlRenderer from '../../../src/controls/DateControlRenderer.vue';
+import { entry as dateControlRendererEntry } from '../../../src/controls/DateControlRenderer.entry';
 import { mountJsonForms } from '../util';
 
 describe('DateControlRenderer.vue', () => {

--- a/packages/vue-vuetify/tests/unit/controls/DateTimeControlRenderer.spec.ts
+++ b/packages/vue-vuetify/tests/unit/controls/DateTimeControlRenderer.spec.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { clearAllIds } from '@jsonforms/core';
-import DateTimeControlRenderer, {
-  entry as dateTimeControlRendererEntry,
-} from '../../../src/controls/DateTimeControlRenderer.vue';
+import DateTimeControlRenderer from '../../../src/controls/DateTimeControlRenderer.vue';
+import { entry as dateTimeControlRendererEntry } from '../../../src/controls/DateTimeControlRenderer.entry';
 import { mountJsonForms } from '../util';
 
 describe('DateTimeControlRenderer.vue', () => {

--- a/packages/vue-vuetify/tests/unit/controls/EnumControlRenderer.spec.ts
+++ b/packages/vue-vuetify/tests/unit/controls/EnumControlRenderer.spec.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { clearAllIds } from '@jsonforms/core';
-import EnumControlRenderer, {
-  entry as enumControlRendererEntry,
-} from '../../../src/controls/EnumControlRenderer.vue';
+import EnumControlRenderer from '../../../src/controls/EnumControlRenderer.vue';
+import { entry as enumControlRendererEntry } from '../../../src/controls/EnumControlRenderer.entry';
 import { wait } from '../../../tests';
 import { mountJsonForms } from '../util';
 

--- a/packages/vue-vuetify/tests/unit/controls/IntegerControlRenderer.spec.ts
+++ b/packages/vue-vuetify/tests/unit/controls/IntegerControlRenderer.spec.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { clearAllIds } from '@jsonforms/core';
-import IntegerControlRenderer, {
-  entry as integerControlRendererEntry,
-} from '../../../src/controls/IntegerControlRenderer.vue';
+import IntegerControlRenderer from '../../../src/controls/IntegerControlRenderer.vue';
+import { entry as integerControlRendererEntry } from '../../../src/controls/IntegerControlRenderer.entry';
 import { wait } from '../../../tests';
 import { mountJsonForms } from '../util';
 

--- a/packages/vue-vuetify/tests/unit/controls/MultiStringControlRenderer.spec.ts
+++ b/packages/vue-vuetify/tests/unit/controls/MultiStringControlRenderer.spec.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { clearAllIds } from '@jsonforms/core';
-import MultiStringControlRenderer, {
-  entry as multiStringControlRendererEntry,
-} from '../../../src/controls/MultiStringControlRenderer.vue';
+import MultiStringControlRenderer from '../../../src/controls/MultiStringControlRenderer.vue';
+import { entry as multiStringControlRendererEntry } from '../../../src/controls/MultiStringControlRenderer.entry';
 import { wait } from '../../../tests';
 import { mountJsonForms } from '../util';
 

--- a/packages/vue-vuetify/tests/unit/controls/NumberControlRenderer.spec.ts
+++ b/packages/vue-vuetify/tests/unit/controls/NumberControlRenderer.spec.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { clearAllIds } from '@jsonforms/core';
-import NumberControlRenderer, {
-  entry as numberControlRendererEntry,
-} from '../../../src/controls/NumberControlRenderer.vue';
+import NumberControlRenderer from '../../../src/controls/NumberControlRenderer.vue';
+import { entry as numberControlRendererEntry } from '../../../src/controls/NumberControlRenderer.entry';
 import { wait } from '../../../tests';
 import { mountJsonForms } from '../util';
 

--- a/packages/vue-vuetify/tests/unit/controls/OneOfEnumControlRenderer.spec.ts
+++ b/packages/vue-vuetify/tests/unit/controls/OneOfEnumControlRenderer.spec.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { clearAllIds } from '@jsonforms/core';
-import OneOfEnumControlRenderer, {
-  entry as oneOfEnumControlRendererEntry,
-} from '../../../src/controls/OneOfEnumControlRenderer.vue';
+import OneOfEnumControlRenderer from '../../../src/controls/OneOfEnumControlRenderer.vue';
+import { entry as oneOfEnumControlRendererEntry } from '../../../src/controls/OneOfEnumControlRenderer.entry';
 import { wait } from '../../../tests';
 import { mountJsonForms } from '../util';
 

--- a/packages/vue-vuetify/tests/unit/controls/StringControlRenderer.spec.ts
+++ b/packages/vue-vuetify/tests/unit/controls/StringControlRenderer.spec.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { clearAllIds } from '@jsonforms/core';
-import StringControlRenderer, {
-  entry as stringControlRendererEntry,
-} from '../../../src/controls/StringControlRenderer.vue';
+import StringControlRenderer from '../../../src/controls/StringControlRenderer.vue';
+import { entry as stringControlRendererEntry } from '../../../src/controls/StringControlRenderer.entry';
 import { wait } from '../../../tests';
 import { mountJsonForms } from '../util';
 

--- a/packages/vue-vuetify/tests/unit/controls/TimeControlRenderer.spec.ts
+++ b/packages/vue-vuetify/tests/unit/controls/TimeControlRenderer.spec.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { clearAllIds } from '@jsonforms/core';
-import TimeControlRenderer, {
-  entry as timeControlRendererEntry,
-} from '../../../src/controls/TimeControlRenderer.vue';
+import TimeControlRenderer from '../../../src/controls/TimeControlRenderer.vue';
+import { entry as timeControlRendererEntry } from '../../../src/controls/TimeControlRenderer.entry';
 import { mountJsonForms } from '../util';
 
 describe('TimeControlRenderer.vue', () => {

--- a/packages/vue-vuetify/tests/unit/layout/ArrayLayoutRenderer.spec.ts
+++ b/packages/vue-vuetify/tests/unit/layout/ArrayLayoutRenderer.spec.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { clearAllIds, type Translator } from '@jsonforms/core';
-import ArrayLayoutRenderer, {
-  entry as arrayLayoutRendererEntry,
-} from '../../../src/layouts/ArrayLayoutRenderer.vue';
+import ArrayLayoutRenderer from '../../../src/layouts/ArrayLayoutRenderer.vue';
+import { entry as arrayLayoutRendererEntry } from '../../../src/layouts/ArrayLayoutRenderer.entry';
 import { mountJsonForms } from '../util';
 
 describe('ArrayLayoutRenderer.vue', () => {


### PR DESCRIPTION
fix #2378

The registry entries for the renderers were configured in the same files as the renderers. This lead to the entries being removed due to tree shaking during production builds using esbuild (as used by Vite).

This extracts all entries to separate files and improves the README to no longer import the renderers asynchronously .