### PR TITLE
Angular Material: Remove EnumOption[] type from AutocompleteControlRenderer.options

### DIFF
--- a/packages/angular-material/src/library/controls/autocomplete.renderer.ts
+++ b/packages/angular-material/src/library/controls/autocomplete.renderer.ts
@@ -110,7 +110,7 @@ export class AutocompleteControlRenderer
   extends JsonFormsControl
   implements OnInit
 {
-  @Input() options?: EnumOption[] | string[];
+  @Input() options?: string[];
   valuesToTranslatedOptions?: Map<string, EnumOption>;
   filteredOptions: Observable<EnumOption[]>;
   shouldFilter: boolean;
@@ -209,28 +209,13 @@ export class AutocompleteControlRenderer
   protected getOwnProps(): OwnPropsOfControl & OwnPropsOfEnum {
     return {
       ...super.getOwnProps(),
-      options: this.stringOptionsToEnumOptions(this.options),
+      options: this.options?.map((str) => {
+        return {
+          label: str,
+          value: str,
+        } satisfies EnumOption;
+      }),
     };
-  }
-
-  /**
-   * For {@link options} input backwards compatibility
-   */
-  protected stringOptionsToEnumOptions(
-    options: typeof this.options
-  ): EnumOption[] | undefined {
-    if (!options) {
-      return undefined;
-    }
-
-    return options.every((item) => typeof item === 'string')
-      ? options.map((str) => {
-          return {
-            label: str,
-            value: str,
-          } satisfies EnumOption;
-        })
-      : options;
   }
 }
 


### PR DESCRIPTION
In #2535, I changed `AutocompleteControlRenderer.options` from `string[]` to `EnumOption[] | string[]`, then mapped the `EnumOption[] | string[]` to `EnumOption[]`, which was the type of the internal `options` prop, using the `stringOptionsToEnumOptions` function.

This allowed users of the `AutocompleteControlRenderer` to pass `EnumOption`s with differing `label` and `value`, which should not be allowed.