### PR TITLE
feat(core): Add validate function based rule condition

### DIFF
--- a/packages/core/src/models/uischema.ts
+++ b/packages/core/src/models/uischema.ts
@@ -150,6 +150,16 @@ export interface SchemaBasedCondition extends BaseCondition, Scoped {
   failWhenUndefined?: boolean;
 }
 
+/** A condition using a validation function to determine its fulfillment. */
+export interface ValidateFunctionCondition extends BaseCondition, Scoped {
+  /**
+   * Validates whether the condition is fulfilled.
+   *
+   * @param data The data as resolved via the scope.
+   * @returns `true` if the condition is fulfilled */
+  validate: (data: unknown) => boolean;
+}
+
 /**
  * A composable condition.
  */
@@ -179,7 +189,8 @@ export type Condition =
   | LeafCondition
   | OrCondition
   | AndCondition
-  | SchemaBasedCondition;
+  | SchemaBasedCondition
+  | ValidateFunctionCondition;
 
 /**
  * Common base interface for any UI schema element.

--- a/packages/core/test/util/runtime.test.ts
+++ b/packages/core/test/util/runtime.test.ts
@@ -33,6 +33,7 @@ import {
   OrCondition,
   RuleEffect,
   SchemaBasedCondition,
+  ValidateFunctionCondition,
 } from '../../src';
 import { evalEnablement, evalVisibility } from '../../src/util/runtime';
 
@@ -489,6 +490,90 @@ test('evalEnablement disable valid case', (t) => {
     ruleValue: 'bar',
   };
   t.is(evalEnablement(uischema, data, undefined, createAjv()), false);
+});
+
+// Add test case for ValidateFunctionCondition with evalEnablement (valid enable case)
+test('evalEnablement enable valid case based on ValidateFunctionCondition', (t) => {
+  const condition: ValidateFunctionCondition = {
+    scope: '#/properties/ruleValue',
+    validate: (data) => data === 'bar',
+  };
+  const uischema: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/value',
+    rule: {
+      effect: RuleEffect.ENABLE,
+      condition: condition,
+    },
+  };
+  const data = {
+    value: 'foo',
+    ruleValue: 'bar',
+  };
+  t.is(evalEnablement(uischema, data, undefined, createAjv()), true);
+});
+
+// Add test case for ValidateFunctionCondition with evalEnablement (invalid enable case)
+test('evalEnablement enable invalid case based on ValidateFunctionCondition', (t) => {
+  const condition: ValidateFunctionCondition = {
+    scope: '#/properties/ruleValue',
+    validate: (data) => data === 'bar',
+  };
+  const uischema: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/value',
+    rule: {
+      effect: RuleEffect.ENABLE,
+      condition: condition,
+    },
+  };
+  const data = {
+    value: 'foo',
+    ruleValue: 'foobar',
+  };
+  t.is(evalEnablement(uischema, data, undefined, createAjv()), false);
+});
+
+// Add test case for ValidateFunctionCondition with evalEnablement (valid disable case)
+test('evalEnablement disable valid case based on ValidateFunctionCondition', (t) => {
+  const condition: ValidateFunctionCondition = {
+    scope: '#/properties/ruleValue',
+    validate: (data) => data === 'bar',
+  };
+  const uischema: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/value',
+    rule: {
+      effect: RuleEffect.DISABLE,
+      condition: condition,
+    },
+  };
+  const data = {
+    value: 'foo',
+    ruleValue: 'bar',
+  };
+  t.is(evalEnablement(uischema, data, undefined, createAjv()), false);
+});
+
+// Add test case for ValidateFunctionCondition with evalEnablement (invalid disable case)
+test('evalEnablement disable invalid case based on ValidateFunctionCondition', (t) => {
+  const condition: ValidateFunctionCondition = {
+    scope: '#/properties/ruleValue',
+    validate: (data) => data === 'bar',
+  };
+  const uischema: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/value',
+    rule: {
+      effect: RuleEffect.DISABLE,
+      condition: condition,
+    },
+  };
+  const data = {
+    value: 'foo',
+    ruleValue: 'foobar',
+  };
+  t.is(evalEnablement(uischema, data, undefined, createAjv()), true);
 });
 
 test('evalEnablement disable invalid case', (t) => {

--- a/packages/examples/src/examples/rule.ts
+++ b/packages/examples/src/examples/rule.ts
@@ -44,6 +44,10 @@ export const schema = {
       type: 'string',
       enum: ['All', 'Some', 'Only potatoes'],
     },
+    vitaminDeficiency: {
+      type: 'string',
+      enum: ['None', 'Vitamin A', 'Vitamin B', 'Vitamin C'],
+    },
   },
 };
 
@@ -97,6 +101,20 @@ export const uischema = {
               scope: '#/properties/vegetables',
               schema: {
                 const: false,
+              },
+            },
+          },
+        },
+        {
+          type: 'Control',
+          label: 'Vitamin deficiency?',
+          scope: '#/properties/vitaminDeficiency',
+          rule: {
+            effect: 'SHOW',
+            condition: {
+              scope: '#',
+              validate: (data: any) => {
+                return !data.dead && data.kindOfVegetables !== 'All';
               },
             },
           },


### PR DESCRIPTION
Add a new rule condition `ValidateFunctionCondition` using a given `validate` function to evaluate the condition result. This allows using arbitrary custom logic to evaluate condition results.
This facilitates not using schema-conditions to be able to only use one pre-compiled AJV for the data schema at a later stage.