### PR TITLE
ci: Adapt publish.yaml to use npm's trusted publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,7 +24,7 @@ jobs:
   publish:
     permissions:
       contents: 'write'
-      id-token: 'write'
+      id-token: 'write' # Required for npm OIDC
     runs-on: 'ubuntu-latest'
     steps:
       - uses: 'actions/checkout@v4'
@@ -87,5 +87,4 @@ jobs:
         if: github.event.inputs.skip_publish == 'false'
         run: "pnpm publish --recursive ${{  github.event.inputs.stable_release == 'true' && ' ' || '--tag next' }}"
         env:
-          NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'
           NPM_CONFIG_PROVENANCE: 'true'


### PR DESCRIPTION
- Add comment to clarify id-token: write permission
- Remove obsolete usage of NPM auth token