### PR TITLE
Angular Material: Remove outdated TSDOC for AutocompleteControlRenderer

### DIFF
--- a/packages/angular-material/src/library/controls/autocomplete.renderer.ts
+++ b/packages/angular-material/src/library/controls/autocomplete.renderer.ts
@@ -47,28 +47,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 
-/**
- * To use this component you will need to add your own tester:
- * <pre><code>
- * ...
- * export const AutocompleteControlRendererTester: RankedTester = rankWith(2, isEnumControl);
- * ...
- * </code></pre>
- * Add the tester and renderer to JSONForms registry:
- * <pre><code>
- * ...
- * { tester: AutocompleteControlRendererTester, renderer: AutocompleteControlRenderer },
- * ...
- * </code></pre>
- * Furthermore you need to update your module.
- * <pre><code>
- * ...
- * imports: [JsonFormsAngularMaterialModule, MatAutocompleteModule],
- * declarations: [AutocompleteControlRenderer]
- * ...
- * </code></pre>
- *
- */
 @Component({
   selector: 'AutocompleteControlRenderer',
   template: `


### PR DESCRIPTION
# Background

The company I work for ([SICPA Product Security](https://www.sicpa.com/)) is considering adopting JSON Forms for a project.

_Unfortunately_ the project is written in Angular, [and I noticed that the Angular Material renderer set is missing quite a lot of supported features compared to the React/Vue renderer sets](https://jsonforms.io/docs/renderer-sets).

As such, I have been testing the Angular Material renderer set quite thoroughly, and will be contributing some missing features, especially to the Angular Material renderer set.

# Description

The existing TSDoc for `AutocompleteControlRenderer` documents that:
- The tester and renderer needs to be registered with the JSONForms registry manually
- The `MatAutocompleteModule` needs to be manually imported

This is no longer needed since #1170