### PR TITLE
deps: Update to Vuetify ^3.9 and Vue ^3.5

### DIFF
--- a/packages/examples/src/examples/numbers.ts
+++ b/packages/examples/src/examples/numbers.ts
@@ -62,6 +62,9 @@ export const uischema = {
         {
           type: 'Control',
           scope: '#/properties/height',
+          options: {
+            step: 1e-2,
+          },
         },
         {
           type: 'Control',

--- a/packages/vue-vanilla/package.json
+++ b/packages/vue-vanilla/package.json
@@ -89,12 +89,12 @@
     "tslib": "^2.5.0",
     "typedoc": "~0.25.3",
     "typescript": "~5.5.0",
-    "vue": "^3.4.21",
+    "vue": "^3.5.17",
     "vue-jest": "^5.0.0-0"
   },
   "peerDependencies": {
     "@jsonforms/core": "3.6.0",
     "@jsonforms/vue": "3.6.0",
-    "vue": "^3.2.26"
+    "vue": "^3.5.0"
   }
 }

--- a/packages/vue-vuetify/dev/store/index.ts
+++ b/packages/vue-vuetify/dev/store/index.ts
@@ -80,7 +80,7 @@ function useHistoryHashQuery<T extends string | boolean | number>(
   queryParam: string,
   initialValue: T,
 ) {
-  const data: Ref<UnwrapRef<T>> = ref<T>(initialValue);
+  const data = ref<T>(initialValue);
 
   // Function to update data based on URL hash
   const updateDataFromHash = () => {

--- a/packages/vue-vuetify/package.json
+++ b/packages/vue-vuetify/package.json
@@ -64,8 +64,8 @@
     "dayjs": "^1.10.6",
     "lodash": "^4.17.21",
     "maska": "^2.1.11",
-    "vue": "^3.4.21",
-    "vuetify": "^3.6.6"
+    "vue": "^3.5.0",
+    "vuetify": "^3.9.0"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^6.5.2",
@@ -106,15 +106,15 @@
     "splitpanes": "^3.1.5",
     "typedoc": "~0.25.3",
     "typescript": "~5.4.0",
-    "vite": "^5.2.8",
+    "vite": "^5.4.19",
     "vite-plugin-dts": "^3.9.1",
     "vite-plugin-node-polyfills": "^0.21.0",
     "vite-plugin-static-copy": "^1.0.5",
-    "vite-plugin-vuetify": "^2.0.3",
+    "vite-plugin-vuetify": "^2.1.1",
     "vitest": "^1.4.0",
-    "vue": "^3.4.21",
+    "vue": "^3.5.17",
     "vue-eslint-parser": "^9.4.2",
     "vue-tsc": "^2.0.11",
-    "vuetify": "^3.6.6"
+    "vuetify": "^3.9.0"
   }
 }

--- a/packages/vue-vuetify/src/controls/DateControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/DateControlRenderer.vue
@@ -49,7 +49,7 @@
                 v-if="showMenu"
                 :model-value="showActions ? proxyModel.value : pickerValue"
                 @update:model-value="
-                  (val) => updateDatePickerValue(val, proxyModel)
+                  (val: any) => updateDatePickerValue(val, proxyModel)
                 "
                 v-bind="vuetifyProps('v-date-picker')"
                 :title="computedLabel"
@@ -57,9 +57,11 @@
                 :max="maxDate"
                 v-model:view-mode="viewMode"
                 @update:month="
-                  (month) => updateDatePickerMonth(month, proxyModel)
+                  (month: number) => updateDatePickerMonth(month, proxyModel)
                 "
-                @update:year="(year) => updateDatePickerYear(year, proxyModel)"
+                @update:year="
+                  (year: number) => updateDatePickerYear(year, proxyModel)
+                "
               >
                 <template v-slot:actions v-if="showActions">
                   <component :is="actions"></component>

--- a/packages/vue-vuetify/src/controls/DateTimeControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/DateTimeControlRenderer.vue
@@ -88,6 +88,19 @@
                             proxyModel.value.time = val;
                           } else {
                             pickerValue.time = val;
+                          }
+                        }
+                      "
+                      @update:minute="
+                        () => {
+                          if (!showActions && !useSeconds) {
+                            showMenu = false;
+                          }
+                        }
+                      "
+                      @update:second="
+                        () => {
+                          if (!showActions && useSeconds) {
                             showMenu = false;
                           }
                         }
@@ -145,7 +158,19 @@
                               date: pickerValue.date,
                               time: val,
                             };
-
+                          }
+                        }
+                      "
+                      @update:minute="
+                        () => {
+                          if (!showActions && !useSeconds) {
+                            showMenu = false;
+                          }
+                        }
+                      "
+                      @update:second="
+                        () => {
+                          if (!showActions && useSeconds) {
                             showMenu = false;
                           }
                         }
@@ -541,10 +566,6 @@ const controlRenderer = defineComponent({
 
         if (this.useTabLayout && val.date) {
           this.activeTab = 'time';
-        }
-
-        if (val.date && val.time && !this.showActions) {
-          this.showMenu = false;
         }
       },
     },

--- a/packages/vue-vuetify/src/controls/DateTimeControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/DateTimeControlRenderer.vue
@@ -197,10 +197,10 @@ import {
   VTab,
   VTabs,
   VTextField,
+  VTimePicker,
   VWindow,
   VWindowItem,
 } from 'vuetify/components';
-import { VTimePicker } from 'vuetify/labs/VTimePicker';
 
 import { vMaska, type MaskOptions, type MaskaDetail } from 'maska';
 import { useDisplay, useLocale } from 'vuetify';

--- a/packages/vue-vuetify/src/controls/IntegerControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/IntegerControlRenderer.vue
@@ -36,7 +36,7 @@ import {
   type RendererProps,
 } from '@jsonforms/vue';
 import { defineComponent } from 'vue';
-import { VNumberInput } from 'vuetify/labs/VNumberInput';
+import { VNumberInput } from 'vuetify/components';
 import { determineClearValue, useVuetifyControl } from '../util';
 import { default as ControlWrapper } from './ControlWrapper.vue';
 import { DisabledIconFocus } from './directives';

--- a/packages/vue-vuetify/src/controls/NumberControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/NumberControlRenderer.vue
@@ -36,7 +36,7 @@ import {
   type RendererProps,
 } from '@jsonforms/vue';
 import { defineComponent } from 'vue';
-import { VNumberInput } from 'vuetify/labs/VNumberInput';
+import { VNumberInput } from 'vuetify/components';
 
 import { determineClearValue, useVuetifyControl } from '../util';
 import { default as ControlWrapper } from './ControlWrapper.vue';

--- a/packages/vue-vuetify/src/controls/NumberControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/NumberControlRenderer.vue
@@ -8,6 +8,7 @@
     <v-number-input
       v-disabled-icon-focus
       :step="step"
+      :precision="precision"
       :id="control.id + '-input'"
       :class="styles.control.input"
       :disabled="!control.enabled"
@@ -65,6 +66,17 @@ const controlRenderer = defineComponent({
     step(): number {
       const options: any = this.appliedOptions;
       return options.step ?? 0.1;
+    },
+    precision(): number | undefined {
+      if (!this.step || Number.isInteger(this.step)) return undefined;
+      // Handle scientific notation and float imprecision
+      const stepStr = this.step.toString();
+      if (stepStr.indexOf('e-') > -1) {
+        // Handle cases like 1e-3
+        return parseInt(stepStr.split('e-')[1], 10);
+      }
+      const fraction = stepStr.split('.')[1];
+      return fraction ? fraction.length : undefined;
     },
   },
 });

--- a/packages/vue-vuetify/src/controls/TimeControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/TimeControlRenderer.vue
@@ -54,6 +54,19 @@
                       proxyModel.value = val;
                     } else {
                       pickerValue = val;
+                    }
+                  }
+                "
+                @update:minute="
+                  () => {
+                    if (!showActions && !useSeconds) {
+                      showMenu = false;
+                    }
+                  }
+                "
+                @update:second="
+                  () => {
+                    if (!showActions && useSeconds) {
                       showMenu = false;
                     }
                   }

--- a/packages/vue-vuetify/src/controls/TimeControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/TimeControlRenderer.vue
@@ -95,8 +95,8 @@ import {
   VMenu,
   VSpacer,
   VTextField,
+  VTimePicker,
 } from 'vuetify/components';
-import { VTimePicker } from 'vuetify/labs/VTimePicker';
 
 import { useLocale } from 'vuetify';
 import type { IconValue } from '../icons';

--- a/packages/vue-vuetify/tests/setup.ts
+++ b/packages/vue-vuetify/tests/setup.ts
@@ -1,0 +1,17 @@
+// Mock the visualViewport API for testing purposes
+if (!window.visualViewport) {
+  window.visualViewport = {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    width: window.innerWidth,
+    height: window.innerHeight,
+    scale: 1,
+    offsetLeft: 0,
+    offsetTop: 0,
+    pageLeft: 0,
+    pageTop: 0,
+    onresize: null,
+    onscroll: null,
+    dispatchEvent: () => true,
+  };
+}

--- a/packages/vue-vuetify/tests/unit/additional/__snapshots__/ListWithDetailRenderer.spec.ts.snap
+++ b/packages/vue-vuetify/tests/unit/additional/__snapshots__/ListWithDetailRenderer.spec.ts.snap
@@ -17,7 +17,7 @@ exports[`ListWithDetailRenderer.vue > should render component and match snapshot
                 </div>
               </div>
               <div data-v-7e93fcc2="" class="v-spacer"></div>
-              <!--v-if--><button data-v-7e93fcc2="" type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-default elevation-0 v-btn--size-default v-btn--variant-text list-with-detail-add" small="" aria-label="MyAdd" aria-describedby="v-tooltip-0"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!--v-if--><button data-v-7e93fcc2="" type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-default elevation-0 v-btn--size-default v-btn--variant-text list-with-detail-add" small="" aria-label="MyAdd" aria-describedby="v-tooltip-v-0"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
                 <!----><span class="v-btn__content" data-no-activator=""><i data-v-7e93fcc2="" class="mdi-plus mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
                 <!---->
                 <!---->

--- a/packages/vue-vuetify/tests/unit/complex/__snapshots__/ArrayControlRenderer.spec.ts.snap
+++ b/packages/vue-vuetify/tests/unit/complex/__snapshots__/ArrayControlRenderer.spec.ts.snap
@@ -33,7 +33,7 @@ exports[`ArrayControlRenderer.vue > should render component and match snapshot 1
               </div>
             </div>
             <div data-v-4896f876="" class="v-spacer"></div>
-            <!--v-if--><button data-v-4896f876="" type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-default elevation-0 v-btn--size-default v-btn--variant-text array-list-add" small="" aria-label="MyAdd" aria-describedby="v-tooltip-0"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!--v-if--><button data-v-4896f876="" type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-default elevation-0 v-btn--size-default v-btn--variant-text array-list-add" small="" aria-label="MyAdd" aria-describedby="v-tooltip-v-0"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
               <!----><span class="v-btn__content" data-no-activator=""><i data-v-4896f876="" class="mdi-plus mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
               <!---->
               <!---->

--- a/packages/vue-vuetify/tests/unit/complex/__snapshots__/OneOfRenderer.spec.ts.snap
+++ b/packages/vue-vuetify/tests/unit/complex/__snapshots__/OneOfRenderer.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`OneOfRenderer.vue > should render component and match snapshot 1`] = `
       <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--error v-input--dirty v-text-field v-select v-select--single v-select--selected input">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--error v-field--no-label v-field--variant-filled v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="listbox" aria-expanded="false" aria-owns="v-menu-2">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--error v-field--no-label v-field--variant-filled v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="listbox" aria-expanded="false" aria-controls="v-menu-v-2">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -26,14 +26,13 @@ exports[`OneOfRenderer.vue > should render component and match snapshot 1`] = `
             </div>
             <!---->
             <div class="v-field__field" data-no-activator="">
