### PR TITLE
docs: update Vue link in Vue Vuetify

### DIFF
--- a/packages/vue-vuetify/README.md
+++ b/packages/vue-vuetify/README.md
@@ -6,7 +6,7 @@ JSON Forms eliminates the tedious task of writing fully-featured forms by hand b
 
 ## Vue Vuetify Renderers
 
-This is the JSON Forms Vue Vuetify renderers package which provides a Vuetify based renderer set for [JSON Forms Vue](https://github.com/eclipsesource/jsonforms/blob/master/packages/vue/vue).
+This is the JSON Forms Vue Vuetify renderers package which provides a Vuetify based renderer set for [JSON Forms Vue](https://github.com/eclipsesource/jsonforms/blob/master/packages/vue).
 The renderers are in a preview state.
 
 ### Quick start


### PR DESCRIPTION
We recently refactored the repo directories and forgot to adjust a link in the Vue Vuetify readme. The link is now updated.