### PR TITLE
Filter error keywords before touch

### DIFF
--- a/packages/vue-vuetify/dev/components/ExampleAppBar.vue
+++ b/packages/vue-vuetify/dev/components/ExampleAppBar.vue
@@ -24,7 +24,7 @@ const appStore = useAppStore();
       <v-container fill-height fluid justify-end
         ><v-row dense>
           <v-col>
-            <v-tooltip bottom>
+            <v-tooltip location="bottom">
               <template v-slot:activator="{ props }">
                 <v-btn
                   icon
@@ -42,7 +42,7 @@ const appStore = useAppStore();
           </v-col>
           <v-col><theme-changer /> </v-col>
           <v-col>
-            <v-tooltip bottom>
+            <v-tooltip location="bottom">
               <template v-slot:activator="{ props }">
                 <v-btn
                   large

--- a/packages/vue-vuetify/dev/components/ExampleSettings.vue
+++ b/packages/vue-vuetify/dev/components/ExampleSettings.vue
@@ -262,7 +262,7 @@ const layouts = appstoreLayouts.map((value: AppstoreLayouts) => ({
     <v-container>
       <v-row>
         <v-col>
-          <v-tooltip bottom>
+          <v-tooltip location="bottom">
             <template v-slot:activator="{ props }">
               <v-switch
                 v-model="appStore.overrideControlTemplate"
@@ -282,7 +282,7 @@ const layouts = appstoreLayouts.map((value: AppstoreLayouts) => ({
       <v-row><v-col>Options</v-col></v-row>
       <v-row>
         <v-col>
-          <v-tooltip bottom>
+          <v-tooltip location="bottom">
             <template v-slot:activator="{ props }">
               <v-switch
                 v-model="appStore.jsonforms.config.hideRequiredAsterisk"
@@ -296,7 +296,7 @@ const layouts = appstoreLayouts.map((value: AppstoreLayouts) => ({
       </v-row>
       <v-row>
         <v-col>
-          <v-tooltip bottom>
+          <v-tooltip location="bottom">
             <template v-slot:activator="{ props }">
               <v-switch
                 v-model="appStore.jsonforms.config.showUnfocusedDescription"
@@ -310,7 +310,7 @@ const layouts = appstoreLayouts.map((value: AppstoreLayouts) => ({
       </v-row>
       <v-row>
         <v-col>
-          <v-tooltip bottom>
+          <v-tooltip location="bottom">
             <template v-slot:activator="{ props }">
               <v-switch
                 v-model="appStore.jsonforms.config.restrict"
@@ -325,7 +325,7 @@ const layouts = appstoreLayouts.map((value: AppstoreLayouts) => ({
       </v-row>
       <v-row>
         <v-col>
-          <v-tooltip bottom>
+          <v-tooltip location="bottom">
             <template v-slot:activator="{ props }">
               <v-switch
                 v-model="appStore.jsonforms.readonly"
@@ -339,7 +339,7 @@ const layouts = appstoreLayouts.map((value: AppstoreLayouts) => ({
       </v-row>
       <v-row>
         <v-col>
-          <v-tooltip bottom>
+          <v-tooltip location="bottom">
             <template v-slot:activator="{ props }">
               <v-switch
                 v-model="appStore.jsonforms.config.collapseNewItems"
@@ -353,7 +353,7 @@ const layouts = appstoreLayouts.map((value: AppstoreLayouts) => ({
       </v-row>
       <v-row>
         <v-col>
-          <v-tooltip bottom>
+          <v-tooltip location="bottom">
             <template v-slot:activator="{ props }">
               <v-switch
                 v-model="appStore.jsonforms.config.hideArraySummaryValidation"
@@ -367,7 +367,7 @@ const layouts = appstoreLayouts.map((value: AppstoreLayouts) => ({
       </v-row>
       <v-row>
         <v-col>
-          <v-tooltip bottom>
+          <v-tooltip location="bottom">
             <template v-slot:activator="{ props }">
               <v-switch
                 v-model="appStore.jsonforms.config.initCollapsed"
@@ -381,7 +381,7 @@ const layouts = appstoreLayouts.map((value: AppstoreLayouts) => ({
       </v-row>
       <v-row>
         <v-col>
-          <v-tooltip bottom>
+          <v-tooltip location="bottom">
             <template v-slot:activator="{ props }">
               <v-switch
                 v-model="appStore.jsonforms.config.hideAvatar"
@@ -395,7 +395,7 @@ const layouts = appstoreLayouts.map((value: AppstoreLayouts) => ({
       </v-row>
       <v-row>
         <v-col>
-          <v-tooltip bottom>
+          <v-tooltip location="bottom">
             <template v-slot:activator="{ props }">
               <v-switch
                 v-model="
@@ -411,7 +411,29 @@ const layouts = appstoreLayouts.map((value: AppstoreLayouts) => ({
       </v-row>
       <v-row>
         <v-col>
-          <v-tooltip bottom>
+          <v-tooltip location="bottom">
+            <template v-slot:activator="{ props }">
+              <v-combobox
+                v-model="
+                  appStore.jsonforms.config.filterErrorKeywordsBeforeTouch
+                "
+                label="Filter Error Keywords Before Touch"
+                placeholder="e.g., required, minLength, pattern"
+                chips
+                closable-chips
+                multiple
+                clearable
+                v-bind="props"
+              ></v-combobox>
+            </template>
+            Hide specific AJV error keywords until the control is touched.
+            Requires "Enable Filter Errors Before Touch".
+          </v-tooltip>
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col>
+          <v-tooltip location="bottom">
             <template v-slot:activator="{ props }">
               <v-switch
                 v-model="

--- a/packages/vue-vuetify/dev/components/ThemeChanger.vue
+++ b/packages/vue-vuetify/dev/components/ThemeChanger.vue
@@ -23,7 +23,7 @@ const setTheme = (theme: string) => {
     offset-y
   >
     <template v-slot:activator="{ props: propsMenu }">
-      <v-tooltip bottom>
+      <v-tooltip location="bottom">
         <template v-slot:activator="{ props: propsTooltip }">
           <v-btn large icon dark>
             <v-icon

--- a/packages/vue-vuetify/dev/store/index.ts
+++ b/packages/vue-vuetify/dev/store/index.ts
@@ -32,6 +32,7 @@ const appstore = reactive({
       hideAvatar: false,
       hideArraySummaryValidation: false,
       enableFilterErrorsBeforeTouch: false,
+      filterErrorKeywordsBeforeTouch: ['required'],
       allowAdditionalPropertiesIfMissing: false,
     },
     locale: useLocalStorage('vuetify-example-locale', 'en'),

--- a/packages/vue-vuetify/dev/views/ExampleView.vue
+++ b/packages/vue-vuetify/dev/views/ExampleView.vue
@@ -355,7 +355,7 @@ const handleAction = (action: Action) => {
                         <v-toolbar flat>
                           <v-toolbar-title>Data</v-toolbar-title>
                           <v-spacer></v-spacer>
-                          <v-tooltip bottom>
+                          <v-tooltip location="bottom">
                             <template v-slot:activator="{ props }">
                               <v-btn
                                 icon
@@ -367,7 +367,7 @@ const handleAction = (action: Action) => {
                             </template>
                             {{ `Reload Example Data` }}
                           </v-tooltip>
-                          <v-tooltip bottom>
+                          <v-tooltip location="bottom">
                             <template v-slot:activator="{ props }">
                               <v-btn
                                 icon
@@ -402,7 +402,7 @@ const handleAction = (action: Action) => {
                 <v-toolbar flat>
                   <v-toolbar-title>Schema</v-toolbar-title>
                   <v-spacer></v-spacer>
-                  <v-tooltip bottom>
+                  <v-tooltip location="bottom">
                     <template v-slot:activator="{ props }">
                       <v-btn icon @click="reloadMonacoSchema" v-bind="props">
                         <v-icon>$reload</v-icon>
@@ -410,7 +410,7 @@ const handleAction = (action: Action) => {
                     </template>
                     {{ `Reload Example Schema` }}
                   </v-tooltip>
-                  <v-tooltip bottom>
+                  <v-tooltip location="bottom">
                     <template v-slot:activator="{ props }">
                       <v-btn icon @click="saveMonacoSchema" v-bind="props">
                         <v-icon>$save</v-icon>
@@ -435,7 +435,7 @@ const handleAction = (action: Action) => {
                 <v-toolbar flat>
                   <v-toolbar-title>UI Schema</v-toolbar-title>
                   <v-spacer></v-spacer>
-                  <v-tooltip bottom>
+                  <v-tooltip location="bottom">
                     <template v-slot:activator="{ props }">
                       <v-btn icon @click="reloadMonacoUiSchema" v-bind="props">
                         <v-icon>$reload</v-icon>
@@ -443,7 +443,7 @@ const handleAction = (action: Action) => {
                     </template>
                     {{ `Reload Example UI Schema` }}
                   </v-tooltip>
-                  <v-tooltip bottom>
+                  <v-tooltip location="bottom">
                     <template v-slot:activator="{ props }">
                       <v-btn icon @click="saveMonacoUiSchema" v-bind="props">
                         <v-icon>$save</v-icon>
@@ -468,7 +468,7 @@ const handleAction = (action: Action) => {
                 <v-toolbar flat>
                   <v-toolbar-title>Data</v-toolbar-title>
                   <v-spacer></v-spacer>
-                  <v-tooltip bottom>
+                  <v-tooltip location="bottom">
                     <template v-slot:activator="{ props }">
                       <v-btn icon @click="reloadMonacoData" v-bind="props">
                         <v-icon>$reload</v-icon>
@@ -476,7 +476,7 @@ const handleAction = (action: Action) => {
                     </template>
                     {{ `Reload Example Data` }}
                   </v-tooltip>
-                  <v-tooltip bottom>
+                  <v-tooltip location="bottom">
                     <template v-slot:activator="{ props }">
                       <v-btn icon @click="saveMonacoData" v-bind="props">
                         <v-icon>$save</v-icon>

--- a/packages/vue-vuetify/src/additional/ListWithDetailRenderer.vue
+++ b/packages/vue-vuetify/src/additional/ListWithDetailRenderer.vue
@@ -15,7 +15,7 @@
             v-if="control.childErrors.length > 0"
             :errors="control.childErrors"
           />
-          <v-tooltip bottom>
+          <v-tooltip location="bottom">
             <template v-slot:activator="{ props }">
               <v-btn
                 icon
@@ -80,7 +80,7 @@
                   </validation-badge>
                 </template>
                 <v-list-item-title>
-                  <v-tooltip bottom>
+                  <v-tooltip location="bottom">
                     <template v-slot:activator="{ props }">
                       <span
                         v-bind="props"
@@ -135,7 +135,7 @@
                     </template>
                     {{ control.translations.down }}
                   </v-tooltip>
-                  <v-tooltip bottom>
+                  <v-tooltip location="bottom">
                     <template v-slot:activator="{ props }">
                       <v-btn
                         v-bind="props"

--- a/packages/vue-vuetify/src/complex/ArrayControlRenderer.vue
+++ b/packages/vue-vuetify/src/complex/ArrayControlRenderer.vue
@@ -22,7 +22,7 @@
           v-if="control.childErrors.length > 0"
           :errors="control.childErrors"
         />
-        <v-tooltip bottom>
+        <v-tooltip location="bottom">
           <template v-slot:activator="{ props }">
             <v-btn
               icon
@@ -110,7 +110,7 @@
                       : 'fixed-cell-small'
                   "
                 >
-                  <v-tooltip bottom>
+                  <v-tooltip location="bottom">
                     <template v-slot:activator="{ props }">
                       <v-btn
                         v-bind="props"
@@ -131,7 +131,7 @@
                     </template>
                     {{ control.translations.up }}
                   </v-tooltip>
-                  <v-tooltip bottom>
+                  <v-tooltip location="bottom">
                     <template v-slot:activator="{ props }">
                       <v-btn
                         v-bind="props"
@@ -152,7 +152,7 @@
                     </template>
                     {{ control.translations.down }}
                   </v-tooltip>
-                  <v-tooltip bottom>
+                  <v-tooltip location="bottom">
                     <template v-slot:activator="{ props }">
                       <v-btn
                         v-bind="props"

--- a/packages/vue-vuetify/src/complex/components/AdditionalProperties.vue
+++ b/packages/vue-vuetify/src/complex/components/AdditionalProperties.vue
@@ -28,7 +28,7 @@
             @change="propertyNameChange"
           ></json-forms
         ></v-col>
-        <v-tooltip bottom>
+        <v-tooltip location="bottom">
           <template v-slot:activator="{ props }">
             <v-btn
               icon
@@ -64,7 +64,7 @@
             :cells="control.cells"
         /></v-col>
         <v-col v-if="control.enabled" class="flex-shrink-1 flex-grow-0">
-          <v-tooltip bottom>
+          <v-tooltip location="bottom">
             <template v-slot:activator="{ props }">
               <v-btn
                 v-bind="props"

--- a/packages/vue-vuetify/src/layouts/ArrayLayoutRenderer.vue
+++ b/packages/vue-vuetify/src/layouts/ArrayLayoutRenderer.vue
@@ -35,7 +35,7 @@
           :styles="styles"
           :icons="icons"
         >
-          <v-tooltip bottom>
+          <v-tooltip location="bottom">
             <template v-slot:activator="{ props }">
               <v-btn
                 icon
@@ -109,7 +109,7 @@
                       align-self="center"
                       v-if="appliedOptions.showSortButtons"
                     >
-                      <v-tooltip bottom>
+                      <v-tooltip location="bottom">
                         <template v-slot:activator="{ props }">
                           <v-btn
                             v-bind="props"
@@ -135,7 +135,7 @@
                       align-self="center"
                       v-if="appliedOptions.showSortButtons"
                     >
-                      <v-tooltip bottom>
+                      <v-tooltip location="bottom">
                         <template v-slot:activator="{ props }">
                           <v-btn
                             v-bind="props"
@@ -160,7 +160,7 @@
                       </v-tooltip>
                     </v-col>
                     <v-col align-self="center">
-                      <v-tooltip bottom>
+                      <v-tooltip location="bottom">
                         <template v-slot:activator="{ props }">
                           <v-btn
                             v-bind="props"

--- a/packages/vue-vuetify/src/util/composition.ts
+++ b/packages/vue-vuetify/src/util/composition.ts
@@ -10,8 +10,11 @@ import {
   defaultJsonFormsI18nState,
   getArrayTranslations,
   getCombinatorTranslations,
+  getCombinedErrorMessage,
   getControlPath,
+  getErrorTranslator,
   getFirstPrimitiveProp,
+  getTranslator,
   isDescriptionHidden,
   type ControlElement,
   type DispatchPropsOfControl,
@@ -132,6 +135,7 @@ export const useVuetifyLabel = <
  */
 export const useVuetifyControl = <
   T extends {
+    schema: JsonSchema;
     uischema: ControlElement;
     path: string;
     config: any;
@@ -198,13 +202,26 @@ export const useVuetifyControl = <
           (error) => input.control.value.path === getControlPath(error),
         ) ?? [];
 
-      const allErrorsFiltered =
-        errorsAtControl.length > 0 &&
-        errorsAtControl.every(
-          (error) => error.keyword && filterKeywords.includes(error.keyword),
-        );
+      // Filter out errors that match the filterKeywords, keep the rest
+      const errorsToShow = errorsAtControl.filter(
+        (error) => !error.keyword || !filterKeywords.includes(error.keyword),
+      );
+      // If no errors were filtered out (all errors remain), return original errors string
+      if (errorsToShow.length === errorsAtControl.length) {
+        return input.control.value.errors;
+      }
 
-      return allErrorsFiltered ? '' : input.control.value.errors;
+      const t = getTranslator()({ jsonforms });
+      const te = getErrorTranslator()({ jsonforms });
+
+      return getCombinedErrorMessage(
+        errorsToShow,
+        te,
+        t,
+        input.control.value.schema,
+        input.control.value.uischema,
+        input.control.value.path,
+      );
     }
 
     // default, all errors are filtered
@@ -410,13 +427,31 @@ export const useVuetifyArrayControl = <
     return `${labelValue}`;
   };
   const filteredChildErrors = computed(() => {
+    if (
+      !input.control.value.childErrors ||
+      input.control.value.childErrors.length === 0 ||
+      !appliedOptions.value.enableFilterErrorsBeforeTouch
+    ) {
+      return input.control.value.childErrors;
+    }
+
     // supress childErrors unless touch filtering is disabled
     // otherwise all child errors will show, irrespective of their control touch state
-    const filtered: ErrorObject[] = appliedOptions.value
-      ?.enableFilterErrorsBeforeTouch
-      ? []
-      : input.control.value.childErrors;
-    return filtered;
+
+    const filterKeywords = appliedOptions.value.filterErrorKeywordsBeforeTouch;
+
+    // Filtering is enabled - check if specific keywords are configured
+    if (Array.isArray(filterKeywords) && filterKeywords.length > 0) {
+      // Granular filtering: only hide specific error keywords
+      const errorsToShow = input.control.value.childErrors.filter(
+        (error) => !error.keyword || !filterKeywords.includes(error.keyword),
+      );
+
+      return errorsToShow;
+    }
+
+    // default, all child errors are filtered
+    return [];
   });
 
   const jsonforms = inject<JsonFormsSubStates>('jsonforms');


### PR DESCRIPTION
A new configuration option, filterErrorKeywordsBeforeTouch, allows selective suppression of validation errors before a control is touched, based on AJV error keywords.

This option exists because in most real-world forms, only certain errors—most commonly required—should be hidden prior to user interaction. Other validation errors (such as minLength, pattern, or format) often provide useful guidance and should remain visible immediately.

Instead of hiding all validation errors before interaction, you can now explicitly choose which error types are suppressed and which are shown.

This option is only applied when enableFilterErrorsBeforeTouch is enabled.
If enableFilterErrorsBeforeTouch is false, filterErrorKeywordsBeforeTouch has no effect and all validation errors are shown immediately.

If enableFilterErrorsBeforeTouch is true and filterErrorKeywordsBeforeTouch is not provided, the default behavior applies: no validation errors are shown before the control is touched.

Once the control is touched, all validation errors are always displayed, regardless of these settings.