-              <!----><label class="v-label v-field-label" for="#3-input">
-                <!---->
-              </label>
+              <!---->
+              <!---->
               <!---->
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-select__selection"><span class="v-select__selection-text">oneOf-0<!----></span></div><input size="1" type="text" id="#3-input" aria-describedby="#3-input-messages" inputmode="none" aria-label="Open" title="Open">
+                <div class="v-select__selection"><span class="v-select__selection-text">oneOf-0<!----></span></div><input size="1" type="text" id="#3-input" aria-describedby="#3-input-messages" inputmode="none" aria-label="Open" title="Open" value="0">
               </div>
               <!---->
             </div>
@@ -51,8 +50,8 @@ exports[`OneOfRenderer.vue > should render component and match snapshot 1`] = `
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#3-input-messages">
+        <div id="#3-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <div class="v-messages__message">must be object</div>
           </transition-group-stub>
           <!---->

--- a/packages/vue-vuetify/tests/unit/controls/__snapshots__/BooleanControlRenderer.spec.ts.snap
+++ b/packages/vue-vuetify/tests/unit/controls/__snapshots__/BooleanControlRenderer.spec.ts.snap
@@ -10,15 +10,15 @@ exports[`BooleanControlRenderer.vue > should render component and match snapshot
           <div class="v-selection-control v-selection-control--dirty v-selection-control--density-default v-checkbox-btn">
             <div class="v-selection-control__wrapper">
               <!---->
-              <div class="v-selection-control__input"><i class="mdi-checkbox-marked mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i><input id="#6-input" aria-disabled="false" aria-label="My Boolean" type="checkbox" aria-describedby="#6-input-messages" placeholder="boolean placeholder" value="true"></div>
+              <div class="v-selection-control__input"><i class="mdi-checkbox-marked mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i><input checked="" id="#6-input" aria-disabled="false" aria-label="My Boolean" type="checkbox" aria-describedby="#6-input-messages" placeholder="boolean placeholder" value="true"></div>
             </div><label class="v-label v-label--clickable" for="#6-input">
               <!---->My Boolean
             </label>
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#6-input-messages">
+        <div id="#6-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <!---->
           </transition-group-stub>
           <!---->

