### PR TITLE
Allow using projects to properly tree-shake lodash

### DIFF
--- a/packages/angular-material/src/library/other/object.renderer.ts
+++ b/packages/angular-material/src/library/other/object.renderer.ts
@@ -40,7 +40,7 @@ import {
   setReadonly,
   UISchemaElement,
 } from '@jsonforms/core';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 @Component({
   selector: 'ObjectRenderer',

--- a/packages/angular/src/library/jsonforms.component.ts
+++ b/packages/angular/src/library/jsonforms.component.ts
@@ -48,7 +48,8 @@ import { JsonFormsBaseRenderer } from './base.renderer';
 import { JsonFormsControl } from './control';
 import { JsonFormsAngularService } from './jsonforms.service';
 
-import { get, isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
+import get from 'lodash/get';
 
 const areEqual = (
   prevProps: StatePropsOfJsonFormsRenderer,

--- a/packages/angular/src/library/jsonforms.service.ts
+++ b/packages/angular/src/library/jsonforms.service.ts
@@ -50,7 +50,7 @@ import {
 import { BehaviorSubject, Observable } from 'rxjs';
 import type { JsonFormsBaseRenderer } from './base.renderer';
 
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import type Ajv from 'ajv';
 import type { ErrorObject } from 'ajv';
 

--- a/packages/core/src/mappers/renderer.ts
+++ b/packages/core/src/mappers/renderer.ts
@@ -85,7 +85,7 @@ import {
 } from '../store';
 import { isInherentlyEnabled } from './util';
 import { CombinatorKeyword } from './combinators';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 const move = (array: any[], index: number, delta: number) => {
   const newIndex: number = index + delta;

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -44,7 +44,7 @@ import {
 } from '../actions';
 import { JsonFormsCore, Reducer, ValidationMode } from '../store';
 import Ajv, { ErrorObject } from 'ajv';
-import { isFunction } from 'lodash';
+import isFunction from 'lodash/isFunction';
 import { createAjv, validate } from '../util';
 
 export const initState: JsonFormsCore = {

--- a/packages/examples/src/examples/arraysI18n.ts
+++ b/packages/examples/src/examples/arraysI18n.ts
@@ -24,7 +24,7 @@
 */
 import { registerExamples } from '../register';
 import { ArrayTranslationEnum, Translator } from '@jsonforms/core';
-import { get } from 'lodash';
+import get from 'lodash/get';
 
 export const schema = {
   type: 'object',

--- a/packages/vue-vanilla/src/complex/ObjectRenderer.vue
+++ b/packages/vue-vanilla/src/complex/ObjectRenderer.vue
@@ -31,7 +31,7 @@ import {
   useJsonFormsControlWithDetail,
 } from '../../config/jsonforms';
 import { useVanillaControl } from '../util';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 const controlRenderer = defineComponent({
   name: 'ObjectRenderer',


### PR DESCRIPTION
Instead of importing top-level module, consistently use deep-imports for lodash. This allows projects to properly tree-shake lodash in their build is substantially reduce the size of the resulting bundle.