### PR TITLE
Default JSON schema values for visibility rules

### DIFF
--- a/packages/core/src/mappers/renderer.ts
+++ b/packages/core/src/mappers/renderer.ts
@@ -1038,9 +1038,12 @@ export const mapStateToLayoutProps = (
   state: JsonFormsState,
   ownProps: OwnPropsOfLayout
 ): LayoutProps => {
-  const rootData = getData(state);
+  const originalData = getData(state);
+  // Create a new object to avoid modifying the original data
+  const rootData = { ...originalData };
   const ajv = getAjv(state);
-  ajv?.compile(getSchema(state))(rootData);
+  const schema = getSchema(state);
+  ajv?.compile(schema)(rootData);
   const { uischema } = ownProps;
   const visible: boolean =
     ownProps.visible === undefined || hasShowRule(uischema)

--- a/packages/core/src/mappers/renderer.ts
+++ b/packages/core/src/mappers/renderer.ts
@@ -1039,10 +1039,12 @@ export const mapStateToLayoutProps = (
   ownProps: OwnPropsOfLayout
 ): LayoutProps => {
   const rootData = getData(state);
+  const ajv = getAjv(state);
+  ajv?.compile(getSchema(state))(rootData);
   const { uischema } = ownProps;
   const visible: boolean =
     ownProps.visible === undefined || hasShowRule(uischema)
-      ? isVisible(ownProps.uischema, rootData, ownProps.path, getAjv(state))
+      ? isVisible(ownProps.uischema, rootData, ownProps.path, ajv)
       : ownProps.visible;
 
   const data = Resolve.data(rootData, ownProps.path);

--- a/packages/core/test/mappers/renderer.test.ts
+++ b/packages/core/test/mappers/renderer.test.ts
@@ -85,6 +85,17 @@ const mockDispatch = (
   return [getCore, dispatch];
 };
 
+const showRule = {
+  effect: RuleEffect.SHOW,
+  condition: {
+    type: 'SCHEMA',
+    scope: '#/properties/firstName',
+    schema: {
+      const: 'Homer',
+    },
+  },
+};
+
 const hideRule = {
   effect: RuleEffect.HIDE,
   condition: {
@@ -1201,6 +1212,68 @@ test('mapStateToLayoutProps - hidden via state with path from ownProps ', (t) =>
         data: {
           foo: { firstName: 'Homer' },
         },
+        uischema,
+        errors: [] as ErrorObject[],
+      },
+    },
+  };
+  const props = mapStateToLayoutProps(state, ownProps);
+  t.false(props.visible);
+});
+
+test('mapStateToLayoutProps - show via state from default values from schema ', (t) => {
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [coreUISchema],
+    rule: showRule,
+  };
+  const ownProps = {
+    uischema,
+  };
+  const state = {
+    jsonforms: {
+      core: {
+        ajv: createAjv({
+          useDefaults: true,
+        }),
+        schema: {
+          type: 'object',
+          properties: {
+            firstName: { type: 'string', default: 'Homer' },
+            lastName: { type: 'string' },
+          },
+        },
+        data: { lastName: 'Simpson' },
+        uischema,
+        errors: [] as ErrorObject[],
+      },
+    },
+  };
+  const props = mapStateToLayoutProps(state, ownProps);
+  t.true(props.visible);
+});
+
+test('mapStateToLayoutProps - do not show via state when the data field is missing ', (t) => {
+  const uischema = {
+    type: 'VerticalLayout',
+    elements: [coreUISchema],
+    rule: showRule,
+  };
+  const ownProps = {
+    uischema,
+  };
+  const state = {
+    jsonforms: {
+      core: {
+        ajv: createAjv(),
+        schema: {
+          type: 'object',
+          properties: {
+            firstName: { type: 'string', default: 'Homer' },
+            lastName: { type: 'string' },
+          },
+        },
+        data: { lastName: 'Simpson' },
         uischema,
         errors: [] as ErrorObject[],
       },


### PR DESCRIPTION
Uses the AJV from state to [assign default values](https://ajv.js.org/guide/modifying-data.html#assigning-defaults) if it has been configured to do so for the JSON schema. Included tests to ensure that the `SHOW` rule uses the default value when it's not present in the data, and that if the `useDefaults` option isn't set the visibility rule should return false.

Fixes #2419