--- a/packages/vue-vuetify/tests/unit/controls/__snapshots__/DateControlRenderer.spec.ts.snap
+++ b/packages/vue-vuetify/tests/unit/controls/__snapshots__/DateControlRenderer.spec.ts.snap
@@ -23,8 +23,8 @@ exports[`DateControlRenderer.vue > should render component and match snapshot 1`
                 <!---->
               </div>
             </div>
-            <div class="v-field__prepend-inner" aria-haspopup="menu" aria-expanded="false" aria-owns="v-menu-2">
-              <!----><i class="mdi-calendar mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-haspopup="menu" aria-expanded="false" aria-owns="v-menu-2"></i>
+            <div class="v-field__prepend-inner" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-2">
+              <!----><i class="mdi-calendar mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-2"></i>
               <!---->
             </div>
             <div class="v-field__field" data-no-activator=""><label class="v-label v-field-label v-field-label--floating" aria-hidden="true" for="#6-input">
@@ -32,7 +32,7 @@ exports[`DateControlRenderer.vue > should render component and match snapshot 1`
               </label><label class="v-label v-field-label" for="#6-input">
                 <!---->My Date
               </label>
-              <!----><input placeholder="date placeholder" size="1" type="text" id="#6-input" aria-describedby="#6-input-messages" class="v-field__input" data-maska-value="03/09/2021">
+              <!----><input placeholder="date placeholder" size="1" type="text" id="#6-input" aria-describedby="#6-input-messages" class="v-field__input" value="03/09/2021" data-maska-value="03/09/2021">
               <!---->
             </div>
             <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
@@ -49,8 +49,8 @@ exports[`DateControlRenderer.vue > should render component and match snapshot 1`
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#6-input-messages">
+        <div id="#6-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <!---->
           </transition-group-stub>
           <!---->
@@ -64,11 +64,11 @@ exports[`DateControlRenderer.vue > should render component and match snapshot 1`
 exports[`DateControlRenderer.vue > should render component and match snapshot when clicked 1`] = `
 "<div class="v-application v-theme--light v-layout v-layout--full-height v-locale--is-ltr">
   <div class="v-application__wrap">
-    <div class="control" id="#7" errors="" label="My Date" required="false" isfocused="true" appliedoptions="[object Object]">
+    <div class="control" id="#7" errors="" label="My Date" required="false" isfocused="false" appliedoptions="[object Object]">
       <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field input">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--prepended v-field--variant-filled v-theme--light v-field--focused v-locale--is-ltr">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--prepended v-field--variant-filled v-theme--light v-locale--is-ltr">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -84,8 +84,8 @@ exports[`DateControlRenderer.vue > should render component and match snapshot wh
                 <!---->
               </div>
             </div>
-            <div class="v-field__prepend-inner" aria-haspopup="menu" aria-expanded="false" aria-owns="v-menu-2">
-              <!----><i class="mdi-calendar mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-haspopup="menu" aria-expanded="false" aria-owns="v-menu-2"></i>
+            <div class="v-field__prepend-inner" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-2">
+              <!----><i class="mdi-calendar mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-2"></i>
               <!---->
             </div>
             <div class="v-field__field" data-no-activator=""><label class="v-label v-field-label v-field-label--floating" aria-hidden="true" for="#7-input">
@@ -93,7 +93,7 @@ exports[`DateControlRenderer.vue > should render component and match snapshot wh
               </label><label class="v-label v-field-label" for="#7-input">
                 <!---->My Date
               </label>
-              <!----><input placeholder="date placeholder" size="1" type="text" id="#7-input" aria-describedby="#7-input-messages" class="v-field__input" data-maska-value="03/09/2021">
+              <!----><input placeholder="date placeholder" size="1" type="text" id="#7-input" aria-describedby="#7-input-messages" class="v-field__input" value="03/09/2021" data-maska-value="03/09/2021">
               <!---->
             </div>
             <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
@@ -110,8 +110,8 @@ exports[`DateControlRenderer.vue > should render component and match snapshot wh
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#7-input-messages">
+        <div id="#7-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <!---->
           </transition-group-stub>
           <!---->

--- a/packages/vue-vuetify/tests/unit/controls/__snapshots__/DateTimeControlRenderer.spec.ts.snap
+++ b/packages/vue-vuetify/tests/unit/controls/__snapshots__/DateTimeControlRenderer.spec.ts.snap
@@ -24,7 +24,7 @@ exports[`DateTimeControlRenderer.vue > should render component and match snapsho
               </div>
             </div>
             <div class="v-field__prepend-inner">
-              <!----><i data-v-bc5e61db="" class="mdi-calendar-clock mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-haspopup="menu" aria-expanded="false" aria-owns="v-menu-2"></i>
+              <!----><i data-v-bc5e61db="" class="mdi-calendar-clock mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-2"></i>
               <!---->
             </div>
             <div class="v-field__field" data-no-activator=""><label class="v-label v-field-label v-field-label--floating" aria-hidden="true" for="#6-input">
@@ -32,7 +32,7 @@ exports[`DateTimeControlRenderer.vue > should render component and match snapsho
               </label><label class="v-label v-field-label" for="#6-input">
                 <!---->My Date Time
               </label>
-              <!----><input placeholder="date-time placeholder" size="1" type="text" id="#6-input" aria-describedby="#6-input-messages" class="v-field__input" data-maska-value="2021-03-09T21:54">
+              <!----><input placeholder="date-time placeholder" size="1" type="text" id="#6-input" aria-describedby="#6-input-messages" class="v-field__input" value="2021-03-09T21:54" data-maska-value="2021-03-09T21:54">
               <!---->
             </div>
             <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
@@ -49,8 +49,8 @@ exports[`DateTimeControlRenderer.vue > should render component and match snapsho
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#6-input-messages">
+        <div id="#6-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <!---->
           </transition-group-stub>
           <!---->
@@ -64,11 +64,11 @@ exports[`DateTimeControlRenderer.vue > should render component and match snapsho
 exports[`DateTimeControlRenderer.vue > should render component and match snapshot when clicked 1`] = `
 "<div class="v-application v-theme--light v-layout v-layout--full-height v-locale--is-ltr">
   <div class="v-application__wrap">
-    <div data-v-bc5e61db="" class="control" id="#7" errors="" label="My Date Time" required="false" isfocused="true" appliedoptions="[object Object]">
+    <div data-v-bc5e61db="" class="control" id="#7" errors="" label="My Date Time" required="false" isfocused="false" appliedoptions="[object Object]">
       <div data-v-bc5e61db="" class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field input">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--prepended v-field--variant-filled v-theme--light v-field--focused v-locale--is-ltr">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--prepended v-field--variant-filled v-theme--light v-locale--is-ltr">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -85,7 +85,7 @@ exports[`DateTimeControlRenderer.vue > should render component and match snapsho
               </div>
             </div>
             <div class="v-field__prepend-inner">
-              <!----><i data-v-bc5e61db="" class="mdi-calendar-clock mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-haspopup="menu" aria-expanded="false" aria-owns="v-menu-2"></i>
+              <!----><i data-v-bc5e61db="" class="mdi-calendar-clock mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-2"></i>
               <!---->
             </div>
             <div class="v-field__field" data-no-activator=""><label class="v-label v-field-label v-field-label--floating" aria-hidden="true" for="#7-input">
@@ -93,7 +93,7 @@ exports[`DateTimeControlRenderer.vue > should render component and match snapsho
               </label><label class="v-label v-field-label" for="#7-input">
                 <!---->My Date Time
               </label>
-              <!----><input placeholder="date-time placeholder" size="1" type="text" id="#7-input" aria-describedby="#7-input-messages" class="v-field__input" data-maska-value="2021-03-09T21:54">
+              <!----><input placeholder="date-time placeholder" size="1" type="text" id="#7-input" aria-describedby="#7-input-messages" class="v-field__input" value="2021-03-09T21:54" data-maska-value="2021-03-09T21:54">
               <!---->
             </div>
             <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
@@ -110,8 +110,8 @@ exports[`DateTimeControlRenderer.vue > should render component and match snapsho
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#7-input-messages">
+        <div id="#7-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <!---->
           </transition-group-stub>
           <!---->

--- a/packages/vue-vuetify/tests/unit/controls/__snapshots__/EnumControlRenderer.spec.ts.snap
+++ b/packages/vue-vuetify/tests/unit/controls/__snapshots__/EnumControlRenderer.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`EnumControlRenderer.vue > should render component and match snapshot 1`
       <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-select v-select--single v-select--selected input">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--variant-filled v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="listbox" aria-expanded="false" aria-owns="v-menu-2">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--variant-filled v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="listbox" aria-expanded="false" aria-controls="v-menu-v-2">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -33,7 +33,7 @@ exports[`EnumControlRenderer.vue > should render component and match snapshot 1`
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-select__selection"><span class="v-select__selection-text">a<!----></span></div><input size="1" type="text" id="#4-input" aria-describedby="#4-input-messages" inputmode="none" aria-label="Open" title="Open">
+                <div class="v-select__selection"><span class="v-select__selection-text">a<!----></span></div><input size="1" type="text" id="#4-input" aria-describedby="#4-input-messages" inputmode="none" aria-label="Open" title="Open" value="a">
               </div>
               <!---->
             </div>
@@ -51,8 +51,8 @@ exports[`EnumControlRenderer.vue > should render component and match snapshot 1`
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#4-input-messages">
+        <div id="#4-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <!---->
           </transition-group-stub>
           <!---->
@@ -66,11 +66,11 @@ exports[`EnumControlRenderer.vue > should render component and match snapshot 1`
 exports[`EnumControlRenderer.vue > should render component and match snapshot when clicked 1`] = `
 "<div class="v-application v-theme--light v-layout v-layout--full-height v-locale--is-ltr">
   <div class="v-application__wrap">
-    <div class="control" id="#5" errors="" label="My Enum" required="false" isfocused="true" appliedoptions="[object Object]">
+    <div class="control" id="#5" errors="" label="My Enum" required="false" isfocused="false" appliedoptions="[object Object]">
       <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-select v-select--single v-select--selected input">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--variant-filled v-theme--light v-field--focused v-locale--is-ltr" role="combobox" aria-haspopup="listbox" aria-expanded="false" aria-owns="v-menu-2">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--variant-filled v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="listbox" aria-expanded="false" aria-controls="v-menu-v-2">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -96,7 +96,7 @@ exports[`EnumControlRenderer.vue > should render component and match snapshot wh
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-select__selection"><span class="v-select__selection-text">a<!----></span></div><input size="1" type="text" id="#5-input" aria-describedby="#5-input-messages" inputmode="none" aria-label="Open" title="Open">
+                <div class="v-select__selection"><span class="v-select__selection-text">a<!----></span></div><input size="1" type="text" id="#5-input" aria-describedby="#5-input-messages" inputmode="none" aria-label="Open" title="Open" value="a">
               </div>
               <!---->
             </div>
@@ -114,8 +114,8 @@ exports[`EnumControlRenderer.vue > should render component and match snapshot wh
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#5-input-messages">
+        <div id="#5-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <!---->
           </transition-group-stub>
           <!---->

--- a/packages/vue-vuetify/tests/unit/controls/__snapshots__/IntegerControlRenderer.spec.ts.snap
+++ b/packages/vue-vuetify/tests/unit/controls/__snapshots__/IntegerControlRenderer.spec.ts.snap
@@ -29,7 +29,7 @@ exports[`IntegerControlRenderer.vue > should render component and match snapshot
               </label><label class="v-label v-field-label" for="#6-input">
                 <!---->My Integer
               </label>
-              <!----><input placeholder="integer placeholder" size="1" type="text" id="#6-input" aria-describedby="#6-input-messages" inputmode="decimal" class="v-field__input">
+              <!----><input placeholder="integer placeholder" size="1" type="text" id="#6-input" aria-describedby="#6-input-messages" inputmode="decimal" class="v-field__input" value="1">
               <!---->
             </div>
             <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
@@ -38,12 +38,12 @@ exports[`IntegerControlRenderer.vue > should render component and match snapshot
             <div class="v-field__append-inner">
               <!---->
               <hr class="v-divider v-divider--vertical v-theme--light" aria-orientation="vertical" role="separator">
-              <div class="v-number-input__control"><button type="button" class="v-btn v-btn--flat v-btn--icon v-theme--light v-btn--density-default v-btn--size-small v-btn--variant-elevated" style="height: 100%;" tabindex="-1" name="decrement-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <div class="v-number-input__control"><button type="button" class="v-btn v-btn--flat v-btn--icon v-theme--light v-btn--density-default v-btn--size-small v-btn--variant-elevated" style="height: 100%;" tabindex="-1" aria-hidden="true" data-testid="decrement"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
                   <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-down mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
                   <!---->
                   <!---->
                 </button>
-                <hr class="v-divider v-divider--vertical v-theme--light" aria-orientation="vertical" role="separator"><button type="button" class="v-btn v-btn--flat v-btn--icon v-theme--light v-btn--density-default v-btn--size-small v-btn--variant-elevated" style="height: 100%;" tabindex="-1" name="increment-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+                <hr class="v-divider v-divider--vertical v-theme--light" aria-orientation="vertical" role="separator"><button type="button" class="v-btn v-btn--flat v-btn--icon v-theme--light v-btn--density-default v-btn--size-small v-btn--variant-elevated" style="height: 100%;" tabindex="-1" aria-hidden="true" data-testid="increment"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
                   <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-up mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
                   <!---->
                   <!---->
@@ -58,8 +58,8 @@ exports[`IntegerControlRenderer.vue > should render component and match snapshot
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#6-input-messages">
+        <div id="#6-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <!---->
           </transition-group-stub>
           <!---->

--- a/packages/vue-vuetify/tests/unit/controls/__snapshots__/MultiStringControlRenderer.spec.ts.snap
+++ b/packages/vue-vuetify/tests/unit/controls/__snapshots__/MultiStringControlRenderer.spec.ts.snap
@@ -29,7 +29,7 @@ exports[`MultiStringControlRenderer.vue > should render component and match snap
               </label><label class="v-label v-field-label" for="#6-input">
                 <!---->My Multi String
               </label>
-              <!----><textarea class="v-field__input" placeholder="multi placeholder" rows="5" id="#6-input" aria-describedby="#6-input-messages" multi-line=""></textarea>
+              <!----><textarea class="v-field__input" placeholder="multi placeholder" rows="5" id="#6-input" aria-describedby="#6-input-messages" multi-line="" value="a"></textarea>
               <!---->
               <!---->
             </div>
@@ -47,8 +47,8 @@ exports[`MultiStringControlRenderer.vue > should render component and match snap
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#6-input-messages">
+        <div id="#6-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <!---->
           </transition-group-stub>
           <!---->

--- a/packages/vue-vuetify/tests/unit/controls/__snapshots__/NumberControlRenderer.spec.ts.snap
+++ b/packages/vue-vuetify/tests/unit/controls/__snapshots__/NumberControlRenderer.spec.ts.snap
@@ -29,7 +29,7 @@ exports[`NumberControlRenderer.vue > should render component and match snapshot 
               </label><label class="v-label v-field-label" for="#6-input">
                 <!---->My Number
               </label>
-              <!----><input placeholder="number placeholder" size="1" type="text" id="#6-input" aria-describedby="#6-input-messages" inputmode="decimal" class="v-field__input" value="1">
+              <!----><input placeholder="number placeholder" size="1" type="text" id="#6-input" aria-describedby="#6-input-messages" inputmode="decimal" class="v-field__input" value="1.0">
               <!---->
             </div>
             <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">

--- a/packages/vue-vuetify/tests/unit/controls/__snapshots__/NumberControlRenderer.spec.ts.snap
+++ b/packages/vue-vuetify/tests/unit/controls/__snapshots__/NumberControlRenderer.spec.ts.snap
@@ -29,7 +29,7 @@ exports[`NumberControlRenderer.vue > should render component and match snapshot 
               </label><label class="v-label v-field-label" for="#6-input">
                 <!---->My Number
               </label>
-              <!----><input placeholder="number placeholder" size="1" type="text" id="#6-input" aria-describedby="#6-input-messages" inputmode="decimal" class="v-field__input">
+              <!----><input placeholder="number placeholder" size="1" type="text" id="#6-input" aria-describedby="#6-input-messages" inputmode="decimal" class="v-field__input" value="1">
               <!---->
             </div>
             <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
@@ -38,12 +38,12 @@ exports[`NumberControlRenderer.vue > should render component and match snapshot 
             <div class="v-field__append-inner">
               <!---->
               <hr class="v-divider v-divider--vertical v-theme--light" aria-orientation="vertical" role="separator">
-              <div class="v-number-input__control"><button type="button" class="v-btn v-btn--flat v-btn--icon v-theme--light v-btn--density-default v-btn--size-small v-btn--variant-elevated" style="height: 100%;" tabindex="-1" name="decrement-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <div class="v-number-input__control"><button type="button" class="v-btn v-btn--flat v-btn--icon v-theme--light v-btn--density-default v-btn--size-small v-btn--variant-elevated" style="height: 100%;" tabindex="-1" aria-hidden="true" data-testid="decrement"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
                   <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-down mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
                   <!---->
                   <!---->
                 </button>
-                <hr class="v-divider v-divider--vertical v-theme--light" aria-orientation="vertical" role="separator"><button type="button" class="v-btn v-btn--flat v-btn--icon v-theme--light v-btn--density-default v-btn--size-small v-btn--variant-elevated" style="height: 100%;" tabindex="-1" name="increment-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+                <hr class="v-divider v-divider--vertical v-theme--light" aria-orientation="vertical" role="separator"><button type="button" class="v-btn v-btn--flat v-btn--icon v-theme--light v-btn--density-default v-btn--size-small v-btn--variant-elevated" style="height: 100%;" tabindex="-1" aria-hidden="true" data-testid="increment"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
                   <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-up mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
                   <!---->
                   <!---->
@@ -58,8 +58,8 @@ exports[`NumberControlRenderer.vue > should render component and match snapshot 
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#6-input-messages">
+        <div id="#6-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <!---->
           </transition-group-stub>
           <!---->

--- a/packages/vue-vuetify/tests/unit/controls/__snapshots__/OneOfEnumControlRenderer.spec.ts.snap
+++ b/packages/vue-vuetify/tests/unit/controls/__snapshots__/OneOfEnumControlRenderer.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`OneOfEnumControlRenderer.vue > should render component and match snapsh
       <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-select v-select--single v-select--selected input">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--variant-filled v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="listbox" aria-expanded="false" aria-owns="v-menu-2">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--variant-filled v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="listbox" aria-expanded="false" aria-controls="v-menu-v-2">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -33,7 +33,7 @@ exports[`OneOfEnumControlRenderer.vue > should render component and match snapsh
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-select__selection"><span class="v-select__selection-text">Foo<!----></span></div><input size="1" type="text" id="#4-input" aria-describedby="#4-input-messages" inputmode="none" aria-label="Open" title="Open">
+                <div class="v-select__selection"><span class="v-select__selection-text">Foo<!----></span></div><input size="1" type="text" id="#4-input" aria-describedby="#4-input-messages" inputmode="none" aria-label="Open" title="Open" value="a">
               </div>
               <!---->
             </div>
@@ -51,8 +51,8 @@ exports[`OneOfEnumControlRenderer.vue > should render component and match snapsh
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#4-input-messages">
+        <div id="#4-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <!---->
           </transition-group-stub>
           <!---->
@@ -66,11 +66,11 @@ exports[`OneOfEnumControlRenderer.vue > should render component and match snapsh
 exports[`OneOfEnumControlRenderer.vue > should render component and match snapshot when clicked 1`] = `
 "<div class="v-application v-theme--light v-layout v-layout--full-height v-locale--is-ltr">
   <div class="v-application__wrap">
-    <div class="control" id="#5" errors="" label="My OneOf Enum" required="false" isfocused="true" appliedoptions="[object Object]">
+    <div class="control" id="#5" errors="" label="My OneOf Enum" required="false" isfocused="false" appliedoptions="[object Object]">
       <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-select v-select--single v-select--selected input">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--variant-filled v-theme--light v-field--focused v-locale--is-ltr" role="combobox" aria-haspopup="listbox" aria-expanded="false" aria-owns="v-menu-2">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--variant-filled v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="listbox" aria-expanded="false" aria-controls="v-menu-v-2">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -96,7 +96,7 @@ exports[`OneOfEnumControlRenderer.vue > should render component and match snapsh
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-select__selection"><span class="v-select__selection-text">Foo<!----></span></div><input size="1" type="text" id="#5-input" aria-describedby="#5-input-messages" inputmode="none" aria-label="Open" title="Open">
+                <div class="v-select__selection"><span class="v-select__selection-text">Foo<!----></span></div><input size="1" type="text" id="#5-input" aria-describedby="#5-input-messages" inputmode="none" aria-label="Open" title="Open" value="a">
               </div>
               <!---->
             </div>
@@ -114,8 +114,8 @@ exports[`OneOfEnumControlRenderer.vue > should render component and match snapsh
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#5-input-messages">
+        <div id="#5-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <!---->
           </transition-group-stub>
           <!---->

--- a/packages/vue-vuetify/tests/unit/controls/__snapshots__/StringControlRenderer.spec.ts.snap
+++ b/packages/vue-vuetify/tests/unit/controls/__snapshots__/StringControlRenderer.spec.ts.snap
@@ -29,7 +29,7 @@ exports[`StringControlRenderer.vue > should render component and match snapshot 
               </label><label class="v-label v-field-label" for="#6-input">
                 <!---->My String
               </label>
-              <!----><input placeholder="string placeholder" size="1" type="text" id="#6-input" aria-describedby="#6-input-messages" class="v-field__input">
+              <!----><input placeholder="string placeholder" size="1" type="text" id="#6-input" aria-describedby="#6-input-messages" class="v-field__input" value="a">
               <!---->
             </div>
             <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
@@ -46,8 +46,8 @@ exports[`StringControlRenderer.vue > should render component and match snapshot 
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#6-input-messages">
+        <div id="#6-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <!---->
           </transition-group-stub>
           <!---->
@@ -65,7 +65,7 @@ exports[`StringControlRenderer.vue with suggestion > should render component and
       <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-text-field v-combobox v-combobox--single input">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--variant-filled v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-owns="v-menu-2">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--variant-filled v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-2">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -91,7 +91,7 @@ exports[`StringControlRenderer.vue with suggestion > should render component and
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text"><!----></span></div><input size="1" type="text" id="#11-input" aria-describedby="#11-input-messages">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text"><!----></span></div><input size="1" type="text" id="#11-input" aria-describedby="#11-input-messages" value="">
               </div>
               <!---->
             </div>
@@ -109,8 +109,8 @@ exports[`StringControlRenderer.vue with suggestion > should render component and
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#11-input-messages">
+        <div id="#11-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <!---->
           </transition-group-stub>
           <!---->
@@ -124,11 +124,11 @@ exports[`StringControlRenderer.vue with suggestion > should render component and
 exports[`StringControlRenderer.vue with suggestion > should render component and match snapshot when clicked 1`] = `
 "<div class="v-application v-theme--light v-layout v-layout--full-height v-locale--is-ltr">
   <div class="v-application__wrap">
-    <div class="control" id="#12" errors="" label="Select Continent" required="false" isfocused="true" appliedoptions="[object Object]">
+    <div class="control" id="#12" errors="" label="Select Continent" required="false" isfocused="false" appliedoptions="[object Object]">
       <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-text-field v-combobox v-combobox--single input">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--variant-filled v-theme--light v-field--focused v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-owns="v-menu-2">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--variant-filled v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-2">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -154,7 +154,7 @@ exports[`StringControlRenderer.vue with suggestion > should render component and
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text"><!----></span></div><input size="1" type="text" id="#12-input" aria-describedby="#12-input-messages">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text"><!----></span></div><input size="1" type="text" id="#12-input" aria-describedby="#12-input-messages" value="">
               </div>
               <!---->
             </div>
@@ -172,8 +172,8 @@ exports[`StringControlRenderer.vue with suggestion > should render component and
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#12-input-messages">
+        <div id="#12-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <!---->
           </transition-group-stub>
           <!---->

--- a/packages/vue-vuetify/tests/unit/controls/__snapshots__/TimeControlRenderer.spec.ts.snap
+++ b/packages/vue-vuetify/tests/unit/controls/__snapshots__/TimeControlRenderer.spec.ts.snap
@@ -23,8 +23,8 @@ exports[`TimeControlRenderer.vue > should render component and match snapshot 1`
                 <!---->
               </div>
             </div>
-            <div class="v-field__prepend-inner" aria-haspopup="menu" aria-expanded="false" aria-owns="v-menu-2">
-              <!----><i class="mdi-clock-outline mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-haspopup="menu" aria-expanded="false" aria-owns="v-menu-2"></i>
+            <div class="v-field__prepend-inner" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-2">
+              <!----><i class="mdi-clock-outline mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-2"></i>
               <!---->
             </div>
             <div class="v-field__field" data-no-activator=""><label class="v-label v-field-label v-field-label--floating" aria-hidden="true" for="#6-input">
@@ -32,7 +32,7 @@ exports[`TimeControlRenderer.vue > should render component and match snapshot 1`
               </label><label class="v-label v-field-label" for="#6-input">
                 <!---->My Time
               </label>
-              <!----><input placeholder="time placeholder" size="1" type="text" id="#6-input" aria-describedby="#6-input-messages" class="v-field__input" data-maska-value="00:20:00">
+              <!----><input placeholder="time placeholder" size="1" type="text" id="#6-input" aria-describedby="#6-input-messages" class="v-field__input" value="00:20:00" data-maska-value="00:20:00">
               <!---->
             </div>
             <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
@@ -49,8 +49,8 @@ exports[`TimeControlRenderer.vue > should render component and match snapshot 1`
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#6-input-messages">
+        <div id="#6-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <!---->
           </transition-group-stub>
           <!---->
@@ -64,11 +64,11 @@ exports[`TimeControlRenderer.vue > should render component and match snapshot 1`
 exports[`TimeControlRenderer.vue > should render component and match snapshot when clicked 1`] = `
 "<div class="v-application v-theme--light v-layout v-layout--full-height v-locale--is-ltr">
   <div class="v-application__wrap">
-    <div class="control" id="#7" errors="" label="My Time" required="false" isfocused="true" appliedoptions="[object Object]">
+    <div class="control" id="#7" errors="" label="My Time" required="false" isfocused="false" appliedoptions="[object Object]">
       <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field input">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--prepended v-field--variant-filled v-theme--light v-field--focused v-locale--is-ltr">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--prepended v-field--variant-filled v-theme--light v-locale--is-ltr">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -84,8 +84,8 @@ exports[`TimeControlRenderer.vue > should render component and match snapshot wh
                 <!---->
               </div>
             </div>
-            <div class="v-field__prepend-inner" aria-haspopup="menu" aria-expanded="false" aria-owns="v-menu-2">
-              <!----><i class="mdi-clock-outline mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-haspopup="menu" aria-expanded="false" aria-owns="v-menu-2"></i>
+            <div class="v-field__prepend-inner" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-2">
+              <!----><i class="mdi-clock-outline mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="-1" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-2"></i>
               <!---->
             </div>
             <div class="v-field__field" data-no-activator=""><label class="v-label v-field-label v-field-label--floating" aria-hidden="true" for="#7-input">
@@ -93,7 +93,7 @@ exports[`TimeControlRenderer.vue > should render component and match snapshot wh
               </label><label class="v-label v-field-label" for="#7-input">
                 <!---->My Time
               </label>
-              <!----><input placeholder="time placeholder" size="1" type="text" id="#7-input" aria-describedby="#7-input-messages" class="v-field__input" data-maska-value="00:20:00">
+              <!----><input placeholder="time placeholder" size="1" type="text" id="#7-input" aria-describedby="#7-input-messages" class="v-field__input" value="00:20:00" data-maska-value="00:20:00">
               <!---->
             </div>
             <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">
@@ -110,8 +110,8 @@ exports[`TimeControlRenderer.vue > should render component and match snapshot wh
           </div>
         </div>
         <!---->
-        <div class="v-input__details">
-          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages" role="alert" aria-live="polite" id="#7-input-messages">
+        <div id="#7-input-messages" class="v-input__details" role="alert" aria-live="polite">
+          <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
             <!---->
           </transition-group-stub>
           <!---->

--- a/packages/vue-vuetify/tests/unit/layout/__snapshots__/ArrayLayoutRenderer.spec.ts.snap
+++ b/packages/vue-vuetify/tests/unit/layout/__snapshots__/ArrayLayoutRenderer.spec.ts.snap
@@ -33,7 +33,7 @@ exports[`ArrayLayoutRenderer.vue > should render component and match snapshot 1`
               </div>
             </div>
             <div data-v-5f91636e="" class="v-spacer"></div>
-            <!--v-if--><button data-v-5f91636e="" type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-default elevation-0 v-btn--size-default v-btn--variant-text array-list-add" small="" aria-label="MyAdd" aria-describedby="v-tooltip-0"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!--v-if--><button data-v-5f91636e="" type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-default elevation-0 v-btn--size-default v-btn--variant-text array-list-add" small="" aria-label="MyAdd" aria-describedby="v-tooltip-v-0"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
               <!----><span class="v-btn__content" data-no-activator=""><i data-v-5f91636e="" class="mdi-plus mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
               <!---->
               <!---->

--- a/packages/vue-vuetify/vitest.config.ts
+++ b/packages/vue-vuetify/vitest.config.ts
@@ -18,6 +18,7 @@ export default mergeConfig(
           inline: ['vuetify'],
         },
       },
+      setupFiles: ['./tests/setup.ts'],
     },
   }),
 );

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -82,10 +82,10 @@
     "tslib": "^2.5.0",
     "typedoc": "~0.25.3",
     "typescript": "~5.5.0",
-    "vue": "^3.4.21"
+    "vue": "^3.5.17"
   },
   "peerDependencies": {
     "@jsonforms/core": "3.6.0",
-    "vue": "^3.2.26"
+    "vue": "^3.5.0"
   }
 }

--- a/packages/vue/src/components/JsonForms.vue
+++ b/packages/vue/src/components/JsonForms.vue
@@ -25,6 +25,7 @@ import {
   JsonFormsI18nState,
   defaultMiddleware,
   Middleware,
+  JsonFormsSubStates,
 } from '@jsonforms/core';
 import { JsonFormsChangeEvent, MaybeReadonly } from '../types';
 import DispatchRenderer from './DispatchRenderer.vue';
@@ -47,7 +48,8 @@ export default defineComponent({
   },
   provide() {
     return {
-      jsonforms: this.jsonforms,
+      // Explicitly type provide to avoid TS7056
+      jsonforms: this.jsonforms as JsonFormsSubStates,
       dispatch: this.dispatch,
     };
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1041,13 +1041,13 @@ importers:
         version: 5.62.0(eslint@8.57.0)(typescript@5.5.4)
       '@vue/cli-plugin-babel':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3))(core-js@3.37.1)(encoding@0.1.13)(vue@3.4.27(typescript@5.5.4))
+        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3))(core-js@3.37.1)(encoding@0.1.13)(vue@3.5.17(typescript@5.5.4))
       '@vue/cli-plugin-typescript':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3))(encoding@0.1.13)(eslint@8.57.0)(typescript@5.5.4)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))
+        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3))(encoding@0.1.13)(eslint@8.57.0)(typescript@5.5.4)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))
       '@vue/cli-service':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3)
+        version: 5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3)
       '@vue/eslint-config-typescript':
         specifier: ^11.0.2
         version: 11.0.3(eslint-plugin-vue@9.26.0(eslint@8.57.0))(eslint@8.57.0)(typescript@5.5.4)
@@ -1056,7 +1056,7 @@ importers:
         version: 2.4.6
       '@vue/vue3-jest':
         specifier: ^27.0.0
-        version: 27.0.0(@babel/core@7.24.5)(babel-jest@27.5.1(@babel/core@7.24.5))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.13.8)(typescript@5.5.4)))(ts-jest@27.1.5(@babel/core@7.24.5)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.24.5))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.13.8)(typescript@5.5.4)))(typescript@5.5.4))(typescript@5.5.4)(vue@3.4.27(typescript@5.5.4))
+        version: 27.0.0(@babel/core@7.24.5)(babel-jest@27.5.1(@babel/core@7.24.5))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.13.8)(typescript@5.5.4)))(ts-jest@27.1.5(@babel/core@7.24.5)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.24.5))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.13.8)(typescript@5.5.4)))(typescript@5.5.4))(typescript@5.5.4)(vue@3.5.17(typescript@5.5.4))
       core-js:
         specifier: ^3.9.1
         version: 3.37.1
