### PR TITLE
feat: Pass oneOf subschema to Translator

### DIFF
--- a/packages/core/src/mappers/renderer.ts
+++ b/packages/core/src/mappers/renderer.ts
@@ -349,11 +349,11 @@ export const oneOfToEnumOptionMapper = (
   if (t) {
     // prefer schema keys as they can be more specialized
     if (e.i18n) {
-      label = t(e.i18n, label);
+      label = t(e.i18n, label, { schema: e });
     } else if (fallbackI18nKey) {
-      label = t(`${fallbackI18nKey}.${label}`, label);
+      label = t(`${fallbackI18nKey}.${label}`, label, { schema: e });
     } else {
-      label = t(label, label);
+      label = t(label, label, { schema: e });
     }
   }
   return {


### PR DESCRIPTION
When translating [oneOf](https://jsonforms.io/docs/multiple-choice#one-of), pass the subschema to the `Translator` to be consistent with other `Translator` calls so that the `Translator` can access the subschema, e.g.
https://github.com/eclipsesource/jsonforms/blob/6bbfbb331df36343b0346d41ed80854456fff9ff/packages/core/src/i18n/i18nUtil.ts#L126-L131