### PR TITLE
core: Remove AJV usage from combinator mappers

### DIFF
--- a/packages/core/src/mappers/combinators.ts
+++ b/packages/core/src/mappers/combinators.ts
@@ -36,6 +36,12 @@ export interface CombinatorSubSchemaRenderInfo {
 
 export type CombinatorKeyword = 'anyOf' | 'oneOf' | 'allOf';
 
+/** Custom schema keyword to define the property identifying different combinator schemas. */
+export const COMBINATOR_TYPE_PROPERTY = 'x-jsf-type-property';
+
+/** Default properties that are used to identify combinator schemas. */
+export const COMBINATOR_IDENTIFICATION_PROPERTIES = ['type', 'kind', 'id'];
+
 export const createCombinatorRenderInfos = (
   combinatorSubSchemas: JsonSchema[],
   rootSchema: JsonSchema,
@@ -67,3 +73,101 @@ export const createCombinatorRenderInfos = (
         `${keyword}-${subSchemaIndex}`,
     };
   });
+
+/**
+ * Returns the identification property of the given data object.
+ * The following heuristics are applied:
+ * If the schema defines a `x-jsf-type-property`, it is used as the identification property.
+ * Otherwise, the first of the following data properties is used:
+ * - `type`
+ * - `kind`
+ * - `id`
+ *
+ * If none of the above properties are present, the first string or number property of the data object is used.
+ */
+export const getCombinatorIdentificationProp = (
+  data: any,
+  schema: JsonSchema
+): string | undefined => {
+  if (typeof data !== 'object' || data === null) {
+    return undefined;
+  }
+
+  // Determine the identification property
+  let idProperty: string | undefined;
+  if (
+    COMBINATOR_TYPE_PROPERTY in schema &&
+    typeof schema[COMBINATOR_TYPE_PROPERTY] === 'string'
+  ) {
+    idProperty = schema[COMBINATOR_TYPE_PROPERTY];
+  } else {
+    // Use the first default identification property that is present in the data object
+    for (const prop of COMBINATOR_IDENTIFICATION_PROPERTIES) {
+      if (Object.prototype.hasOwnProperty.call(data, prop)) {
+        idProperty = prop;
+        break;
+      }
+    }
+  }
+
+  // If no identification property was found, use the first string or number property
+  // of the data object
+  if (idProperty === undefined) {
+    for (const key of Object.keys(data)) {
+      if (typeof data[key] === 'string' || typeof data[key] === 'number') {
+        idProperty = key;
+        break;
+      }
+    }
+  }
+
+  return idProperty;
+};
+
+/**
+ * Returns the index of the schema in the given combinator keyword that matches the identification property of the given data object.
+ * The heuristic only works for data objects with a corresponding schema. If the data is a primitive value or an array, the heuristic does not work.
+ *
+ * If the index cannot be determined, `-1` is returned.
+ *
+ * @returns the index of the fitting schema or `-1` if no fitting schema was found
+ */
+export const getCombinatorIndexOfFittingSchema = (
+  data: any,
+  keyword: CombinatorKeyword,
+  schema: JsonSchema,
+  rootSchema: JsonSchema
+): number => {
+  let indexOfFittingSchema = -1;
+  const idProperty = getCombinatorIdentificationProp(data, schema);
+  if (idProperty === undefined) {
+    return indexOfFittingSchema;
+  }
+
+  for (let i = 0; i < schema[keyword]?.length; i++) {
+    let resolvedSchema = schema[keyword][i];
+    if (resolvedSchema.$ref) {
+      resolvedSchema = Resolve.schema(
+        rootSchema,
+        resolvedSchema.$ref,
+        rootSchema
+      );
+    }
+
+    // Match the identification property against a constant value in resolvedSchema
+    const maybeConstIdValue = resolvedSchema.properties?.[idProperty]?.const;
+
+    if (
+      maybeConstIdValue !== undefined &&
+      data[idProperty] === maybeConstIdValue
+    ) {
+      indexOfFittingSchema = i;
+      console.debug(
+        `Data matches the resolved schema for property ${idProperty}`
+      );
+      break;
+    }
+  }
+
+  return indexOfFittingSchema;
+};

--- a/packages/core/src/mappers/renderer.ts
+++ b/packages/core/src/mappers/renderer.ts
@@ -1123,6 +1123,11 @@ export interface StatePropsOfCombinator extends StatePropsOfControl {
   data: any;
 }
 
