### PR TITLE
refactor: Use type imports for AJV where possible

### DIFF
--- a/packages/angular/src/library/jsonforms-root.component.ts
+++ b/packages/angular/src/library/jsonforms-root.component.ts
@@ -44,7 +44,8 @@ import {
   ValidationMode,
   defaultMiddleware,
 } from '@jsonforms/core';
-import Ajv, { ErrorObject } from 'ajv';
+import type Ajv from 'ajv';
+import type { ErrorObject } from 'ajv';
 import { JsonFormsAngularService, USE_STATE_VALUE } from './jsonforms.service';
 import { Subscription } from 'rxjs';
 

--- a/packages/core/src/reducers/core.ts
+++ b/packages/core/src/reducers/core.ts
@@ -43,7 +43,8 @@ import {
   UpdateCoreAction,
 } from '../actions';
 import { JsonFormsCore, Reducer, ValidationMode } from '../store';
-import Ajv, { ErrorObject } from 'ajv';
+import type Ajv from 'ajv';
+import type { ErrorObject } from 'ajv';
 import isFunction from 'lodash/isFunction';
 import { createAjv, validate } from '../util';
 

--- a/packages/core/src/store/jsonFormsCore.ts
+++ b/packages/core/src/store/jsonFormsCore.ts
@@ -1,4 +1,5 @@
-import Ajv, { ErrorObject } from 'ajv';
+import type Ajv from 'ajv';
+import type { ErrorObject } from 'ajv';
 import { JsonSchema, UISchemaElement } from '../models';
 import get from 'lodash/get';
 import { errorsAt } from '../util';

--- a/packages/core/src/store/store.ts
+++ b/packages/core/src/store/store.ts
@@ -26,7 +26,8 @@
 import type { Store } from './type';
 import { RankedTester, UISchemaTester } from '../testers';
 import { JsonSchema, UISchemaElement } from '../models';
-import Ajv, { ErrorObject, ValidateFunction } from 'ajv';
+import type Ajv from 'ajv';
+import type { ErrorObject, ValidateFunction } from 'ajv';
 import { JsonFormsI18nState } from './i18nTypes';
 
 /**

--- a/packages/material-renderers/src/util/layout.tsx
+++ b/packages/material-renderers/src/util/layout.tsx
@@ -24,7 +24,7 @@
 */
 import isEmpty from 'lodash/isEmpty';
 import React, { ComponentType } from 'react';
-import Ajv from 'ajv';
+import type Ajv from 'ajv';
 import type { UISchemaElement } from '@jsonforms/core';
 import {
   getAjv,

--- a/packages/vanilla-renderers/src/util/props.tsx
+++ b/packages/vanilla-renderers/src/util/props.tsx
@@ -23,7 +23,7 @@
   THE SOFTWARE.
 */
 
-import Ajv from 'ajv';
+import type Ajv from 'ajv';
 import React, { ComponentType, useMemo } from 'react';
 import isEmpty from 'lodash/isEmpty';
 import type {

--- a/packages/vue-vuetify/dev/validate/keywords.ts
+++ b/packages/vue-vuetify/dev/validate/keywords.ts
@@ -1,4 +1,4 @@
-import Ajv from 'ajv';
+import type Ajv from 'ajv';
 import keywords from 'ajv-keywords';
 import dynamicDefaults from 'ajv-keywords/dist/definitions/dynamicDefaults';
 import tranform from './transform';

--- a/packages/vue-vuetify/tests/unit/util/TestComponent.vue
+++ b/packages/vue-vuetify/tests/unit/util/TestComponent.vue
@@ -29,7 +29,8 @@ import {
   type JsonFormsChangeEvent,
   type MaybeReadonly,
 } from '@jsonforms/vue';
-import Ajv, { type ErrorObject } from 'ajv';
+import type Ajv from 'ajv';
+import type { ErrorObject } from 'ajv';
 import { defineComponent, reactive, type PropType } from 'vue';
 import { VApp } from 'vuetify/components';
 

--- a/packages/vue/src/components/JsonForms.vue
+++ b/packages/vue/src/components/JsonForms.vue
@@ -29,7 +29,8 @@ import {
 import { JsonFormsChangeEvent, MaybeReadonly } from '../types';
 import DispatchRenderer from './DispatchRenderer.vue';
 
-import Ajv, { ErrorObject } from 'ajv';
+import type Ajv from 'ajv';
+import type { ErrorObject } from 'ajv';
 
 // TODO fix @typescript-eslint/ban-types
 // eslint-disable-next-line @typescript-eslint/ban-types


### PR DESCRIPTION
This makes it clearer where the actual AJV implementation is used and where we only depend on the typing.