@@ -1104,7 +1104,7 @@ importers:
         version: 5.12.0(rollup@2.79.1)
       rollup-plugin-vue:
         specifier: ^6.0.0
-        version: 6.0.0(@vue/compiler-sfc@3.4.27)
+        version: 6.0.0(@vue/compiler-sfc@3.5.17)
       ts-jest:
         specifier: ^27.1.5
         version: 27.1.5(@babel/core@7.24.5)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.24.5))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.13.8)(typescript@5.5.4)))(typescript@5.5.4)
@@ -1118,8 +1118,8 @@ importers:
         specifier: ~5.5.0
         version: 5.5.4
       vue:
-        specifier: ^3.4.21
-        version: 3.4.27(typescript@5.5.4)
+        specifier: ^3.5.17
+        version: 3.5.17(typescript@5.5.4)
 
   packages/vue-vanilla:
     dependencies:
@@ -1162,16 +1162,16 @@ importers:
         version: 5.62.0(eslint@8.57.0)(typescript@5.5.4)
       '@vue/cli-plugin-babel':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3))(core-js@3.37.1)(encoding@0.1.13)(vue@3.4.27(typescript@5.5.4))
+        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3))(core-js@3.37.1)(encoding@0.1.13)(vue@3.5.17(typescript@5.5.4))
       '@vue/cli-plugin-typescript':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3))(encoding@0.1.13)(eslint@8.57.0)(typescript@5.5.4)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))