+export type StatePropsOfAllOfRenderer = Omit<
+  StatePropsOfCombinator,
+  'indexOfFittingSchema'
+>;
+
 export const mapStateToCombinatorRendererProps = (
   state: JsonFormsState,
   ownProps: OwnPropsOfControl,
@@ -1155,6 +1160,12 @@ export const mapStateToCombinatorRendererProps = (
 export interface CombinatorRendererProps
   extends StatePropsOfCombinator,
     DispatchPropsOfControl {}
+
+export type AllOfRendererProps = Omit<
+  CombinatorRendererProps,
+  'indexOfFittingSchema'
+>;
+
 /**
  * Map state to all of renderer props.
  * @param state the store's state
@@ -1164,8 +1175,20 @@ export interface CombinatorRendererProps
 export const mapStateToAllOfProps = (
   state: JsonFormsState,
   ownProps: OwnPropsOfControl
-): StatePropsOfCombinator =>
-  mapStateToCombinatorRendererProps(state, ownProps, 'allOf');
+): StatePropsOfAllOfRenderer => {
+  const { data, schema, rootSchema, i18nKeyPrefix, label, ...props } =
+    mapStateToControlProps(state, ownProps);
+
+  return {
+    data,
+    schema,
+    rootSchema,
+    ...props,
+    i18nKeyPrefix,
+    label,
+    uischemas: getUISchemas(state),
+  };
+};
 
 export const mapStateToAnyOfProps = (
   state: JsonFormsState,

--- a/packages/core/src/mappers/renderer.ts
+++ b/packages/core/src/mappers/renderer.ts
@@ -84,7 +84,10 @@ import {
   getUiSchema,
 } from '../store';
 import { isInherentlyEnabled } from './util';
-import { CombinatorKeyword } from './combinators';
+import {
+  CombinatorKeyword,
+  getCombinatorIndexOfFittingSchema,
+} from './combinators';
 import isEqual from 'lodash/isEqual';
 
 const move = (array: any[], index: number, delta: number) => {
@@ -1128,43 +1131,12 @@ export const mapStateToCombinatorRendererProps = (
   const { data, schema, rootSchema, i18nKeyPrefix, label, ...props } =
     mapStateToControlProps(state, ownProps);
 
-  const ajv = state.jsonforms.core.ajv;
-  const structuralKeywords = [
-    'required',
-    'additionalProperties',
-    'type',
-    'enum',
-    'const',
-  ];
-  const dataIsValid = (errors: ErrorObject[]): boolean => {
-    return (
-      !errors ||
-      errors.length === 0 ||
-      !errors.find((e) => structuralKeywords.indexOf(e.keyword) !== -1)
-    );
-  };
-  let indexOfFittingSchema: number;
-  // TODO instead of compiling the combinator subschemas we can compile the original schema
-  // without the combinator alternatives and then revalidate and check the errors for the
-  // element
-  for (let i = 0; i < schema[keyword]?.length; i++) {
-    try {
-      let _schema = schema[keyword][i];
-      if (_schema.$ref) {
-        _schema = Resolve.schema(rootSchema, _schema.$ref, rootSchema);
-      }
-      const valFn = ajv.compile(_schema);
-      valFn(data);
-      if (dataIsValid(valFn.errors)) {
-        indexOfFittingSchema = i;
-        break;
-      }
-    } catch (error) {
-      console.debug(
-        "Combinator subschema is not self contained, can't hand it over to AJV"
-      );
-    }
-  }
+  const indexOfFittingSchema = getCombinatorIndexOfFittingSchema(
+    data,
+    keyword,
+    schema,
+    rootSchema
+  );
 
   return {
     data,
@@ -1173,7 +1145,9 @@ export const mapStateToCombinatorRendererProps = (
     ...props,
     i18nKeyPrefix,
     label,
-    indexOfFittingSchema,
+    // Fall back to the first schema if none fits
+    indexOfFittingSchema:
+      indexOfFittingSchema !== -1 ? indexOfFittingSchema : 0,
     uischemas: getUISchemas(state),
   };
 };

--- a/packages/core/test/mappers/combinators.test.ts
+++ b/packages/core/test/mappers/combinators.test.ts
@@ -1,6 +1,9 @@
 import test from 'ava';
 import { ControlElement } from '../../src/models';
-import { createCombinatorRenderInfos } from '../../src/mappers';
+import {
+  createCombinatorRenderInfos,
+  getCombinatorIndexOfFittingSchema,
+} from '../../src/mappers';
 
 const rootSchema = {
   type: 'object',
@@ -110,4 +113,245 @@ test('createCombinatorRenderInfos - uses keyword + index when no labels provided
   );
   t.deepEqual(duaRenderInfo.label, 'anyOf-0');
   t.deepEqual(lipaRenderInfo.label, 'anyOf-1');
+});
+
+const schemaWithCustomIdProperty = {
+  properties: {
+    customId: { const: '123' },
+  },
+};
+
+const schemaWithId = {
+  properties: {
+    id: { const: '123' },
+  },
+};
+
+const schemaWithIdWithoutConst = {
+  properties: {
+    type: { type: 'string' },
+  },
+};
+
+const schemaWithType = {
+  properties: {
+    type: { const: 'typeValue' },
+  },
+};
+
+const schemaWithKind = {
+  properties: {
+    kind: { const: 'kindValue' },
+  },
+};
+
+const schemaWithFirstString = {
+  properties: {
+    obj: { type: 'object' },
+    name: { const: 'John' },
+  },
+};
+
+const schemaWithFirstNumber = {
+  properties: {
+    obj: { type: 'object' },
+    identity: { const: 123 },
+  },
+};
+
+const schemaWithFirstNumberWithoutConst = {
+  properties: {
+    obj: { type: 'object' },
+    identity: { type: 'number' },
+  },
+};
+
+const indexRootSchema = {
+  definitions: {
+    schemaWithCustomIdProperty,
+    schemaWithId,
+    schemaWithIdWithoutConst,
+    schemaWithType,
+    schemaWithKind,
+    schemaWithFirstString,
+    schemaWithFirstNumber,
+    schemaWithFirstNumberWithoutConst,
+  },
+};
+
+test('getCombinatorIndexOfFittingSchema - schema with x-jsf-type-property', (t) => {
+  const data = { customId: '123' };
+  const keyword = 'anyOf';
+  const schema = {
+    anyOf: [schemaWithId, schemaWithCustomIdProperty],
+    'x-jsf-type-property': 'customId',
+  };
+
+  const result = getCombinatorIndexOfFittingSchema(
+    data,
+    keyword,
+    schema,
+    indexRootSchema
+  );
+  t.is(result, 1);
+});
+
+test('getCombinatorIndexOfFittingSchema - data with id property', (t) => {
+  const data = { id: '123' };
+  const keyword = 'anyOf';
+  const schema = { anyOf: [schemaWithId, schemaWithKind] };
+
+  const result = getCombinatorIndexOfFittingSchema(
+    data,
+    keyword,
+    schema,
+    indexRootSchema
+  );
+  t.is(result, 0);
+});
+
+test('getCombinatorIndexOfFittingSchema - data with id property without const', (t) => {
+  const data = { id: '123', type: 'typeValue' };
+  const keyword = 'anyOf';
+  const schema = { anyOf: [schemaWithIdWithoutConst, schemaWithKind] };
+
+  const result = getCombinatorIndexOfFittingSchema(
+    data,
+    keyword,
+    schema,
+    indexRootSchema
+  );
+  // First schema does not have a const and, thus, cannot match
+  t.is(result, -1);
+});
+
+test('getCombinatorIndexOfFittingSchema - data with unfitting id property value', (t) => {
+  const data = { id: '321' };
+  const keyword = 'anyOf';
+  const schema = { anyOf: [schemaWithId, schemaWithKind] };
+
+  const result = getCombinatorIndexOfFittingSchema(
+    data,
+    keyword,
+    schema,
+    indexRootSchema
+  );
+  t.is(result, -1);
+});
+
+test('getCombinatorIndexOfFittingSchema - data with type property', (t) => {
+  const data = { type: 'typeValue' };
+  const keyword = 'anyOf';
+  const schema = { anyOf: [schemaWithId, schemaWithType] };
+
+  const result = getCombinatorIndexOfFittingSchema(
+    data,
+    keyword,
+    schema,
+    indexRootSchema
+  );
+  t.is(result, 1);
+});
+
+test('getCombinatorIndexOfFittingSchema - data with unfitting type property value', (t) => {
+  const data = { type: 'wrongTypeValue' };
+  const keyword = 'anyOf';
+  const schema = { anyOf: [schemaWithId, schemaWithType] };
+
+  const result = getCombinatorIndexOfFittingSchema(
+    data,
+    keyword,
+    schema,
+    indexRootSchema
+  );
+  t.is(result, -1);
+});
+
+test('getCombinatorIndexOfFittingSchema - schema with refs and data with type property', (t) => {
+  const data = { type: 'typeValue' };
+  const keyword = 'anyOf';
+  const schema = {
+    anyOf: [
+      { $ref: '#/definitions/schemaWithId' },
+      { $ref: '#/definitions/schemaWithType' },
+    ],
+  };
+
+  const result = getCombinatorIndexOfFittingSchema(
+    data,
+    keyword,
+    schema,
+    indexRootSchema
+  );
+  t.is(result, 1);
+});
+
+test('getCombinatorIndexOfFittingSchema - data with kind property', (t) => {
+  const data = { kind: 'kindValue' };
+  const keyword = 'anyOf';
+  const schema = { anyOf: [schemaWithKind] };
+
+  const result = getCombinatorIndexOfFittingSchema(
+    data,
+    keyword,
+    schema,
+    indexRootSchema
+  );
+  t.is(result, 0);
+});
+
+test('getCombinatorIndexOfFittingSchema - data with unfitting kind property value', (t) => {
+  const data = { kind: 'wrongKindValue' };
+  const keyword = 'anyOf';
+  const schema = { anyOf: [schemaWithKind] };
+
+  const result = getCombinatorIndexOfFittingSchema(
+    data,
+    keyword,
+    schema,
+    indexRootSchema
+  );
+  t.is(result, -1);
+});
+
+test('getCombinatorIndexOfFittingSchema - data with first string property', (t) => {
+  const data = { obj: {}, name: 'John' };
+  const keyword = 'anyOf';
+  const schema = { anyOf: [{}, schemaWithFirstString] };
+
+  const result = getCombinatorIndexOfFittingSchema(
+    data,
+    keyword,
+    schema,
+    indexRootSchema
+  );
+  t.is(result, 1);
+});
+
+test('getCombinatorIndexOfFittingSchema - data with first number property', (t) => {
+  const data = { obj: {}, identity: 123 };
+  const keyword = 'anyOf';
+  const schema = { anyOf: [schemaWithFirstNumber] };
+
+  const result = getCombinatorIndexOfFittingSchema(
+    data,
+    keyword,
+    schema,
+    indexRootSchema
+  );
+  t.is(result, 0);
+});
+
+test('getCombinatorIndexOfFittingSchema - no matching schema', (t) => {
+  const data = { name: 'Doe' };
+  const keyword = 'anyOf';
+  const schema = { anyOf: [schemaWithFirstString] };
+
+  const result = getCombinatorIndexOfFittingSchema(
+    data,
+    keyword,
+    schema,
+    indexRootSchema
+  );
+  t.is(result, -1);
 });

--- a/packages/core/test/mappers/renderer.test.ts
+++ b/packages/core/test/mappers/renderer.test.ts
@@ -63,7 +63,6 @@ import {
   mapStateToLayoutProps,
   mapStateToMultiEnumControlProps,
   mapStateToOneOfEnumControlProps,
-  mapStateToOneOfProps,
 } from '../../src/mappers';
 import { clearAllIds, convertDateToString, createAjv } from '../../src/util';
 import { rankWith } from '../../src';
@@ -1208,69 +1207,6 @@ test('mapStateToLayoutProps - hidden via state with path from ownProps ', (t) =>
   };
   const props = mapStateToLayoutProps(state, ownProps);
   t.false(props.visible);
-});
-
-test("mapStateToOneOfProps - indexOfFittingSchema should not select schema if enum doesn't match", (t) => {
-  const uischema: ControlElement = {
-    type: 'Control',
-    scope: '#/properties/method',
-  };
-
-  const ownProps = {
-    uischema,
-  };
-
-  const state = {
-    jsonforms: {
-      core: {
-        ajv: createAjv(),
-        schema: {
-          type: 'object',
-          properties: {
-            method: {
-              oneOf: [
-                {
-                  title: 'Injection',
-                  type: 'object',
-                  properties: {
-                    method: {
-                      title: 'Method',
-                      type: 'string',
-                      enum: ['Injection'],
-                      default: 'Injection',
-                    },
-                  },
-                  required: ['method'],
-                },
-                {
-                  title: 'Infusion',
-                  type: 'object',
-                  properties: {
-                    method: {
-                      title: 'Method',
-                      type: 'string',
-                      enum: ['Infusion'],
-                      default: 'Infusion',
-                    },
-                  },
-                  required: ['method'],
-                },
-              ],
-            },
-          },
-        },
-        data: {
-          method: {
-            method: 'Infusion',
-          },
-        },
-        uischema,
-      },
-    },
-  };
-
-  const oneOfProps = mapStateToOneOfProps(state, ownProps);
-  t.is(oneOfProps.indexOfFittingSchema, 1);
 });
 
 test('mapStateToMultiEnumControlProps - oneOf items', (t) => {

--- a/packages/examples/src/examples/anyOf.ts
+++ b/packages/examples/src/examples/anyOf.ts
@@ -31,6 +31,7 @@ export const schema = {
     address: {
       type: 'object',
       properties: {
+        mytype: { const: 'address', default: 'address' },
         street_address: { type: 'string' },
         city: { type: 'string' },
         state: { type: 'string' },
@@ -40,6 +41,7 @@ export const schema = {
     user: {
       type: 'object',
       properties: {
+        mytype: { const: 'user', default: 'user' },
         name: { type: 'string' },
         mail: { type: 'string' },
       },
@@ -63,6 +65,7 @@ export const schema = {
         { $ref: '#/definitions/address' },
         { $ref: '#/definitions/user' },
       ],
+      'x-jsf-type-property': 'mytype',
     },
     addressesOrUsers: {
       anyOf: [
@@ -104,9 +107,9 @@ export const uischema = {
 
 const data = {
   addressOrUser: {
-    street_address: '1600 Pennsylvania Avenue NW',
-    city: 'Washington',
-    state: 'DC',
+    mytype: 'user',
+    name: 'Peter',
+    email: 'peter@example.org',
   },
 };
 

--- a/packages/examples/src/examples/oneOf.ts
+++ b/packages/examples/src/examples/oneOf.ts
@@ -31,6 +31,7 @@ export const schema = {
     address: {
       type: 'object',
       properties: {
+        type: { const: 'address', default: 'address' },
         street_address: { type: 'string' },
         city: { type: 'string' },
         state: { type: 'string' },
@@ -41,6 +42,7 @@ export const schema = {
     user: {
       type: 'object',
       properties: {
+        type: { const: 'user', default: 'user' },
         name: { type: 'string' },
         mail: { type: 'string' },
       },
@@ -80,6 +82,7 @@ export const uischema = {
 const data = {
   name: 'test',
   addressOrUser: {
+    type: 'user',
     name: 'User',
     mail: 'mail@example.com',
   },

--- a/packages/examples/src/examples/oneOfArray.ts
+++ b/packages/examples/src/examples/oneOfArray.ts
@@ -31,6 +31,7 @@ export const schema = {
     address: {
       type: 'object',
       properties: {
+        kind: { const: 'address', default: 'address' },
         street_address: { type: 'string' },
         city: { type: 'string' },
         state: { type: 'string' },
@@ -40,6 +41,7 @@ export const schema = {
     user: {
       type: 'object',
       properties: {
+        kind: { const: 'user', default: 'user' },
         name: { type: 'string' },
         mail: { type: 'string' },
       },
@@ -77,11 +79,13 @@ const data = {
   name: 'test',
   addressOrUsers: [
     {
+      kind: 'address',
       street_address: '1600 Pennsylvania Avenue NW',
       city: 'Washington',
       state: 'DC',
     },
     {
+      kind: 'user',
       name: 'User',
       mail: 'user@user.user',
     },

--- a/packages/material-renderers/src/complex/MaterialAllOfRenderer.tsx
+++ b/packages/material-renderers/src/complex/MaterialAllOfRenderer.tsx
@@ -31,7 +31,7 @@ import {
   JsonSchema,
   RankedTester,
   rankWith,
-  StatePropsOfCombinator,
+  StatePropsOfAllOfRenderer,
 } from '@jsonforms/core';
 import { JsonFormsDispatch, withJsonFormsAllOfProps } from '@jsonforms/react';
 
@@ -44,7 +44,7 @@ export const MaterialAllOfRenderer = ({
   path,
   uischemas,
   uischema,
-}: StatePropsOfCombinator) => {
+}: StatePropsOfAllOfRenderer) => {
   const delegateUISchema = findMatchingUISchema(uischemas)(
     schema,
     uischema.scope,

--- a/packages/material-renderers/test/renderers/MaterialOneOfRenderer.test.tsx
+++ b/packages/material-renderers/test/renderers/MaterialOneOfRenderer.test.tsx
@@ -114,7 +114,7 @@ describe('Material oneOf renderer', () => {
     expect(firstTab.html()).toContain('Mui-selected');
   });
 
-  it('should render and select second tab due to datatype', () => {
+  it('should render and select first tab for primitive combinator data', () => {
     const schema = {
       type: 'object',
       properties: {
@@ -150,11 +150,11 @@ describe('Material oneOf renderer', () => {
     );
     expect(wrapper.find(MaterialOneOfRenderer).length).toBeTruthy();
 
-    const secondTab = wrapper.find(Tab).at(1);
+    const secondTab = wrapper.find(Tab).at(0);
     expect(secondTab.html()).toContain('Mui-selected');
   });
 
-  it('should render and select second tab due to schema with additionalProperties', () => {
+  it('should render and select second tab due to string prop with matching const value', () => {
     const schema = {
       type: 'object',
       properties: {
@@ -164,7 +164,7 @@ describe('Material oneOf renderer', () => {
               title: 'String',
               type: 'object',
               properties: {
-                foo: { type: 'string' },
+                foo: { type: 'string', const: 'foo' },
               },
               additionalProperties: false,
             },
@@ -172,7 +172,7 @@ describe('Material oneOf renderer', () => {
               title: 'Number',
               type: 'object',
               properties: {
-                bar: { type: 'string' },
+                bar: { type: 'string', const: 'bar' },
               },
               additionalProperties: false,
             },
@@ -202,7 +202,7 @@ describe('Material oneOf renderer', () => {
     expect(secondTab.html()).toContain('Mui-selected');
   });
 
-  it('should render and select second tab due to schema with required', () => {
+  it('should render and select second tab due const custom property', () => {
     const schema = {
       type: 'object',
       properties: {
@@ -213,6 +213,7 @@ describe('Material oneOf renderer', () => {
               type: 'object',
               properties: {
                 foo: { type: 'string' },
+                myprop: { const: 'foo' },
               },
               required: ['foo'],
             },
@@ -221,10 +222,12 @@ describe('Material oneOf renderer', () => {
               type: 'object',
               properties: {
                 bar: { type: 'string' },
+                myprop: { const: 'bar' },
               },
               required: ['bar'],
             },
           ],
+          'x-jsf-type-property': 'myprop',
         },
       },
     };
@@ -234,7 +237,7 @@ describe('Material oneOf renderer', () => {
       scope: '#/properties/value',
     };
     const data = {
-      value: { bar: 'bar' },
+      value: { bar: 'bar', myprop: 'bar' },
     };
     wrapper = mount(
       <JsonForms

--- a/packages/react/src/JsonFormsContext.tsx
+++ b/packages/react/src/JsonFormsContext.tsx
@@ -81,6 +81,7 @@ import {
   arrayDefaultTranslations,
   getArrayTranslations,
   ArrayTranslations,
+  AllOfRendererProps,
 } from '@jsonforms/core';
 import debounce from 'lodash/debounce';
 import React, {
@@ -561,12 +562,12 @@ const withContextToAnyOfProps = (
   };
 
 const withContextToAllOfProps = (
-  Component: ComponentType<CombinatorRendererProps>
+  Component: ComponentType<AllOfRendererProps>
 ): ComponentType<OwnPropsOfControl> =>
   function WithContextToAllOfProps({
     ctx,
     props,
-  }: JsonFormsStateContext & CombinatorRendererProps) {
+  }: JsonFormsStateContext & AllOfRendererProps) {
     const allOfProps = ctxToAllOfProps(ctx, props);
     const dispatchProps = ctxDispatchToControlProps(ctx.dispatch);
     return <Component {...props} {...allOfProps} {...dispatchProps} />;
@@ -764,7 +765,7 @@ export const withJsonFormsAnyOfProps = (
   );
 
 export const withJsonFormsAllOfProps = (
-  Component: ComponentType<CombinatorRendererProps>,
+  Component: ComponentType<AllOfRendererProps>,
   memoize = true
 ): ComponentType<OwnPropsOfControl> =>
   withJsonFormsContext(


### PR DESCRIPTION
- Adapt algorithm to determine the fitting schema index for combinators to no longer use AJV
- New heuristic uses identifying properties that should match a const value in the schema
- Adapt MaterialOneOfRenderer.test.tsx to fit new heuristic
- Describe changes and add examples to migration guide
- Adapt some of the anyOf and oneOf examples to custom and new identification properties

In contrast to oneOf and anyOf rendererer, allOf renderers do not need the `indexOfFittingSchema` because all schemas apply at once.
Thus, remove using mapStateToCombinatorRendererProps from mapStateToAllOfProps and, with this, the unnecessary calculation of the index.

fix #2371 