### PR TITLE
angular: remove deprecated use of ComponentFactoryResolver

### DIFF
--- a/packages/angular/src/library/jsonforms.component.ts
+++ b/packages/angular/src/library/jsonforms.component.ts
@@ -24,7 +24,6 @@
 */
 import maxBy from 'lodash/maxBy';
 import {
-  ComponentFactoryResolver,
   Directive,
   Input,
   OnInit,
@@ -76,7 +75,6 @@ export class JsonFormsOutlet
 
   constructor(
     private viewContainerRef: ViewContainerRef,
-    private componentFactoryResolver: ComponentFactoryResolver,
     private jsonformsService: JsonFormsAngularService
   ) {
     super();
@@ -128,11 +126,9 @@ export class JsonFormsOutlet
       bestComponent = renderer.renderer;
     }
 
-    const componentFactory =
-      this.componentFactoryResolver.resolveComponentFactory(bestComponent);
     this.viewContainerRef.clear();
     const currentComponentRef =
-      this.viewContainerRef.createComponent(componentFactory);
+      this.viewContainerRef.createComponent(bestComponent);
 
     if (currentComponentRef.instance instanceof JsonFormsBaseRenderer) {
       const instance =


### PR DESCRIPTION
- Replaced by using ViewContainerRef.createComponent directly with a component.
- Needed for compatibility with Angular 22 which removes API access to ComponentFactoryResolver