+        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3))(encoding@0.1.13)(eslint@8.57.0)(typescript@5.5.4)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))
       '@vue/cli-plugin-unit-mocha':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3))(encoding@0.1.13)(webpack@5.94.0)
+        version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3))(encoding@0.1.13)(webpack@5.94.0)
       '@vue/cli-service':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3)
+        version: 5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3)
       '@vue/eslint-config-typescript':
         specifier: ^11.0.2
         version: 11.0.3(eslint-plugin-vue@9.26.0(eslint@8.57.0))(eslint@8.57.0)(typescript@5.5.4)
@@ -1225,7 +1225,7 @@ importers:
         version: 5.12.0(rollup@2.79.1)
       rollup-plugin-vue:
         specifier: ^6.0.0
-        version: 6.0.0(@vue/compiler-sfc@3.4.27)
+        version: 6.0.0(@vue/compiler-sfc@3.5.17)
       symlink-dir:
         specifier: ^5.0.0
         version: 5.2.1
@@ -1239,11 +1239,11 @@ importers:
         specifier: ~5.5.0
         version: 5.5.4
       vue:
-        specifier: ^3.4.21
-        version: 3.4.27(typescript@5.5.4)
+        specifier: ^3.5.17
+        version: 3.5.17(typescript@5.5.4)
       vue-jest:
         specifier: ^5.0.0-0
-        version: 5.0.0-alpha.10(@babel/core@7.24.5)(babel-jest@27.5.1(@babel/core@7.24.5))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.13.8)(typescript@5.5.4)))(typescript@5.5.4)(vue@3.4.27(typescript@5.5.4))
+        version: 5.0.0-alpha.10(@babel/core@7.24.5)(babel-jest@27.5.1(@babel/core@7.24.5))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.13.8)(typescript@5.5.4)))(typescript@5.5.4)(vue@3.5.17(typescript@5.5.4))
 
   packages/vue-vuetify:
     devDependencies:
@@ -1282,7 +1282,7 @@ importers:
         version: 2.2.6
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
-        version: 5.1.2(vite@5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))(vue@3.4.27(typescript@5.4.5))
+        version: 5.1.2(vite@5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))(vue@3.5.17(typescript@5.4.5))
       '@vitest/coverage-v8':
         specifier: ^1.6.0
         version: 1.6.0(vitest@1.6.0(@types/node@22.13.8)(jsdom@24.1.1)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))
@@ -1362,26 +1362,26 @@ importers:
         specifier: ~5.4.0
         version: 5.4.5
       vite:
-        specifier: ^5.2.8
-        version: 5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
+        specifier: ^5.4.19
+        version: 5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
       vite-plugin-dts:
         specifier: ^3.9.1
-        version: 3.9.1(@types/node@22.13.8)(rollup@4.22.4)(typescript@5.4.5)(vite@5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))
+        version: 3.9.1(@types/node@22.13.8)(rollup@4.22.4)(typescript@5.4.5)(vite@5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))
       vite-plugin-node-polyfills:
         specifier: ^0.21.0
-        version: 0.21.0(rollup@4.22.4)(vite@5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))
+        version: 0.21.0(rollup@4.22.4)(vite@5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))
       vite-plugin-static-copy:
         specifier: ^1.0.5
-        version: 1.0.6(vite@5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))
+        version: 1.0.6(vite@5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))
       vite-plugin-vuetify:
-        specifier: ^2.0.3
-        version: 2.0.4(vite@5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))(vue@3.4.27(typescript@5.4.5))(vuetify@3.7.0)
+        specifier: ^2.1.1
+        version: 2.1.1(vite@5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))(vue@3.5.17(typescript@5.4.5))(vuetify@3.9.0)
       vitest:
         specifier: ^1.4.0
         version: 1.6.0(@types/node@22.13.8)(jsdom@24.1.1)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
       vue:
-        specifier: ^3.4.21
-        version: 3.4.27(typescript@5.4.5)
+        specifier: ^3.5.17
+        version: 3.5.17(typescript@5.4.5)
       vue-eslint-parser:
         specifier: ^9.4.2
         version: 9.4.2(eslint@8.57.0)
@@ -1389,8 +1389,8 @@ importers:
         specifier: ^2.0.11
         version: 2.0.29(typescript@5.4.5)
       vuetify:
-        specifier: ^3.6.6
-        version: 3.7.0(typescript@5.4.5)(vite-plugin-vuetify@2.0.4)(vue@3.4.27(typescript@5.4.5))
+        specifier: ^3.9.0
+        version: 3.9.0(typescript@5.4.5)(vite-plugin-vuetify@2.1.1)(vue@3.5.17(typescript@5.4.5))
 
 packages:
   '@achrinza/node-ipc@9.2.8':
@@ -2090,6 +2090,13 @@ packages:
       }
     engines: { node: '>=6.9.0' }
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution:
+      {
+        integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==,
+      }
+    engines: { node: '>=6.9.0' }
+
   '@babel/helper-validator-identifier@7.24.5':
     resolution:
       {
@@ -2101,6 +2108,13 @@ packages:
     resolution:
       {
         integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution:
+      {
+        integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==,
       }
     engines: { node: '>=6.9.0' }
 
@@ -2165,6 +2179,14 @@ packages:
     resolution:
       {
         integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==,
+      }
+    engines: { node: '>=6.0.0' }
+    hasBin: true
+
+  '@babel/parser@7.28.0':
+    resolution:
+      {
+        integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==,
       }
     engines: { node: '>=6.0.0' }
     hasBin: true
@@ -3518,6 +3540,13 @@ packages:
     resolution:
       {
         integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/types@7.28.0':
+    resolution:
+      {
+        integrity: sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==,
       }
     engines: { node: '>=6.9.0' }
 
@@ -7207,10 +7236,22 @@ packages:
         integrity: sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==,
       }
 
+  '@vue/compiler-core@3.5.17':
+    resolution:
+      {
+        integrity: sha512-Xe+AittLbAyV0pabcN7cP7/BenRBNcteM4aSDCtRvGw0d9OL+HG1u/XHLY/kt1q4fyMeZYXyIYrsHuPSiDPosA==,
+      }
+
   '@vue/compiler-dom@3.4.27':
     resolution:
       {
         integrity: sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==,
+      }
+
+  '@vue/compiler-dom@3.5.17':
+    resolution:
+      {
+        integrity: sha512-+2UgfLKoaNLhgfhV5Ihnk6wB4ljyW1/7wUIog2puUqajiC29Lp5R/IKDdkebh9jTbTogTbsgB+OY9cEWzG95JQ==,
       }
 
   '@vue/compiler-sfc@2.7.16':
@@ -7225,10 +7266,22 @@ packages:
         integrity: sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==,
       }
 
+  '@vue/compiler-sfc@3.5.17':
+    resolution:
+      {
+        integrity: sha512-rQQxbRJMgTqwRugtjw0cnyQv9cP4/4BxWfTdRBkqsTfLOHWykLzbOc3C4GGzAmdMDxhzU/1Ija5bTjMVrddqww==,
+      }
+
   '@vue/compiler-ssr@3.4.27':
     resolution:
       {
         integrity: sha512-CVRzSJIltzMG5FcidsW0jKNQnNRYC8bT21VegyMMtHmhW3UOI7knmUehzswXLrExDLE6lQCZdrhD4ogI7c+vuw==,
+      }
+
+  '@vue/compiler-ssr@3.5.17':
+    resolution:
+      {
+        integrity: sha512-hkDbA0Q20ZzGgpj5uZjb9rBzQtIHLS78mMilwrlpWk2Ep37DYntUz0PonQ6kr113vfOEdM+zTBuJDaceNIW0tQ==,
       }
 
   '@vue/compiler-vue2@2.7.16':
@@ -7302,36 +7355,42 @@ packages:
       typescript:
         optional: true
 
-  '@vue/reactivity@3.4.27':
+  '@vue/reactivity@3.5.17':
     resolution:
       {
-        integrity: sha512-kK0g4NknW6JX2yySLpsm2jlunZJl2/RJGZ0H9ddHdfBVHcNzxmQ0sS0b09ipmBoQpY8JM2KmUw+a6sO8Zo+zIA==,
+        integrity: sha512-l/rmw2STIscWi7SNJp708FK4Kofs97zc/5aEPQh4bOsReD/8ICuBcEmS7KGwDj5ODQLYWVN2lNibKJL1z5b+Lw==,
       }
 
-  '@vue/runtime-core@3.4.27':
+  '@vue/runtime-core@3.5.17':
     resolution:
       {
-        integrity: sha512-7aYA9GEbOOdviqVvcuweTLe5Za4qBZkUY7SvET6vE8kyypxVgaT1ixHLg4urtOlrApdgcdgHoTZCUuTGap/5WA==,
+        integrity: sha512-QQLXa20dHg1R0ri4bjKeGFKEkJA7MMBxrKo2G+gJikmumRS7PTD4BOU9FKrDQWMKowz7frJJGqBffYMgQYS96Q==,
       }
 
-  '@vue/runtime-dom@3.4.27':
+  '@vue/runtime-dom@3.5.17':
     resolution:
       {
-        integrity: sha512-ScOmP70/3NPM+TW9hvVAz6VWWtZJqkbdf7w6ySsws+EsqtHvkhxaWLecrTorFxsawelM5Ys9FnDEMt6BPBDS0Q==,
+        integrity: sha512-8El0M60TcwZ1QMz4/os2MdlQECgGoVHPuLnQBU3m9h3gdNRW9xRmI8iLS4t/22OQlOE6aJvNNlBiCzPHur4H9g==,
       }
 
-  '@vue/server-renderer@3.4.27':
+  '@vue/server-renderer@3.5.17':
     resolution:
       {
-        integrity: sha512-dlAMEuvmeA3rJsOMJ2J1kXU7o7pOxgsNHVr9K8hB3ImIkSuBrIdy0vF66h8gf8Tuinf1TK3mPAz2+2sqyf3KzA==,
+        integrity: sha512-BOHhm8HalujY6lmC3DbqF6uXN/K00uWiEeF22LfEsm9Q93XeJ/plHTepGwf6tqFcF7GA5oGSSAAUock3VvzaCA==,
       }
     peerDependencies:
-      vue: 3.4.27
+      vue: 3.5.17
 
   '@vue/shared@3.4.27':
     resolution:
       {
         integrity: sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA==,
+      }
+
+  '@vue/shared@3.5.17':
+    resolution:
+      {
+        integrity: sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==,
       }
 
   '@vue/test-utils@2.4.6':
@@ -7370,10 +7429,10 @@ packages:
         integrity: sha512-Iu8Tbg3f+emIIMmI2ycSI8QcEuAUgPTgHwesDU1eKMLE4YC/c/sFbGc70QgMq31ijRftV0R7vCm9co6rldCeOA==,
       }
 
