### PR TITLE
chore: update LICENSE text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 The MIT License
 
-Copyright (c) 2019 EclipseSource Munich
-https://github.com/eclipsesource/jsonforms
+Copyright (c) 2019 EclipseSource GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates the LICENSE text to
- refer to EclipseSource instead of EclipseSource Munich
- remove the link to the repository, enabling GH auto detection