### PR TITLE
feat: improve support for `minItems` and `maxItems` for array layout and control

### DIFF
--- a/packages/core/src/mappers/renderer.ts
+++ b/packages/core/src/mappers/renderer.ts
@@ -785,6 +785,7 @@ export interface ControlWithDetailProps
  */
 export interface StatePropsOfArrayControl
   extends StatePropsOfControlWithDetail {
+  arraySchema: JsonSchema;
   childErrors?: ErrorObject[];
   minItems?: number;
   maxItems?: number;
@@ -813,6 +814,7 @@ export const mapStateToArrayControlProps = (
     path,
     uischema,
     schema: resolvedSchema,
+    arraySchema: schema,
     childErrors,
     renderers: ownProps.renderers || getRenderers(state),
     cells: ownProps.cells || getCells(state),
@@ -1143,6 +1145,7 @@ export const mapStateToOneOfProps = (
 
 export interface StatePropsOfArrayLayout extends StatePropsOfControlWithDetail {
   data: number;
+  arraySchema: JsonSchema;
   minItems?: number;
   maxItems?: number;
   disableRemove?: boolean;
@@ -1184,6 +1187,7 @@ export const mapStateToArrayLayoutProps = (
     path,
     uischema,
     schema: resolvedSchema,
+    arraySchema: schema,
     data: props.data ? props.data.length : 0,
     errors: allErrors,
     minItems: schema.minItems,

--- a/packages/core/src/mappers/renderer.ts
+++ b/packages/core/src/mappers/renderer.ts
@@ -787,8 +787,6 @@ export interface StatePropsOfArrayControl
   extends StatePropsOfControlWithDetail {
   arraySchema: JsonSchema;
   childErrors?: ErrorObject[];
-  minItems?: number;
-  maxItems?: number;
 }
 
 /**
@@ -818,8 +816,6 @@ export const mapStateToArrayControlProps = (
     childErrors,
     renderers: ownProps.renderers || getRenderers(state),
     cells: ownProps.cells || getCells(state),
-    minItems: schema.minItems,
-    maxItems: schema.maxItems,
   };
 };
 
@@ -1146,8 +1142,10 @@ export const mapStateToOneOfProps = (
 export interface StatePropsOfArrayLayout extends StatePropsOfControlWithDetail {
   data: number;
   arraySchema: JsonSchema;
+  /**
+   * @deprecated Use `arraySchema.minItems` instead.
+   */
   minItems?: number;
-  maxItems?: number;
   disableRemove?: boolean;
   disableAdd?: boolean;
 }
@@ -1191,7 +1189,6 @@ export const mapStateToArrayLayoutProps = (
     data: props.data ? props.data.length : 0,
     errors: allErrors,
     minItems: schema.minItems,
-    maxItems: schema.maxItems,
   };
 };
 

--- a/packages/core/src/mappers/renderer.ts
+++ b/packages/core/src/mappers/renderer.ts
@@ -786,6 +786,8 @@ export interface ControlWithDetailProps
 export interface StatePropsOfArrayControl
   extends StatePropsOfControlWithDetail {
   childErrors?: ErrorObject[];
+  minItems?: number;
+  maxItems?: number;
 }
 
 /**
@@ -814,6 +816,8 @@ export const mapStateToArrayControlProps = (
     childErrors,
     renderers: ownProps.renderers || getRenderers(state),
     cells: ownProps.cells || getCells(state),
+    minItems: schema.minItems,
+    maxItems: schema.maxItems,
   };
 };
 
@@ -1140,6 +1144,7 @@ export const mapStateToOneOfProps = (
 export interface StatePropsOfArrayLayout extends StatePropsOfControlWithDetail {
   data: number;
   minItems?: number;
+  maxItems?: number;
   disableRemove?: boolean;
   disableAdd?: boolean;
 }
@@ -1182,6 +1187,7 @@ export const mapStateToArrayLayoutProps = (
     data: props.data ? props.data.length : 0,
     errors: allErrors,
     minItems: schema.minItems,
+    maxItems: schema.maxItems,
   };
 };
 

--- a/packages/core/test/mappers/renderer.test.ts
+++ b/packages/core/test/mappers/renderer.test.ts
@@ -811,7 +811,7 @@ test('mapStateToLayoutProps - visible via state with path from ownProps ', (t) =
   t.true(props.visible);
 });
 
-test('mapStateToArrayControlProps - should include minItems in array layout props', (t) => {
+test('mapStateToArrayControlProps - should include minItems in array control props', (t) => {
   const schema: JsonSchema = {
     type: 'array',
     minItems: 42,
@@ -850,7 +850,7 @@ test('mapStateToArrayControlProps - should include minItems in array layout prop
   t.is(props.minItems, 42);
 });
 
-test('mapStateToArrayControlProps - should include maxItems in array layout props', (t) => {
+test('mapStateToArrayControlProps - should include maxItems in array control props', (t) => {
   const schema: JsonSchema = {
     type: 'array',
     maxItems: 42,

--- a/packages/core/test/mappers/renderer.test.ts
+++ b/packages/core/test/mappers/renderer.test.ts
@@ -847,7 +847,7 @@ test('mapStateToArrayControlProps - should include minItems in array control pro
   };
 
   const props = mapStateToArrayControlProps(state, ownProps);
-  t.is(props.minItems, 42);
+  t.is(props.arraySchema.minItems, 42);
 });
 
 test('mapStateToArrayControlProps - should include maxItems in array control props', (t) => {
@@ -886,7 +886,7 @@ test('mapStateToArrayControlProps - should include maxItems in array control pro
   };
 
   const props = mapStateToArrayControlProps(state, ownProps);
-  t.is(props.maxItems, 42);
+  t.is(props.arraySchema.maxItems, 42);
 });
 
 test('mapStateToArrayLayoutProps - should include minItems in array layout props', (t) => {
@@ -925,7 +925,7 @@ test('mapStateToArrayLayoutProps - should include minItems in array layout props
   };
 
   const props = mapStateToArrayLayoutProps(state, ownProps);
-  t.is(props.minItems, 42);
+  t.is(props.arraySchema.minItems, 42);
 });
 
 test('mapStateToArrayLayoutProps - should include maxItems in array layout props', (t) => {
@@ -964,7 +964,7 @@ test('mapStateToArrayLayoutProps - should include maxItems in array layout props
   };
 
   const props = mapStateToArrayLayoutProps(state, ownProps);
-  t.is(props.maxItems, 42);
+  t.is(props.arraySchema.maxItems, 42);
 });
 
 test('mapStateToLayoutProps should return renderers prop via ownProps', (t) => {

--- a/packages/core/test/mappers/renderer.test.ts
+++ b/packages/core/test/mappers/renderer.test.ts
@@ -54,6 +54,7 @@ import {
   mapDispatchToControlProps,
   mapDispatchToMultiEnumProps,
   mapStateToAnyOfProps,
+  mapStateToArrayControlProps,
   mapStateToArrayLayoutProps,
   mapStateToControlProps,
   mapStateToEnumControlProps,
@@ -810,6 +811,84 @@ test('mapStateToLayoutProps - visible via state with path from ownProps ', (t) =
   t.true(props.visible);
 });
 
+test('mapStateToArrayControlProps - should include minItems in array layout props', (t) => {
+  const schema: JsonSchema = {
+    type: 'array',
+    minItems: 42,
+    items: {
+      type: 'object',
+      properties: {
+        message: {
+          type: 'string',
+          default: 'foo',
+        },
+      },
+    },
+  };
+
+  const uischema: ControlElement = {
+    type: 'Control',
+    scope: '#',
+  };
+
+  const state = {
+    jsonforms: {
+      core: {
+        schema,
+        data: {},
+        uischema,
+        errors: [] as ErrorObject[],
+      },
+    },
+  };
+
+  const ownProps = {
+    uischema,
+  };
+
+  const props = mapStateToArrayControlProps(state, ownProps);
+  t.is(props.minItems, 42);
+});
+
+test('mapStateToArrayControlProps - should include maxItems in array layout props', (t) => {
+  const schema: JsonSchema = {
+    type: 'array',
+    maxItems: 42,
+    items: {
+      type: 'object',
+      properties: {
+        message: {
+          type: 'string',
+          default: 'foo',
+        },
+      },
+    },
+  };
+
+  const uischema: ControlElement = {
+    type: 'Control',
+    scope: '#',
+  };
+
+  const state = {
+    jsonforms: {
+      core: {
+        schema,
+        data: {},
+        uischema,
+        errors: [] as ErrorObject[],
+      },
+    },
+  };
+
+  const ownProps = {
+    uischema,
+  };
+
+  const props = mapStateToArrayControlProps(state, ownProps);
+  t.is(props.maxItems, 42);
+});
+
 test('mapStateToArrayLayoutProps - should include minItems in array layout props', (t) => {
   const schema: JsonSchema = {
     type: 'array',
@@ -847,6 +926,45 @@ test('mapStateToArrayLayoutProps - should include minItems in array layout props
 
   const props = mapStateToArrayLayoutProps(state, ownProps);
   t.is(props.minItems, 42);
+});
+
+test('mapStateToArrayLayoutProps - should include maxItems in array layout props', (t) => {
+  const schema: JsonSchema = {
+    type: 'array',
+    maxItems: 42,
+    items: {
+      type: 'object',
+      properties: {
+        message: {
+          type: 'string',
+          default: 'foo',
+        },
+      },
+    },
+  };
+
+  const uischema: ControlElement = {
+    type: 'Control',
+    scope: '#',
+  };
+
+  const state = {
+    jsonforms: {
+      core: {
+        schema,
+        data: {},
+        uischema,
+        errors: [] as ErrorObject[],
+      },
+    },
+  };
+
+  const ownProps = {
+    uischema,
+  };
+
+  const props = mapStateToArrayLayoutProps(state, ownProps);
+  t.is(props.maxItems, 42);
 });
 
 test('mapStateToLayoutProps should return renderers prop via ownProps', (t) => {

--- a/packages/vanilla-renderers/src/complex/array/ArrayControlRenderer.tsx
+++ b/packages/vanilla-renderers/src/complex/array/ArrayControlRenderer.tsx
@@ -193,6 +193,7 @@ export const ArrayControlRenderer = ({
   enabled,
   errors,
   translations,
+  arraySchema,
 }: ArrayControlProps &
   VanillaRendererProps & { translations: ArrayTranslations }) => {
   const controlElement = uischema as ControlElement;
@@ -221,6 +222,7 @@ export const ArrayControlRenderer = ({
       label={label}
       path={path}
       schema={schema}
+      arraySchema={arraySchema}
       errors={errors}
       addItem={addItem}
       removeItems={removeItems}


### PR DESCRIPTION
Added improved support for the `minItems` and `maxItems` properties, to allow for more fine-grained control and validation in ArrayControl and ArrayLayout applications. I have also added additional tests to cover these properties.

----

While working on this, I realized that the current handling of array (or items) schemas is too restrictive for custom implementations. Specifically, the schema is being completely replaced by the items schema, which typically only includes a basic type description and hides important details like the `min` and `max` item properties from the original array schema.

https://github.com/eclipsesource/jsonforms/blob/fcef896c8927269d3f3ed609a7255651085b193d/packages/core/src/mappers/renderer.ts#L798-L818

To address these limitations, I see two possible approaches:

1. Add a `parentSchema` property to preserve the original schema, keeping the existing behavior while easing the constraints. This might introduce some confusion around naming.
2. Store the original schema in the `schema` property and put the resolved schema in a new `arraySchema` or `itemsSchema` property. However, this would change the current behavior, requiring migration.

I’d appreciate your thoughts on these options.