-  '@vuetify/loader-shared@2.0.3':
+  '@vuetify/loader-shared@2.1.0':
     resolution:
       {
-        integrity: sha512-Ss3GC7eJYkp2SF6xVzsT7FAruEmdihmn4OCk2+UocREerlXKWgOKKzTN5PN3ZVN5q05jHHrsNhTuWbhN61Bpdg==,
+        integrity: sha512-dNE6Ceym9ijFsmJKB7YGW0cxs7xbYV8+1LjU6jd4P14xOt/ji4Igtgzt0rJFbxu+ZhAzqz853lhB0z8V9Dy9cQ==,
       }
     peerDependencies:
       vue: ^3.0.0
@@ -15071,6 +15130,12 @@ packages:
         integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==,
       }
 
+  magic-string@0.30.17:
+    resolution:
+      {
+        integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==,
+      }
+
   magicast@0.3.4:
     resolution:
       {
@@ -15712,6 +15777,14 @@ packages:
     resolution:
       {
         integrity: sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==,
+      }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+    hasBin: true
+
+  nanoid@3.3.11:
+    resolution:
+      {
+        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
       }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
@@ -17533,6 +17606,13 @@ packages:
     resolution:
       {
         integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
+
+  postcss@8.5.6:
+    resolution:
+      {
+        integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==,
       }
     engines: { node: ^10 || ^12 || >=14 }
 
@@ -20927,10 +21007,10 @@ packages:
     peerDependencies:
       vite: ^5.0.0
 
-  vite-plugin-vuetify@2.0.4:
+  vite-plugin-vuetify@2.1.1:
     resolution:
       {
-        integrity: sha512-A4cliYUoP/u4AWSRVRvAPKgpgR987Pss7LpFa7s1GvOe8WjgDq92Rt3eVXrvgxGCWvZsPKziVqfHHdCMqeDhfw==,
+        integrity: sha512-Pb7bKhQH8qPMzURmEGq2aIqCJkruFNsyf1NcrrtnjsOIkqJPMcBbiP0oJoO8/uAmyB5W/1JTbbUEsyXdMM0QHQ==,
       }
     engines: { node: ^18.0.0 || >=20.0.0 }
     peerDependencies:
@@ -20938,10 +21018,10 @@ packages:
       vue: ^3.0.0
       vuetify: ^3.0.0
 
-  vite@5.4.2:
+  vite@5.4.19:
     resolution:
       {
-        integrity: sha512-dDrQTRHp5C1fTFzcSaMxjk6vdpKvT+2/mIdE07Gw2ykehT49O0z/VHS3zZ8iV/Gh8BJJKHWOe5RjaNrW5xf/GA==,
+        integrity: sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==,
       }
     engines: { node: ^18.0.0 || >=20.0.0 }
     hasBin: true
@@ -21184,10 +21264,10 @@ packages:
       }
     deprecated: Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.
 
-  vue@3.4.27:
+  vue@3.5.17:
     resolution:
       {
-        integrity: sha512-8s/56uK6r01r1icG/aEOHqyMVxd1bkYcSe9j8HcKtr/xTOFWvnzIVTehNW+5Yt89f+DLBe4A569pnZLS5HzAMA==,
+        integrity: sha512-LbHV3xPN9BeljML+Xctq4lbz2lVHCR6DtbpTf5XIO6gugpXUN49j2QQPcMj086r9+AkJ0FfUT8xjulKKBkkr9g==,
       }
     peerDependencies:
       typescript: '*'
@@ -21195,24 +21275,21 @@ packages:
       typescript:
         optional: true
 
-  vuetify@3.7.0:
+  vuetify@3.9.0:
     resolution:
       {
-        integrity: sha512-x+UaU4SPYNcJSE/voCTBFrNn0q9Spzx2EMfDdUj0NYgHGKb59OqnZte+AjaJaoOXy1AHYIGEpm5Ryk2BEfgWuw==,
+        integrity: sha512-vjqyHP5gBFH4x0BAjdRAcS3FXY5OfHaKnC6Hhgln8tePZtKc3AUhF7BEJtcrD3l6XwL8gaYx/wMt+UP7X5EZJw==,
       }
     engines: { node: ^12.20 || >=14.13 }
     peerDependencies:
       typescript: '>=4.7'
-      vite-plugin-vuetify: '>=1.0.0'
-      vue: ^3.3.0
-      vue-i18n: ^9.0.0
-      webpack-plugin-vuetify: '>=2.0.0'
+      vite-plugin-vuetify: '>=2.1.0'
+      vue: ^3.5.0
+      webpack-plugin-vuetify: '>=3.1.0'
     peerDependenciesMeta:
       typescript:
         optional: true
       vite-plugin-vuetify:
-        optional: true
-      vue-i18n:
         optional: true
       webpack-plugin-vuetify:
         optional: true
@@ -22082,7 +22159,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1802.12(chokidar@3.6.0)
-      '@angular-devkit/build-webpack': 0.1802.12(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.94.0(esbuild@0.23.0)))(webpack@5.94.0(esbuild@0.23.0))
+      '@angular-devkit/build-webpack': 0.1802.12(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.91.0))(webpack@5.94.0(esbuild@0.23.0))
       '@angular-devkit/core': 18.2.12(chokidar@3.6.0)
       '@angular/build': 18.2.12(@angular/compiler-cli@18.2.13(@angular/compiler@18.2.13(@angular/core@18.2.13(rxjs@6.6.7)(zone.js@0.14.10)))(typescript@5.5.4))(@types/node@22.13.8)(chokidar@3.6.0)(less@4.2.0)(postcss@8.4.41)(stylus@0.57.0)(terser@5.31.6)(typescript@5.5.4)
       '@angular/compiler-cli': 18.2.13(@angular/compiler@18.2.13(@angular/core@18.2.13(rxjs@6.6.7)(zone.js@0.14.10)))(typescript@5.5.4)
@@ -22167,7 +22244,7 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@angular-devkit/build-webpack@0.1802.12(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.94.0(esbuild@0.23.0)))(webpack@5.94.0(esbuild@0.23.0))':
+  '@angular-devkit/build-webpack@0.1802.12(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.91.0))(webpack@5.94.0(esbuild@0.23.0))':
     dependencies:
       '@angular-devkit/architect': 0.1802.12(chokidar@3.6.0)
       rxjs: 7.8.1
@@ -22728,9 +22805,13 @@ snapshots:
 
   '@babel/helper-string-parser@7.25.9': {}
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.24.5': {}
 
   '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/helper-validator-identifier@7.27.1': {}
 
   '@babel/helper-validator-option@7.23.5': {}
 
@@ -22777,6 +22858,10 @@ snapshots:
   '@babel/parser@7.26.2':
     dependencies:
       '@babel/types': 7.26.0
+
+  '@babel/parser@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.0
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.24.5(@babel/core@7.24.5)':
     dependencies:
