### PR TITLE
deps: Support React ^19.0.0 as peer dependency

### DIFF
--- a/packages/material-renderers/package.json
+++ b/packages/material-renderers/package.json
@@ -91,7 +91,7 @@
     "@mui/icons-material": "^5.11.16 || ^6.0.0",
     "@mui/material": "^5.13.0 || ^6.0.0",
     "@mui/x-date-pickers": "^6.0.0 || ^7.0.0",
-    "react": "^16.12.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.12.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@emotion/react": "^11.5.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -87,7 +87,7 @@
   },
   "peerDependencies": {
     "@jsonforms/core": "3.5.0-beta.1",
-    "react": "^16.12.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.12.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "optionalPeerDependencies": {
     "react-redux": "^7.1.3"

--- a/packages/vanilla-renderers/package.json
+++ b/packages/vanilla-renderers/package.json
@@ -49,7 +49,7 @@
   "peerDependencies": {
     "@jsonforms/core": "3.5.0-beta.1",
     "@jsonforms/react": "3.5.0-beta.1",
-    "react": "^16.12.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.12.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.2",


### PR DESCRIPTION
fix #2404

I also briefly tested the react seed with React 19 and did not encounter any issues :)