### PR TITLE
core: handle nullable object/array in generateUISchema

### DIFF
--- a/packages/core/src/generators/uischema.ts
+++ b/packages/core/src/generators/uischema.ts
@@ -141,13 +141,21 @@ const generateUISchema = (
     return null;
   }
 
-  if (types.length > 1) {
+  // If the schema declares multiple types alongside 'null' (e.g. ['null', 'object']),
+  // treat it as a nullable instance of the non-null type for UI generation purposes.
+  // Without this, a nested nullable object would only produce a single Control,
+  // which can lead to infinite recursion when an object renderer regenerates the
+  // UI schema for that nested schema (see issue #2411).
+  const nonNullTypes = types.filter((t) => t !== 'null');
+  const effectiveTypes = nonNullTypes.length > 0 ? nonNullTypes : types;
+
+  if (effectiveTypes.length > 1) {
     const controlObject: ControlElement = createControlElement(currentRef);
     schemaElements.push(controlObject);
     return controlObject;
   }
 
-  if (currentRef === '#' && types[0] === 'object') {
+  if (currentRef === '#' && effectiveTypes[0] === 'object') {
     const layout: Layout = createLayout(layoutType);
     schemaElements.push(layout);
 
@@ -178,7 +186,7 @@ const generateUISchema = (
     return layout;
   }
 
-  switch (types[0]) {
+  switch (effectiveTypes[0]) {
     case 'object': // object items will be handled by the object control itself
     /* falls through */
     case 'array': // array items will be handled by the array control itself

--- a/packages/core/test/generators/uischema.test.ts
+++ b/packages/core/test/generators/uischema.test.ts
@@ -206,6 +206,105 @@ test(`nested object not expanded`, (t) => {
   t.deepEqual(generateDefaultUISchema(schema), uischema);
 });
 
+test('generate ui schema for nullable object property (issue #2411)', (t) => {
+  const schema: JsonSchema = {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+      },
+      geometry: {
+        type: ['null', 'object'],
+        properties: {
+          shape: {
+            type: 'string',
+          },
+        },
+      },
+    },
+  };
+  const nameControl: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/name',
+  };
+  const geometryControl: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/geometry',
+  };
+  const uischema: Layout = {
+    type: 'VerticalLayout',
+    elements: [nameControl, geometryControl],
+  };
+  t.deepEqual(generateDefaultUISchema(schema), uischema);
+});
+
+test('generate ui schema for nullable object at root', (t) => {
+  const schema: JsonSchema = {
+    type: ['null', 'object'],
+    properties: {
+      shape: {
+        type: 'string',
+      },
+      size: {
+        type: 'number',
+      },
+    },
+  };
+  const shapeControl: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/shape',
+  };
+  const sizeControl: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/size',
+  };
+  const uischema: Layout = {
+    type: 'VerticalLayout',
+    elements: [shapeControl, sizeControl],
+  };
+  t.deepEqual(generateDefaultUISchema(schema), uischema);
+});
+
+test('generate ui schema for nullable primitive property', (t) => {
+  const schema: JsonSchema = {
+    type: 'object',
+    properties: {
+      maybeName: {
+        type: ['null', 'string'],
+      },
+    },
+  };
+  const control: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/maybeName',
+  };
+  const uischema: Layout = {
+    type: 'VerticalLayout',
+    elements: [control],
+  };
+  t.deepEqual(generateDefaultUISchema(schema), uischema);
+});
+
+test('generate ui schema falls back to single Control for multi non-null types', (t) => {
+  const schema: JsonSchema = {
+    type: 'object',
+    properties: {
+      mixed: {
+        type: ['string', 'integer'],
+      },
+    },
+  };
+  const control: ControlElement = {
+    type: 'Control',
+    scope: '#/properties/mixed',
+  };
+  const uischema: Layout = {
+    type: 'VerticalLayout',
+    elements: [control],
+  };
+  t.deepEqual(generateDefaultUISchema(schema), uischema);
+});
+
 test(`don't ignore non-json-schema id attributes`, (t) => {
   const schema = {
     type: 'object',

--- a/packages/examples/src/examples/mixed-object.ts
+++ b/packages/examples/src/examples/mixed-object.ts
@@ -36,6 +36,19 @@ export const schema = {
     nullableString: {
       type: ['string', 'null'],
     },
+    nullableObject: {
+      type: ['object', 'null'],
+      description:
+        'A nullable object whose properties should still be rendered.',
+      properties: {
+        shape: {
+          type: 'string',
+        },
+        size: {
+          type: 'number',
+        },
+      },
+    },
     mixed: {
       type: [
         'array',
@@ -64,6 +77,10 @@ export const uischema = {
     },
     {
       type: 'Control',
+      scope: '#/properties/nullableObject',
+    },
+    {
+      type: 'Control',
       scope: '#/properties/mixed',
     },
   ],
@@ -72,6 +89,10 @@ export const uischema = {
 const data = {
   mixedSimple: 'String',
   nullableString: null as any,
+  nullableObject: {
+    shape: 'circle',
+    size: 5,
+  },
 };
 
 registerExamples([


### PR DESCRIPTION
Treat ['null', T] type arrays as nullable T for UI generation so that nested nullable objects traverse their properties instead of producing a bare Control. This avoids infinite recursion in object renderers that regenerate the UI schema for nested nullable objects.

Fixes #2411