@@ -23992,6 +24077,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
+
+  '@babel/types@7.28.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -26276,10 +26366,10 @@ snapshots:
     dependencies:
       vite: 5.4.6(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
 
-  '@vitejs/plugin-vue@5.1.2(vite@5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))(vue@3.4.27(typescript@5.4.5))':
+  '@vitejs/plugin-vue@5.1.2(vite@5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))(vue@3.5.17(typescript@5.4.5))':
     dependencies:
-      vite: 5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
-      vue: 3.4.27(typescript@5.4.5)
+      vite: 5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
+      vue: 3.5.17(typescript@5.4.5)
 
   '@vitest/coverage-v8@1.6.0(vitest@1.6.0(@types/node@22.13.8)(jsdom@24.1.1)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))':
     dependencies:
@@ -26395,7 +26485,7 @@ snapshots:
       lodash.kebabcase: 4.1.1
       svg-tags: 1.0.0
 
-  '@vue/babel-preset-app@5.0.8(@babel/core@7.24.5)(core-js@3.37.1)(vue@3.4.27(typescript@5.5.4))':
+  '@vue/babel-preset-app@5.0.8(@babel/core@7.24.5)(core-js@3.37.1)(vue@3.5.17(typescript@5.5.4))':
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-compilation-targets': 7.23.6
@@ -26408,17 +26498,17 @@ snapshots:
       '@babel/preset-env': 7.24.5(@babel/core@7.24.5)
       '@babel/runtime': 7.24.5
       '@vue/babel-plugin-jsx': 1.2.2(@babel/core@7.24.5)
-      '@vue/babel-preset-jsx': 1.4.0(@babel/core@7.24.5)(vue@3.4.27(typescript@5.5.4))
+      '@vue/babel-preset-jsx': 1.4.0(@babel/core@7.24.5)(vue@3.5.17(typescript@5.5.4))
       babel-plugin-dynamic-import-node: 2.3.3
       core-js-compat: 3.37.1
       semver: 7.6.2
     optionalDependencies:
       core-js: 3.37.1
-      vue: 3.4.27(typescript@5.5.4)
+      vue: 3.5.17(typescript@5.5.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@vue/babel-preset-jsx@1.4.0(@babel/core@7.24.5)(vue@3.4.27(typescript@5.5.4))':
+  '@vue/babel-preset-jsx@1.4.0(@babel/core@7.24.5)(vue@3.5.17(typescript@5.5.4))':
     dependencies:
       '@babel/core': 7.24.5
       '@vue/babel-helper-vue-jsx-merge-props': 1.4.0
@@ -26430,7 +26520,7 @@ snapshots:
       '@vue/babel-sugar-v-model': 1.4.0(@babel/core@7.24.5)
       '@vue/babel-sugar-v-on': 1.4.0(@babel/core@7.24.5)
     optionalDependencies:
-      vue: 3.4.27(typescript@5.5.4)
+      vue: 3.5.17(typescript@5.5.4)
 
   '@vue/babel-sugar-composition-api-inject-h@1.4.0(@babel/core@7.24.5)':
     dependencies:
@@ -26471,11 +26561,11 @@ snapshots:
 
   '@vue/cli-overlay@5.0.8': {}
 
-  '@vue/cli-plugin-babel@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3))(core-js@3.37.1)(encoding@0.1.13)(vue@3.4.27(typescript@5.5.4))':
+  '@vue/cli-plugin-babel@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3))(core-js@3.37.1)(encoding@0.1.13)(vue@3.5.17(typescript@5.5.4))':
     dependencies:
       '@babel/core': 7.24.5
-      '@vue/babel-preset-app': 5.0.8(@babel/core@7.24.5)(core-js@3.37.1)(vue@3.4.27(typescript@5.5.4))
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3)
+      '@vue/babel-preset-app': 5.0.8(@babel/core@7.24.5)(core-js@3.37.1)(vue@3.5.17(typescript@5.5.4))
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
       babel-loader: 8.3.0(@babel/core@7.24.5)(webpack@5.91.0)
       thread-loader: 3.0.4(webpack@5.91.0)
@@ -26490,18 +26580,18 @@ snapshots:
       - vue
       - webpack-cli
 
-  '@vue/cli-plugin-router@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3))(encoding@0.1.13)':
+  '@vue/cli-plugin-router@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3))(encoding@0.1.13)':
     dependencies:
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
-  '@vue/cli-plugin-typescript@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3))(encoding@0.1.13)(eslint@8.57.0)(typescript@5.5.4)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))':
+  '@vue/cli-plugin-typescript@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3))(encoding@0.1.13)(eslint@8.57.0)(typescript@5.5.4)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))':
     dependencies:
       '@babel/core': 7.24.5
       '@types/webpack-env': 1.18.5
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
       babel-loader: 8.3.0(@babel/core@7.24.5)(webpack@5.91.0)
       fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.57.0)(typescript@5.5.4)(vue-template-compiler@2.7.16)(webpack@5.91.0)
@@ -26509,7 +26599,7 @@ snapshots:
       thread-loader: 3.0.4(webpack@5.91.0)
       ts-loader: 9.5.1(typescript@5.5.4)(webpack@5.91.0)
       typescript: 5.5.4
-      vue: 3.4.27(typescript@5.5.4)
+      vue: 3.5.17(typescript@5.5.4)
       webpack: 5.91.0(webpack-cli@5.1.4)
     optionalDependencies:
       vue-template-compiler: 2.7.16
@@ -26522,9 +26612,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@vue/cli-plugin-unit-mocha@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3))(encoding@0.1.13)(webpack@5.94.0)':
+  '@vue/cli-plugin-unit-mocha@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3))(encoding@0.1.13)(webpack@5.94.0)':
     dependencies:
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
       jsdom: 18.1.1
       jsdom-global: 3.0.2(jsdom@18.1.1)
@@ -26538,22 +26628,22 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@vue/cli-plugin-vuex@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3))':
+  '@vue/cli-plugin-vuex@5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3))':
     dependencies:
-      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3)
+      '@vue/cli-service': 5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3)
 
-  '@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3)':
+  '@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3)':
     dependencies:
       '@babel/helper-compilation-targets': 7.23.6
       '@soda/friendly-errors-webpack-plugin': 1.8.1(webpack@5.91.0)
       '@soda/get-current-script': 1.0.2
       '@types/minimist': 1.2.5
       '@vue/cli-overlay': 5.0.8
-      '@vue/cli-plugin-router': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3))(encoding@0.1.13)
-      '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.4.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.4.27(typescript@5.5.4))(webpack-sources@3.2.3))
+      '@vue/cli-plugin-router': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3))(encoding@0.1.13)
+      '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.17)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(vue@3.5.17(typescript@5.5.4))(webpack-sources@3.2.3))
       '@vue/cli-shared-utils': 5.0.8(encoding@0.1.13)
       '@vue/component-compiler-utils': 3.3.0(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)
-      '@vue/vue-loader-v15': vue-loader@15.11.1(@vue/compiler-sfc@3.4.27)(css-loader@6.11.0(webpack@5.91.0))(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(webpack@5.91.0)
+      '@vue/vue-loader-v15': vue-loader@15.11.1(@vue/compiler-sfc@3.5.17)(css-loader@6.11.0(webpack@5.91.0))(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(webpack@5.91.0)
       '@vue/web-component-wrapper': 1.3.0
       acorn: 8.11.3
       acorn-walk: 8.3.2
@@ -26590,7 +26680,7 @@ snapshots:
       ssri: 8.0.1
       terser-webpack-plugin: 5.3.10(webpack@5.91.0)
       thread-loader: 3.0.4(webpack@5.91.0)
-      vue-loader: 17.4.2(@vue/compiler-sfc@3.4.27)(vue@3.4.27(typescript@5.5.4))(webpack@5.91.0)
+      vue-loader: 17.4.2(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.5.4))(webpack@5.91.0)
       vue-style-loader: 4.1.3
       webpack: 5.91.0(webpack-cli@5.1.4)
       webpack-bundle-analyzer: 4.10.2
@@ -26697,10 +26787,23 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.0
 
+  '@vue/compiler-core@3.5.17':
+    dependencies:
+      '@babel/parser': 7.28.0
+      '@vue/shared': 3.5.17
+      entities: 4.5.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.4.27':
     dependencies:
       '@vue/compiler-core': 3.4.27
       '@vue/shared': 3.4.27
+
+  '@vue/compiler-dom@3.5.17':
+    dependencies:
+      '@vue/compiler-core': 3.5.17
+      '@vue/shared': 3.5.17
 
   '@vue/compiler-sfc@2.7.16':
     dependencies:
@@ -26722,10 +26825,27 @@ snapshots:
       postcss: 8.4.38
       source-map-js: 1.2.0
 
+  '@vue/compiler-sfc@3.5.17':
+    dependencies:
+      '@babel/parser': 7.28.0
+      '@vue/compiler-core': 3.5.17
+      '@vue/compiler-dom': 3.5.17
+      '@vue/compiler-ssr': 3.5.17
+      '@vue/shared': 3.5.17
+      estree-walker: 2.0.2
+      magic-string: 0.30.17
+      postcss: 8.5.6
+      source-map-js: 1.2.1
+
   '@vue/compiler-ssr@3.4.27':
     dependencies:
       '@vue/compiler-dom': 3.4.27
       '@vue/shared': 3.4.27
+
+  '@vue/compiler-ssr@3.5.17':
+    dependencies:
+      '@vue/compiler-dom': 3.5.17
+      '@vue/shared': 3.5.17
 
   '@vue/compiler-vue2@2.7.16':
     dependencies:
@@ -26859,34 +26979,37 @@ snapshots:
     optionalDependencies:
       typescript: 5.4.5
 
-  '@vue/reactivity@3.4.27':
+  '@vue/reactivity@3.5.17':
     dependencies:
-      '@vue/shared': 3.4.27
+      '@vue/shared': 3.5.17
 
-  '@vue/runtime-core@3.4.27':
+  '@vue/runtime-core@3.5.17':
     dependencies:
-      '@vue/reactivity': 3.4.27
-      '@vue/shared': 3.4.27
+      '@vue/reactivity': 3.5.17
+      '@vue/shared': 3.5.17
 
-  '@vue/runtime-dom@3.4.27':
+  '@vue/runtime-dom@3.5.17':
     dependencies:
-      '@vue/runtime-core': 3.4.27
-      '@vue/shared': 3.4.27
+      '@vue/reactivity': 3.5.17
+      '@vue/runtime-core': 3.5.17
+      '@vue/shared': 3.5.17
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.4.27(vue@3.4.27(typescript@5.4.5))':
+  '@vue/server-renderer@3.5.17(vue@3.5.17(typescript@5.4.5))':
     dependencies:
-      '@vue/compiler-ssr': 3.4.27
-      '@vue/shared': 3.4.27
-      vue: 3.4.27(typescript@5.4.5)
+      '@vue/compiler-ssr': 3.5.17
+      '@vue/shared': 3.5.17
+      vue: 3.5.17(typescript@5.4.5)
 
-  '@vue/server-renderer@3.4.27(vue@3.4.27(typescript@5.5.4))':
+  '@vue/server-renderer@3.5.17(vue@3.5.17(typescript@5.5.4))':
     dependencies:
-      '@vue/compiler-ssr': 3.4.27
-      '@vue/shared': 3.4.27
-      vue: 3.4.27(typescript@5.5.4)
+      '@vue/compiler-ssr': 3.5.17
+      '@vue/shared': 3.5.17
+      vue: 3.5.17(typescript@5.5.4)
 
   '@vue/shared@3.4.27': {}
+
+  '@vue/shared@3.5.17': {}
 
   '@vue/test-utils@2.4.6':
     dependencies:
@@ -26895,7 +27018,7 @@ snapshots:
 
   '@vue/tsconfig@0.5.1': {}
 
-  '@vue/vue3-jest@27.0.0(@babel/core@7.24.5)(babel-jest@27.5.1(@babel/core@7.24.5))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.13.8)(typescript@5.5.4)))(ts-jest@27.1.5(@babel/core@7.24.5)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.24.5))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.13.8)(typescript@5.5.4)))(typescript@5.5.4))(typescript@5.5.4)(vue@3.4.27(typescript@5.5.4))':
+  '@vue/vue3-jest@27.0.0(@babel/core@7.24.5)(babel-jest@27.5.1(@babel/core@7.24.5))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.13.8)(typescript@5.5.4)))(ts-jest@27.1.5(@babel/core@7.24.5)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.24.5))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.13.8)(typescript@5.5.4)))(typescript@5.5.4))(typescript@5.5.4)(vue@3.5.17(typescript@5.5.4))':
     dependencies:
       '@babel/core': 7.24.5
       '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.24.5)
@@ -26906,18 +27029,18 @@ snapshots:
       jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.13.8)(typescript@5.5.4))
       source-map: 0.5.6
       tsconfig: 7.0.0
-      vue: 3.4.27(typescript@5.5.4)
+      vue: 3.5.17(typescript@5.5.4)
     optionalDependencies:
       ts-jest: 27.1.5(@babel/core@7.24.5)(@types/jest@27.5.2)(babel-jest@27.5.1(@babel/core@7.24.5))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.13.8)(typescript@5.5.4)))(typescript@5.5.4)
       typescript: 5.5.4
 
   '@vue/web-component-wrapper@1.3.0': {}
 
-  '@vuetify/loader-shared@2.0.3(vue@3.4.27(typescript@5.4.5))(vuetify@3.7.0)':
+  '@vuetify/loader-shared@2.1.0(vue@3.5.17(typescript@5.4.5))(vuetify@3.9.0)':
     dependencies:
       upath: 2.0.1
-      vue: 3.4.27(typescript@5.4.5)
-      vuetify: 3.7.0(typescript@5.4.5)(vite-plugin-vuetify@2.0.4)(vue@3.4.27(typescript@5.4.5))
+      vue: 3.5.17(typescript@5.4.5)
+      vuetify: 3.9.0(typescript@5.4.5)(vite-plugin-vuetify@2.1.1)(vue@3.5.17(typescript@5.4.5))
 
   '@webassemblyjs/ast@1.12.1':
     dependencies:
@@ -32532,6 +32655,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  magic-string@0.30.17:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
   magicast@0.3.4:
     dependencies:
       '@babel/parser': 7.24.5
@@ -32992,6 +33119,8 @@ snapshots:
   nan@2.19.0: {}
 
   nanoid@3.1.20: {}
+
+  nanoid@3.3.11: {}
 
   nanoid@3.3.7: {}
 
@@ -34457,6 +34586,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   prelude-ls@1.2.1: {}
 
   prettier-linter-helpers@1.0.0:
@@ -35128,9 +35263,9 @@ snapshots:
     optionalDependencies:
       rollup: 2.79.1
 
-  rollup-plugin-vue@6.0.0(@vue/compiler-sfc@3.4.27):
+  rollup-plugin-vue@6.0.0(@vue/compiler-sfc@3.5.17):
     dependencies:
-      '@vue/compiler-sfc': 3.4.27
+      '@vue/compiler-sfc': 3.5.17
       debug: 4.3.4
       hash-sum: 2.0.0
       rollup-pluginutils: 2.8.2
@@ -36677,7 +36812,7 @@ snapshots:
       debug: 4.3.7
       pathe: 1.1.2
       picocolors: 1.0.1
-      vite: 5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
+      vite: 5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -36689,7 +36824,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-dts@3.9.1(@types/node@22.13.8)(rollup@4.22.4)(typescript@5.4.5)(vite@5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)):
+  vite-plugin-dts@3.9.1(@types/node@22.13.8)(rollup@4.22.4)(typescript@5.4.5)(vite@5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)):
     dependencies:
       '@microsoft/api-extractor': 7.43.0(@types/node@22.13.8)
       '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
@@ -36700,44 +36835,44 @@ snapshots:
       typescript: 5.4.5
       vue-tsc: 1.8.27(typescript@5.4.5)
     optionalDependencies:
-      vite: 5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
+      vite: 5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-node-polyfills@0.21.0(rollup@4.22.4)(vite@5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)):
+  vite-plugin-node-polyfills@0.21.0(rollup@4.22.4)(vite@5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.22.4)
       node-stdlib-browser: 1.2.0
-      vite: 5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
+      vite: 5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
     transitivePeerDependencies:
       - rollup
 
-  vite-plugin-static-copy@1.0.6(vite@5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)):
+  vite-plugin-static-copy@1.0.6(vite@5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)):
     dependencies:
       chokidar: 3.6.0
       fast-glob: 3.3.2
       fs-extra: 11.2.0
       picocolors: 1.0.1
-      vite: 5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
+      vite: 5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
 
-  vite-plugin-vuetify@2.0.4(vite@5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))(vue@3.4.27(typescript@5.4.5))(vuetify@3.7.0):
+  vite-plugin-vuetify@2.1.1(vite@5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))(vue@3.5.17(typescript@5.4.5))(vuetify@3.9.0):
     dependencies:
-      '@vuetify/loader-shared': 2.0.3(vue@3.4.27(typescript@5.4.5))(vuetify@3.7.0)
-      debug: 4.3.4
+      '@vuetify/loader-shared': 2.1.0(vue@3.5.17(typescript@5.4.5))(vuetify@3.9.0)
+      debug: 4.3.7
       upath: 2.0.1
-      vite: 5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
-      vue: 3.4.27(typescript@5.4.5)
-      vuetify: 3.7.0(typescript@5.4.5)(vite-plugin-vuetify@2.0.4)(vue@3.4.27(typescript@5.4.5))
+      vite: 5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
+      vue: 3.5.17(typescript@5.4.5)
+      vuetify: 3.9.0(typescript@5.4.5)(vite-plugin-vuetify@2.1.1)(vue@3.5.17(typescript@5.4.5))
     transitivePeerDependencies:
       - supports-color
 
-  vite@5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6):
+  vite@5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.41
-      rollup: 4.21.0
+      postcss: 8.5.6
+      rollup: 4.22.4
     optionalDependencies:
       '@types/node': 22.13.8
       fsevents: 2.3.3
@@ -36778,7 +36913,7 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
+      vite: 5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
       vite-node: 1.6.0(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -36821,7 +36956,7 @@ snapshots:
 
   vue-hot-reload-api@2.3.4: {}
 
-  vue-jest@5.0.0-alpha.10(@babel/core@7.24.5)(babel-jest@27.5.1(@babel/core@7.24.5))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.13.8)(typescript@5.5.4)))(typescript@5.5.4)(vue@3.4.27(typescript@5.5.4)):
+  vue-jest@5.0.0-alpha.10(@babel/core@7.24.5)(babel-jest@27.5.1(@babel/core@7.24.5))(jest@27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.13.8)(typescript@5.5.4)))(typescript@5.5.4)(vue@3.5.17(typescript@5.5.4)):
     dependencies:
       '@babel/core': 7.24.5
       '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.24.5)
@@ -36832,11 +36967,11 @@ snapshots:
       jest: 27.5.1(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@22.13.8)(typescript@5.5.4))
       source-map: 0.5.6
       tsconfig: 7.0.0
-      vue: 3.4.27(typescript@5.5.4)
+      vue: 3.5.17(typescript@5.5.4)
     optionalDependencies:
       typescript: 5.5.4
 
-  vue-loader@15.11.1(@vue/compiler-sfc@3.4.27)(css-loader@6.11.0(webpack@5.91.0))(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(webpack@5.91.0):
+  vue-loader@15.11.1(@vue/compiler-sfc@3.5.17)(css-loader@6.11.0(webpack@5.91.0))(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)(prettier@2.8.8)(vue-template-compiler@2.7.16)(webpack@5.91.0):
     dependencies:
       '@vue/component-compiler-utils': 3.3.0(ejs@3.1.10)(handlebars@4.7.8)(lodash@4.17.21)
       css-loader: 6.11.0(webpack@5.91.0)
@@ -36846,7 +36981,7 @@ snapshots:
       vue-style-loader: 4.1.3
       webpack: 5.91.0(webpack-cli@5.1.4)
     optionalDependencies:
-      '@vue/compiler-sfc': 3.4.27
+      '@vue/compiler-sfc': 3.5.17
       prettier: 2.8.8
       vue-template-compiler: 2.7.16
     transitivePeerDependencies:
@@ -36904,15 +37039,15 @@ snapshots:
       - walrus
       - whiskers
 
-  vue-loader@17.4.2(@vue/compiler-sfc@3.4.27)(vue@3.4.27(typescript@5.5.4))(webpack@5.91.0):
+  vue-loader@17.4.2(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.5.4))(webpack@5.91.0):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
       watchpack: 2.4.1
       webpack: 5.91.0(webpack-cli@5.1.4)
     optionalDependencies:
-      '@vue/compiler-sfc': 3.4.27
-      vue: 3.4.27(typescript@5.5.4)
+      '@vue/compiler-sfc': 3.5.17
+      vue: 3.5.17(typescript@5.5.4)
 
   vue-style-loader@4.1.3:
     dependencies:
@@ -36945,32 +37080,32 @@ snapshots:
       '@vue/compiler-sfc': 2.7.16
       csstype: 3.1.3
 
-  vue@3.4.27(typescript@5.4.5):
+  vue@3.5.17(typescript@5.4.5):
     dependencies:
-      '@vue/compiler-dom': 3.4.27
-      '@vue/compiler-sfc': 3.4.27
-      '@vue/runtime-dom': 3.4.27
-      '@vue/server-renderer': 3.4.27(vue@3.4.27(typescript@5.4.5))
-      '@vue/shared': 3.4.27
+      '@vue/compiler-dom': 3.5.17
+      '@vue/compiler-sfc': 3.5.17
+      '@vue/runtime-dom': 3.5.17
+      '@vue/server-renderer': 3.5.17(vue@3.5.17(typescript@5.4.5))
+      '@vue/shared': 3.5.17
     optionalDependencies:
       typescript: 5.4.5
 
-  vue@3.4.27(typescript@5.5.4):
+  vue@3.5.17(typescript@5.5.4):
     dependencies:
-      '@vue/compiler-dom': 3.4.27
-      '@vue/compiler-sfc': 3.4.27
-      '@vue/runtime-dom': 3.4.27
-      '@vue/server-renderer': 3.4.27(vue@3.4.27(typescript@5.5.4))
-      '@vue/shared': 3.4.27
+      '@vue/compiler-dom': 3.5.17
+      '@vue/compiler-sfc': 3.5.17
+      '@vue/runtime-dom': 3.5.17
+      '@vue/server-renderer': 3.5.17(vue@3.5.17(typescript@5.5.4))
+      '@vue/shared': 3.5.17
     optionalDependencies:
       typescript: 5.5.4
 
-  vuetify@3.7.0(typescript@5.4.5)(vite-plugin-vuetify@2.0.4)(vue@3.4.27(typescript@5.4.5)):
+  vuetify@3.9.0(typescript@5.4.5)(vite-plugin-vuetify@2.1.1)(vue@3.5.17(typescript@5.4.5)):
     dependencies:
-      vue: 3.4.27(typescript@5.4.5)
+      vue: 3.5.17(typescript@5.4.5)
     optionalDependencies:
       typescript: 5.4.5
-      vite-plugin-vuetify: 2.0.4(vite@5.4.2(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))(vue@3.4.27(typescript@5.4.5))(vuetify@3.7.0)
+      vite-plugin-vuetify: 2.1.1(vite@5.4.19(@types/node@22.13.8)(less@4.2.0)(sass@1.77.6)(stylus@0.57.0)(terser@5.31.6))(vue@3.5.17(typescript@5.4.5))(vuetify@3.9.0)
 
   w3c-hr-time@1.0.2:
     dependencies:


### PR DESCRIPTION
- Update to latest Vuetify 3.9.0
- Update to latest Vue 3.5.17
- Update Vue peer dependency to ^3.5.0
- Fix imports for Vuetify promoted from labs
- Fix typings for update events in Vuetify DateControlRenderer
- Regenerate Vuetify test snapshots to fit changes in Vuetify (e.g. setting values in HTML element)
- Add visualViewport mock for Vuetify tests as this seems to be needed after dependency update
- In JsonForms.vue explicitly type provided state as `JsonFormsSubStates` to avoid TS7056