### PR TITLE
feat(renderers): add mixed and additional property editors

### DIFF
--- a/packages/angular-material/src/library/index.ts
+++ b/packages/angular-material/src/library/index.ts
@@ -62,6 +62,7 @@ import {
   ObjectControlRenderer,
   ObjectControlRendererTester,
 } from './other/object.renderer';
+import { MixedRenderer, MixedRendererTester } from './other/mixed.renderer';
 import {
   VerticalLayoutRenderer,
   verticalLayoutTester,
@@ -109,6 +110,7 @@ export const angularMaterialRenderers: {
   { tester: ToggleControlRendererTester, renderer: ToggleControlRenderer },
   { tester: enumControlTester, renderer: EnumControlRenderer },
   { tester: oneOfEnumControlTester, renderer: OneOfEnumControlRenderer },
+  { tester: MixedRendererTester, renderer: MixedRenderer },
   { tester: ObjectControlRendererTester, renderer: ObjectControlRenderer },
   // layouts
   { tester: verticalLayoutTester, renderer: VerticalLayoutRenderer },

--- a/packages/angular-material/src/library/module.ts
+++ b/packages/angular-material/src/library/module.ts
@@ -43,6 +43,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTableModule } from '@angular/material/table';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatTreeModule } from '@angular/material/tree';
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { JsonFormsModule } from '@jsonforms/angular';
 import { BooleanControlRenderer } from './controls/boolean.renderer';
@@ -57,6 +58,8 @@ import { TextAreaRenderer } from './controls/textarea.renderer';
 import { TextControlRenderer } from './controls/text.renderer';
 import { ToggleControlRenderer } from './controls/toggle.renderer';
 import { LabelRenderer } from './other/label.renderer';
+import { AdditionalPropertiesRenderer } from './other/additional-properties.renderer';
+import { MixedRenderer } from './other/mixed.renderer';
 import { JsonFormsDetailComponent } from './other/master-detail/detail';
 import { MasterListComponent } from './other/master-detail/master';
 import { ObjectControlRenderer } from './other/object.renderer';
@@ -92,6 +95,7 @@ import { LayoutChildrenRenderPropsPipe } from './layouts';
     MatToolbarModule,
     MatTooltipModule,
     MatBadgeModule,
+    MatTreeModule,
     BooleanControlRenderer,
     TextAreaRenderer,
     TextControlRenderer,
@@ -106,6 +110,8 @@ import { LayoutChildrenRenderPropsPipe } from './layouts';
     LabelRenderer,
     MasterListComponent,
     JsonFormsDetailComponent,
+    AdditionalPropertiesRenderer,
+    MixedRenderer,
     ObjectControlRenderer,
     EnumControlRenderer,
     OneOfEnumControlRenderer,
@@ -147,6 +153,8 @@ import { LayoutChildrenRenderPropsPipe } from './layouts';
     LabelRenderer,
     MasterListComponent,
     JsonFormsDetailComponent,
+    AdditionalPropertiesRenderer,
+    MixedRenderer,
     ObjectControlRenderer,
     EnumControlRenderer,
     OneOfEnumControlRenderer,

--- a/packages/angular-material/src/library/other/additional-properties.renderer.ts
+++ b/packages/angular-material/src/library/other/additional-properties.renderer.ts
@@ -1,0 +1,698 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017-2026 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ViewEncapsulation,
+  Input,
+  OnChanges,
+  SimpleChanges,
+  inject,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { JsonFormsModule, JsonFormsAngularService } from '@jsonforms/angular';
+import {
+  Actions,
+  composePaths,
+  ControlElement,
+  createControlElement,
+  createDefaultValue,
+  Generate,
+  GroupLayout,
+  JsonFormsCellRendererRegistryEntry,
+  JsonFormsRendererRegistryEntry,
+  JsonSchema,
+  JsonSchema7,
+  Resolve,
+  UISchemaElement,
+} from '@jsonforms/core';
+import startCase from 'lodash/startCase';
+
+interface AdditionalPropertyItem {
+  propertyName: string;
+  path: string;
+  schema: JsonSchema;
+  uischema: UISchemaElement;
+}
+
+const ANY_TYPE: JsonSchema7['type'] = [
+  'array',
+  'boolean',
+  'integer',
+  'null',
+  'number',
+  'object',
+  'string',
+];
+
+const toObjectSchema = (schema: JsonSchema): JsonSchema7 =>
+  typeof schema === 'object' ? (schema as JsonSchema7) : {};
+
+const hasAdditionalProperties = (schema: JsonSchema): boolean => {
+  const objectSchema = toObjectSchema(schema);
+  return (
+    Boolean(
+      objectSchema.patternProperties &&
+        Object.keys(objectSchema.patternProperties).length > 0
+    ) ||
+    typeof objectSchema.additionalProperties === 'object' ||
+    objectSchema.additionalProperties === true
+  );
+};
+
+const getMatchingAdditionalPropertySchema = (
+  propName: string,
+  parentSchema: JsonSchema,
+  rootSchema: JsonSchema
+): JsonSchema => {
+  const objectSchema = toObjectSchema(parentSchema);
+  let propSchema: JsonSchema | undefined;
+
+  if (objectSchema.patternProperties) {
+    const matchedPattern = Object.keys(objectSchema.patternProperties).find(
+      (pattern) => new RegExp(pattern).test(propName)
+    );
+    if (matchedPattern) {
+      propSchema = objectSchema.patternProperties[matchedPattern];
+    }
+  }
+
+  if (
+    (!propSchema && typeof objectSchema.additionalProperties === 'object') ||
+    objectSchema.additionalProperties === true
+  ) {
+    propSchema =
+      objectSchema.additionalProperties === true
+        ? { additionalProperties: true }
+        : objectSchema.additionalProperties;
+  }
+
+  if (typeof propSchema === 'object' && typeof propSchema.$ref === 'string') {
+    propSchema = Resolve.schema(rootSchema, propSchema.$ref, rootSchema);
+  }
+
+  propSchema = propSchema ?? {};
+
+  if (typeof propSchema === 'object' && propSchema.type === undefined) {
+    propSchema = {
+      ...propSchema,
+      type: ANY_TYPE,
+    };
+  }
+
+  return propSchema;
+};
+
+const toAdditionalPropertyItem = (
+  propName: string,
+  parentPath: string,
+  parentSchema: JsonSchema,
+  rootSchema: JsonSchema
+): AdditionalPropertyItem => {
+  let propSchema = getMatchingAdditionalPropertySchema(
+    propName,
+    parentSchema,
+    rootSchema
+  );
+  let propUiSchema: UISchemaElement = createControlElement('#');
+
+  if (typeof propSchema === 'object' && propSchema.type === 'array') {
+    propUiSchema = Generate.uiSchema(
+      propSchema,
+      'Group',
+      undefined,
+      rootSchema
+    );
+    (propUiSchema as GroupLayout).label =
+      propSchema.title ?? startCase(propName);
+  }
+
+  if (typeof propSchema === 'object') {
+    propSchema = {
+      ...propSchema,
+      title: propName,
+    };
+    if (propSchema.type === 'object') {
+      propSchema.additionalProperties =
+        propSchema.additionalProperties !== false
+          ? propSchema.additionalProperties ?? true
+          : false;
+    } else if (propSchema.type === 'array') {
+      propSchema.items = propSchema.items ?? {};
+    }
+  }
+
+  return {
+    propertyName: propName,
+    path: composePaths(parentPath, propName),
+    schema: propSchema,
+    uischema: propUiSchema,
+  };
+};
+
+const getPropertyNamePattern = (schema: JsonSchema): string | undefined => {
+  const objectSchema = toObjectSchema(schema);
+  const propertyNames = objectSchema.propertyNames as JsonSchema7 | undefined;
+  if (typeof propertyNames === 'object' && propertyNames.pattern) {
+    return propertyNames.pattern;
+  }
+
+  if (
+    objectSchema.additionalProperties === false &&
+    objectSchema.patternProperties
+  ) {
+    const patterns = Object.keys(objectSchema.patternProperties);
+    return patterns.length > 0 ? patterns.join('|') : undefined;
+  }
+
+  return undefined;
+};
+
+@Component({
+  selector: 'AdditionalPropertiesRenderer',
+  template: `
+    <div class="additional-properties" *ngIf="shouldShow">
+      <div
+        class="additional-properties-add"
+        [class.additional-properties-add--with-title]="
+          additionalPropertiesTitle
+        "
+      >
+        <span
+          class="additional-properties-title"
+          *ngIf="additionalPropertiesTitle"
+        >
+          {{ additionalPropertiesTitle }}
+        </span>
+        <mat-form-field class="property-name-field">
+          <mat-label>Property Name</mat-label>
+          <input
+            matInput
+            [(ngModel)]="newPropertyName"
+            (ngModelChange)="updatePropertyNameError()"
+            (keydown.enter)="addProperty()"
+          />
+          <button
+            mat-icon-button
+            matSuffix
+            type="button"
+            [attr.aria-label]="
+              label ? 'Add to ' + label + ' button' : 'Add button'
+            "
+            [disabled]="addPropertyDisabled"
+            (click)="addProperty()"
+            [matTooltip]="label ? 'Add to ' + label : 'Add'"
+          >
+            <mat-icon>add</mat-icon>
+          </button>
+          <mat-hint class="property-name-error" *ngIf="propertyNameError">{{
+            propertyNameError
+          }}</mat-hint>
+        </mat-form-field>
+      </div>
+
+      <div
+        class="additional-property-row"
+        *ngFor="let item of additionalPropertyItems; trackBy: trackProperty"
+      >
+        <div class="additional-property-control">
+          <jsonforms-outlet
+            [uischema]="item.uischema"
+            [schema]="item.schema"
+            [path]="item.path"
+            [preserveUndefinedAsDefault]="true"
+          ></jsonforms-outlet>
+        </div>
+        <div class="additional-property-actions" *ngIf="enabled">
+          <mat-menu
+            #renameMenu="matMenu"
+            xPosition="before"
+            yPosition="above"
+            panelClass="additional-property-rename-panel"
+          >
+            <div
+              class="additional-property-rename-menu"
+              (click)="$event.stopPropagation()"
+            >
+              <mat-form-field class="rename-property-name-field">
+                <mat-label>Property Name</mat-label>
+                <input
+                  matInput
+                  [(ngModel)]="renameValue"
+                  (ngModelChange)="updateRenameError(item.propertyName)"
+                  (keydown.enter)="
+                    renameProperty(item.propertyName);
+                    !renameError && renameTrigger.closeMenu()
+                  "
+                  (keydown.escape)="cancelRename(); renameTrigger.closeMenu()"
+                />
+                <mat-error *ngIf="renameError">{{ renameError }}</mat-error>
+              </mat-form-field>
+              <div class="additional-property-rename-actions">
+                <button
+                  mat-button
+                  type="button"
+                  [disabled]="renameDisabled(item.propertyName)"
+                  (click)="
+                    renameProperty(item.propertyName); renameTrigger.closeMenu()
+                  "
+                >
+                  Rename
+                </button>
+                <button
+                  mat-button
+                  type="button"
+                  (click)="cancelRename(); renameTrigger.closeMenu()"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </mat-menu>
+          <button
+            #renameTrigger="matMenuTrigger"
+            mat-icon-button
+            class="additional-property-action-button"
+            type="button"
+            aria-label="Rename property button"
+            [matMenuTriggerFor]="renameMenu"
+            (menuOpened)="startRename(item.propertyName)"
+            (menuClosed)="cancelRename()"
+            matTooltip="Rename"
+          >
+            <mat-icon>edit</mat-icon>
+          </button>
+          <button
+            mat-icon-button
+            class="additional-property-action-button"
+            color="warn"
+            type="button"
+            aria-label="Delete button"
+            [disabled]="
+              removePropertyDisabled ||
+              renamingPropertyName === item.propertyName
+            "
+            (click)="removeProperty(item.propertyName)"
+            matTooltip="Delete"
+          >
+            <mat-icon>delete_outline</mat-icon>
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: [
+    `
+      .additional-properties {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        margin-top: 8px;
+        width: 100%;
+      }
+      .additional-properties-add,
+      .additional-property-row {
+        align-items: flex-start;
+        display: grid;
+        gap: 8px;
+      }
+      .additional-properties-add {
+        grid-template-columns: minmax(0, 1fr);
+      }
+      .additional-properties-add--with-title {
+        grid-template-columns: minmax(180px, max-content) minmax(0, 1fr);
+      }
+      .additional-properties-title {
+        align-self: center;
+        color: rgba(0, 0, 0, 0.6);
+        font-size: 14px;
+      }
+      .property-name-field {
+        min-width: 0;
+        width: 100%;
+      }
+      .property-name-error {
+        color: var(--mat-sys-error, #ba1a1a);
+      }
+      .additional-property-row {
+        grid-template-columns: minmax(0, 1fr) auto;
+        width: 100%;
+      }
+      .additional-property-control {
+        min-width: 0;
+        width: 100%;
+      }
+      .additional-property-actions {
+        align-items: center;
+        display: inline-flex;
+        flex-direction: column;
+        gap: 0;
+        opacity: 0.72;
+        transition: opacity 120ms ease;
+      }
+      .additional-property-row:hover .additional-property-actions {
+        opacity: 1;
+      }
+      .additional-property-action-button.mat-mdc-icon-button {
+        --mdc-icon-button-state-layer-size: 24px;
+        height: 24px;
+        padding: 2px;
+        width: 24px;
+      }
+      .additional-property-action-button mat-icon {
+        font-size: 16px;
+        height: 16px;
+        line-height: 16px;
+        width: 16px;
+      }
+      .additional-property-rename-menu {
+        box-sizing: border-box;
+        max-width: 100%;
+        overflow: hidden;
+        padding: 12px;
+        width: 280px;
+      }
+      .additional-property-rename-actions {
+        align-items: center;
+        display: flex;
+        gap: 8px;
+        justify-content: flex-end;
+      }
+      .rename-property-name-field {
+        width: 100%;
+      }
+      .additional-property-rename-panel.mat-mdc-menu-panel {
+        max-width: min(320px, calc(100vw - 32px));
+        min-width: 0;
+        overflow-x: hidden;
+      }
+      .additional-property-rename-panel .mat-mdc-menu-content {
+        overflow-x: hidden;
+        padding: 0;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  imports: [
+    CommonModule,
+    FormsModule,
+    JsonFormsModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatMenuModule,
+    MatTooltipModule,
+  ],
+})
+export class AdditionalPropertiesRenderer implements OnChanges {
+  @Input() cells?: JsonFormsCellRendererRegistryEntry[];
+  @Input() config?: any;
+  @Input() data: any;
+  @Input() enabled: boolean;
+  @Input() label: string;
+  @Input() path: string;
+  @Input() renderers?: JsonFormsRendererRegistryEntry[];
+  @Input() rootSchema: JsonSchema;
+  @Input() schema: JsonSchema;
+  @Input() uischema: ControlElement;
+
+  additionalKeys: string[] = [];
+  additionalPropertyItems: AdditionalPropertyItem[] = [];
+  additionalPropertiesTitle: string | undefined;
+  newPropertyName = '';
+  propertyNameError: string | undefined;
+  renamingPropertyName: string | undefined;
+  renameValue = '';
+  renameError: string | undefined;
+  shouldShow = false;
+
+  private additionalPropertyItemCache = new Map<
+    string,
+    AdditionalPropertyItem
+  >();
+  private jsonFormsService = inject(JsonFormsAngularService);
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.schema || changes.rootSchema || changes.path) {
+      this.additionalPropertyItemCache.clear();
+    }
+    this.updateItems();
+  }
+
+  get addPropertyDisabled(): boolean {
+    return (
+      !this.enabled ||
+      Boolean(this.propertyNameError) ||
+      !this.newPropertyName ||
+      (this.config?.restrict && this.maxPropertiesReached)
+    );
+  }
+
+  get removePropertyDisabled(): boolean {
+    return (
+      !this.enabled || (this.config?.restrict && this.minPropertiesReached)
+    );
+  }
+
+  get maxPropertiesReached(): boolean {
+    const objectSchema = toObjectSchema(this.schema);
+    return (
+      objectSchema.maxProperties !== undefined &&
+      this.data &&
+      Object.keys(this.data).length >= objectSchema.maxProperties
+    );
+  }
+
+  get minPropertiesReached(): boolean {
+    const objectSchema = toObjectSchema(this.schema);
+    return (
+      objectSchema.minProperties !== undefined &&
+      this.data &&
+      Object.keys(this.data).length <= objectSchema.minProperties
+    );
+  }
+
+  addProperty(): void {
+    this.propertyNameError = this.validatePropertyName(this.newPropertyName);
+    if (this.addPropertyDisabled) {
+      return;
+    }
+
+    const additionalProperty = toAdditionalPropertyItem(
+      this.newPropertyName,
+      this.path,
+      this.schema,
+      this.rootSchema
+    );
+    const updatedData =
+      typeof this.data === 'object' &&
+      this.data !== null &&
+      !Array.isArray(this.data)
+        ? { ...this.data }
+        : {};
+
+    updatedData[this.newPropertyName] = createDefaultValue(
+      additionalProperty.schema,
+      this.rootSchema
+    );
+    this.jsonFormsService.updateCore(
+      Actions.update(this.path, () => updatedData)
+    );
+    this.newPropertyName = '';
+    this.propertyNameError = undefined;
+  }
+
+  updatePropertyNameError(): void {
+    this.propertyNameError = this.validatePropertyName(this.newPropertyName);
+  }
+
+  removeProperty(propertyName: string): void {
+    if (
+      this.removePropertyDisabled ||
+      typeof this.data !== 'object' ||
+      this.data === null
+    ) {
+      return;
+    }
+
+    const updatedData = { ...this.data };
+    delete updatedData[propertyName];
+    this.jsonFormsService.updateCore(
+      Actions.update(this.path, () => updatedData)
+    );
+  }
+
+  startRename(propertyName: string): void {
+    this.renamingPropertyName = propertyName;
+    this.renameValue = propertyName;
+    this.renameError = undefined;
+  }
+
+  cancelRename(): void {
+    this.renamingPropertyName = undefined;
+    this.renameValue = '';
+    this.renameError = undefined;
+  }
+
+  renameDisabled(propertyName: string): boolean {
+    const trimmed = this.renameValue.trim();
+    return (
+      !this.enabled ||
+      !trimmed ||
+      trimmed === propertyName ||
+      Boolean(this.validatePropertyName(trimmed, propertyName))
+    );
+  }
+
+  updateRenameError(propertyName: string): void {
+    this.renameError = this.validatePropertyName(
+      this.renameValue.trim(),
+      propertyName
+    );
+  }
+
+  renameProperty(propertyName: string): void {
+    const trimmed = this.renameValue.trim();
+    this.renameError = this.validatePropertyName(trimmed, propertyName);
+
+    if (
+      this.renameError ||
+      !trimmed ||
+      trimmed === propertyName ||
+      typeof this.data !== 'object' ||
+      this.data === null ||
+      Array.isArray(this.data)
+    ) {
+      return;
+    }
+
+    const updatedData = Object.fromEntries(
+      Object.entries(this.data).map(([key, value]) => [
+        key === propertyName ? trimmed : key,
+        value,
+      ])
+    );
+    this.jsonFormsService.updateCore(
+      Actions.update(this.path, () => updatedData)
+    );
+    this.cancelRename();
+  }
+
+  trackProperty(_index: number, item: AdditionalPropertyItem): string {
+    return item.propertyName;
+  }
+
+  private updateItems(): void {
+    const objectSchema = toObjectSchema(this.schema);
+    const reservedPropertyNames = Object.keys(objectSchema.properties ?? {});
+    this.additionalKeys = Object.keys(this.data ?? {}).filter(
+      (key) => !reservedPropertyNames.includes(key)
+    );
+    this.additionalPropertyItems = this.additionalKeys.map((propertyName) =>
+      this.getAdditionalPropertyItem(propertyName)
+    );
+    const additionalKeySet = new Set(this.additionalKeys);
+    Array.from(this.additionalPropertyItemCache.keys()).forEach(
+      (propertyName) => {
+        if (!additionalKeySet.has(propertyName)) {
+          this.additionalPropertyItemCache.delete(propertyName);
+        }
+      }
+    );
+    const allowIfMissing =
+      this.config?.allowAdditionalPropertiesIfMissing === true &&
+      objectSchema.additionalProperties === undefined;
+    this.shouldShow =
+      hasAdditionalProperties(this.schema) ||
+      allowIfMissing ||
+      this.additionalKeys.length > 0;
+    this.additionalPropertiesTitle = toObjectSchema(
+      objectSchema.additionalProperties as JsonSchema
+    ).title;
+    this.propertyNameError = this.validatePropertyName(this.newPropertyName);
+  }
+
+  private getAdditionalPropertyItem(
+    propertyName: string
+  ): AdditionalPropertyItem {
+    const cached = this.additionalPropertyItemCache.get(propertyName);
+    if (cached) {
+      return cached;
+    }
+
+    const item = toAdditionalPropertyItem(
+      propertyName,
+      this.path,
+      this.schema,
+      this.rootSchema
+    );
+    this.additionalPropertyItemCache.set(propertyName, item);
+    return item;
+  }
+
+  private validatePropertyName(
+    propertyName: string,
+    currentPropertyName?: string
+  ): string | undefined {
+    if (!propertyName) {
+      return undefined;
+    }
+
+    if (
+      typeof this.data === 'object' &&
+      this.data !== null &&
+      Object.prototype.hasOwnProperty.call(this.data, propertyName)
+    ) {
+      if (propertyName === currentPropertyName) {
+        return undefined;
+      }
+      return `Property '${propertyName}' already defined`;
+    }
+
+    if (
+      propertyName.includes('[') ||
+      propertyName.includes(']') ||
+      propertyName.includes('.')
+    ) {
+      return `Property name '${propertyName}' is invalid`;
+    }
+
+    const pattern = getPropertyNamePattern(this.schema);
+    if (pattern && !new RegExp(pattern).test(propertyName)) {
+      return `Property name must match pattern: ${pattern}`;
+    }
+
+    return undefined;
+  }
+}

--- a/packages/angular-material/src/library/other/index.ts
+++ b/packages/angular-material/src/library/other/index.ts
@@ -24,5 +24,7 @@
 */
 export * from './label.renderer';
 export * from './master-detail';
+export * from './additional-properties.renderer';
+export * from './mixed.renderer';
 export * from './object.renderer';
 export * from './table.renderer';

--- a/packages/angular-material/src/library/other/mixed.renderer.ts
+++ b/packages/angular-material/src/library/other/mixed.renderer.ts
@@ -1,0 +1,1678 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017-2026 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import { CommonModule } from '@angular/common';
+import { FlatTreeControl } from '@angular/cdk/tree';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  HostListener,
+  inject,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatTreeModule } from '@angular/material/tree';
+import {
+  JsonFormsControl,
+  JsonFormsModule,
+  JsonFormsAngularService,
+} from '@jsonforms/angular';
+import {
+  Actions,
+  compose,
+  ControlElement,
+  createControlElement,
+  createDefaultValue,
+  findUISchema,
+  isControl,
+  JsonFormsUISchemaRegistryEntry,
+  JsonSchema,
+  JsonSchema7,
+  rankWith,
+  RankedTester,
+  Resolve,
+  Scopable,
+  StatePropsOfControl,
+  TesterContext,
+  UISchemaElement,
+} from '@jsonforms/core';
+import cloneDeep from 'lodash/cloneDeep';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
+
+type JsonDataType =
+  | 'array'
+  | 'boolean'
+  | 'integer'
+  | 'null'
+  | 'number'
+  | 'object'
+  | 'string';
+
+interface SchemaRenderInfo {
+  schema: JsonSchema;
+  resolvedSchema: JsonSchema;
+  uischema: UISchemaElement;
+  label: string;
+  index: number;
+}
+
+interface TreeNodeControl {
+  schema: JsonSchema;
+  uischema: ControlElement;
+  path: string;
+  label: string;
+}
+
+interface MixedTreeNode {
+  nodeId: string;
+  title: string;
+  jsonType: JsonDataType;
+  label: string;
+  canRename: boolean;
+  canDelete: boolean;
+  control: TreeNodeControl;
+  children?: MixedTreeNode[];
+}
+
+interface VisibleTreeItem {
+  node: MixedTreeNode;
+  depth: number;
+  hasChildren: boolean;
+  open: boolean;
+}
+
+const ROOT_TREE_NODE_ID = '$root';
+const ANY_TYPE: JsonDataType[] = [
+  'array',
+  'boolean',
+  'integer',
+  'null',
+  'number',
+  'object',
+  'string',
+];
+
+const toTreeNodeId = (path: string) =>
+  path ? `$path:${path}` : ROOT_TREE_NODE_ID;
+
+const resolveSchema = (schema: JsonSchema, rootSchema: JsonSchema) => {
+  if (typeof schema === 'object' && typeof schema?.$ref === 'string') {
+    return Resolve.schema(rootSchema, schema.$ref, rootSchema) ?? schema;
+  }
+  return schema;
+};
+
+const cleanSchema = (schema: JsonSchema): JsonSchema => {
+  if (typeof schema !== 'object') {
+    return schema;
+  }
+
+  const validKeywords: Record<string, string[]> = {
+    array: ['items', 'minItems', 'maxItems', 'uniqueItems', 'contains'],
+    object: [
+      'properties',
+      'required',
+      'additionalProperties',
+      'minProperties',
+      'maxProperties',
+      'patternProperties',
+      'dependencies',
+      'propertyNames',
+    ],
+    string: ['minLength', 'maxLength', 'pattern', 'format'],
+    number: [
+      'minimum',
+      'maximum',
+      'exclusiveMinimum',
+      'exclusiveMaximum',
+      'multipleOf',
+    ],
+    integer: [
+      'minimum',
+      'maximum',
+      'exclusiveMinimum',
+      'exclusiveMaximum',
+      'multipleOf',
+    ],
+    boolean: [],
+    null: [],
+  };
+
+  const schemaType = schema.type as string;
+  for (const validType in validKeywords) {
+    if (validType !== schemaType) {
+      validKeywords[validType].forEach((key) => {
+        delete (schema as any)[key];
+      });
+    }
+  }
+
+  return schema;
+};
+
+const getJsonDataType = (value: any): JsonDataType | null => {
+  if (typeof value === 'string') {
+    return 'string';
+  }
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? 'integer' : 'number';
+  }
+  if (typeof value === 'boolean') {
+    return 'boolean';
+  }
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+  if (value === null) {
+    return 'null';
+  }
+  if (typeof value === 'object') {
+    return 'object';
+  }
+
+  return null;
+};
+
+const getSchemaTypesAsArray = (schema: JsonSchema): string[] => {
+  if (typeof schema !== 'object') {
+    return ANY_TYPE;
+  }
+
+  if (typeof schema.type === 'string') {
+    return [schema.type];
+  }
+
+  if (Array.isArray(schema.type)) {
+    return schema.type;
+  }
+
+  if (Array.isArray(schema.enum)) {
+    const enumTypes = new Set(
+      schema.enum.map((value) => getJsonDataType(value))
+    );
+    if (!enumTypes.has(null)) {
+      return Array.from(enumTypes).filter((type) => type !== null) as string[];
+    }
+  }
+
+  return ANY_TYPE;
+};
+
+const createMixedRenderInfos = (
+  schema: JsonSchema,
+  rootSchema: JsonSchema,
+  control: ControlElement,
+  path: string,
+  uischemas: JsonFormsUISchemaRegistryEntry[]
+): SchemaRenderInfo[] => {
+  const resolvedSchemas: JsonSchema[] = [];
+  schema = resolveSchema(schema, rootSchema);
+
+  if (typeof schema === 'object' && typeof schema.type === 'string') {
+    resolvedSchemas.push(schema);
+  } else {
+    getSchemaTypesAsArray(schema).forEach((type) => {
+      resolvedSchemas.push({
+        ...(typeof schema === 'object' ? schema : {}),
+        type,
+        default:
+          typeof schema === 'object' &&
+          schema.default !== undefined &&
+          type === getJsonDataType(schema.default)
+            ? schema.default
+            : undefined,
+      });
+    });
+  }
+
+  return resolvedSchemas
+    .map((resolvedSchema) => {
+      if (
+        typeof resolvedSchema === 'object' &&
+        resolvedSchema.type === 'array'
+      ) {
+        resolvedSchema.items = resolvedSchema.items ?? {};
+        resolvedSchema.items = resolveSchema(
+          resolvedSchema.items as JsonSchema,
+          rootSchema
+        );
+
+        if ((resolvedSchema.items as any) === true) {
+          resolvedSchema.items = { type: ANY_TYPE };
+        } else if (
+          typeof (resolvedSchema.items as JsonSchema7).type !== 'string' &&
+          !Array.isArray((resolvedSchema.items as JsonSchema7).type)
+        ) {
+          (resolvedSchema.items as JsonSchema7).type = ANY_TYPE;
+        }
+      }
+
+      const cleanedSchema = cleanSchema(cloneDeep(resolvedSchema));
+      const schemaType =
+        typeof cleanedSchema === 'object' ? cleanedSchema.type : undefined;
+      const detailsForSchema = control.options
+        ? control.options[`${schemaType}-detail`]
+        : undefined;
+      const schemaControl = detailsForSchema
+        ? {
+            ...control,
+            options: { ...control.options, detail: detailsForSchema },
+          }
+        : control;
+
+      const uischema = findUISchema(
+        uischemas,
+        cleanedSchema,
+        control.scope,
+        path,
+        () => createControlElement(control.scope ?? '#'),
+        schemaControl,
+        rootSchema
+      );
+
+      return {
+        schema: cleanedSchema,
+        resolvedSchema,
+        uischema,
+        label: `${schemaType}`,
+      };
+    })
+    .filter((info) => info.uischema)
+    .map((info, index) => ({ ...info, index }));
+};
+
+const findPropertySchema = (
+  parentSchema: JsonSchema,
+  propName: string,
+  rootSchema: JsonSchema
+): JsonSchema | undefined => {
+  if (typeof parentSchema !== 'object') {
+    return undefined;
+  }
+
+  if (parentSchema.properties?.[propName]) {
+    return resolveSchema(parentSchema.properties[propName], rootSchema);
+  }
+
+  if (parentSchema.patternProperties) {
+    const matchedPattern = Object.keys(parentSchema.patternProperties).find(
+      (pattern) => new RegExp(pattern).test(propName)
+    );
+
+    if (matchedPattern) {
+      return resolveSchema(
+        parentSchema.patternProperties[matchedPattern],
+        rootSchema
+      );
+    }
+  }
+
+  if (typeof parentSchema.additionalProperties === 'object') {
+    return resolveSchema(parentSchema.additionalProperties, rootSchema);
+  }
+
+  if (parentSchema.additionalProperties === true) {
+    return { additionalProperties: true };
+  }
+
+  return undefined;
+};
+
+const getArrayItemSchema = (
+  parentSchema: JsonSchema,
+  index: number,
+  rootSchema: JsonSchema
+): JsonSchema | undefined => {
+  if (typeof parentSchema !== 'object' || !parentSchema.items) {
+    return undefined;
+  }
+
+  let itemSchema: JsonSchema | undefined;
+  if (Array.isArray(parentSchema.items)) {
+    if (index < parentSchema.items.length) {
+      itemSchema = parentSchema.items[index];
+    } else if (parentSchema.additionalItems) {
+      itemSchema =
+        typeof parentSchema.additionalItems === 'object'
+          ? parentSchema.additionalItems
+          : undefined;
+    }
+  } else {
+    itemSchema = parentSchema.items as JsonSchema;
+  }
+
+  return itemSchema ? resolveSchema(itemSchema, rootSchema) : undefined;
+};
+
+const prepareObjectSchema = (schema: JsonSchema): JsonSchema => {
+  const objectSchema = cleanSchema(
+    cloneDeep({ ...(typeof schema === 'object' ? schema : {}), type: 'object' })
+  ) as JsonSchema7;
+  objectSchema.additionalProperties =
+    objectSchema.additionalProperties !== false
+      ? objectSchema.additionalProperties ?? true
+      : false;
+  return objectSchema;
+};
+
+const prepareArraySchema = (
+  schema: JsonSchema,
+  rootSchema: JsonSchema
+): JsonSchema => {
+  const arraySchema = cleanSchema(
+    cloneDeep({ ...(typeof schema === 'object' ? schema : {}), type: 'array' })
+  ) as JsonSchema7;
+  arraySchema.items = arraySchema.items ?? {};
+  arraySchema.items = resolveSchema(
+    arraySchema.items as JsonSchema,
+    rootSchema
+  ) as JsonSchema7 | JsonSchema7[];
+
+  if ((arraySchema.items as any) === true) {
+    arraySchema.items = { type: ANY_TYPE };
+  } else if (
+    typeof (arraySchema.items as JsonSchema7).type !== 'string' &&
+    !Array.isArray((arraySchema.items as JsonSchema7).type)
+  ) {
+    (arraySchema.items as JsonSchema7).type = ANY_TYPE;
+  }
+
+  return arraySchema;
+};
+
+const createFallbackChildSchema = (title: string): JsonSchema => ({
+  type: ANY_TYPE,
+  title,
+});
+
+const getSchemaDefaultType = (schema: JsonSchema): JsonDataType => {
+  const schemaTypes = getSchemaTypesAsArray(schema);
+  const firstType =
+    schemaTypes.find((type) => type !== 'null') ?? schemaTypes[0];
+  return (firstType ?? 'object') as JsonDataType;
+};
+
+const prepareChildSchema = (
+  childType: JsonDataType,
+  currentSchema: JsonSchema,
+  key: string,
+  index: number | null,
+  rootSchema: JsonSchema
+): JsonSchema => {
+  let childSchema: JsonSchema | undefined;
+
+  if (index !== null) {
+    childSchema = getArrayItemSchema(currentSchema, index, rootSchema);
+    childSchema = childSchema
+      ? { ...(childSchema as JsonSchema7), title: `Item ${index}` }
+      : createFallbackChildSchema(`Item ${index}`);
+  } else {
+    childSchema = findPropertySchema(currentSchema, key, rootSchema);
+    childSchema = childSchema
+      ? { ...(childSchema as JsonSchema7), title: key }
+      : createFallbackChildSchema(key);
+  }
+
+  if (
+    childType !== 'object' &&
+    childType !== 'array' &&
+    typeof childSchema === 'object' &&
+    (!childSchema.type || (childSchema.type as any) === true)
+  ) {
+    childSchema.type = ANY_TYPE;
+  }
+
+  if (childType === 'object') {
+    return prepareObjectSchema(childSchema);
+  }
+
+  if (childType === 'array') {
+    return prepareArraySchema(childSchema, rootSchema);
+  }
+
+  return childSchema;
+};
+
+const createTreeNodeControl = (
+  schema: JsonSchema,
+  path: string,
+  label: string,
+  nodeType: JsonDataType,
+  controlCache: Map<string, TreeNodeControl>
+): TreeNodeControl => {
+  const cacheKey = `${path}\u0000${nodeType}`;
+  const cached = controlCache.get(cacheKey);
+  if (cached) {
+    cached.label = label;
+    return cached;
+  }
+
+  const control = {
+    schema,
+    uischema: createControlElement('#'),
+    path,
+    label,
+  };
+  controlCache.set(cacheKey, control);
+  return control;
+};
+
+const withoutEmptyChildren = (node: MixedTreeNode): MixedTreeNode => {
+  const children = node.children?.map(withoutEmptyChildren) ?? [];
+  if (children.length === 0) {
+    const { children: _children, ...rest } = node;
+    return rest;
+  }
+
+  return {
+    ...node,
+    children,
+  };
+};
+
+const getDisplayTitle = (label: string, type: JsonDataType): string => {
+  if (label) {
+    return label;
+  }
+  return type === 'array' ? '[]' : '{}';
+};
+
+const isDynamicProperty = (parentSchema: JsonSchema, key: string): boolean =>
+  typeof parentSchema !== 'object' || !parentSchema.properties?.[key];
+
+const buildTreeFromData = (
+  data: any,
+  schema: JsonSchema,
+  rootSchema: JsonSchema,
+  path: string,
+  label: string,
+  showPrimitives: boolean,
+  controlCache: Map<string, TreeNodeControl>
+): MixedTreeNode[] => {
+  const dataType = getJsonDataType(data);
+  if (dataType !== 'object' && dataType !== 'array') {
+    return [];
+  }
+
+  const nodes: MixedTreeNode[] = [];
+
+  const traverse = (
+    value: any,
+    currentPath: string,
+    currentLabel: string,
+    currentSchema: JsonSchema,
+    children: MixedTreeNode[],
+    canRename = false,
+    canDelete = false
+  ) => {
+    const type = getJsonDataType(value);
+
+    if (type === 'object') {
+      const objectSchema = prepareObjectSchema(currentSchema);
+      const node: MixedTreeNode = {
+        nodeId: toTreeNodeId(currentPath),
+        title: getDisplayTitle(currentLabel, type),
+        jsonType: type,
+        label: currentLabel,
+        canRename,
+        canDelete,
+        control: createTreeNodeControl(
+          objectSchema,
+          currentPath,
+          currentLabel,
+          type,
+          controlCache
+        ),
+        children: [],
+      };
+      children.push(node);
+
+      Object.keys(value).forEach((key) => {
+        const childValue = value[key];
+        const childPath = compose(currentPath, key);
+        const rawChildType = getJsonDataType(childValue);
+        const initialChildSchema =
+          findPropertySchema(currentSchema, key, rootSchema) ??
+          createFallbackChildSchema(key);
+        const childType =
+          rawChildType ?? getSchemaDefaultType(initialChildSchema);
+        const childSchema = prepareChildSchema(
+          childType,
+          currentSchema,
+          key,
+          null,
+          rootSchema
+        );
+
+        if (childType === 'object' || childType === 'array') {
+          traverse(
+            childValue ?? (childType === 'array' ? [] : {}),
+            childPath,
+            key,
+            childSchema,
+            node.children,
+            isDynamicProperty(currentSchema, key),
+            true
+          );
+        } else if (showPrimitives) {
+          node.children.push({
+            nodeId: toTreeNodeId(childPath),
+            title: key,
+            jsonType: childType,
+            label: key,
+            canRename: isDynamicProperty(currentSchema, key),
+            canDelete: true,
+            control: createTreeNodeControl(
+              childSchema,
+              childPath,
+              key,
+              childType,
+              controlCache
+            ),
+            children: [],
+          });
+        }
+      });
+    } else if (type === 'array') {
+      const arraySchema = prepareArraySchema(currentSchema, rootSchema);
+      const node: MixedTreeNode = {
+        nodeId: toTreeNodeId(currentPath),
+        title: getDisplayTitle(currentLabel, type),
+        jsonType: type,
+        label: currentLabel,
+        canRename,
+        canDelete,
+        control: createTreeNodeControl(
+          arraySchema,
+          currentPath,
+          currentLabel,
+          type,
+          controlCache
+        ),
+        children: [],
+      };
+      children.push(node);
+
+      value.forEach((childValue: any, index: number) => {
+        const childType = getJsonDataType(childValue);
+        const childPath = compose(currentPath, `${index}`);
+        const childSchema = prepareChildSchema(
+          childType ?? 'object',
+          currentSchema,
+          '',
+          index,
+          rootSchema
+        );
+        const resolvedChildType =
+          childType ?? getSchemaDefaultType(childSchema);
+        const childLabel = `Item ${index}`;
+
+        if (resolvedChildType === 'object' || resolvedChildType === 'array') {
+          traverse(
+            childValue ?? (resolvedChildType === 'array' ? [] : {}),
+            childPath,
+            childLabel,
+            childSchema,
+            node.children,
+            false,
+            true
+          );
+        } else if (showPrimitives) {
+          node.children.push({
+            nodeId: toTreeNodeId(childPath),
+            title: childLabel,
+            jsonType: resolvedChildType,
+            label: childLabel,
+            canRename: false,
+            canDelete: true,
+            control: createTreeNodeControl(
+              childSchema,
+              childPath,
+              childLabel,
+              resolvedChildType,
+              controlCache
+            ),
+            children: [],
+          });
+        }
+      });
+    }
+  };
+
+  traverse(data, path, label, resolveSchema(schema, rootSchema), nodes);
+
+  return nodes.map(withoutEmptyChildren);
+};
+
+const flattenTree = (nodes: MixedTreeNode[]): MixedTreeNode[] =>
+  nodes.flatMap((node) => [node, ...flattenTree(node.children ?? [])]);
+
+const getTreeStructureSignature = (
+  value: any,
+  showPrimitives: boolean
+): string => {
+  const type = getJsonDataType(value);
+
+  if (type === 'object') {
+    return `o{${Object.keys(value)
+      .map((key) => {
+        const childType = getJsonDataType(value[key]);
+        if (childType === 'object' || childType === 'array') {
+          return `${key}:${getTreeStructureSignature(
+            value[key],
+            showPrimitives
+          )}`;
+        }
+        return showPrimitives ? `${key}:p` : '';
+      })
+      .filter(Boolean)
+      .join('|')}}`;
+  }
+
+  if (type === 'array') {
+    return `a[${value
+      .map((childValue: any) => {
+        const childType = getJsonDataType(childValue);
+        if (childType === 'object' || childType === 'array') {
+          return getTreeStructureSignature(childValue, showPrimitives);
+        }
+        return showPrimitives ? 'p' : '';
+      })
+      .join('|')}]`;
+  }
+
+  return showPrimitives ? 'p' : '';
+};
+
+const flattenVisibleTree = (
+  nodes: MixedTreeNode[],
+  openedNodeIds: Set<string>,
+  depth = 0,
+  search = ''
+): VisibleTreeItem[] => {
+  const normalizedSearch = search.trim().toLocaleLowerCase();
+  const isSearching = Boolean(normalizedSearch);
+
+  return nodes.flatMap((node) => {
+    const hasChildren = Boolean(node.children?.length);
+    const isOpened = hasChildren && openedNodeIds.has(node.nodeId);
+    const matchesSearch =
+      !normalizedSearch ||
+      node.title.toLocaleLowerCase().includes(normalizedSearch) ||
+      node.label.toLocaleLowerCase().includes(normalizedSearch);
+    const childItems =
+      hasChildren && (isSearching || isOpened)
+        ? flattenVisibleTree(
+            node.children ?? [],
+            openedNodeIds,
+            depth + 1,
+            normalizedSearch
+          )
+        : [];
+    const hasMatchingChildren = childItems.length > 0;
+
+    if (isSearching && !matchesSearch && !hasMatchingChildren) {
+      return [];
+    }
+
+    const open = isSearching || isOpened;
+    const item: VisibleTreeItem = { node, depth, hasChildren, open };
+
+    return hasChildren && open ? [item, ...childItems] : [item];
+  });
+};
+
+const findNodeById = (
+  nodes: MixedTreeNode[],
+  targetNodeId: string
+): MixedTreeNode | undefined => {
+  for (const node of nodes) {
+    if (node.nodeId === targetNodeId) {
+      return node;
+    }
+    const child = findNodeById(node.children ?? [], targetNodeId);
+    if (child) {
+      return child;
+    }
+  }
+  return undefined;
+};
+
+const getRelativePath = (rootPath: string, nodePath: string): string | null => {
+  if (nodePath === rootPath) {
+    return null;
+  }
+  return rootPath && nodePath.startsWith(`${rootPath}.`)
+    ? nodePath.slice(rootPath.length + 1)
+    : nodePath;
+};
+
+const getParentPath = (rootPath: string, nodePath: string): string => {
+  const lastDot = nodePath.lastIndexOf('.');
+  return lastDot > 0 ? nodePath.substring(0, lastDot) : rootPath;
+};
+
+const schemaSupportsInputType = (
+  schemaType: JsonSchema7['type'] | undefined,
+  dataType: JsonDataType | null
+): boolean => {
+  if (!dataType || typeof schemaType !== 'string') {
+    return false;
+  }
+
+  return (
+    schemaType === dataType ||
+    (schemaType === 'number' && dataType === 'integer')
+  );
+};
+
+const isDefaultGenUiSchema = (uischema: UISchemaElement): boolean => {
+  const elements = (uischema as any)?.elements;
+  return (
+    (uischema.type === 'VerticalLayout' || uischema.type === 'Group') &&
+    Array.isArray(elements) &&
+    elements.length === 1 &&
+    elements[0].scope === '#' &&
+    elements[0].type === 'Control'
+  );
+};
+
+@Component({
+  selector: 'MixedRenderer',
+  template: `
+    <div class="mixed-renderer" *ngIf="!hidden">
+      <ng-template #mixedHeader>
+        <div
+          class="mixed-header"
+          [class.mixed-header-root]="showTreeView"
+          [class.mixed-header-inline]="isNestedComplexType"
+          [class.mixed-header-detail]="showInlineDetail"
+        >
+          <mat-form-field
+            class="mixed-type-selector"
+            (click)="$event.stopPropagation()"
+            (keydown)="$event.stopPropagation()"
+          >
+            <mat-label>{{ label }}</mat-label>
+            <mat-select
+              [disabled]="!isEnabled()"
+              [value]="selectedIndex"
+              (selectionChange)="handleSelectChange($event.value)"
+            >
+              <mat-option [value]="undefined"><em>None</em></mat-option>
+              <mat-option
+                *ngFor="let info of mixedRenderInfos"
+                [value]="info.index"
+              >
+                {{ info.label }}
+              </mat-option>
+            </mat-select>
+            <mat-error>{{ error }}</mat-error>
+          </mat-form-field>
+          <span class="mixed-root-label" *ngIf="showTreeView">{{ label }}</span>
+          <button
+            *ngIf="isNestedComplexType"
+            mat-icon-button
+            color="primary"
+            type="button"
+            [disabled]="!parentMixedRenderer"
+            [matTooltip]="'View ' + label"
+            (click)="selectNestedPath()"
+          >
+            <mat-icon>visibility</mat-icon>
+          </button>
+          <div class="mixed-inline-detail" *ngIf="showInlineDetail">
+            <jsonforms-outlet
+              [uischema]="activeInfo.uischema"
+              [schema]="activeInfo.schema"
+              [path]="propsPath"
+              [preserveUndefinedAsDefault]="true"
+            ></jsonforms-outlet>
+          </div>
+        </div>
+      </ng-template>
+
+      <ng-template #mixedTree>
+        <div class="mixed-tree-shell">
+          <aside class="mixed-tree-pane" [style.flex-basis.px]="treeWidth">
+            <mat-form-field class="mixed-search">
+              <mat-label>Search</mat-label>
+              <mat-icon matPrefix>search</mat-icon>
+              <input
+                matInput
+                [(ngModel)]="treeSearch"
+                (ngModelChange)="rebuildVisibleTree()"
+              />
+            </mat-form-field>
+
+            <mat-tree
+              class="mixed-tree-list"
+              [dataSource]="visibleTreeItems"
+              [treeControl]="treeControl"
+              [trackBy]="trackTreeItem"
+            >
+              <mat-tree-node
+                class="mixed-tree-item"
+                tabindex="0"
+                *matTreeNodeDef="let item"
+                [class.active]="item.node.nodeId === activeNodeId"
+                [style.padding-left.px]="8 + item.depth * 20"
+                (click)="selectNode(item.node.nodeId)"
+                (keydown.enter)="selectNode(item.node.nodeId)"
+                (keydown.space)="
+                  selectNode(item.node.nodeId); $event.preventDefault()
+                "
+              >
+                <button
+                  mat-icon-button
+                  class="mixed-expand-button"
+                  type="button"
+                  *ngIf="item.hasChildren"
+                  (click)="toggleNode(item.node, $event)"
+                >
+                  <mat-icon>{{
+                    item.open ? 'expand_more' : 'chevron_right'
+                  }}</mat-icon>
+                </button>
+                <span
+                  class="mixed-expand-spacer"
+                  *ngIf="!item.hasChildren"
+                ></span>
+                <mat-icon class="mixed-type-icon">{{
+                  getTypeIcon(item.node.jsonType)
+                }}</mat-icon>
+
+                <span
+                  class="mixed-tree-label"
+                  *ngIf="renamingNodeId !== item.node.nodeId"
+                >
+                  {{ item.node.title }}
+                </span>
+                <mat-form-field
+                  class="mixed-rename-field"
+                  *ngIf="renamingNodeId === item.node.nodeId"
+                  (click)="$event.stopPropagation()"
+                >
+                  <input
+                    matInput
+                    [(ngModel)]="renameValue"
+                    (keydown.enter)="commitRename(item.node)"
+                    (keydown.escape)="cancelRename()"
+                    (blur)="commitRename(item.node)"
+                  />
+                  <mat-error *ngIf="renameError">{{ renameError }}</mat-error>
+                </mat-form-field>
+
+                <span class="mixed-tree-actions">
+                  <button
+                    mat-icon-button
+                    type="button"
+                    *ngIf="item.node.control.path === propsPath"
+                    [matTooltip]="
+                      showPrimitivesInTree
+                        ? 'Hide primitives'
+                        : 'Show primitives'
+                    "
+                    (click)="togglePrimitiveVisibility($event)"
+                  >
+                    <mat-icon>{{
+                      showPrimitivesInTree ? 'visibility' : 'visibility_off'
+                    }}</mat-icon>
+                  </button>
+                  <button
+                    mat-icon-button
+                    class="mixed-hover-action"
+                    type="button"
+                    *ngIf="
+                      item.node.control.path !== propsPath &&
+                      item.node.canRename &&
+                      isEnabled()
+                    "
+                    matTooltip="Rename"
+                    (click)="startRename(item.node, $event)"
+                  >
+                    <mat-icon>edit</mat-icon>
+                  </button>
+                  <button
+                    mat-icon-button
+                    color="warn"
+                    class="mixed-hover-action"
+                    type="button"
+                    *ngIf="
+                      item.node.control.path !== propsPath &&
+                      item.node.canDelete &&
+                      isEnabled()
+                    "
+                    matTooltip="Delete"
+                    (click)="deleteNode(item.node, $event)"
+                  >
+                    <mat-icon>delete_outline</mat-icon>
+                  </button>
+                </span>
+              </mat-tree-node>
+            </mat-tree>
+          </aside>
+
+          <div
+            class="mixed-splitter"
+            [class.dragging]="draggingSplitter"
+            (mousedown)="startSplitterDrag($event)"
+          ></div>
+
+          <section class="mixed-detail-pane">
+            <jsonforms-outlet
+              *ngIf="selectedNode"
+              [uischema]="selectedNode.control.uischema"
+              [schema]="selectedNode.control.schema"
+              [path]="selectedNode.control.path"
+              [preserveUndefinedAsDefault]="true"
+            ></jsonforms-outlet>
+          </section>
+        </div>
+      </ng-template>
+
+      <mat-expansion-panel
+        *ngIf="showTreeView; else inlineMixed"
+        class="mixed-root-panel"
+        [expanded]="treeExpanded"
+        (opened)="treeExpanded = true"
+        (closed)="treeExpanded = false"
+      >
+        <mat-expansion-panel-header class="mixed-root-panel-header">
+          <ng-container *ngTemplateOutlet="mixedHeader"></ng-container>
+        </mat-expansion-panel-header>
+        <ng-container *ngTemplateOutlet="mixedTree"></ng-container>
+      </mat-expansion-panel>
+
+      <ng-template #inlineMixed>
+        <ng-container *ngTemplateOutlet="mixedHeader"></ng-container>
+      </ng-template>
+    </div>
+  `,
+  styles: [
+    `
+      .mixed-renderer {
+        width: 100%;
+      }
+      .mixed-root-panel {
+        box-shadow: none;
+      }
+      .mixed-root-panel-header {
+        height: auto;
+        min-height: 64px;
+      }
+      .mixed-root-panel-header .mixed-header {
+        width: 100%;
+      }
+      .mixed-header {
+        align-items: flex-start;
+        display: flex;
+        gap: 8px;
+      }
+      .mixed-header-root {
+        align-items: center;
+        display: grid;
+        grid-template-columns: minmax(180px, 360px) minmax(0, 1fr);
+      }
+      .mixed-header-inline {
+        align-items: flex-start;
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+      }
+      .mixed-header-detail {
+        align-items: flex-start;
+        display: grid;
+        grid-template-columns: minmax(180px, 280px) minmax(0, 1fr);
+      }
+      .mixed-type-selector,
+      .mixed-search,
+      .mixed-rename-field {
+        width: 100%;
+      }
+      .mixed-root-label {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .mixed-tree-shell {
+        border: 1px solid rgba(0, 0, 0, 0.12);
+        display: flex;
+        min-height: 320px;
+        overflow: hidden;
+      }
+      .mixed-tree-pane {
+        box-sizing: border-box;
+        flex: 0 0 320px;
+        min-width: 220px;
+        max-width: 640px;
+        padding: 8px;
+      }
+      .mixed-tree-list {
+        max-height: 560px;
+        overflow: auto;
+        padding: 4px 0;
+      }
+      .mixed-tree-item {
+        align-items: center;
+        background: transparent;
+        border: 0;
+        border-radius: 4px;
+        box-sizing: border-box;
+        color: inherit;
+        cursor: pointer;
+        display: flex;
+        font: inherit;
+        min-height: 36px;
+        outline: none;
+        padding: 0 4px 0 0;
+        position: relative;
+        text-align: left;
+        user-select: none;
+        width: 100%;
+      }
+      .mixed-tree-item:hover {
+        background: rgba(0, 0, 0, 0.04);
+      }
+      .mixed-tree-item:focus-visible {
+        box-shadow: inset 0 0 0 2px #3f51b5;
+      }
+      .mixed-tree-item.active {
+        background: rgba(63, 81, 181, 0.12);
+      }
+      .mixed-tree-item:hover .mixed-hover-action,
+      .mixed-tree-item.active .mixed-hover-action {
+        opacity: 1;
+      }
+      .mixed-expand-button,
+      .mixed-expand-spacer {
+        flex: 0 0 32px;
+      }
+      .mixed-expand-button.mat-mdc-icon-button,
+      .mixed-tree-actions .mat-mdc-icon-button {
+        --mdc-icon-button-state-layer-size: 28px;
+        height: 28px;
+        padding: 2px;
+        width: 28px;
+      }
+      .mixed-type-icon {
+        align-items: center;
+        display: inline-flex;
+        flex: 0 0 28px;
+        font-size: 20px;
+        height: 24px;
+        justify-content: center;
+        width: 28px;
+      }
+      .mixed-tree-label {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-align: left;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .mixed-rename-field {
+        flex: 1 1 auto;
+      }
+      .mixed-tree-actions {
+        align-items: center;
+        display: flex;
+        flex: 0 0 auto;
+        margin-left: 4px;
+      }
+      .mixed-hover-action {
+        opacity: 0;
+      }
+      .mixed-splitter {
+        background: rgba(0, 0, 0, 0.12);
+        cursor: col-resize;
+        flex: 0 0 6px;
+      }
+      .mixed-splitter.dragging {
+        background: #3f51b5;
+      }
+      .mixed-detail-pane {
+        flex: 1 1 auto;
+        min-width: 0;
+        padding: 16px;
+      }
+      .mixed-inline-detail {
+        min-width: 0;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    CommonModule,
+    FormsModule,
+    JsonFormsModule,
+    MatButtonModule,
+    MatExpansionModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatSelectModule,
+    MatTooltipModule,
+    MatTreeModule,
+  ],
+})
+export class MixedRenderer extends JsonFormsControl {
+  mixedRenderInfos: SchemaRenderInfo[] = [];
+  selectedIndex: number | undefined;
+  valueType: JsonDataType | null = null;
+  activeNodeId = ROOT_TREE_NODE_ID;
+  openedNodes = new Set<string>();
+  treeNodes: MixedTreeNode[] = [];
+  visibleTreeItems: VisibleTreeItem[] = [];
+  selectedNode: MixedTreeNode | undefined;
+  treeSearch = '';
+  showPrimitivesInTree = false;
+  renamingNodeId: string | null = null;
+  renameValue = '';
+  renameError: string | null = null;
+  treeWidth = 320;
+  treeExpanded = true;
+  draggingSplitter = false;
+  activeInfo: SchemaRenderInfo | undefined;
+  showTreeView = false;
+  isNestedComplexType = false;
+  showInlineDetail = false;
+  treeControl = new FlatTreeControl<VisibleTreeItem, string>(
+    (item) => item.depth,
+    (item) => item.hasChildren,
+    {
+      trackBy: (item) => item.node.nodeId,
+    }
+  );
+
+  protected jsonFormsService = inject(JsonFormsAngularService);
+  parentMixedRenderer = inject(MixedRenderer, {
+    optional: true,
+    skipSelf: true,
+  });
+  private treeControlCache = new Map<string, TreeNodeControl>();
+  private treeStructureSignature: string | undefined;
+  private treeSchemaIndex: number | undefined;
+
+  mapAdditionalProps(props: StatePropsOfControl): void {
+    const uischemas =
+      this.jsonFormsService.getState().jsonforms.uischemas ?? [];
+    this.valueType = getJsonDataType(this.data);
+    this.mixedRenderInfos = createMixedRenderInfos(
+      this.scopedSchema,
+      this.rootSchema,
+      this.uischema,
+      this.propsPath,
+      uischemas
+    );
+    this.selectedIndex = this.findMatchingInfo()?.index;
+    this.activeInfo =
+      this.selectedIndex !== undefined
+        ? this.mixedRenderInfos[this.selectedIndex]
+        : undefined;
+    this.showTreeView =
+      !this.parentMixedRenderer &&
+      (this.valueType === 'object' || this.valueType === 'array');
+    this.isNestedComplexType =
+      Boolean(this.parentMixedRenderer) &&
+      (this.valueType === 'object' || this.valueType === 'array');
+    this.showInlineDetail =
+      !this.showTreeView &&
+      !this.isNestedComplexType &&
+      Boolean(this.activeInfo) &&
+      this.activeInfo?.resolvedSchema?.type !== 'null';
+
+    if (this.showTreeView) {
+      const nextStructureSignature = getTreeStructureSignature(
+        this.data,
+        this.showPrimitivesInTree
+      );
+      const nextSchemaIndex = this.activeInfo?.index;
+      if (
+        this.treeNodes.length === 0 ||
+        this.treeStructureSignature !== nextStructureSignature ||
+        this.treeSchemaIndex !== nextSchemaIndex
+      ) {
+        this.rebuildTree(nextStructureSignature, nextSchemaIndex);
+      }
+    } else {
+      this.treeNodes = [];
+      this.visibleTreeItems = [];
+      this.selectedNode = undefined;
+      this.treeStructureSignature = undefined;
+      this.treeSchemaIndex = undefined;
+    }
+
+    if (props.errors) {
+      this.error = props.errors;
+    }
+  }
+
+  handleSelectChange(newIndex: number | undefined): void {
+    const newData =
+      newIndex !== undefined
+        ? createDefaultValue(
+            this.mixedRenderInfos[newIndex].resolvedSchema,
+            this.rootSchema
+          )
+        : undefined;
+
+    this.jsonFormsService.updateCore(
+      Actions.update(this.propsPath, () => newData)
+    );
+    this.selectedIndex = newIndex;
+    this.activeInfo =
+      newIndex !== undefined ? this.mixedRenderInfos[newIndex] : undefined;
+    this.valueType =
+      newIndex !== undefined
+        ? ((this.mixedRenderInfos[newIndex]?.resolvedSchema as JsonSchema7)
+            ?.type as JsonDataType)
+        : null;
+    this.activeNodeId = toTreeNodeId(this.propsPath);
+  }
+
+  selectPath(targetPath: string): void {
+    this.activeNodeId = toTreeNodeId(targetPath);
+    this.getPathAncestorNodeIds(targetPath).forEach((nodeId) =>
+      this.openedNodes.add(nodeId)
+    );
+    this.selectedNode = findNodeById(this.treeNodes, this.activeNodeId);
+    this.rebuildVisibleTree();
+  }
+
+  selectNestedPath(): void {
+    this.parentMixedRenderer?.selectPath(this.propsPath);
+  }
+
+  selectNode(nodeId: string): void {
+    this.activeNodeId = nodeId;
+    this.selectedNode = findNodeById(this.treeNodes, nodeId);
+  }
+
+  toggleNode(node: MixedTreeNode, event: MouseEvent): void {
+    event.stopPropagation();
+    if (!node.children?.length) {
+      return;
+    }
+
+    if (this.openedNodes.has(node.nodeId)) {
+      this.openedNodes.delete(node.nodeId);
+    } else {
+      this.openedNodes.add(node.nodeId);
+    }
+    this.rebuildVisibleTree();
+  }
+
+  togglePrimitiveVisibility(event: MouseEvent): void {
+    event.stopPropagation();
+    this.showPrimitivesInTree = !this.showPrimitivesInTree;
+    this.rebuildTree();
+  }
+
+  startRename(node: MixedTreeNode, event: MouseEvent): void {
+    event.stopPropagation();
+    if (!node.canRename) {
+      return;
+    }
+    this.renamingNodeId = node.nodeId;
+    this.renameValue = node.label;
+    this.renameError = null;
+  }
+
+  cancelRename(): void {
+    this.renamingNodeId = null;
+    this.renameValue = '';
+    this.renameError = null;
+  }
+
+  commitRename(node: MixedTreeNode): void {
+    if (this.renamingNodeId !== node.nodeId) {
+      return;
+    }
+
+    const trimmed = this.renameValue.trim();
+    if (!trimmed || trimmed === node.label) {
+      this.cancelRename();
+      return;
+    }
+
+    const parentPath = getParentPath(this.propsPath, node.control.path);
+    const parentRelativePath = getRelativePath(this.propsPath, parentPath);
+    const parentData =
+      parentRelativePath === null
+        ? this.data
+        : get(this.data, parentRelativePath);
+
+    if (
+      typeof parentData !== 'object' ||
+      parentData === null ||
+      Array.isArray(parentData)
+    ) {
+      this.cancelRename();
+      return;
+    }
+
+    if (trimmed in parentData) {
+      this.renameError = `Property "${trimmed}" already exists`;
+      return;
+    }
+
+    let parentSchema = this.getParentSchema(parentPath);
+    if (parentSchema) {
+      parentSchema = resolveSchema(parentSchema, this.rootSchema);
+    }
+
+    if (typeof parentSchema === 'object' && parentSchema.patternProperties) {
+      const patterns = Object.keys(parentSchema.patternProperties);
+      const hadMatchingPattern = patterns.some((pattern) =>
+        new RegExp(pattern).test(node.label)
+      );
+      const hasMatchingPattern = patterns.some((pattern) =>
+        new RegExp(pattern).test(trimmed)
+      );
+      if (hadMatchingPattern && !hasMatchingPattern) {
+        this.renameError = `Property name must match pattern: ${patterns.join(
+          ', '
+        )}`;
+        return;
+      }
+    }
+
+    const propertyNames = (parentSchema as JsonSchema7)?.propertyNames as
+      | JsonSchema7
+      | undefined;
+    if (propertyNames?.pattern) {
+      const pattern = new RegExp(propertyNames.pattern);
+      if (!pattern.test(trimmed)) {
+        this.renameError = `Property name must match pattern: ${propertyNames.pattern}`;
+        return;
+      }
+    }
+
+    const updatedData = Object.fromEntries(
+      Object.entries(parentData).map(([key, value]) => [
+        key === node.label ? trimmed : key,
+        value,
+      ])
+    );
+    this.jsonFormsService.updateCore(
+      Actions.update(parentPath, () => updatedData)
+    );
+
+    const newPath = compose(parentPath, trimmed);
+    this.selectPath(newPath);
+    this.cancelRename();
+  }
+
+  deleteNode(node: MixedTreeNode, event: MouseEvent): void {
+    event.stopPropagation();
+    if (!node.canDelete) {
+      return;
+    }
+
+    const parentPath = getParentPath(this.propsPath, node.control.path);
+    const parentRelativePath = getRelativePath(this.propsPath, parentPath);
+    const parentData =
+      parentRelativePath === null
+        ? this.data
+        : get(this.data, parentRelativePath);
+    const key = node.control.path.slice(
+      parentPath.length ? parentPath.length + 1 : 0
+    );
+
+    if (Array.isArray(parentData)) {
+      const index = Number(key);
+      if (!Number.isInteger(index)) {
+        return;
+      }
+      const updatedData = [...parentData];
+      updatedData.splice(index, 1);
+      this.jsonFormsService.updateCore(
+        Actions.update(parentPath, () => updatedData)
+      );
+    } else if (typeof parentData === 'object' && parentData !== null) {
+      const updatedData = { ...parentData };
+      delete updatedData[key];
+      this.jsonFormsService.updateCore(
+        Actions.update(parentPath, () => updatedData)
+      );
+    }
+
+    if (
+      this.activeNodeId === node.nodeId ||
+      this.activeNodeId.startsWith(`${node.nodeId}.`)
+    ) {
+      this.selectPath(parentPath);
+    }
+  }
+
+  rebuildVisibleTree(): void {
+    this.visibleTreeItems = flattenVisibleTree(
+      this.treeNodes,
+      this.openedNodes,
+      0,
+      this.treeSearch
+    );
+  }
+
+  trackTreeItem(_index: number, item: VisibleTreeItem): string {
+    return item.node.nodeId;
+  }
+
+  getTypeIcon(type: JsonDataType): string {
+    switch (type) {
+      case 'array':
+        return 'format_list_bulleted';
+      case 'object':
+        return 'folder';
+      case 'boolean':
+        return 'toggle_on';
+      case 'integer':
+      case 'number':
+        return 'pin';
+      case 'string':
+        return 'abc';
+      case 'null':
+      default:
+        return 'add';
+    }
+  }
+
+  startSplitterDrag(event: MouseEvent): void {
+    event.preventDefault();
+    this.draggingSplitter = true;
+  }
+
+  @HostListener('document:mousemove', ['$event'])
+  onDocumentMouseMove(event: MouseEvent): void {
+    if (!this.draggingSplitter) {
+      return;
+    }
+    this.treeWidth = Math.min(640, Math.max(220, event.clientX - 32));
+  }
+
+  @HostListener('document:mouseup')
+  onDocumentMouseUp(): void {
+    this.draggingSplitter = false;
+  }
+
+  private findMatchingInfo(): SchemaRenderInfo | undefined {
+    const currentlySelected =
+      this.selectedIndex !== undefined
+        ? this.mixedRenderInfos[this.selectedIndex]
+        : undefined;
+    if (
+      currentlySelected &&
+      schemaSupportsInputType(
+        (currentlySelected.resolvedSchema as JsonSchema7).type,
+        this.valueType
+      )
+    ) {
+      return currentlySelected;
+    }
+
+    const exact = this.mixedRenderInfos.find(
+      (entry) => (entry.resolvedSchema as JsonSchema7).type === this.valueType
+    );
+    return (
+      exact ??
+      this.mixedRenderInfos.find(
+        (entry) =>
+          (entry.resolvedSchema as JsonSchema7).type === 'number' &&
+          this.valueType === 'integer'
+      )
+    );
+  }
+
+  private rebuildTree(
+    structureSignature = getTreeStructureSignature(
+      this.data,
+      this.showPrimitivesInTree
+    ),
+    schemaIndex = this.activeInfo?.index
+  ): void {
+    this.treeNodes = buildTreeFromData(
+      this.data,
+      this.activeInfo?.resolvedSchema ?? this.scopedSchema,
+      this.rootSchema,
+      this.propsPath,
+      this.label,
+      this.showPrimitivesInTree,
+      this.treeControlCache
+    );
+    this.treeStructureSignature = structureSignature;
+    this.treeSchemaIndex = schemaIndex;
+
+    const allNodeIds = flattenTree(this.treeNodes).map((node) => node.nodeId);
+    const allNodeIdSet = new Set(allNodeIds);
+    const rootNodeId = toTreeNodeId(this.propsPath);
+    if (!allNodeIdSet.has(this.activeNodeId)) {
+      this.activeNodeId = rootNodeId;
+    }
+    this.openedNodes = new Set(
+      [rootNodeId, ...Array.from(this.openedNodes)].filter((nodeId) =>
+        allNodeIdSet.has(nodeId)
+      )
+    );
+    this.selectedNode = findNodeById(this.treeNodes, this.activeNodeId);
+    this.rebuildVisibleTree();
+  }
+
+  private getPathAncestorNodeIds(targetPath: string): string[] {
+    const relativePath = getRelativePath(this.propsPath, targetPath);
+    const segments =
+      relativePath === null ? [] : relativePath.split('.').filter(Boolean);
+    const result = [toTreeNodeId(this.propsPath)];
+    let currentPath = this.propsPath;
+
+    segments.slice(0, -1).forEach((segment) => {
+      currentPath = compose(currentPath, segment);
+      result.push(toTreeNodeId(currentPath));
+    });
+
+    return result;
+  }
+
+  private getParentSchema(parentPath: string): JsonSchema | undefined {
+    const parentRelativePath = getRelativePath(this.propsPath, parentPath);
+    if (parentRelativePath === null) {
+      return this.activeInfo?.resolvedSchema ?? this.scopedSchema;
+    }
+
+    const segments = parentRelativePath.split('.');
+    let currentSchema: JsonSchema =
+      this.activeInfo?.resolvedSchema ?? this.scopedSchema;
+
+    for (const segment of segments) {
+      currentSchema = resolveSchema(currentSchema, this.rootSchema);
+      if (typeof currentSchema !== 'object') {
+        return {};
+      }
+      if (currentSchema.type === 'array') {
+        currentSchema = (currentSchema.items as JsonSchema) ?? {};
+      } else {
+        currentSchema =
+          currentSchema.properties?.[segment] ??
+          findPropertySchema(currentSchema, segment, this.rootSchema) ??
+          {};
+      }
+    }
+
+    return currentSchema;
+  }
+}
+
+export const isMixedSchema = (
+  uischema: UISchemaElement & Scopable,
+  schema: JsonSchema,
+  context: TesterContext
+) => {
+  if (schema && typeof schema === 'boolean') {
+    return true;
+  }
+
+  if (!schema || typeof schema !== 'object') {
+    return false;
+  }
+
+  if (Array.isArray(schema.type)) {
+    return true;
+  }
+
+  if (schema.type === 'object') {
+    const schemaPath = uischema.scope;
+    if (schemaPath && !isEmpty(schemaPath)) {
+      const currentDataSchema = Resolve.schema(
+        schema,
+        schemaPath,
+        context?.rootSchema
+      );
+      if (currentDataSchema === undefined) {
+        return false;
+      }
+      if (Array.isArray(currentDataSchema.type)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+export const isMixedControl = (
+  uischema: UISchemaElement,
+  schema: JsonSchema,
+  context: TesterContext
+) =>
+  isMixedSchema(uischema as UISchemaElement & Scopable, schema, context) &&
+  (isControl(uischema) || isDefaultGenUiSchema(uischema));
+
+export const MixedRendererTester: RankedTester = rankWith(20, isMixedControl);

--- a/packages/angular-material/src/library/other/object.renderer.ts
+++ b/packages/angular-material/src/library/other/object.renderer.ts
@@ -30,6 +30,7 @@ import {
   JsonFormsModule,
 } from '@jsonforms/angular';
 import { MatCardModule } from '@angular/material/card';
+import { AdditionalPropertiesRenderer } from './additional-properties.renderer';
 import {
   ControlWithDetailProps,
   findUISchema,
@@ -47,12 +48,25 @@ import cloneDeep from 'lodash/cloneDeep';
   selector: 'ObjectRenderer',
   template: `
     <mat-card class="object-layout" appearance="outlined">
+      <mat-card-title *ngIf="objectLabel" class="object-layout-title">
+        {{ objectLabel }}
+      </mat-card-title>
       <jsonforms-outlet
         [uischema]="detailUiSchema"
         [schema]="scopedSchema"
         [path]="propsPath"
       >
       </jsonforms-outlet>
+      <AdditionalPropertiesRenderer
+        [config]="additionalPropertiesConfig"
+        [data]="data"
+        [enabled]="isEnabled()"
+        [label]="label"
+        [path]="propsPath"
+        [rootSchema]="rootSchema"
+        [schema]="scopedSchema"
+        [uischema]="uischema"
+      ></AdditionalPropertiesRenderer>
     </mat-card>
   `,
   styles: [
@@ -60,14 +74,23 @@ import cloneDeep from 'lodash/cloneDeep';
       .object-layout {
         padding: 16px;
       }
+      .object-layout-title {
+        margin-bottom: 16px;
+      }
     `,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [JsonFormsModule, MatCardModule],
+  imports: [JsonFormsModule, MatCardModule, AdditionalPropertiesRenderer],
 })
 export class ObjectControlRenderer extends JsonFormsControlWithDetail {
   detailUiSchema: UISchemaElement;
+  additionalPropertiesConfig: any;
+  objectLabel: string | undefined;
   mapAdditionalProps(props: ControlWithDetailProps) {
+    this.additionalPropertiesConfig = {
+      ...props.config,
+      ...props.uischema.options,
+    };
     this.detailUiSchema = findUISchema(
       props.uischemas,
       props.schema,
@@ -81,7 +104,7 @@ export class ObjectControlRenderer extends JsonFormsControlWithDetail {
         delete newSchema.allOf;
         return Generate.uiSchema(
           newSchema,
-          'Group',
+          'VerticalLayout',
           undefined,
           this.rootSchema
         );
@@ -91,8 +114,16 @@ export class ObjectControlRenderer extends JsonFormsControlWithDetail {
     );
     if (isEmpty(props.path)) {
       this.detailUiSchema.type = 'VerticalLayout';
+      this.objectLabel = undefined;
     } else {
-      (this.detailUiSchema as GroupLayout).label = startCase(props.path);
+      this.objectLabel =
+        (this.detailUiSchema as GroupLayout).label ?? startCase(props.path);
+      if (this.detailUiSchema.type === 'Group') {
+        this.detailUiSchema = {
+          ...this.detailUiSchema,
+          type: 'VerticalLayout',
+        } as UISchemaElement;
+      }
     }
     if (!this.isEnabled()) {
       setReadonly(this.detailUiSchema);

--- a/packages/angular-material/src/library/other/object.renderer.ts
+++ b/packages/angular-material/src/library/other/object.renderer.ts
@@ -24,6 +24,7 @@
 */
 import isEmpty from 'lodash/isEmpty';
 import startCase from 'lodash/startCase';
+import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import {
   JsonFormsControlWithDetail,
@@ -80,7 +81,12 @@ import cloneDeep from 'lodash/cloneDeep';
     `,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [JsonFormsModule, MatCardModule, AdditionalPropertiesRenderer],
+  imports: [
+    CommonModule,
+    JsonFormsModule,
+    MatCardModule,
+    AdditionalPropertiesRenderer,
+  ],
 })
 export class ObjectControlRenderer extends JsonFormsControlWithDetail {
   detailUiSchema: UISchemaElement;

--- a/packages/angular-material/test/object-control.spec.ts
+++ b/packages/angular-material/test/object-control.spec.ts
@@ -129,10 +129,11 @@ describe('Object Control', () => {
     fixture.detectChanges();
     component.ngOnInit();
     fixture.whenStable().then(() => {
-      // one for the object renderer and one for the group
-      expect(fixture.nativeElement.querySelectorAll('mat-card').length).toBe(2);
+      expect(fixture.nativeElement.querySelectorAll('mat-card').length).toBe(1);
       expect(
-        fixture.nativeElement.querySelectorAll('mat-card-title')[0].textContent
+        fixture.nativeElement
+          .querySelectorAll('mat-card-title')[0]
+          .textContent.trim()
       ).toBe('Foo');
     });
   }));

--- a/packages/angular/src/library/abstract-control.ts
+++ b/packages/angular/src/library/abstract-control.ts
@@ -33,6 +33,7 @@ import {
   Actions,
   computeLabel,
   ControlElement,
+  createDefaultValue,
   Id,
   JsonFormsState,
   JsonSchema,
@@ -56,6 +57,7 @@ export abstract class JsonFormsAbstractControl<
   @Input() id: string;
   @Input() disabled: boolean;
   @Input() visible: boolean;
+  @Input() preserveUndefinedAsDefault = false;
 
   form: FormControl;
   data: any;
@@ -87,8 +89,14 @@ export abstract class JsonFormsAbstractControl<
   getEventValue = (event: any) => event.value;
 
   onChange(ev: any) {
+    const eventValue = this.getEventValue(ev);
+    const value =
+      this.preserveUndefinedAsDefault && eventValue === undefined
+        ? createDefaultValue(this.scopedSchema, this.rootSchema)
+        : eventValue;
+
     this.jsonFormsService.updateCore(
-      Actions.update(this.propsPath, () => this.getEventValue(ev))
+      Actions.update(this.propsPath, () => value)
     );
     this.triggerValidation();
   }

--- a/packages/angular/src/library/jsonforms.component.ts
+++ b/packages/angular/src/library/jsonforms.component.ts
@@ -27,7 +27,9 @@ import {
   Directive,
   inject,
   Input,
+  OnChanges,
   OnInit,
+  SimpleChanges,
   Type,
   ViewContainerRef,
 } from '@angular/core';
@@ -70,12 +72,14 @@ const areEqual = (
 })
 export class JsonFormsOutlet
   extends JsonFormsBaseRenderer<UISchemaElement>
-  implements OnInit
+  implements OnInit, OnChanges
 {
   private previousProps: StatePropsOfJsonFormsRenderer;
 
   private viewContainerRef = inject(ViewContainerRef);
   private jsonformsService = inject(JsonFormsAngularService);
+
+  @Input() preserveUndefinedAsDefault = false;
 
   @Input()
   set renderProps(renderProps: OwnPropsOfRenderer) {
@@ -83,6 +87,21 @@ export class JsonFormsOutlet
     this.schema = renderProps.schema;
     this.uischema = renderProps.uischema;
     this.update(this.jsonformsService.getState());
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.renderProps) {
+      return;
+    }
+
+    if (
+      changes.schema ||
+      changes.uischema ||
+      changes.path ||
+      changes.preserveUndefinedAsDefault
+    ) {
+      this.update(this.jsonformsService.getState());
+    }
   }
 
   ngOnInit(): void {
@@ -135,6 +154,8 @@ export class JsonFormsOutlet
       instance.path = this.path;
       if (instance instanceof JsonFormsControl) {
         const controlInstance = instance as JsonFormsControl;
+        controlInstance.preserveUndefinedAsDefault =
+          this.preserveUndefinedAsDefault;
         if (controlInstance.id === undefined) {
           const id = isControl(props.uischema)
             ? Id.createId(props.uischema.scope)

--- a/packages/material-renderers/package.json
+++ b/packages/material-renderers/package.json
@@ -98,6 +98,7 @@
     "@mui/icons-material": "^7.0.0",
     "@mui/material": "^7.0.0",
     "@mui/x-date-pickers": "^8.0.0",
+    "@mui/x-tree-view": "^8.0.0",
     "react": "^16.12.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
@@ -108,6 +109,7 @@
     "@mui/icons-material": "^7.3.0",
     "@mui/material": "^7.3.0",
     "@mui/x-date-pickers": "^8.11.3",
+    "@mui/x-tree-view": "^8.29.0",
     "@rollup/plugin-commonjs": "^23.0.3",
     "@rollup/plugin-json": "^5.0.2",
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/packages/material-renderers/src/complex/DynamicPropertyDispatch.tsx
+++ b/packages/material-renderers/src/complex/DynamicPropertyDispatch.tsx
@@ -1,0 +1,111 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017-2026 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import React, { useMemo } from 'react';
+import {
+  CoreActions,
+  createDefaultValue,
+  JsonFormsCellRendererRegistryEntry,
+  JsonFormsRendererRegistryEntry,
+  JsonSchema,
+  UPDATE_DATA,
+  UpdateAction,
+  UISchemaElement,
+} from '@jsonforms/core';
+import {
+  JsonFormsContext,
+  JsonFormsDispatch,
+  useJsonForms,
+} from '@jsonforms/react';
+
+interface DynamicPropertyDispatchProps {
+  cells?: JsonFormsCellRendererRegistryEntry[];
+  enabled?: boolean;
+  path: string;
+  readonly?: boolean;
+  renderers?: JsonFormsRendererRegistryEntry[];
+  rootSchema: JsonSchema;
+  schema: JsonSchema;
+  uischema: UISchemaElement;
+}
+
+const isUpdateAction = (action: CoreActions): action is UpdateAction =>
+  action.type === UPDATE_DATA;
+
+export const DynamicPropertyDispatch = ({
+  cells,
+  enabled,
+  path,
+  readonly,
+  renderers,
+  rootSchema,
+  schema,
+  uischema,
+}: DynamicPropertyDispatchProps) => {
+  const jsonforms = useJsonForms();
+  const dispatch = useMemo(() => {
+    if (!jsonforms.dispatch) {
+      return jsonforms.dispatch;
+    }
+
+    return (action: CoreActions) => {
+      if (isUpdateAction(action) && action.path === path) {
+        jsonforms.dispatch?.({
+          ...action,
+          updater: (existingData: any) => {
+            const value = action.updater(existingData);
+            return value === undefined
+              ? createDefaultValue(schema, rootSchema)
+              : value;
+          },
+        });
+        return;
+      }
+
+      jsonforms.dispatch?.(action);
+    };
+  }, [jsonforms, path, rootSchema, schema]);
+
+  const contextValue = useMemo(
+    () => ({
+      ...jsonforms,
+      dispatch,
+    }),
+    [dispatch, jsonforms]
+  );
+
+  return (
+    <JsonFormsContext.Provider value={contextValue}>
+      <JsonFormsDispatch
+        schema={schema}
+        uischema={uischema}
+        path={path}
+        renderers={renderers}
+        cells={cells}
+        enabled={enabled}
+        readonly={readonly}
+      />
+    </JsonFormsContext.Provider>
+  );
+};

--- a/packages/material-renderers/src/complex/MaterialAdditionalProperties.tsx
+++ b/packages/material-renderers/src/complex/MaterialAdditionalProperties.tsx
@@ -1,0 +1,609 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017-2026 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import React, { useMemo, useState } from 'react';
+import {
+  composePaths,
+  ControlElement,
+  createControlElement,
+  createDefaultValue,
+  Generate,
+  GroupLayout,
+  JsonFormsCellRendererRegistryEntry,
+  JsonFormsRendererRegistryEntry,
+  JsonFormsUISchemaRegistryEntry,
+  JsonSchema,
+  JsonSchema7,
+  resolveSchema,
+  UISchemaElement,
+} from '@jsonforms/core';
+import {
+  Box,
+  Button,
+  IconButton,
+  InputAdornment,
+  Popover,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { Add, DeleteOutline, EditOutlined } from '@mui/icons-material';
+import merge from 'lodash/merge';
+import startCase from 'lodash/startCase';
+import { useInputVariant } from '../util';
+import { DynamicPropertyDispatch } from './DynamicPropertyDispatch';
+
+interface AdditionalPropertyItem {
+  propertyName: string;
+  path: string;
+  schema: JsonSchema;
+  uischema: UISchemaElement;
+}
+
+export interface MaterialAdditionalPropertiesProps {
+  cells?: JsonFormsCellRendererRegistryEntry[];
+  config?: any;
+  data: any;
+  enabled: boolean;
+  handleChange(path: string, value: any): void;
+  label: string;
+  path: string;
+  readonly?: boolean;
+  renderers?: JsonFormsRendererRegistryEntry[];
+  rootSchema: JsonSchema;
+  schema: JsonSchema;
+  uischema: ControlElement;
+  uischemas?: JsonFormsUISchemaRegistryEntry[];
+}
+
+const ANY_TYPE: JsonSchema7['type'] = [
+  'array',
+  'boolean',
+  'integer',
+  'null',
+  'number',
+  'object',
+  'string',
+];
+
+const toObjectSchema = (schema: JsonSchema): JsonSchema7 =>
+  typeof schema === 'object' ? (schema as JsonSchema7) : {};
+
+const hasAdditionalProperties = (schema: JsonSchema): boolean => {
+  const objectSchema = toObjectSchema(schema);
+  return (
+    Boolean(
+      objectSchema.patternProperties &&
+        Object.keys(objectSchema.patternProperties).length > 0
+    ) ||
+    typeof objectSchema.additionalProperties === 'object' ||
+    objectSchema.additionalProperties === true
+  );
+};
+
+const getMatchingAdditionalPropertySchema = (
+  propName: string,
+  parentSchema: JsonSchema,
+  rootSchema: JsonSchema
+): JsonSchema => {
+  const objectSchema = toObjectSchema(parentSchema);
+  let propSchema: JsonSchema | undefined;
+
+  if (objectSchema.patternProperties) {
+    const matchedPattern = Object.keys(objectSchema.patternProperties).find(
+      (pattern) => new RegExp(pattern).test(propName)
+    );
+    if (matchedPattern) {
+      propSchema = objectSchema.patternProperties[matchedPattern];
+    }
+  }
+
+  if (
+    (!propSchema && typeof objectSchema.additionalProperties === 'object') ||
+    objectSchema.additionalProperties === true
+  ) {
+    propSchema =
+      objectSchema.additionalProperties === true
+        ? { additionalProperties: true }
+        : objectSchema.additionalProperties;
+  }
+
+  if (typeof propSchema === 'object' && typeof propSchema.$ref === 'string') {
+    propSchema = resolveSchema(rootSchema, propSchema.$ref, rootSchema);
+  }
+
+  propSchema = propSchema ?? {};
+
+  if (typeof propSchema === 'object' && propSchema.type === undefined) {
+    propSchema = {
+      ...propSchema,
+      type: ANY_TYPE,
+    };
+  }
+
+  return propSchema;
+};
+
+const toAdditionalPropertyItem = (
+  propName: string,
+  parentPath: string,
+  parentSchema: JsonSchema,
+  rootSchema: JsonSchema
+): AdditionalPropertyItem => {
+  let propSchema = getMatchingAdditionalPropertySchema(
+    propName,
+    parentSchema,
+    rootSchema
+  );
+  let propUiSchema: UISchemaElement = createControlElement('#');
+
+  if (typeof propSchema === 'object' && propSchema.type === 'array') {
+    propUiSchema = Generate.uiSchema(
+      propSchema,
+      'Group',
+      undefined,
+      rootSchema
+    );
+    (propUiSchema as GroupLayout).label =
+      propSchema.title ?? startCase(propName);
+  }
+
+  if (typeof propSchema === 'object') {
+    propSchema = {
+      ...propSchema,
+      title: propName,
+    };
+    if (propSchema.type === 'object') {
+      propSchema.additionalProperties =
+        propSchema.additionalProperties !== false
+          ? propSchema.additionalProperties ?? true
+          : false;
+    } else if (propSchema.type === 'array') {
+      propSchema.items = propSchema.items ?? {};
+    }
+  }
+
+  return {
+    propertyName: propName,
+    path: composePaths(parentPath, propName),
+    schema: propSchema,
+    uischema: propUiSchema,
+  };
+};
+
+const getPropertyNamePattern = (schema: JsonSchema): string | undefined => {
+  const objectSchema = toObjectSchema(schema);
+  const propertyNames = objectSchema.propertyNames as JsonSchema7 | undefined;
+  if (typeof propertyNames === 'object' && propertyNames.pattern) {
+    return propertyNames.pattern;
+  }
+
+  if (
+    objectSchema.additionalProperties === false &&
+    objectSchema.patternProperties
+  ) {
+    const patterns = Object.keys(objectSchema.patternProperties);
+    return patterns.length > 0 ? patterns.join('|') : undefined;
+  }
+
+  return undefined;
+};
+
+const validatePropertyName = (
+  propertyName: string,
+  data: any,
+  schema: JsonSchema,
+  currentPropertyName?: string
+): string | undefined => {
+  if (!propertyName) {
+    return undefined;
+  }
+
+  if (
+    typeof data === 'object' &&
+    data !== null &&
+    Object.prototype.hasOwnProperty.call(data, propertyName)
+  ) {
+    if (propertyName === currentPropertyName) {
+      return undefined;
+    }
+    return `Property '${propertyName}' already defined`;
+  }
+
+  if (
+    propertyName.includes('[') ||
+    propertyName.includes(']') ||
+    propertyName.includes('.')
+  ) {
+    return `Property name '${propertyName}' is invalid`;
+  }
+
+  const pattern = getPropertyNamePattern(schema);
+  if (pattern && !new RegExp(pattern).test(propertyName)) {
+    return `Property name must match pattern: ${pattern}`;
+  }
+
+  return undefined;
+};
+
+export const MaterialAdditionalProperties = ({
+  cells,
+  config,
+  data,
+  enabled,
+  handleChange,
+  label,
+  path,
+  readonly,
+  renderers,
+  rootSchema,
+  schema,
+  uischema,
+}: MaterialAdditionalPropertiesProps) => {
+  const [newPropertyName, setNewPropertyName] = useState('');
+  const [renamingPropertyName, setRenamingPropertyName] = useState<
+    string | null
+  >(null);
+  const [renameAnchorEl, setRenameAnchorEl] = useState<HTMLElement | null>(
+    null
+  );
+  const [renameValue, setRenameValue] = useState('');
+  const inputVariant = useInputVariant();
+  const appliedOptions = merge({}, config, uischema.options);
+  const objectSchema = toObjectSchema(schema);
+  const reservedPropertyNames = Object.keys(objectSchema.properties ?? {});
+  const additionalKeys = Object.keys(data ?? {}).filter(
+    (key) => !reservedPropertyNames.includes(key)
+  );
+  const additionalPropertyItems = useMemo(
+    () =>
+      additionalKeys.map((propertyName) =>
+        toAdditionalPropertyItem(propertyName, path, schema, rootSchema)
+      ),
+    [additionalKeys.join('\u0000'), path, rootSchema, schema]
+  );
+  const allowIfMissing =
+    appliedOptions.allowAdditionalPropertiesIfMissing === true &&
+    objectSchema.additionalProperties === undefined;
+  const shouldShow =
+    hasAdditionalProperties(schema) ||
+    allowIfMissing ||
+    additionalKeys.length > 0;
+
+  if (!shouldShow) {
+    return null;
+  }
+
+  const propertyNameError = validatePropertyName(newPropertyName, data, schema);
+  const maxPropertiesReached =
+    objectSchema.maxProperties !== undefined &&
+    data &&
+    Object.keys(data).length >= objectSchema.maxProperties;
+  const minPropertiesReached =
+    objectSchema.minProperties !== undefined &&
+    data &&
+    Object.keys(data).length <= objectSchema.minProperties;
+  const addPropertyDisabled =
+    !enabled ||
+    readonly ||
+    (appliedOptions.restrict && maxPropertiesReached) ||
+    Boolean(propertyNameError) ||
+    !newPropertyName;
+  const removePropertyDisabled =
+    !enabled || readonly || (appliedOptions.restrict && minPropertiesReached);
+  const additionalPropertiesTitle = toObjectSchema(
+    objectSchema.additionalProperties as JsonSchema
+  ).title;
+
+  const addProperty = () => {
+    if (addPropertyDisabled) {
+      return;
+    }
+
+    const additionalProperty = toAdditionalPropertyItem(
+      newPropertyName,
+      path,
+      schema,
+      rootSchema
+    );
+    const updatedData =
+      typeof data === 'object' && data !== null && !Array.isArray(data)
+        ? { ...data }
+        : {};
+
+    updatedData[newPropertyName] = createDefaultValue(
+      additionalProperty.schema,
+      rootSchema
+    );
+    handleChange(path, updatedData);
+    setNewPropertyName('');
+  };
+
+  const removeProperty = (propertyName: string) => {
+    if (removePropertyDisabled || typeof data !== 'object' || data === null) {
+      return;
+    }
+
+    const updatedData = { ...data };
+    delete updatedData[propertyName];
+    handleChange(path, updatedData);
+  };
+  const renameProperty = (propertyName: string) => {
+    const trimmed = renameValue.trim();
+    const renameError = validatePropertyName(
+      trimmed,
+      data,
+      schema,
+      propertyName
+    );
+    if (
+      renameError ||
+      !trimmed ||
+      trimmed === propertyName ||
+      typeof data !== 'object' ||
+      data === null ||
+      Array.isArray(data)
+    ) {
+      return;
+    }
+
+    const updatedData = Object.fromEntries(
+      Object.entries(data).map(([key, value]) => [
+        key === propertyName ? trimmed : key,
+        value,
+      ])
+    );
+    handleChange(path, updatedData);
+    setRenamingPropertyName(null);
+    setRenameAnchorEl(null);
+    setRenameValue('');
+  };
+  const cancelRename = () => {
+    setRenamingPropertyName(null);
+    setRenameAnchorEl(null);
+    setRenameValue('');
+  };
+  const startRename = (propertyName: string, anchorEl: HTMLElement | null) => {
+    setRenamingPropertyName(propertyName);
+    setRenameAnchorEl(anchorEl);
+    setRenameValue(propertyName);
+  };
+
+  return (
+    <Box
+      sx={{
+        mt: 1,
+      }}
+    >
+      <Box
+        sx={{
+          alignItems: 'flex-start',
+          display: 'grid',
+          gap: 1,
+          gridTemplateColumns: additionalPropertiesTitle
+            ? 'minmax(120px, auto) 1fr auto'
+            : '1fr auto',
+        }}
+      >
+        {additionalPropertiesTitle ? (
+          <Typography sx={{ pt: 1 }} variant='body2'>
+            {additionalPropertiesTitle}
+          </Typography>
+        ) : null}
+        <TextField
+          fullWidth
+          error={Boolean(propertyNameError)}
+          helperText={propertyNameError}
+          label='Property Name'
+          size='small'
+          value={newPropertyName}
+          variant={inputVariant}
+          onChange={(event) => setNewPropertyName(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              addProperty();
+            }
+          }}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position='end'>
+                <Tooltip title={label ? `Add to ${label}` : 'Add'}>
+                  <span>
+                    <IconButton
+                      aria-label={
+                        label ? `Add to ${label} button` : 'Add button'
+                      }
+                      disabled={addPropertyDisabled}
+                      edge='end'
+                      size='small'
+                      onClick={addProperty}
+                    >
+                      <Add fontSize='small' />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              </InputAdornment>
+            ),
+          }}
+        />
+      </Box>
+      <Box sx={{ mt: 1 }}>
+        {additionalPropertyItems.map((item) => {
+          const isRenaming = renamingPropertyName === item.propertyName;
+          const renameError = validatePropertyName(
+            renameValue.trim(),
+            data,
+            schema,
+            item.propertyName
+          );
+          const renameDisabled =
+            !enabled ||
+            readonly ||
+            Boolean(renameError) ||
+            !renameValue.trim() ||
+            renameValue.trim() === item.propertyName;
+
+          return (
+            <Box
+              key={item.propertyName}
+              sx={{
+                alignItems: 'flex-start',
+                display: 'grid',
+                gap: 1,
+                gridTemplateColumns: enabled ? 'minmax(0, 1fr) auto' : '1fr',
+                minWidth: 0,
+                width: '100%',
+                '&:hover .additional-property-actions': {
+                  opacity: 1,
+                },
+              }}
+            >
+              <Box sx={{ minWidth: 0, width: '100%' }}>
+                <DynamicPropertyDispatch
+                  schema={item.schema}
+                  uischema={item.uischema}
+                  path={item.path}
+                  renderers={renderers}
+                  cells={cells}
+                  enabled={enabled}
+                  readonly={readonly}
+                  rootSchema={rootSchema}
+                />
+              </Box>
+              {enabled ? (
+                <Box
+                  className='additional-property-actions'
+                  sx={{
+                    alignItems: 'center',
+                    display: 'inline-flex',
+                    flexDirection: 'column',
+                    opacity: isRenaming ? 1 : 0.72,
+                    transition: 'opacity 120ms ease',
+                  }}
+                >
+                  <Tooltip title='Rename'>
+                    <span>
+                      <IconButton
+                        aria-label='Rename property button'
+                        disabled={readonly}
+                        size='small'
+                        sx={{
+                          height: 24,
+                          p: 0.25,
+                          width: 24,
+                          '& .MuiSvgIcon-root': {
+                            fontSize: 16,
+                          },
+                        }}
+                        onClick={(event) =>
+                          startRename(item.propertyName, event.currentTarget)
+                        }
+                      >
+                        <EditOutlined />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                  <Tooltip title='Delete'>
+                    <span>
+                      <IconButton
+                        aria-label='Delete button'
+                        color='error'
+                        disabled={removePropertyDisabled || isRenaming}
+                        size='small'
+                        sx={{
+                          height: 24,
+                          p: 0.25,
+                          width: 24,
+                          '& .MuiSvgIcon-root': {
+                            fontSize: 16,
+                          },
+                        }}
+                        onClick={() => removeProperty(item.propertyName)}
+                      >
+                        <DeleteOutline />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                </Box>
+              ) : null}
+              <Popover
+                anchorEl={renameAnchorEl}
+                anchorOrigin={{
+                  horizontal: 'right',
+                  vertical: 'top',
+                }}
+                open={isRenaming}
+                transformOrigin={{
+                  horizontal: 'right',
+                  vertical: 'bottom',
+                }}
+                onClose={cancelRename}
+              >
+                <Box sx={{ p: 1.5, width: 300 }}>
+                  <TextField
+                    autoFocus
+                    error={Boolean(renameError)}
+                    fullWidth
+                    helperText={renameError}
+                    label='Property Name'
+                    size='small'
+                    value={renameValue}
+                    variant={inputVariant}
+                    onChange={(event) => setRenameValue(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') {
+                        renameProperty(item.propertyName);
+                      } else if (event.key === 'Escape') {
+                        cancelRename();
+                      }
+                    }}
+                  />
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      gap: 1,
+                      justifyContent: 'flex-end',
+                      mt: 1,
+                    }}
+                  >
+                    <Button
+                      disabled={renameDisabled}
+                      size='small'
+                      onClick={() => renameProperty(item.propertyName)}
+                    >
+                      Rename
+                    </Button>
+                    <Button size='small' onClick={cancelRename}>
+                      Cancel
+                    </Button>
+                  </Box>
+                </Box>
+              </Popover>
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+};

--- a/packages/material-renderers/src/complex/MaterialMixedRenderer.tsx
+++ b/packages/material-renderers/src/complex/MaterialMixedRenderer.tsx
@@ -1022,6 +1022,7 @@ export const MaterialMixedRenderer = ({
   const [treeWidth, setTreeWidth] = useState(320);
   const [treeExpanded, setTreeExpanded] = useState(true);
   const [draggingSplitter, setDraggingSplitter] = useState(false);
+  const splitContainerRef = useRef<HTMLDivElement | null>(null);
   const latestTreeData = useRef(data);
   const treeControlCache = useRef(new Map<string, TreeNodeControl>());
   const inputVariant = useInputVariant();
@@ -1143,24 +1144,46 @@ export const MaterialMixedRenderer = ({
     );
   }, [treeNodes, path, activeNodeId]);
 
+  const updateTreeWidthFromPointer = useCallback((clientX: number) => {
+    const splitContainer = splitContainerRef.current;
+    if (!splitContainer) {
+      return;
+    }
+
+    const { left, width } = splitContainer.getBoundingClientRect();
+    const minTreeWidth = 220;
+    const minDetailWidth = 320;
+    const maxTreeWidth = Math.min(
+      640,
+      Math.max(minTreeWidth, width - minDetailWidth)
+    );
+
+    setTreeWidth(
+      Math.min(maxTreeWidth, Math.max(minTreeWidth, clientX - left))
+    );
+  }, []);
+
   useEffect(() => {
     if (!draggingSplitter) {
       return undefined;
     }
 
-    const onMouseMove = (event: MouseEvent) => {
-      setTreeWidth(Math.min(640, Math.max(220, event.clientX - 32)));
+    const onPointerMove = (event: PointerEvent) => {
+      event.preventDefault();
+      updateTreeWidthFromPointer(event.clientX);
     };
-    const onMouseUp = () => setDraggingSplitter(false);
+    const onPointerEnd = () => setDraggingSplitter(false);
 
-    window.addEventListener('mousemove', onMouseMove);
-    window.addEventListener('mouseup', onMouseUp);
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', onPointerEnd);
+    window.addEventListener('pointercancel', onPointerEnd);
 
     return () => {
-      window.removeEventListener('mousemove', onMouseMove);
-      window.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerup', onPointerEnd);
+      window.removeEventListener('pointercancel', onPointerEnd);
     };
-  }, [draggingSplitter]);
+  }, [draggingSplitter, updateTreeWidthFromPointer]);
 
   const getPathAncestorNodeIds = useCallback(
     (targetPath: string): string[] => {
@@ -1589,7 +1612,10 @@ export const MaterialMixedRenderer = ({
             </Box>
           </AccordionSummary>
           <AccordionDetails sx={{ p: 0 }}>
-            <Box sx={{ display: 'flex', minHeight: 320 }}>
+            <Box
+              ref={splitContainerRef}
+              sx={{ display: 'flex', minHeight: 320 }}
+            >
               <Box
                 sx={{
                   borderRight: '1px solid',
@@ -1641,10 +1667,17 @@ export const MaterialMixedRenderer = ({
               <Divider
                 flexItem
                 orientation='vertical'
-                onMouseDown={() => setDraggingSplitter(true)}
+                onPointerDown={(event) => {
+                  event.preventDefault();
+                  event.currentTarget.setPointerCapture?.(event.pointerId);
+                  setDraggingSplitter(true);
+                  updateTreeWidthFromPointer(event.clientX);
+                }}
                 sx={{
                   bgcolor: draggingSplitter ? 'primary.main' : 'divider',
                   cursor: 'col-resize',
+                  touchAction: 'none',
+                  userSelect: 'none',
                   width: 6,
                 }}
               />

--- a/packages/material-renderers/src/complex/MaterialMixedRenderer.tsx
+++ b/packages/material-renderers/src/complex/MaterialMixedRenderer.tsx
@@ -1,0 +1,1777 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017-2026 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  compose,
+  ControlElement,
+  ControlProps,
+  createControlElement,
+  createDefaultValue,
+  findUISchema,
+  isControl,
+  JsonFormsUISchemaRegistryEntry,
+  JsonSchema,
+  JsonSchema7,
+  rankWith,
+  RankedTester,
+  resolveSchema as resolveSchemaCore,
+  Scopable,
+  TesterContext,
+  UISchemaElement,
+} from '@jsonforms/core';
+import { useJsonForms, withJsonFormsControlProps } from '@jsonforms/react';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Collapse,
+  Divider,
+  FormControl,
+  IconButton,
+  InputAdornment,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { SimpleTreeView, TreeItem } from '@mui/x-tree-view';
+import {
+  Abc,
+  Add,
+  DeleteOutline,
+  EditOutlined,
+  ExpandMore,
+  FolderOutlined,
+  FormatListBulleted,
+  Numbers,
+  Search,
+  ToggleOnOutlined,
+  Visibility,
+  VisibilityOff,
+} from '@mui/icons-material';
+import cloneDeep from 'lodash/cloneDeep';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
+import set from 'lodash/set';
+import { useInputVariant } from '../util';
+import { DynamicPropertyDispatch } from './DynamicPropertyDispatch';
+
+type JsonDataType =
+  | 'array'
+  | 'boolean'
+  | 'integer'
+  | 'null'
+  | 'number'
+  | 'object'
+  | 'string';
+
+interface SchemaRenderInfo {
+  schema: JsonSchema;
+  resolvedSchema: JsonSchema;
+  uischema: UISchemaElement;
+  label: string;
+  index: number;
+}
+
+interface TreeNodeControl {
+  id: string;
+  schema: JsonSchema;
+  uischema: ControlElement;
+  path: string;
+  label: string;
+  required: boolean;
+  enabled: boolean;
+  readonly?: boolean;
+}
+
+interface MixedTreeNode {
+  nodeId: string;
+  title: string;
+  jsonType: JsonDataType;
+  label: string;
+  canRename: boolean;
+  canDelete: boolean;
+  control: TreeNodeControl;
+  children?: MixedTreeNode[];
+}
+
+interface NavigationContext {
+  selectPath: (path: string) => void;
+}
+
+const MixedNavigationContext = createContext<NavigationContext | undefined>(
+  undefined
+);
+
+const EMPTY_UISCHEMAS: JsonFormsUISchemaRegistryEntry[] = [];
+const ROOT_TREE_NODE_ID = '$root';
+const toTreeNodeId = (path: string) =>
+  path ? `$path:${path}` : ROOT_TREE_NODE_ID;
+
+const resolveSchema = (schema: JsonSchema, rootSchema: JsonSchema) => {
+  if (typeof schema === 'object' && typeof schema?.$ref === 'string') {
+    return resolveSchemaCore(rootSchema, schema.$ref, rootSchema) ?? schema;
+  }
+  return schema;
+};
+
+const cleanSchema = (schema: JsonSchema): JsonSchema => {
+  if (typeof schema !== 'object') {
+    return schema;
+  }
+
+  const validKeywords: Record<string, string[]> = {
+    array: ['items', 'minItems', 'maxItems', 'uniqueItems', 'contains'],
+    object: [
+      'properties',
+      'required',
+      'additionalProperties',
+      'minProperties',
+      'maxProperties',
+      'patternProperties',
+      'dependencies',
+      'propertyNames',
+    ],
+    string: ['minLength', 'maxLength', 'pattern', 'format'],
+    number: [
+      'minimum',
+      'maximum',
+      'exclusiveMinimum',
+      'exclusiveMaximum',
+      'multipleOf',
+    ],
+    integer: [
+      'minimum',
+      'maximum',
+      'exclusiveMinimum',
+      'exclusiveMaximum',
+      'multipleOf',
+    ],
+    boolean: [],
+    null: [],
+  };
+
+  const schemaType = schema.type as string;
+  for (const validType in validKeywords) {
+    if (validType !== schemaType) {
+      validKeywords[validType].forEach((key) => {
+        delete (schema as any)[key];
+      });
+    }
+  }
+
+  return schema;
+};
+
+const getJsonDataType = (value: any): JsonDataType | null => {
+  if (typeof value === 'string') {
+    return 'string';
+  }
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? 'integer' : 'number';
+  }
+  if (typeof value === 'boolean') {
+    return 'boolean';
+  }
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+  if (value === null) {
+    return 'null';
+  }
+  if (typeof value === 'object') {
+    return 'object';
+  }
+
+  return null;
+};
+
+const getSchemaTypesAsArray = (schema: JsonSchema): string[] => {
+  if (typeof schema !== 'object') {
+    return [
+      'array',
+      'boolean',
+      'integer',
+      'null',
+      'number',
+      'object',
+      'string',
+    ];
+  }
+
+  if (typeof schema.type === 'string') {
+    return [schema.type];
+  }
+
+  if (Array.isArray(schema.type)) {
+    return schema.type;
+  }
+
+  if (Array.isArray(schema.enum)) {
+    const enumTypes = new Set(
+      schema.enum.map((value) => getJsonDataType(value))
+    );
+    if (!enumTypes.has(null)) {
+      return Array.from(enumTypes).filter((type) => type !== null) as string[];
+    }
+  }
+
+  return ['array', 'boolean', 'integer', 'null', 'number', 'object', 'string'];
+};
+
+const createMixedRenderInfos = (
+  parentSchema: JsonSchema,
+  schema: JsonSchema,
+  rootSchema: JsonSchema,
+  control: ControlElement,
+  path: string,
+  uischemas: JsonFormsUISchemaRegistryEntry[]
+): SchemaRenderInfo[] => {
+  const resolvedSchemas: JsonSchema[] = [];
+  schema = resolveSchema(schema, rootSchema);
+
+  if (typeof schema === 'object' && typeof schema.type === 'string') {
+    resolvedSchemas.push(schema);
+  } else {
+    const types = getSchemaTypesAsArray(schema);
+
+    types.forEach((type) => {
+      resolvedSchemas.push({
+        ...(typeof schema === 'object' ? schema : {}),
+        type,
+        default:
+          typeof schema === 'object' &&
+          schema.default !== undefined &&
+          type === getJsonDataType(schema.default)
+            ? schema.default
+            : undefined,
+      });
+    });
+  }
+
+  return resolvedSchemas
+    .map((resolvedSchema) => {
+      if (
+        typeof resolvedSchema === 'object' &&
+        resolvedSchema.type === 'array'
+      ) {
+        resolvedSchema.items = resolvedSchema.items ?? {};
+        resolvedSchema.items = resolveSchema(
+          resolvedSchema.items as JsonSchema,
+          rootSchema
+        );
+
+        if ((resolvedSchema.items as any) === true) {
+          resolvedSchema.items = {
+            type: [
+              'array',
+              'boolean',
+              'integer',
+              'null',
+              'number',
+              'object',
+              'string',
+            ],
+          };
+        } else if (
+          typeof (resolvedSchema.items as JsonSchema7).type !== 'string' &&
+          !Array.isArray((resolvedSchema.items as JsonSchema7).type)
+        ) {
+          (resolvedSchema.items as JsonSchema7).type = [
+            'array',
+            'boolean',
+            'integer',
+            'null',
+            'number',
+            'object',
+            'string',
+          ];
+        }
+      }
+
+      let cleanedSchema = cleanSchema(cloneDeep(resolvedSchema));
+      const schemaType =
+        typeof cleanedSchema === 'object' ? cleanedSchema.type : undefined;
+      const detailsForSchema = control.options
+        ? control.options[`${schemaType}-detail`]
+        : undefined;
+      const schemaControl = detailsForSchema
+        ? {
+            ...control,
+            options: { ...control.options, detail: detailsForSchema },
+          }
+        : control;
+
+      if (
+        typeof cleanedSchema === 'object' &&
+        control.scope &&
+        (cleanedSchema.type === 'object' || cleanedSchema.type === 'array')
+      ) {
+        const segments = control.scope.split('/');
+        const startFromRoot = segments[0] === '#' || segments[0] === '';
+        const startIndex = startFromRoot ? 1 : 0;
+
+        if (segments.length > startIndex) {
+          const schemaPath = segments.slice(startIndex).join('.');
+          if (schemaPath && isEqual(get(parentSchema, schemaPath), schema)) {
+            const newSchema = cloneDeep(parentSchema);
+            set(newSchema, schemaPath, cleanedSchema);
+            cleanedSchema = newSchema;
+          }
+        }
+      }
+
+      const uischema = findUISchema(
+        uischemas,
+        cleanedSchema,
+        control.scope,
+        path,
+        () => createControlElement(control.scope ?? '#'),
+        schemaControl,
+        rootSchema
+      );
+
+      return {
+        schema: cleanedSchema,
+        resolvedSchema,
+        uischema,
+        label: `${schemaType}`,
+      };
+    })
+    .filter((info) => info.uischema)
+    .map((info, index) => ({ ...info, index }));
+};
+
+const findPropertySchema = (
+  parentSchema: JsonSchema,
+  propName: string,
+  rootSchema: JsonSchema
+): JsonSchema | undefined => {
+  if (typeof parentSchema !== 'object') {
+    return undefined;
+  }
+
+  if (parentSchema.properties?.[propName]) {
+    return resolveSchema(parentSchema.properties[propName], rootSchema);
+  }
+
+  if (parentSchema.patternProperties) {
+    const matchedPattern = Object.keys(parentSchema.patternProperties).find(
+      (pattern) => new RegExp(pattern).test(propName)
+    );
+
+    if (matchedPattern) {
+      return resolveSchema(
+        parentSchema.patternProperties[matchedPattern],
+        rootSchema
+      );
+    }
+  }
+
+  if (typeof parentSchema.additionalProperties === 'object') {
+    return resolveSchema(parentSchema.additionalProperties, rootSchema);
+  }
+
+  if (parentSchema.additionalProperties === true) {
+    return { additionalProperties: true };
+  }
+
+  return undefined;
+};
+
+const getArrayItemSchema = (
+  parentSchema: JsonSchema,
+  index: number,
+  rootSchema: JsonSchema
+): JsonSchema | undefined => {
+  if (typeof parentSchema !== 'object' || !parentSchema.items) {
+    return undefined;
+  }
+
+  let itemSchema: JsonSchema | undefined;
+  if (Array.isArray(parentSchema.items)) {
+    if (index < parentSchema.items.length) {
+      itemSchema = parentSchema.items[index];
+    } else if (parentSchema.additionalItems) {
+      itemSchema =
+        typeof parentSchema.additionalItems === 'object'
+          ? parentSchema.additionalItems
+          : undefined;
+    }
+  } else {
+    itemSchema = parentSchema.items as JsonSchema;
+  }
+
+  return itemSchema ? resolveSchema(itemSchema, rootSchema) : undefined;
+};
+
+const prepareObjectSchema = (schema: JsonSchema): JsonSchema => {
+  const objectSchema = cleanSchema(
+    cloneDeep({ ...(typeof schema === 'object' ? schema : {}), type: 'object' })
+  ) as JsonSchema7;
+  objectSchema.additionalProperties =
+    objectSchema.additionalProperties !== false
+      ? objectSchema.additionalProperties ?? true
+      : false;
+  return objectSchema;
+};
+
+const prepareArraySchema = (
+  schema: JsonSchema,
+  rootSchema: JsonSchema
+): JsonSchema => {
+  const arraySchema = cleanSchema(
+    cloneDeep({ ...(typeof schema === 'object' ? schema : {}), type: 'array' })
+  ) as JsonSchema7;
+  arraySchema.items = arraySchema.items ?? {};
+  arraySchema.items = resolveSchema(
+    arraySchema.items as JsonSchema,
+    rootSchema
+  ) as JsonSchema7 | JsonSchema7[];
+
+  if ((arraySchema.items as any) === true) {
+    arraySchema.items = {
+      type: [
+        'array',
+        'boolean',
+        'integer',
+        'null',
+        'number',
+        'object',
+        'string',
+      ],
+    };
+  } else if (
+    typeof (arraySchema.items as JsonSchema7).type !== 'string' &&
+    !Array.isArray((arraySchema.items as JsonSchema7).type)
+  ) {
+    (arraySchema.items as JsonSchema7).type = [
+      'array',
+      'boolean',
+      'integer',
+      'null',
+      'number',
+      'object',
+      'string',
+    ];
+  }
+
+  return arraySchema;
+};
+
+const createFallbackChildSchema = (title: string): JsonSchema => ({
+  type: ['array', 'boolean', 'integer', 'null', 'number', 'object', 'string'],
+  title,
+});
+
+const getSchemaDefaultType = (schema: JsonSchema): JsonDataType => {
+  const schemaTypes = getSchemaTypesAsArray(schema);
+  const firstType =
+    schemaTypes.find((type) => type !== 'null') ?? schemaTypes[0];
+  return (firstType ?? 'object') as JsonDataType;
+};
+
+const schemaSupportsInputType = (
+  schemaType: JsonSchema7['type'] | undefined,
+  dataType: JsonDataType | null
+): boolean => {
+  if (!dataType || typeof schemaType !== 'string') {
+    return false;
+  }
+
+  return (
+    schemaType === dataType ||
+    (schemaType === 'number' && dataType === 'integer')
+  );
+};
+
+const prepareChildSchema = (
+  childType: JsonDataType,
+  currentSchema: JsonSchema,
+  key: string,
+  index: number | null,
+  rootSchema: JsonSchema
+): JsonSchema => {
+  let childSchema: JsonSchema | undefined;
+
+  if (index !== null) {
+    childSchema = getArrayItemSchema(currentSchema, index, rootSchema);
+    childSchema = childSchema
+      ? { ...(childSchema as JsonSchema7), title: `Item ${index}` }
+      : {
+          type: [
+            'array',
+            'boolean',
+            'integer',
+            'null',
+            'number',
+            'object',
+            'string',
+          ],
+          title: `Item ${index}`,
+        };
+  } else {
+    childSchema = findPropertySchema(currentSchema, key, rootSchema);
+    childSchema = childSchema
+      ? { ...(childSchema as JsonSchema7), title: key }
+      : createFallbackChildSchema(key);
+  }
+
+  if (
+    childType !== 'object' &&
+    childType !== 'array' &&
+    typeof childSchema === 'object' &&
+    (!childSchema.type || (childSchema.type as any) === true)
+  ) {
+    childSchema.type = [
+      'array',
+      'boolean',
+      'integer',
+      'null',
+      'number',
+      'object',
+      'string',
+    ];
+  }
+
+  if (childType === 'object') {
+    return prepareObjectSchema(childSchema);
+  }
+
+  if (childType === 'array') {
+    return prepareArraySchema(childSchema, rootSchema);
+  }
+
+  return childSchema;
+};
+
+const createTreeNodeControl = (
+  schema: JsonSchema,
+  path: string,
+  label: string,
+  enabled: boolean,
+  readonly: boolean | undefined,
+  nodeType: JsonDataType,
+  controlCache: Map<string, TreeNodeControl>
+): TreeNodeControl => {
+  const cacheKey = `${path}\u0000${nodeType}`;
+  const cached = controlCache.get(cacheKey);
+  if (cached) {
+    cached.label = label;
+    cached.enabled = enabled;
+    cached.readonly = readonly;
+    return cached;
+  }
+
+  const control = {
+    id: path,
+    schema,
+    uischema: createControlElement('#'),
+    path,
+    label,
+    required: false,
+    enabled,
+    readonly,
+  };
+  controlCache.set(cacheKey, control);
+  return control;
+};
+
+const withoutEmptyChildren = (node: MixedTreeNode): MixedTreeNode => {
+  const children = node.children?.map(withoutEmptyChildren) ?? [];
+  if (children.length === 0) {
+    const { children: _children, ...rest } = node;
+    return rest;
+  }
+
+  return {
+    ...node,
+    children,
+  };
+};
+
+const getDisplayTitle = (label: string, type: JsonDataType): string => {
+  if (label) {
+    return label;
+  }
+  return type === 'array' ? '[]' : '{}';
+};
+
+const isDynamicProperty = (parentSchema: JsonSchema, key: string): boolean =>
+  typeof parentSchema !== 'object' || !parentSchema.properties?.[key];
+
+const buildTreeFromData = (
+  data: any,
+  schema: JsonSchema,
+  rootSchema: JsonSchema,
+  path: string,
+  label: string,
+  enabled: boolean,
+  readonly: boolean | undefined,
+  showPrimitives: boolean,
+  controlCache: Map<string, TreeNodeControl>
+): MixedTreeNode[] => {
+  const dataType = getJsonDataType(data);
+  if (dataType !== 'object' && dataType !== 'array') {
+    return [];
+  }
+
+  const nodes: MixedTreeNode[] = [];
+
+  const traverse = (
+    value: any,
+    currentPath: string,
+    currentLabel: string,
+    currentSchema: JsonSchema,
+    children: MixedTreeNode[],
+    canRename = false,
+    canDelete = false
+  ) => {
+    const type = getJsonDataType(value);
+
+    if (type === 'object') {
+      const objectSchema = prepareObjectSchema(currentSchema);
+      const node: MixedTreeNode = {
+        nodeId: toTreeNodeId(currentPath),
+        title: getDisplayTitle(currentLabel, type),
+        jsonType: type,
+        label: currentLabel,
+        canRename,
+        canDelete,
+        control: createTreeNodeControl(
+          objectSchema,
+          currentPath,
+          currentLabel,
+          enabled,
+          readonly,
+          type,
+          controlCache
+        ),
+        children: [],
+      };
+      children.push(node);
+
+      Object.keys(value).forEach((key) => {
+        const childValue = value[key];
+        const childPath = compose(currentPath, key);
+        const rawChildType = getJsonDataType(childValue);
+        const initialChildSchema =
+          findPropertySchema(currentSchema, key, rootSchema) ??
+          createFallbackChildSchema(key);
+        const childType =
+          rawChildType ?? getSchemaDefaultType(initialChildSchema);
+        const childSchema = prepareChildSchema(
+          childType,
+          currentSchema,
+          key,
+          null,
+          rootSchema
+        );
+
+        if (childType === 'object' || childType === 'array') {
+          traverse(
+            childValue ?? (childType === 'array' ? [] : {}),
+            childPath,
+            key,
+            childSchema,
+            node.children,
+            isDynamicProperty(currentSchema, key),
+            true
+          );
+        } else if (showPrimitives) {
+          node.children.push({
+            nodeId: toTreeNodeId(childPath),
+            title: key,
+            jsonType: childType,
+            label: key,
+            canRename: isDynamicProperty(currentSchema, key),
+            canDelete: true,
+            control: createTreeNodeControl(
+              childSchema,
+              childPath,
+              key,
+              enabled,
+              readonly,
+              childType,
+              controlCache
+            ),
+            children: [],
+          });
+        }
+      });
+    } else if (type === 'array') {
+      const arraySchema = prepareArraySchema(currentSchema, rootSchema);
+      const node: MixedTreeNode = {
+        nodeId: toTreeNodeId(currentPath),
+        title: getDisplayTitle(currentLabel, type),
+        jsonType: type,
+        label: currentLabel,
+        canRename,
+        canDelete,
+        control: createTreeNodeControl(
+          arraySchema,
+          currentPath,
+          currentLabel,
+          enabled,
+          readonly,
+          type,
+          controlCache
+        ),
+        children: [],
+      };
+      children.push(node);
+
+      value.forEach((childValue: any, index: number) => {
+        const childType = getJsonDataType(childValue);
+        const childPath = compose(currentPath, `${index}`);
+        const childSchema = prepareChildSchema(
+          childType ?? 'object',
+          currentSchema,
+          '',
+          index,
+          rootSchema
+        );
+        const resolvedChildType =
+          childType ?? getSchemaDefaultType(childSchema);
+        const childLabel = `Item ${index}`;
+
+        if (resolvedChildType === 'object' || resolvedChildType === 'array') {
+          traverse(
+            childValue ?? (resolvedChildType === 'array' ? [] : {}),
+            childPath,
+            childLabel,
+            childSchema,
+            node.children,
+            false,
+            true
+          );
+        } else if (showPrimitives) {
+          node.children.push({
+            nodeId: toTreeNodeId(childPath),
+            title: childLabel,
+            jsonType: resolvedChildType,
+            label: childLabel,
+            canRename: false,
+            canDelete: true,
+            control: createTreeNodeControl(
+              childSchema,
+              childPath,
+              childLabel,
+              enabled,
+              readonly,
+              resolvedChildType,
+              controlCache
+            ),
+            children: [],
+          });
+        }
+      });
+    }
+  };
+
+  traverse(data, path, label, resolveSchema(schema, rootSchema), nodes);
+
+  return nodes.map(withoutEmptyChildren);
+};
+
+const flattenTree = (nodes: MixedTreeNode[]): MixedTreeNode[] =>
+  nodes.flatMap((node) => [node, ...flattenTree(node.children ?? [])]);
+
+const getTreeStructureSignature = (
+  value: any,
+  showPrimitives: boolean
+): string => {
+  const type = getJsonDataType(value);
+
+  if (type === 'object') {
+    return `o{${Object.keys(value)
+      .map((key) => {
+        const childType = getJsonDataType(value[key]);
+        if (childType === 'object' || childType === 'array') {
+          return `${key}:${getTreeStructureSignature(
+            value[key],
+            showPrimitives
+          )}`;
+        }
+        return showPrimitives ? `${key}:p` : '';
+      })
+      .filter(Boolean)
+      .join('|')}}`;
+  }
+
+  if (type === 'array') {
+    return `a[${value
+      .map((childValue: any) => {
+        const childType = getJsonDataType(childValue);
+        if (childType === 'object' || childType === 'array') {
+          return getTreeStructureSignature(childValue, showPrimitives);
+        }
+        return showPrimitives ? 'p' : '';
+      })
+      .join('|')}]`;
+  }
+
+  return showPrimitives ? 'p' : '';
+};
+
+const filterTreeNodes = (
+  nodes: MixedTreeNode[],
+  search: string
+): MixedTreeNode[] => {
+  const normalizedSearch = search.trim().toLocaleLowerCase();
+  if (!normalizedSearch) {
+    return nodes;
+  }
+
+  return nodes.flatMap((node) => {
+    const children = filterTreeNodes(node.children ?? [], normalizedSearch);
+    const matchesSearch =
+      node.title.toLocaleLowerCase().includes(normalizedSearch) ||
+      node.label.toLocaleLowerCase().includes(normalizedSearch);
+
+    if (!matchesSearch && children.length === 0) {
+      return [];
+    }
+
+    return [
+      {
+        ...node,
+        children,
+      },
+    ];
+  });
+};
+
+const findNodeById = (
+  nodes: MixedTreeNode[],
+  targetNodeId: string
+): MixedTreeNode | undefined => {
+  for (const node of nodes) {
+    if (node.nodeId === targetNodeId) {
+      return node;
+    }
+    const child = findNodeById(node.children ?? [], targetNodeId);
+    if (child) {
+      return child;
+    }
+  }
+  return undefined;
+};
+
+const getTypeIcon = (type: JsonDataType | undefined) => {
+  switch (type) {
+    case 'array':
+      return <FormatListBulleted fontSize='small' />;
+    case 'object':
+      return <FolderOutlined fontSize='small' />;
+    case 'boolean':
+      return <ToggleOnOutlined fontSize='small' />;
+    case 'integer':
+    case 'number':
+      return <Numbers fontSize='small' />;
+    case 'string':
+      return <Abc fontSize='small' />;
+    case 'null':
+    default:
+      return <Add fontSize='small' sx={{ visibility: 'hidden' }} />;
+  }
+};
+
+const getRelativePath = (rootPath: string, nodePath: string): string | null => {
+  if (nodePath === rootPath) {
+    return null;
+  }
+  return rootPath && nodePath.startsWith(`${rootPath}.`)
+    ? nodePath.slice(rootPath.length + 1)
+    : nodePath;
+};
+
+const getParentPath = (rootPath: string, nodePath: string): string => {
+  const lastDot = nodePath.lastIndexOf('.');
+  return lastDot > 0 ? nodePath.substring(0, lastDot) : rootPath;
+};
+
+const TypeSelector = ({
+  id,
+  label,
+  required,
+  enabled,
+  readonly,
+  errors,
+  selectedIndex,
+  infos,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  required?: boolean;
+  enabled: boolean;
+  readonly?: boolean;
+  errors?: string;
+  selectedIndex: number | undefined;
+  infos: SchemaRenderInfo[];
+  onChange: (index: number | undefined) => void;
+}) => {
+  const variant = useInputVariant();
+  const hasErrors = Boolean(errors);
+
+  return (
+    <FormControl
+      fullWidth
+      error={hasErrors}
+      required={required}
+      variant={variant}
+      size='small'
+    >
+      <InputLabel id={`${id}-type-label`}>{label}</InputLabel>
+      <Select
+        labelId={`${id}-type-label`}
+        id={`${id}-type-selector`}
+        value={selectedIndex ?? ''}
+        label={label}
+        disabled={!enabled}
+        readOnly={readonly}
+        onChange={(event) => {
+          const value = event.target.value as number | '';
+          onChange(value === '' ? undefined : Number(value));
+        }}
+      >
+        <MenuItem value=''>
+          <em>None</em>
+        </MenuItem>
+        {infos.map((info) => (
+          <MenuItem key={info.index} value={info.index}>
+            {info.label}
+          </MenuItem>
+        ))}
+      </Select>
+      {hasErrors && (
+        <Typography color='error' variant='caption' sx={{ mt: 0.5, ml: 1.75 }}>
+          {errors}
+        </Typography>
+      )}
+    </FormControl>
+  );
+};
+
+export const MaterialMixedRenderer = ({
+  cells,
+  data,
+  enabled,
+  errors,
+  handleChange,
+  id,
+  label,
+  path,
+  readonly,
+  renderers,
+  required,
+  rootSchema,
+  schema: controlSchema,
+  uischema,
+  visible,
+}: ControlProps) => {
+  const jsonforms = useJsonForms();
+  const navigationContext = useContext(MixedNavigationContext);
+  const isRoot = !navigationContext;
+  const [valueType, setValueType] = useState<JsonDataType | null>(
+    getJsonDataType(data)
+  );
+  const [selectedIndex, setSelectedIndex] = useState<number | undefined>();
+  const [activeNodeId, setActiveNodeId] = useState(toTreeNodeId(path));
+  const [openedNodes, setOpenedNodes] = useState<string[]>([]);
+  const [treeSearch, setTreeSearch] = useState('');
+  const [showPrimitivesInTree, setShowPrimitivesInTree] = useState(false);
+  const [renamingNodeId, setRenamingNodeId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [renameError, setRenameError] = useState<string | null>(null);
+  const [treeWidth, setTreeWidth] = useState(320);
+  const [treeExpanded, setTreeExpanded] = useState(true);
+  const [draggingSplitter, setDraggingSplitter] = useState(false);
+  const latestTreeData = useRef(data);
+  const treeControlCache = useRef(new Map<string, TreeNodeControl>());
+  const inputVariant = useInputVariant();
+
+  const uischemas = jsonforms.uischemas ?? EMPTY_UISCHEMAS;
+  const mixedRenderInfos = useMemo(
+    () =>
+      createMixedRenderInfos(
+        controlSchema,
+        controlSchema,
+        rootSchema,
+        uischema,
+        path,
+        uischemas
+      ),
+    [controlSchema, rootSchema, uischema, path, uischemas]
+  );
+  const matchingSchema = useMemo(() => {
+    const exact = mixedRenderInfos.find(
+      (entry) => entry.resolvedSchema.type === valueType
+    );
+    return (
+      exact ??
+      mixedRenderInfos.find(
+        (entry) =>
+          entry.resolvedSchema.type === 'number' && valueType === 'integer'
+      )
+    );
+  }, [mixedRenderInfos, valueType]);
+  const activeInfo =
+    selectedIndex !== undefined ? mixedRenderInfos[selectedIndex] : undefined;
+  const activeType = activeInfo?.resolvedSchema?.type;
+  const inlineDetailInfo =
+    activeInfo?.schema && activeInfo?.uischema && activeType !== 'null'
+      ? activeInfo
+      : undefined;
+  const showTreeView =
+    isRoot && (valueType === 'object' || valueType === 'array');
+  const isNestedComplexType =
+    !isRoot && (valueType === 'object' || valueType === 'array');
+  latestTreeData.current = data;
+
+  useEffect(() => {
+    setValueType(getJsonDataType(data));
+  }, [data]);
+
+  useEffect(() => {
+    const currentlySelected =
+      selectedIndex !== undefined ? mixedRenderInfos[selectedIndex] : undefined;
+    if (
+      currentlySelected &&
+      schemaSupportsInputType(currentlySelected.resolvedSchema.type, valueType)
+    ) {
+      return;
+    }
+    setSelectedIndex(matchingSchema?.index);
+  }, [matchingSchema?.index, mixedRenderInfos, selectedIndex, valueType]);
+
+  const treeStructureSignature = useMemo(
+    () =>
+      showTreeView ? getTreeStructureSignature(data, showPrimitivesInTree) : '',
+    [data, showPrimitivesInTree, showTreeView]
+  );
+  const treeNodes = useMemo(
+    () =>
+      showTreeView
+        ? buildTreeFromData(
+            latestTreeData.current,
+            activeInfo?.resolvedSchema ?? controlSchema,
+            rootSchema,
+            path,
+            label,
+            enabled,
+            readonly,
+            showPrimitivesInTree,
+            treeControlCache.current
+          )
+        : [],
+    [
+      activeInfo?.resolvedSchema,
+      controlSchema,
+      enabled,
+      label,
+      path,
+      readonly,
+      rootSchema,
+      showPrimitivesInTree,
+      showTreeView,
+      treeStructureSignature,
+    ]
+  );
+  const selectedNode = useMemo(
+    () => findNodeById(treeNodes, activeNodeId),
+    [treeNodes, activeNodeId]
+  );
+  const filteredTreeNodes = useMemo(
+    () => filterTreeNodes(treeNodes, treeSearch),
+    [treeNodes, treeSearch]
+  );
+  const expandedTreeItems = useMemo(
+    () =>
+      treeSearch.trim()
+        ? flattenTree(filteredTreeNodes).map((node) => node.nodeId)
+        : openedNodes,
+    [filteredTreeNodes, openedNodes, treeSearch]
+  );
+
+  useEffect(() => {
+    const allNodeIds = flattenTree(treeNodes).map((node) => node.nodeId);
+    const allNodeIdSet = new Set(allNodeIds);
+    const rootNodeId = toTreeNodeId(path);
+    if (!allNodeIdSet.has(activeNodeId)) {
+      setActiveNodeId(rootNodeId);
+    }
+    setOpenedNodes((current) =>
+      Array.from(new Set([rootNodeId, ...current])).filter((nodeId) =>
+        allNodeIdSet.has(nodeId)
+      )
+    );
+  }, [treeNodes, path, activeNodeId]);
+
+  useEffect(() => {
+    if (!draggingSplitter) {
+      return undefined;
+    }
+
+    const onMouseMove = (event: MouseEvent) => {
+      setTreeWidth(Math.min(640, Math.max(220, event.clientX - 32)));
+    };
+    const onMouseUp = () => setDraggingSplitter(false);
+
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+
+    return () => {
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+    };
+  }, [draggingSplitter]);
+
+  const getPathAncestorNodeIds = useCallback(
+    (targetPath: string): string[] => {
+      const segments = targetPath.split('.').filter(Boolean);
+      const result = [toTreeNodeId(path)];
+      let currentPath = path;
+
+      segments.slice(0, -1).forEach((segment) => {
+        currentPath = compose(currentPath, segment);
+        result.push(toTreeNodeId(currentPath));
+      });
+
+      return result;
+    },
+    [path]
+  );
+
+  const selectPath = useCallback(
+    (targetPath: string) => {
+      setActiveNodeId(toTreeNodeId(targetPath));
+      setOpenedNodes((current) =>
+        Array.from(new Set([...current, ...getPathAncestorNodeIds(targetPath)]))
+      );
+    },
+    [getPathAncestorNodeIds]
+  );
+
+  const navigationValue = useMemo(() => ({ selectPath }), [selectPath]);
+
+  const getParentSchema = useCallback(
+    (parentPath: string): JsonSchema | undefined => {
+      const parentRelativePath = getRelativePath(path, parentPath);
+      if (parentRelativePath === null) {
+        return activeInfo?.resolvedSchema ?? controlSchema;
+      }
+
+      const segments = parentRelativePath.split('.');
+      let currentSchema: JsonSchema =
+        activeInfo?.resolvedSchema ?? controlSchema;
+
+      for (const segment of segments) {
+        currentSchema = resolveSchema(currentSchema, rootSchema);
+        if (typeof currentSchema !== 'object') {
+          return {};
+        }
+        if (currentSchema.type === 'array') {
+          currentSchema = (currentSchema.items as JsonSchema) ?? {};
+        } else {
+          currentSchema =
+            currentSchema.properties?.[segment] ??
+            findPropertySchema(currentSchema, segment, rootSchema) ??
+            {};
+        }
+      }
+
+      return currentSchema;
+    },
+    [activeInfo?.resolvedSchema, controlSchema, path, rootSchema]
+  );
+
+  const startRename = useCallback((node: MixedTreeNode) => {
+    if (!node.canRename) {
+      return;
+    }
+    setRenamingNodeId(node.nodeId);
+    setRenameValue(node.label);
+    setRenameError(null);
+  }, []);
+
+  const cancelRename = useCallback(() => {
+    setRenamingNodeId(null);
+    setRenameValue('');
+    setRenameError(null);
+  }, []);
+
+  const commitRename = useCallback(
+    (node: MixedTreeNode) => {
+      if (renamingNodeId !== node.nodeId) {
+        return;
+      }
+
+      const trimmed = renameValue.trim();
+      if (!trimmed || trimmed === node.label) {
+        cancelRename();
+        return;
+      }
+
+      const parentPath = getParentPath(path, node.control.path);
+      const parentRelativePath = getRelativePath(path, parentPath);
+      const parentData =
+        parentRelativePath === null ? data : get(data, parentRelativePath);
+
+      if (
+        typeof parentData !== 'object' ||
+        parentData === null ||
+        Array.isArray(parentData)
+      ) {
+        cancelRename();
+        return;
+      }
+
+      if (trimmed in parentData) {
+        setRenameError(`Property "${trimmed}" already exists`);
+        return;
+      }
+
+      let parentSchema = getParentSchema(parentPath);
+      if (parentSchema) {
+        parentSchema = resolveSchema(parentSchema, rootSchema);
+      }
+
+      if (typeof parentSchema === 'object' && parentSchema.patternProperties) {
+        const patterns = Object.keys(parentSchema.patternProperties);
+        const hadMatchingPattern = patterns.some((pattern) =>
+          new RegExp(pattern).test(node.label)
+        );
+        const hasMatchingPattern = patterns.some((pattern) =>
+          new RegExp(pattern).test(trimmed)
+        );
+        if (hadMatchingPattern && !hasMatchingPattern) {
+          setRenameError(
+            `Property name must match pattern: ${patterns.join(', ')}`
+          );
+          return;
+        }
+      }
+
+      const propertyNames = (parentSchema as JsonSchema7)?.propertyNames as
+        | JsonSchema7
+        | undefined;
+      if (propertyNames?.pattern) {
+        const pattern = new RegExp(propertyNames.pattern);
+        if (!pattern.test(trimmed)) {
+          setRenameError(
+            `Property name must match pattern: ${propertyNames.pattern}`
+          );
+          return;
+        }
+      }
+
+      const updatedData = Object.fromEntries(
+        Object.entries(parentData).map(([key, value]) => [
+          key === node.label ? trimmed : key,
+          value,
+        ])
+      );
+      handleChange(parentPath, updatedData);
+
+      const newPath = compose(parentPath, trimmed);
+      selectPath(newPath);
+      cancelRename();
+    },
+    [
+      cancelRename,
+      data,
+      getParentSchema,
+      handleChange,
+      path,
+      renameValue,
+      renamingNodeId,
+      rootSchema,
+      selectPath,
+    ]
+  );
+
+  const deleteNode = useCallback(
+    (node: MixedTreeNode) => {
+      if (!node.canDelete) {
+        return;
+      }
+
+      const parentPath = getParentPath(path, node.control.path);
+      const parentRelativePath = getRelativePath(path, parentPath);
+      const parentData =
+        parentRelativePath === null ? data : get(data, parentRelativePath);
+      const key = node.control.path.slice(
+        parentPath.length ? parentPath.length + 1 : 0
+      );
+
+      if (Array.isArray(parentData)) {
+        const index = Number(key);
+        if (!Number.isInteger(index)) {
+          return;
+        }
+        const updatedData = [...parentData];
+        updatedData.splice(index, 1);
+        handleChange(parentPath, updatedData);
+      } else if (typeof parentData === 'object' && parentData !== null) {
+        const updatedData = { ...parentData };
+        delete updatedData[key];
+        handleChange(parentPath, updatedData);
+      }
+
+      if (
+        activeNodeId === node.nodeId ||
+        activeNodeId.startsWith(`${node.nodeId}.`)
+      ) {
+        selectPath(parentPath);
+      }
+    },
+    [activeNodeId, data, handleChange, path, selectPath]
+  );
+
+  const handleSelectChange = useCallback(
+    (newIndex: number | undefined) => {
+      const newData =
+        newIndex !== undefined
+          ? createDefaultValue(
+              mixedRenderInfos[newIndex].resolvedSchema,
+              rootSchema
+            )
+          : undefined;
+
+      handleChange(path, newData);
+      setSelectedIndex(newIndex);
+      const type =
+        newIndex !== undefined
+          ? mixedRenderInfos[newIndex]?.resolvedSchema?.type
+          : null;
+      setValueType(type as JsonDataType | null);
+      setActiveNodeId(toTreeNodeId(path));
+    },
+    [handleChange, mixedRenderInfos, path, rootSchema]
+  );
+
+  if (!visible) {
+    return null;
+  }
+
+  const typeSelector = (
+    <TypeSelector
+      id={id}
+      label={label}
+      required={required}
+      enabled={enabled}
+      readonly={readonly}
+      errors={errors}
+      selectedIndex={selectedIndex}
+      infos={mixedRenderInfos}
+      onChange={handleSelectChange}
+    />
+  );
+
+  const renderTreeNode = (node: MixedTreeNode): React.ReactNode => (
+    <TreeItem
+      key={node.nodeId}
+      itemId={node.nodeId}
+      label={
+        <Box
+          sx={{
+            alignItems: 'center',
+            display: 'flex',
+            minHeight: 32,
+            minWidth: 0,
+            width: '100%',
+            '&:hover .mixed-tree-action, .Mui-selected & .mixed-tree-action': {
+              opacity: 1,
+            },
+          }}
+        >
+          <Box
+            sx={{
+              alignItems: 'center',
+              display: 'inline-flex',
+              flex: '0 0 28px',
+              justifyContent: 'center',
+            }}
+          >
+            {getTypeIcon(node.jsonType)}
+          </Box>
+          {renamingNodeId === node.nodeId ? (
+            <TextField
+              autoFocus
+              error={Boolean(renameError)}
+              helperText={renameError}
+              size='small'
+              value={renameValue}
+              variant={inputVariant}
+              onClick={(event) => event.stopPropagation()}
+              onBlur={() => commitRename(node)}
+              onChange={(event) => setRenameValue(event.target.value)}
+              onKeyDown={(event) => {
+                event.stopPropagation();
+                if (event.key === 'Enter') {
+                  commitRename(node);
+                } else if (event.key === 'Escape') {
+                  cancelRename();
+                }
+              }}
+            />
+          ) : (
+            <Typography
+              noWrap
+              sx={{ flex: '1 1 auto', minWidth: 0 }}
+              variant='body2'
+            >
+              {node.title}
+            </Typography>
+          )}
+          <Box
+            sx={{
+              alignItems: 'center',
+              display: 'flex',
+              flex: '0 0 auto',
+              gap: 0.25,
+              ml: 0.5,
+            }}
+          >
+            {node.control.path === path ? (
+              <Tooltip
+                title={
+                  showPrimitivesInTree ? 'Hide primitives' : 'Show primitives'
+                }
+              >
+                <IconButton
+                  size='small'
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setShowPrimitivesInTree((current) => !current);
+                  }}
+                >
+                  {showPrimitivesInTree ? (
+                    <Visibility fontSize='small' />
+                  ) : (
+                    <VisibilityOff fontSize='small' />
+                  )}
+                </IconButton>
+              </Tooltip>
+            ) : enabled ? (
+              <>
+                {node.canRename ? (
+                  <Tooltip title='Rename'>
+                    <IconButton
+                      className='mixed-tree-action'
+                      size='small'
+                      sx={{ opacity: 0 }}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        startRename(node);
+                      }}
+                    >
+                      <EditOutlined fontSize='small' />
+                    </IconButton>
+                  </Tooltip>
+                ) : null}
+                {node.canDelete ? (
+                  <Tooltip title='Delete'>
+                    <IconButton
+                      className='mixed-tree-action'
+                      color='error'
+                      size='small'
+                      sx={{ opacity: 0 }}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        deleteNode(node);
+                      }}
+                    >
+                      <DeleteOutline fontSize='small' />
+                    </IconButton>
+                  </Tooltip>
+                ) : null}
+              </>
+            ) : null}
+          </Box>
+        </Box>
+      }
+      sx={{
+        '& .MuiTreeItem-content': {
+          minHeight: 36,
+          pr: 0.5,
+        },
+        '& .MuiTreeItem-label': {
+          minWidth: 0,
+        },
+      }}
+    >
+      {node.children?.map((child) => renderTreeNode(child))}
+    </TreeItem>
+  );
+
+  if (showTreeView) {
+    return (
+      <MixedNavigationContext.Provider value={navigationValue}>
+        <Accordion
+          disableGutters
+          expanded={treeExpanded}
+          variant='outlined'
+          onChange={(_, expanded) => setTreeExpanded(expanded)}
+          sx={{
+            overflow: 'hidden',
+            width: '100%',
+            '&:before': {
+              display: 'none',
+            },
+          }}
+        >
+          <AccordionSummary
+            expandIcon={<ExpandMore />}
+            sx={{
+              px: 2,
+              py: 0,
+              '& .MuiAccordionSummary-content': {
+                minWidth: 0,
+              },
+            }}
+          >
+            <Box
+              sx={{
+                alignItems: 'center',
+                display: 'grid',
+                gap: 2,
+                gridTemplateColumns: 'minmax(180px, 360px) 1fr',
+                minWidth: 0,
+                width: '100%',
+              }}
+            >
+              <Box
+                onClick={(event) => event.stopPropagation()}
+                onFocus={(event) => event.stopPropagation()}
+              >
+                {typeSelector}
+              </Box>
+              <Typography noWrap variant='body1'>
+                {label}
+              </Typography>
+            </Box>
+          </AccordionSummary>
+          <AccordionDetails sx={{ p: 0 }}>
+            <Box sx={{ display: 'flex', minHeight: 320 }}>
+              <Box
+                sx={{
+                  borderRight: '1px solid',
+                  borderColor: 'divider',
+                  flex: `0 0 ${treeWidth}px`,
+                  maxWidth: 640,
+                  minWidth: 220,
+                  p: 1,
+                }}
+              >
+                <TextField
+                  fullWidth
+                  size='small'
+                  variant={inputVariant}
+                  label='Search'
+                  value={treeSearch}
+                  onChange={(event) => setTreeSearch(event.target.value)}
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position='start'>
+                        <Search fontSize='small' />
+                      </InputAdornment>
+                    ),
+                  }}
+                />
+                <SimpleTreeView
+                  expansionTrigger='iconContainer'
+                  expandedItems={expandedTreeItems}
+                  selectedItems={activeNodeId}
+                  onExpandedItemsChange={(_, itemIds) => {
+                    if (!treeSearch.trim()) {
+                      setOpenedNodes(itemIds);
+                    }
+                  }}
+                  onSelectedItemsChange={(_, itemId) => {
+                    if (typeof itemId === 'string') {
+                      setActiveNodeId(itemId);
+                    }
+                  }}
+                  sx={{
+                    mt: 1,
+                    maxHeight: 'calc(100vh - 300px)',
+                    overflow: 'auto',
+                  }}
+                >
+                  {filteredTreeNodes.map((node) => renderTreeNode(node))}
+                </SimpleTreeView>
+              </Box>
+              <Divider
+                flexItem
+                orientation='vertical'
+                onMouseDown={() => setDraggingSplitter(true)}
+                sx={{
+                  bgcolor: draggingSplitter ? 'primary.main' : 'divider',
+                  cursor: 'col-resize',
+                  width: 6,
+                }}
+              />
+              <Box sx={{ flex: '1 1 auto', minWidth: 0, p: 2 }}>
+                {selectedNode ? (
+                  <DynamicPropertyDispatch
+                    schema={selectedNode.control.schema}
+                    uischema={selectedNode.control.uischema}
+                    path={selectedNode.control.path}
+                    renderers={renderers}
+                    cells={cells}
+                    enabled={selectedNode.control.enabled}
+                    readonly={readonly}
+                    rootSchema={rootSchema}
+                  />
+                ) : null}
+              </Box>
+            </Box>
+          </AccordionDetails>
+        </Accordion>
+      </MixedNavigationContext.Provider>
+    );
+  }
+
+  if (isNestedComplexType) {
+    return (
+      <Box sx={{ alignItems: 'flex-start', display: 'flex', gap: 1 }}>
+        <Box sx={{ flex: '1 1 auto', minWidth: 0 }}>{typeSelector}</Box>
+        <Tooltip title={`View ${label}`}>
+          <span>
+            <IconButton
+              color='primary'
+              disabled={!navigationContext}
+              onClick={() => navigationContext?.selectPath(path)}
+              size='small'
+              sx={{ mt: 0.75 }}
+            >
+              <Visibility fontSize='small' />
+            </IconButton>
+          </span>
+        </Tooltip>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ alignItems: 'flex-start', display: 'flex', gap: 1 }}>
+      <Box sx={{ minWidth: 180, flex: '0 0 220px' }}>{typeSelector}</Box>
+      <Box sx={{ flex: '1 1 auto', minWidth: 0 }}>
+        {inlineDetailInfo ? (
+          <Collapse in>
+            <DynamicPropertyDispatch
+              schema={inlineDetailInfo.schema}
+              uischema={inlineDetailInfo.uischema}
+              path={path}
+              renderers={renderers}
+              cells={cells}
+              enabled={enabled}
+              readonly={readonly}
+              rootSchema={rootSchema}
+            />
+          </Collapse>
+        ) : null}
+      </Box>
+    </Box>
+  );
+};
+
+export const isMixedSchema = (
+  uischema: UISchemaElement & Scopable,
+  schema: JsonSchema,
+  context: TesterContext
+) => {
+  if (schema && typeof schema === 'boolean') {
+    return true;
+  }
+
+  if (!schema || typeof schema !== 'object') {
+    return false;
+  }
+
+  if (Array.isArray(schema.type)) {
+    return true;
+  }
+
+  if (schema.type === 'object') {
+    const schemaPath = uischema.scope;
+    if (schemaPath && !isEmpty(schemaPath)) {
+      const currentDataSchema = resolveSchemaCore(
+        schema,
+        schemaPath,
+        context?.rootSchema
+      );
+      if (currentDataSchema === undefined) {
+        return false;
+      }
+      if (Array.isArray(currentDataSchema.type)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+const isDefaultGenUiSchema = (uischema: UISchemaElement): boolean => {
+  const elements = (uischema as any)?.elements;
+  return (
+    (uischema.type === 'VerticalLayout' || uischema.type === 'Group') &&
+    Array.isArray(elements) &&
+    elements.length === 1 &&
+    elements[0].scope === '#' &&
+    elements[0].type === 'Control'
+  );
+};
+
+export const isMixedControl = (
+  uischema: UISchemaElement,
+  schema: JsonSchema,
+  context: TesterContext
+) =>
+  isMixedSchema(uischema as UISchemaElement & Scopable, schema, context) &&
+  (isControl(uischema) || isDefaultGenUiSchema(uischema));
+
+export const materialMixedControlTester: RankedTester = rankWith(
+  20,
+  isMixedControl
+);
+
+export default withJsonFormsControlProps(MaterialMixedRenderer);

--- a/packages/material-renderers/src/complex/MaterialObjectRenderer.tsx
+++ b/packages/material-renderers/src/complex/MaterialObjectRenderer.tsx
@@ -24,28 +24,55 @@
 */
 import isEmpty from 'lodash/isEmpty';
 import {
+  ControlProps,
   findUISchema,
   Generate,
+  GroupLayout,
   isObjectControl,
   RankedTester,
   rankWith,
-  StatePropsOfControlWithDetail,
+  UISchemaElement,
 } from '@jsonforms/core';
-import { JsonFormsDispatch, withJsonFormsDetailProps } from '@jsonforms/react';
+import {
+  JsonFormsDispatch,
+  useJsonForms,
+  withJsonFormsControlProps,
+} from '@jsonforms/react';
 import React, { useMemo } from 'react';
+import { MaterialAdditionalProperties } from './MaterialAdditionalProperties';
+import { Card, CardContent, CardHeader } from '@mui/material';
+
+const objectCardStyle: { [x: string]: any } = { marginBottom: '10px' };
+
+const withoutGroupFrame = (uischema: UISchemaElement): UISchemaElement => {
+  if (uischema.type !== 'Group') {
+    return uischema;
+  }
+
+  const { label: _label, ...layout } = uischema as GroupLayout;
+  return {
+    ...layout,
+    type: 'VerticalLayout',
+  };
+};
 
 export const MaterialObjectRenderer = ({
-  renderers,
   cells,
-  uischemas,
-  schema,
+  config,
+  data,
+  enabled,
+  handleChange,
   label,
   path,
-  visible,
-  enabled,
+  readonly,
+  renderers,
+  schema,
   uischema,
   rootSchema,
-}: StatePropsOfControlWithDetail) => {
+  visible,
+}: ControlProps) => {
+  const jsonforms = useJsonForms();
+  const uischemas = jsonforms.uischemas ?? [];
   const detailUiSchema = useMemo(
     () =>
       findUISchema(
@@ -54,32 +81,64 @@ export const MaterialObjectRenderer = ({
         uischema.scope,
         path,
         () =>
-          isEmpty(path)
-            ? Generate.uiSchema(schema, 'VerticalLayout', undefined, rootSchema)
-            : {
-                ...Generate.uiSchema(schema, 'Group', undefined, rootSchema),
-                label,
-              },
+          Generate.uiSchema(schema, 'VerticalLayout', undefined, rootSchema),
         uischema,
         rootSchema
       ),
-    [uischemas, schema, uischema.scope, path, label, uischema, rootSchema]
+    [uischemas, schema, uischema.scope, path, uischema, rootSchema]
   );
+  const dispatchUiSchema = useMemo(
+    () => (isEmpty(path) ? detailUiSchema : withoutGroupFrame(detailUiSchema)),
+    [detailUiSchema, path]
+  );
+  const objectLabel =
+    detailUiSchema.type === 'Group'
+      ? (detailUiSchema as GroupLayout).label ?? label
+      : label;
 
   if (!visible) {
     return null;
   }
 
+  const content = (
+    <>
+      <JsonFormsDispatch
+        visible={visible}
+        enabled={enabled}
+        schema={schema}
+        uischema={dispatchUiSchema}
+        path={path}
+        renderers={renderers}
+        cells={cells}
+        readonly={readonly}
+      />
+      <MaterialAdditionalProperties
+        cells={cells}
+        config={config}
+        data={data}
+        enabled={enabled}
+        handleChange={handleChange}
+        label={label}
+        path={path}
+        readonly={readonly}
+        renderers={renderers}
+        rootSchema={rootSchema}
+        schema={schema}
+        uischema={uischema}
+        uischemas={uischemas}
+      />
+    </>
+  );
+
+  if (isEmpty(path)) {
+    return content;
+  }
+
   return (
-    <JsonFormsDispatch
-      visible={visible}
-      enabled={enabled}
-      schema={schema}
-      uischema={detailUiSchema}
-      path={path}
-      renderers={renderers}
-      cells={cells}
-    />
+    <Card style={objectCardStyle} variant='outlined'>
+      {!isEmpty(objectLabel) && <CardHeader title={objectLabel} />}
+      <CardContent>{content}</CardContent>
+    </Card>
   );
 };
 
@@ -88,4 +147,4 @@ export const materialObjectControlTester: RankedTester = rankWith(
   isObjectControl
 );
 
-export default withJsonFormsDetailProps(MaterialObjectRenderer);
+export default withJsonFormsControlProps(MaterialObjectRenderer);

--- a/packages/material-renderers/src/complex/index.ts
+++ b/packages/material-renderers/src/complex/index.ts
@@ -25,6 +25,7 @@
 import MaterialAllOfRenderer, {
   materialAllOfControlTester,
 } from './MaterialAllOfRenderer';
+import { MaterialAdditionalProperties } from './MaterialAdditionalProperties';
 import MaterialAnyOfRenderer, {
   materialAnyOfControlTester,
 } from './MaterialAnyOfRenderer';
@@ -34,6 +35,9 @@ import MaterialArrayControlRenderer, {
 import MaterialEnumArrayRenderer, {
   materialEnumArrayRendererTester,
 } from './MaterialEnumArrayRenderer';
+import MaterialMixedRenderer, {
+  materialMixedControlTester,
+} from './MaterialMixedRenderer';
 import MaterialObjectRenderer, {
   materialObjectControlTester,
 } from './MaterialObjectRenderer';
@@ -42,6 +46,7 @@ import MaterialOneOfRenderer, {
 } from './MaterialOneOfRenderer';
 
 export {
+  MaterialAdditionalProperties,
   materialAllOfControlTester,
   MaterialAllOfRenderer,
   materialAnyOfControlTester,
@@ -50,6 +55,8 @@ export {
   MaterialArrayControlRenderer,
   materialEnumArrayRendererTester,
   MaterialEnumArrayRenderer,
+  materialMixedControlTester,
+  MaterialMixedRenderer,
   materialObjectControlTester,
   MaterialObjectRenderer,
   materialOneOfControlTester,

--- a/packages/material-renderers/src/complex/unwrapped.ts
+++ b/packages/material-renderers/src/complex/unwrapped.ts
@@ -26,6 +26,7 @@ import { MaterialAllOfRenderer } from './MaterialAllOfRenderer';
 import { MaterialAnyOfRenderer } from './MaterialAnyOfRenderer';
 import { MaterialArrayControlRenderer } from './MaterialArrayControlRenderer';
 import { MaterialEnumArrayRenderer } from './MaterialEnumArrayRenderer';
+import { MaterialMixedRenderer } from './MaterialMixedRenderer';
 import { MaterialObjectRenderer } from './MaterialObjectRenderer';
 import { MaterialOneOfRenderer } from './MaterialOneOfRenderer';
 
@@ -34,6 +35,7 @@ export const UnwrappedComplex = {
   MaterialAnyOfRenderer,
   MaterialArrayControlRenderer,
   MaterialEnumArrayRenderer,
+  MaterialMixedRenderer,
   MaterialObjectRenderer,
   MaterialOneOfRenderer,
 };

--- a/packages/material-renderers/src/index.ts
+++ b/packages/material-renderers/src/index.ts
@@ -33,6 +33,8 @@ import {
   MaterialAnyOfRenderer,
   MaterialArrayControlRenderer,
   materialArrayControlTester,
+  MaterialMixedRenderer,
+  materialMixedControlTester,
   materialObjectControlTester,
   MaterialObjectRenderer,
   materialOneOfControlTester,
@@ -126,6 +128,7 @@ export * from './util';
 
 export const materialRenderers: JsonFormsRendererRegistryEntry[] = [
   // controls
+  { tester: materialMixedControlTester, renderer: MaterialMixedRenderer },
   {
     tester: materialArrayControlTester,
     renderer: MaterialArrayControlRenderer,

--- a/packages/vue-vuetify/dev/views/ExampleView.vue
+++ b/packages/vue-vuetify/dev/views/ExampleView.vue
@@ -29,8 +29,7 @@ import examples from '../examples';
 import { useAppStore } from '../store';
 import { createAjv } from '../validate';
 
-import { Pane, Splitpanes } from 'splitpanes';
-import 'splitpanes/dist/splitpanes.css';
+import { VPane, VSplitpanes } from '../../src/components';
 import { getCustomRenderersForExample } from '../renderers';
 
 const { extendedVuetifyRenderers } = await import('../../src');
@@ -332,12 +331,11 @@ const handleAction = (action: Action) => {
               </v-card-title>
               <v-divider class="mx-4"></v-divider>
               <div class="json-forms">
-                <splitpanes
-                  :class="['default-theme', 'splitpanes-vuetify']"
-                  :rtl="appStore.rtl"
+                <v-splitpanes
+                  class="splitpanes-vuetify"
                   v-if="appStore.layout === 'demo-and-data'"
                 >
-                  <pane min-size="20">
+                  <v-pane min-size="20">
                     <v-card>
                       <v-card-title>
                         <v-toolbar flat>
@@ -348,8 +346,8 @@ const handleAction = (action: Action) => {
                       <v-divider class="mx-4"></v-divider>
                       <example-form :state="state" @jsfchange="onChange" />
                     </v-card>
-                  </pane>
-                  <pane>
+                  </v-pane>
+                  <v-pane>
                     <v-card>
                       <v-card-title>
                         <v-toolbar flat>
@@ -389,8 +387,8 @@ const handleAction = (action: Action) => {
                         :editorBeforeMount="registerValidations"
                       ></monaco-editor>
                     </v-card>
-                  </pane>
-                </splitpanes>
+                  </v-pane>
+                </v-splitpanes>
 
                 <example-form :state="state" @jsfchange="onChange" v-else />
               </div>
@@ -509,28 +507,3 @@ const handleAction = (action: Action) => {
     </div>
   </div>
 </template>
-<style lang="scss" scoped>
-:deep(.default-theme) {
-  &.splitpanes--vertical > .splitpanes__splitter,
-  .splitpanes--vertical > .splitpanes__splitter {
-    border-left: 1px solid rgb(var(--v-theme-on-surface-variant));
-  }
-
-  &.splitpanes--horizontal > .splitpanes__splitter,
-  .splitpanes--horizontal > .splitpanes__splitter {
-    border-top: 1px solid rgb(var(--v-theme-on-surface-variant));
-  }
-
-  .splitpanes__splitter {
-    background-color: rgb(var(--v-theme-surface));
-    &:before,
-    &:after {
-      background-color: rgb(var(--v-theme-on-surface-variant));
-    }
-    &:hover:before,
-    &:hover:after {
-      background-color: rgb(var(--v-theme-on-surface-variant));
-    }
-  }
-}
-</style>

--- a/packages/vue-vuetify/package.json
+++ b/packages/vue-vuetify/package.json
@@ -68,6 +68,7 @@
     "dayjs": "^1.10.6",
     "lodash": "^4.17.21",
     "maska": "^2.1.11",
+    "splitpanes": "^3.2.0",
     "vue": "^3.5.0",
     "vuetify": "^3.11.0"
   },
@@ -107,7 +108,7 @@
     "resize-observer-polyfill": "^1.5.1",
     "rimraf": "^6.1.0",
     "rollup-plugin-postcss": "^4.0.2",
-    "splitpanes": "^3.1.5",
+    "splitpanes": "^3.2.0",
     "typedoc": "~0.25.3",
     "typescript": "~5.8.3",
     "vite": "^5.4.21",

--- a/packages/vue-vuetify/src/complex/MixedRenderer.vue
+++ b/packages/vue-vuetify/src/complex/MixedRenderer.vue
@@ -1,13 +1,13 @@
 <template>
-  <div class="prefixed-input" v-if="control.visible">
-    <template v-if="valueType === 'array' || valueType === 'object'">
-      <v-expansion-panels accordion flat v-model="currentlyExpanded">
+  <div v-if="control.visible" class="mixed-renderer">
+    <template v-if="showTreeView">
+      <v-expansion-panels v-model="currentlyExpanded" flat>
         <v-expansion-panel>
           <v-expansion-panel-title class="py-0 px-0">
             <v-container class="py-0">
               <v-row>
-                <v-col align-self="center" class="pl-0"
-                  ><v-select
+                <v-col align-self="center" class="pl-0">
+                  <v-select
                     v-if="mixedRenderInfos"
                     v-disabled-icon-focus
                     :id="control.id + '-input-selector'"
@@ -18,83 +18,251 @@
                     :error-messages="control.errors"
                     :items="mixedRenderInfos"
                     :clearable="isControlEditable(control)"
-                    @update:model-value="handleSelectChange"
                     :item-title="
                       (item: SchemaRenderInfo) => t(item.label, item.label)
                     "
                     item-value="index"
                     v-model="selectedIndex"
                     v-bind="vuetifyProps('v-select')"
+                    @update:model-value="handleSelectChange"
                     @click.stop
                     @focus="handleFocus"
                     @blur="handleBlur"
-                  >
-                  </v-select
-                ></v-col>
-                <v-col cols="3" align-self="center" class="text-truncate">{{
-                  computedLabel
-                }}</v-col>
+                  />
+                </v-col>
+                <v-col cols="3" align-self="center" class="text-truncate">
+                  {{ computedLabel }}
+                </v-col>
               </v-row>
             </v-container>
           </v-expansion-panel-title>
+
           <v-expansion-panel-text>
-            <dispatch-renderer
-              class="input"
-              v-if="schema && !(nullable && control.data === null)"
-              :schema="schema"
-              :uischema="uischema"
-              :path="path"
-              :renderers="control.renderers"
-              :cells="control.cells"
-              :enabled="control.enabled"
-              :readonly="control.readonly"
-            >
-            </dispatch-renderer>
+            <v-container fluid class="mixed-tree-container pa-0">
+              <v-splitpanes class="mixed-splitpanes">
+                <v-pane min-size="20" size="25">
+                  <div class="mixed-tree-pane">
+                    <v-text-field
+                      v-model="treeSearch"
+                      class="mixed-tree-search"
+                      density="compact"
+                      hide-details
+                      clearable
+                      label="Search"
+                      :prepend-inner-icon="icons.current.value.search"
+                      v-bind="vuetifyProps('v-text-field')"
+                    />
+                    <v-treeview
+                      v-model:opened="openedNodes"
+                      v-model:activated="activatedTreeNodes"
+                      :items="treeNodes"
+                      :search="treeSearch"
+                      :collapse-icon="icons.current.value.treeCollapse"
+                      :expand-icon="icons.current.value.treeExpand"
+                      activatable
+                      color="primary"
+                      density="compact"
+                      item-children="children"
+                      item-title="title"
+                      item-value="nodeId"
+                      class="mixed-tree"
+                      open-on-click
+                    >
+                      <template #prepend="{ item }">
+                        <v-icon
+                          size="small"
+                          :icon="getTypeIcon(item.jsonType)"
+                        />
+                      </template>
+
+                      <template #title="{ item }">
+                        <v-text-field
+                          v-if="renamingNodeId === item.nodeId"
+                          v-model="renameValue"
+                          class="mixed-rename-input"
+                          density="compact"
+                          hide-details
+                          autofocus
+                          :error="Boolean(renameError)"
+                          :title="renameError ?? undefined"
+                          v-bind="vuetifyProps('v-text-field')"
+                          @click.stop
+                          @keydown.stop.enter="commitRename(item)"
+                          @keydown.stop.esc="cancelRename"
+                          @blur="commitRename(item)"
+                        />
+                        <span v-else class="mixed-tree-title">
+                          {{ item.title }}
+                        </span>
+                      </template>
+
+                      <template #append="{ item }">
+                        <div class="mixed-tree-actions">
+                          <v-tooltip
+                            v-if="item.control.path === control.path"
+                            location="top"
+                          >
+                            <template #activator="{ props }">
+                              <v-btn
+                                v-bind="props"
+                                class="mixed-tree-action"
+                                :icon="
+                                  showPrimitivesInTree
+                                    ? icons.current.value.visibilityOn
+                                    : icons.current.value.visibilityOff
+                                "
+                                variant="text"
+                                size="x-small"
+                                @click.stop="toggleShowPrimitives"
+                              />
+                            </template>
+                            <span>
+                              {{
+                                showPrimitivesInTree
+                                  ? 'Hide primitives'
+                                  : 'Show primitives'
+                              }}
+                            </span>
+                          </v-tooltip>
+                          <template v-else-if="control.enabled">
+                            <v-tooltip v-if="item.canRename" location="top">
+                              <template #activator="{ props }">
+                                <v-btn
+                                  v-bind="props"
+                                  class="mixed-tree-action mixed-hover-action"
+                                  :icon="icons.current.value.itemEdit"
+                                  variant="text"
+                                  size="x-small"
+                                  @click.stop="startRename(item)"
+                                />
+                              </template>
+                              <span>Rename</span>
+                            </v-tooltip>
+                            <v-tooltip v-if="item.canDelete" location="top">
+                              <template #activator="{ props }">
+                                <v-btn
+                                  v-bind="props"
+                                  class="mixed-tree-action mixed-hover-action"
+                                  :icon="icons.current.value.itemDelete"
+                                  variant="text"
+                                  size="x-small"
+                                  color="error"
+                                  @click.stop="deleteNode(item)"
+                                />
+                              </template>
+                              <span>Delete</span>
+                            </v-tooltip>
+                          </template>
+                        </div>
+                      </template>
+                    </v-treeview>
+                  </div>
+                </v-pane>
+
+                <v-pane min-size="35" size="75">
+                  <div class="mixed-detail-pane">
+                    <dispatch-renderer
+                      v-if="selectedNode"
+                      :schema="selectedNode.control.schema"
+                      :uischema="selectedNode.control.uischema"
+                      :path="selectedNode.control.path"
+                      :renderers="control.renderers"
+                      :cells="control.cells"
+                      :enabled="selectedNode.control.enabled"
+                      :readonly="selectedNode.control.readonly"
+                    />
+                  </div>
+                </v-pane>
+              </v-splitpanes>
+            </v-container>
           </v-expansion-panel-text>
         </v-expansion-panel>
       </v-expansion-panels>
     </template>
+
+    <template v-else-if="isNestedComplexType">
+      <div class="mixed-nested-complex">
+        <v-select
+          class="select"
+          v-if="mixedRenderInfos"
+          v-disabled-icon-focus
+          :id="control.id + '-input-selector'"
+          :disabled="!control.enabled"
+          :readonly="control.readonly"
+          :label="computedLabel"
+          :required="control.required"
+          :error-messages="control.errors"
+          :items="mixedRenderInfos"
+          :clearable="isControlEditable(control)"
+          :item-title="(item: SchemaRenderInfo) => t(item.label, item.label)"
+          item-value="index"
+          v-model="selectedIndex"
+          v-bind="vuetifyProps('v-select')"
+          @update:model-value="handleSelectChange"
+          @click.stop
+          @focus="handleFocus"
+          @blur="handleBlur"
+        />
+        <v-tooltip location="top">
+          <template #activator="{ props }">
+            <v-btn
+              v-bind="props"
+              class="mixed-navigate-button"
+              :icon="icons.current.value.visibilityOn"
+              variant="text"
+              color="primary"
+              :disabled="!navigationContext"
+              @click="selectCurrentPath"
+            />
+          </template>
+          <span>View {{ computedLabel }}</span>
+        </v-tooltip>
+      </div>
+    </template>
+
     <template v-else>
-      <v-select
-        class="select"
-        v-if="mixedRenderInfos"
-        v-disabled-icon-focus
-        :id="control.id + '-input-selector'"
-        :disabled="!control.enabled"
-        :readonly="control.readonly"
-        :label="computedLabel"
-        :required="control.required"
-        :error-messages="control.errors"
-        :items="mixedRenderInfos"
-        :clearable="isControlEditable(control)"
-        @update:model-value="handleSelectChange"
-        :item-title="(item: SchemaRenderInfo) => t(item.label, item.label)"
-        item-value="index"
-        v-model="selectedIndex"
-        v-bind="vuetifyProps('v-select')"
-        @click.stop
-        @focus="handleFocus"
-        @blur="handleBlur"
-      >
-      </v-select>
-      <dispatch-renderer
-        class="input"
-        v-if="schema && !(nullable && control.data === null)"
-        :schema="schema"
-        :uischema="uischema"
-        :path="path"
-        :renderers="control.renderers"
-        :cells="control.cells"
-        :enabled="control.enabled"
-        :readonly="control.readonly"
-      >
-      </dispatch-renderer>
+      <div class="mixed-primitive">
+        <v-select
+          class="select"
+          v-if="mixedRenderInfos"
+          v-disabled-icon-focus
+          :id="control.id + '-input-selector'"
+          :disabled="!control.enabled"
+          :readonly="control.readonly"
+          :label="computedLabel"
+          :required="control.required"
+          :error-messages="control.errors"
+          :items="mixedRenderInfos"
+          :clearable="isControlEditable(control)"
+          :item-title="(item: SchemaRenderInfo) => t(item.label, item.label)"
+          item-value="index"
+          v-model="selectedIndex"
+          v-bind="vuetifyProps('v-select')"
+          @update:model-value="handleSelectChange"
+          @click.stop
+          @focus="handleFocus"
+          @blur="handleBlur"
+        />
+        <dispatch-renderer
+          class="input"
+          v-if="schema && uischema && !(nullable && control.data === null)"
+          :schema="schema"
+          :uischema="uischema"
+          :path="path"
+          :renderers="control.renderers"
+          :cells="control.cells"
+          :enabled="control.enabled"
+          :readonly="control.readonly"
+        />
+      </div>
     </template>
   </div>
 </template>
 
 <script lang="ts">
 import {
+  Resolve,
+  compose,
   createControlElement,
   createDefaultValue,
   findUISchema,
@@ -112,18 +280,37 @@ import {
   useTranslator,
   type RendererProps,
 } from '@jsonforms/vue';
-import { computed, defineComponent, provide, ref, watch } from 'vue';
+import cloneDeep from 'lodash/cloneDeep';
+import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
+import set from 'lodash/set';
 import {
+  computed,
+  defineComponent,
+  inject,
+  provide,
+  ref,
+  watch,
+  type InjectionKey,
+} from 'vue';
+import {
+  VBtn,
   VCol,
   VContainer,
   VExpansionPanel,
-  VExpansionPanels,
   VExpansionPanelText,
   VExpansionPanelTitle,
+  VExpansionPanels,
+  VIcon,
   VRow,
   VSelect,
+  VTextField,
+  VTooltip,
+  VTreeview,
 } from 'vuetify/components';
+import { VPane, VSplitpanes } from '../components';
 import { DisabledIconFocus } from '../controls';
+import type { IconValue } from '../icons';
 import {
   IsDynamicPropertyContext,
   isControlEditable,
@@ -131,10 +318,15 @@ import {
   useIcons,
   useVuetifyControl,
 } from '../util';
-import cloneDeep from 'lodash/cloneDeep';
-import set from 'lodash/set';
-import get from 'lodash/get';
-import isEqual from 'lodash/isEqual';
+
+type JsonDataType =
+  | 'array'
+  | 'boolean'
+  | 'integer'
+  | 'null'
+  | 'number'
+  | 'object'
+  | 'string';
 
 interface SchemaRenderInfo {
   schema: JsonSchema;
@@ -143,8 +335,48 @@ interface SchemaRenderInfo {
   label: string;
 }
 
-function cleanSchema(schema: JsonSchema) {
-  // Define valid keywords for each JSON Schema type
+interface TreeNodeControl {
+  id: string;
+  schema: JsonSchema;
+  uischema: ControlElement;
+  path: string;
+  label: string;
+  required: boolean;
+  enabled: boolean;
+  readonly: boolean;
+}
+
+interface MixedTreeNode {
+  nodeId: string;
+  title: string;
+  jsonType: JsonDataType;
+  label: string;
+  canRename: boolean;
+  canDelete: boolean;
+  control: TreeNodeControl;
+  children?: MixedTreeNode[];
+}
+
+interface NavigationContext {
+  selectPath: (path: string) => void;
+}
+
+const NavigationContextSymbol: InjectionKey<NavigationContext> = Symbol.for(
+  'jsonforms-vue-vuetify:MixedRendererNavigationContext',
+);
+
+const ROOT_TREE_NODE_ID = '$root';
+const toTreeNodeId = (path: string) =>
+  path ? `$path:${path}` : ROOT_TREE_NODE_ID;
+
+function resolveSchema(schema: JsonSchema, rootSchema: JsonSchema): JsonSchema {
+  if (typeof schema?.$ref === 'string') {
+    return Resolve.schema(rootSchema, schema.$ref, rootSchema) ?? schema;
+  }
+  return schema;
+}
+
+function cleanSchema(schema: JsonSchema): JsonSchema {
   const validKeywords: Record<string, string[]> = {
     array: ['items', 'minItems', 'maxItems', 'uniqueItems', 'contains'],
     object: [
@@ -176,19 +408,16 @@ function cleanSchema(schema: JsonSchema) {
     null: [],
   };
 
-  // Function to remove invalid keywords based on type
-  function clean(schema: JsonSchema) {
-    for (const validType in validKeywords) {
-      if (validType !== schema.type) {
-        const keywords = validKeywords[validType];
-        keywords.forEach((key) => {
-          delete (schema as any)[key];
-        });
-      }
+  const schemaType = schema.type as string;
+  for (const validType in validKeywords) {
+    if (validType !== schemaType) {
+      validKeywords[validType].forEach((key) => {
+        delete (schema as any)[key];
+      });
     }
   }
 
-  return clean(schema);
+  return schema;
 }
 
 function getSchemaTypesAsArray(schema: JsonSchema): string[] {
@@ -205,12 +434,10 @@ function getSchemaTypesAsArray(schema: JsonSchema): string[] {
       schema.enum.map((value) => getJsonDataType(value)),
     );
     if (!enumTypes.has(null)) {
-      // return only if we were able to determine all types, otherwise return the default
       return Array.from(enumTypes).filter((type) => type !== null) as string[];
     }
   }
 
-  // return any
   return ['array', 'boolean', 'integer', 'null', 'number', 'object', 'string'];
 }
 
@@ -223,6 +450,7 @@ const createMixedRenderInfos = (
   uischemas: JsonFormsUISchemaRegistryEntry[],
 ): SchemaRenderInfo[] => {
   let resolvedSchemas: JsonSchema[] = [];
+  schema = resolveSchema(schema, rootSchema);
 
   if (typeof schema.type === 'string') {
     resolvedSchemas.push(schema);
@@ -245,6 +473,11 @@ const createMixedRenderInfos = (
   return resolvedSchemas.map((resolvedSchema) => {
     if (resolvedSchema.type === 'array') {
       resolvedSchema.items = resolvedSchema.items ?? {};
+      resolvedSchema.items = resolveSchema(
+        resolvedSchema.items as JsonSchema,
+        rootSchema,
+      );
+
       if ((resolvedSchema.items as any) === true) {
         resolvedSchema.items = {
           type: [
@@ -273,11 +506,10 @@ const createMixedRenderInfos = (
       }
     }
 
-    // help determining the correct renders by removing keywords not appropriate for the type
-    cleanSchema(resolvedSchema);
+    let cleanedSchema = cleanSchema(cloneDeep(resolvedSchema));
 
     const detailsForSchema = control.options
-      ? control.options[resolvedSchema.type + '-detail']
+      ? control.options[cleanedSchema.type + '-detail']
       : undefined;
 
     const schemaControl = detailsForSchema
@@ -287,31 +519,27 @@ const createMixedRenderInfos = (
         }
       : control;
 
-    const _resolvedSchema = resolvedSchema;
-
     if (
       control.scope &&
-      (resolvedSchema.type === 'object' || resolvedSchema.type === 'array')
+      (cleanedSchema.type === 'object' || cleanedSchema.type === 'array')
     ) {
       const segments = control.scope.split('/');
       const startFromRoot = segments[0] === '#' || segments[0] === '';
       const startIndex = startFromRoot ? 1 : 0;
 
       if (segments.length > startIndex) {
-        // for object schema the object renderer expects to get the parent schema
         const schemaPath = segments.slice(startIndex).join('.');
         if (schemaPath && isEqual(get(parentSchema, schemaPath), schema)) {
-          // double check that the schema that we are going to replace is the schema that is with the mixed type
           const newSchema = cloneDeep(parentSchema);
-          set(newSchema, schemaPath, resolvedSchema);
-          resolvedSchema = newSchema;
+          set(newSchema, schemaPath, cleanedSchema);
+          cleanedSchema = newSchema;
         }
       }
     }
 
     const uischema = findUISchema(
       uischemas,
-      resolvedSchema,
+      cleanedSchema,
       control.scope,
       path,
       () => createControlElement(control.scope ?? '#'),
@@ -320,15 +548,15 @@ const createMixedRenderInfos = (
     );
 
     return {
-      schema: resolvedSchema,
-      resolvedSchema: _resolvedSchema,
+      schema: cleanedSchema,
+      resolvedSchema,
       uischema,
-      label: `${_resolvedSchema.type}`,
+      label: `${resolvedSchema.type}`,
     };
   });
 };
 
-export function getJsonDataType(value: any): string | null {
+export function getJsonDataType(value: any): JsonDataType | null {
   if (typeof value === 'string') {
     return 'string';
   } else if (typeof value === 'number') {
@@ -346,18 +574,465 @@ export function getJsonDataType(value: any): string | null {
   return null;
 }
 
+function schemaSupportsInputType(
+  schemaType: JsonSchema['type'] | undefined,
+  dataType: JsonDataType | null,
+): boolean {
+  if (!dataType || typeof schemaType !== 'string') {
+    return false;
+  }
+
+  return (
+    schemaType === dataType ||
+    (schemaType === 'number' && dataType === 'integer')
+  );
+}
+
+function findPropertySchema(
+  parentSchema: JsonSchema,
+  propName: string,
+  rootSchema: JsonSchema,
+): JsonSchema | undefined {
+  if (parentSchema.properties?.[propName]) {
+    return resolveSchema(parentSchema.properties[propName], rootSchema);
+  }
+
+  if (parentSchema.patternProperties) {
+    const matchedPattern = Object.keys(parentSchema.patternProperties).find(
+      (pattern) => new RegExp(pattern).test(propName),
+    );
+
+    if (matchedPattern) {
+      return resolveSchema(
+        parentSchema.patternProperties[matchedPattern],
+        rootSchema,
+      );
+    }
+  }
+
+  if (typeof parentSchema.additionalProperties === 'object') {
+    return resolveSchema(parentSchema.additionalProperties, rootSchema);
+  }
+
+  if (parentSchema.additionalProperties === true) {
+    return { additionalProperties: true };
+  }
+
+  return undefined;
+}
+
+function getArrayItemSchema(
+  parentSchema: JsonSchema,
+  index: number,
+  rootSchema: JsonSchema,
+): JsonSchema | undefined {
+  if (!parentSchema.items) {
+    return undefined;
+  }
+
+  let itemSchema: JsonSchema | undefined;
+  if (Array.isArray(parentSchema.items)) {
+    if (index < parentSchema.items.length) {
+      itemSchema = parentSchema.items[index];
+    } else if (parentSchema.additionalItems) {
+      itemSchema =
+        typeof parentSchema.additionalItems === 'object'
+          ? parentSchema.additionalItems
+          : undefined;
+    }
+  } else {
+    itemSchema = parentSchema.items as JsonSchema;
+  }
+
+  return itemSchema ? resolveSchema(itemSchema, rootSchema) : undefined;
+}
+
+function prepareObjectSchema(schema: JsonSchema): JsonSchema {
+  const objectSchema = cleanSchema(cloneDeep({ ...schema, type: 'object' }));
+  objectSchema.additionalProperties =
+    objectSchema.additionalProperties !== false
+      ? (objectSchema.additionalProperties ?? true)
+      : false;
+  return objectSchema;
+}
+
+function prepareArraySchema(
+  schema: JsonSchema,
+  rootSchema: JsonSchema,
+): JsonSchema {
+  const arraySchema = cleanSchema(cloneDeep({ ...schema, type: 'array' }));
+  arraySchema.items = arraySchema.items ?? {};
+  arraySchema.items = resolveSchema(
+    arraySchema.items as JsonSchema,
+    rootSchema,
+  );
+
+  if ((arraySchema.items as any) === true) {
+    arraySchema.items = {
+      type: [
+        'array',
+        'boolean',
+        'integer',
+        'null',
+        'number',
+        'object',
+        'string',
+      ],
+    };
+  } else if (
+    typeof (arraySchema.items as JsonSchema7).type !== 'string' &&
+    !Array.isArray((arraySchema.items as JsonSchema7).type)
+  ) {
+    (arraySchema.items as JsonSchema7).type = [
+      'array',
+      'boolean',
+      'integer',
+      'null',
+      'number',
+      'object',
+      'string',
+    ];
+  }
+
+  return arraySchema;
+}
+
+function prepareChildSchema(
+  childType: JsonDataType,
+  currentSchema: JsonSchema,
+  key: string,
+  index: number | null,
+  rootSchema: JsonSchema,
+): JsonSchema {
+  let childSchema: JsonSchema | undefined;
+
+  if (index !== null) {
+    childSchema = getArrayItemSchema(currentSchema, index, rootSchema);
+    childSchema = childSchema
+      ? { ...childSchema, title: `Item ${index}` }
+      : {
+          type: [
+            'array',
+            'boolean',
+            'integer',
+            'null',
+            'number',
+            'object',
+            'string',
+          ],
+          title: `Item ${index}`,
+        };
+  } else {
+    childSchema = findPropertySchema(currentSchema, key, rootSchema);
+    childSchema = childSchema
+      ? { ...childSchema, title: key }
+      : {
+          type: [
+            'array',
+            'boolean',
+            'integer',
+            'null',
+            'number',
+            'object',
+            'string',
+          ],
+          title: key,
+        };
+  }
+
+  if (
+    childType !== 'object' &&
+    childType !== 'array' &&
+    (!childSchema.type || (childSchema.type as any) === true)
+  ) {
+    childSchema.type = [
+      'array',
+      'boolean',
+      'integer',
+      'null',
+      'number',
+      'object',
+      'string',
+    ];
+  }
+
+  if (childType === 'object') {
+    return prepareObjectSchema(childSchema);
+  }
+
+  if (childType === 'array') {
+    return prepareArraySchema(childSchema, rootSchema);
+  }
+
+  return childSchema;
+}
+
+function createFallbackChildSchema(title: string): JsonSchema {
+  return {
+    type: ['array', 'boolean', 'integer', 'null', 'number', 'object', 'string'],
+    title,
+  };
+}
+
+function getSchemaDefaultType(schema: JsonSchema): JsonDataType {
+  const schemaTypes = getSchemaTypesAsArray(schema);
+  const firstType =
+    schemaTypes.find((type) => type !== 'null') ?? schemaTypes[0];
+  return (firstType ?? 'object') as JsonDataType;
+}
+
+function createTreeNodeControl(
+  schema: JsonSchema,
+  path: string,
+  label: string,
+  enabled: boolean,
+  readonly: boolean,
+): TreeNodeControl {
+  return {
+    id: path,
+    schema,
+    uischema: createControlElement('#'),
+    path,
+    label,
+    required: false,
+    enabled,
+    readonly,
+  };
+}
+
+function withoutEmptyChildren(node: MixedTreeNode): MixedTreeNode {
+  const children = node.children?.map(withoutEmptyChildren) ?? [];
+  if (children.length === 0) {
+    const rest = { ...node };
+    delete rest.children;
+    return rest;
+  }
+  return {
+    ...node,
+    children,
+  };
+}
+
+function getDisplayTitle(label: string, type: JsonDataType): string {
+  if (label) {
+    return label;
+  }
+  return type === 'array' ? '[]' : '{}';
+}
+
+function isDynamicProperty(parentSchema: JsonSchema, key: string): boolean {
+  return !parentSchema.properties?.[key];
+}
+
+function buildTreeFromData(
+  data: any,
+  schema: JsonSchema,
+  rootSchema: JsonSchema,
+  path: string,
+  label: string,
+  enabled: boolean,
+  readonly: boolean,
+  showPrimitives: boolean,
+): MixedTreeNode[] {
+  const dataType = getJsonDataType(data);
+  if (dataType !== 'object' && dataType !== 'array') {
+    return [];
+  }
+
+  const nodes: MixedTreeNode[] = [];
+
+  function traverse(
+    value: any,
+    currentPath: string,
+    currentLabel: string,
+    currentSchema: JsonSchema,
+    children: MixedTreeNode[],
+    canRename = false,
+    canDelete = false,
+  ) {
+    const type = getJsonDataType(value);
+
+    if (type === 'object') {
+      const objectSchema = prepareObjectSchema(currentSchema);
+      const nodeId = toTreeNodeId(currentPath);
+      const node: MixedTreeNode = {
+        nodeId,
+        title: getDisplayTitle(currentLabel, type),
+        jsonType: type,
+        label: currentLabel,
+        canRename,
+        canDelete,
+        control: createTreeNodeControl(
+          objectSchema,
+          currentPath,
+          currentLabel,
+          enabled,
+          readonly,
+        ),
+        children: [],
+      };
+      children.push(node);
+
+      Object.keys(value).forEach((key) => {
+        const childValue = value[key];
+        const childPath = compose(currentPath, key);
+        const rawChildType = getJsonDataType(childValue);
+        const childCanRename = isDynamicProperty(currentSchema, key);
+        const childCanDelete = true;
+        const initialChildSchema =
+          findPropertySchema(currentSchema, key, rootSchema) ??
+          createFallbackChildSchema(key);
+        const childType =
+          rawChildType ?? getSchemaDefaultType(initialChildSchema);
+        const childSchema = prepareChildSchema(
+          childType,
+          currentSchema,
+          key,
+          null,
+          rootSchema,
+        );
+
+        if (childType === 'object' || childType === 'array') {
+          traverse(
+            childValue ?? (childType === 'array' ? [] : {}),
+            childPath,
+            key,
+            childSchema,
+            node.children!,
+            childCanRename,
+            childCanDelete,
+          );
+        } else if (showPrimitives) {
+          const nodeId = toTreeNodeId(childPath);
+          node.children!.push({
+            nodeId,
+            title: key,
+            jsonType: childType,
+            label: key,
+            canRename: childCanRename,
+            canDelete: childCanDelete,
+            control: createTreeNodeControl(
+              childSchema,
+              childPath,
+              key,
+              enabled,
+              readonly,
+            ),
+            children: [],
+          });
+        }
+      });
+    } else if (type === 'array') {
+      const arraySchema = prepareArraySchema(currentSchema, rootSchema);
+      const nodeId = toTreeNodeId(currentPath);
+      const node: MixedTreeNode = {
+        nodeId,
+        title: getDisplayTitle(currentLabel, type),
+        jsonType: type,
+        label: currentLabel,
+        canRename,
+        canDelete,
+        control: createTreeNodeControl(
+          arraySchema,
+          currentPath,
+          currentLabel,
+          enabled,
+          readonly,
+        ),
+        children: [],
+      };
+      children.push(node);
+
+      value.forEach((childValue: any, index: number) => {
+        const childType = getJsonDataType(childValue);
+        const childPath = compose(currentPath, `${index}`);
+        const childSchema = prepareChildSchema(
+          childType ?? 'object',
+          currentSchema,
+          '',
+          index,
+          rootSchema,
+        );
+        const resolvedChildType =
+          childType ?? getSchemaDefaultType(childSchema);
+        const childLabel = `Item ${index}`;
+        if (resolvedChildType === 'object' || resolvedChildType === 'array') {
+          traverse(
+            childValue ?? (resolvedChildType === 'array' ? [] : {}),
+            childPath,
+            childLabel,
+            childSchema,
+            node.children!,
+            false,
+            true,
+          );
+        } else if (showPrimitives) {
+          const nodeId = toTreeNodeId(childPath);
+          node.children!.push({
+            nodeId,
+            title: childLabel,
+            jsonType: resolvedChildType,
+            label: childLabel,
+            canRename: false,
+            canDelete: true,
+            control: createTreeNodeControl(
+              childSchema,
+              childPath,
+              childLabel,
+              enabled,
+              readonly,
+            ),
+            children: [],
+          });
+        }
+      });
+    }
+  }
+
+  traverse(data, path, label, resolveSchema(schema, rootSchema), nodes);
+
+  return nodes.map(withoutEmptyChildren);
+}
+
+function flattenTree(nodes: MixedTreeNode[]): MixedTreeNode[] {
+  return nodes.flatMap((node) => [node, ...flattenTree(node.children ?? [])]);
+}
+
+function findNodeByPath(
+  nodes: MixedTreeNode[],
+  targetPath: string,
+): MixedTreeNode | undefined {
+  for (const node of nodes) {
+    if (node.nodeId === targetPath) {
+      return node;
+    }
+    const child = findNodeByPath(node.children ?? [], targetPath);
+    if (child) {
+      return child;
+    }
+  }
+  return undefined;
+}
+
 const controlRenderer = defineComponent({
   name: 'mixed-renderer',
   components: {
     DispatchRenderer,
-    VSelect,
+    VBtn,
+    VCol,
+    VContainer,
     VExpansionPanel,
     VExpansionPanels,
     VExpansionPanelTitle,
     VExpansionPanelText,
-    VContainer,
+    VIcon,
     VRow,
-    VCol,
+    VSelect,
+    VTextField,
+    VTreeview,
+    VPane,
+    VSplitpanes,
+    VTooltip,
   },
   directives: {
     DisabledIconFocus,
@@ -369,35 +1044,29 @@ const controlRenderer = defineComponent({
     const path = props.path;
     const parentSchema = props.schema;
     const input = useJsonFormsControl(props);
-
-    const control = input.control.value;
-    const valueType = ref(getJsonDataType(control.data));
+    const vuetifyControl = useCombinatorTranslations(useVuetifyControl(input));
+    const valueType = ref(getJsonDataType(input.control.value.data));
     const jsonforms = useJsonForms();
     const icons = useIcons();
-
-    watch(
-      () => input.control.value.data,
-      (newValue, oldValue) => {
-        if (newValue !== oldValue) {
-          const oldValueType = valueType.value;
-          valueType.value = getJsonDataType(newValue);
-
-          if (oldValueType !== valueType.value) {
-            // adjust the index
-            selectedIndex.value = matchingSchema.value?.index;
-          }
-        }
-      },
-      { deep: false },
-    );
+    const t = useTranslator();
+    const navigationContext = inject(NavigationContextSymbol, undefined);
+    const isRoot = !navigationContext;
+    const activeNodeId = ref(toTreeNodeId(input.control.value.path));
+    const openedNodes = ref<string[]>([]);
+    const treeSearch = ref('');
+    const currentlyExpanded = ref<number | null>(0);
+    const showPrimitivesInTree = ref(false);
+    const renamingNodeId = ref<string | null>(null);
+    const renameValue = ref('');
+    const renameError = ref<string | null>(null);
 
     const mixedRenderInfos = computed<
       (SchemaRenderInfo & {
         index: number;
       })[]
     >(() => {
+      const control = input.control.value;
       const result = createMixedRenderInfos(
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         parentSchema,
         control.schema,
         control.rootSchema,
@@ -408,13 +1077,24 @@ const controlRenderer = defineComponent({
 
       return result
         .filter((info) => info.uischema)
-        .map((info, index) => ({ ...info, index: index }));
+        .map((info, index) => ({ ...info, index }));
     });
 
     const nullable = computed(() =>
       mixedRenderInfos.value.some(
         (info) => info.resolvedSchema.type === 'null',
       ),
+    );
+
+    const showTreeView = computed(
+      () =>
+        isRoot && (valueType.value === 'object' || valueType.value === 'array'),
+    );
+
+    const isNestedComplexType = computed(
+      () =>
+        !isRoot &&
+        (valueType.value === 'object' || valueType.value === 'array'),
     );
 
     const matchingSchema = computed(() => {
@@ -435,31 +1115,355 @@ const controlRenderer = defineComponent({
       matchingSchema.value?.index,
     );
 
-    const t = useTranslator();
-
     const schema = computed(() =>
       selectedIndex.value !== null && selectedIndex.value !== undefined
-        ? mixedRenderInfos.value[selectedIndex.value].schema
+        ? mixedRenderInfos.value[selectedIndex.value]?.schema
         : undefined,
     );
+
     const resolvedSchema = computed(() =>
       selectedIndex.value !== null && selectedIndex.value !== undefined
-        ? mixedRenderInfos.value[selectedIndex.value].resolvedSchema
+        ? mixedRenderInfos.value[selectedIndex.value]?.resolvedSchema
         : undefined,
     );
 
     const uischema = computed(() =>
       selectedIndex.value !== null && selectedIndex.value !== undefined
-        ? mixedRenderInfos.value[selectedIndex.value].uischema
+        ? mixedRenderInfos.value[selectedIndex.value]?.uischema
         : undefined,
     );
 
-    const currentlyExpanded = ref<number | null>(null);
-    // use the default value since all properties are dynamic so preserve the property key
+    const treeNodes = computed(() =>
+      showTreeView.value
+        ? buildTreeFromData(
+            input.control.value.data,
+            resolvedSchema.value ?? input.control.value.schema,
+            input.control.value.rootSchema,
+            input.control.value.path,
+            vuetifyControl.computedLabel.value,
+            input.control.value.enabled,
+            input.control.value.readonly,
+            showPrimitivesInTree.value,
+          )
+        : [],
+    );
+
+    const selectedNode = computed(() =>
+      findNodeByPath(treeNodes.value, activeNodeId.value),
+    );
+
+    const activatedTreeNodes = computed<string[]>({
+      get: () => [activeNodeId.value],
+      set: (value) => {
+        const nodeId = value[0];
+        if (nodeId && findNodeByPath(treeNodes.value, nodeId)) {
+          activeNodeId.value = nodeId;
+        }
+      },
+    });
+
+    const getPathAncestorNodeIds = (path: string): string[] => {
+      const segments = path.split('.').filter(Boolean);
+      const result = [toTreeNodeId(input.control.value.path)];
+      let currentPath = input.control.value.path;
+
+      segments.slice(0, -1).forEach((segment) => {
+        currentPath = compose(currentPath, segment);
+        result.push(toTreeNodeId(currentPath));
+      });
+
+      return result;
+    };
+
+    const selectPath = (path: string) => {
+      const nodeId = toTreeNodeId(path);
+      activeNodeId.value = nodeId;
+      openedNodes.value = Array.from(
+        new Set([...openedNodes.value, ...getPathAncestorNodeIds(path)]),
+      );
+    };
+
+    if (isRoot) {
+      provide(NavigationContextSymbol, { selectPath });
+    }
+
+    watch(
+      () => input.control.value.data,
+      (newValue, oldValue) => {
+        if (newValue !== oldValue) {
+          const oldValueType = valueType.value;
+          valueType.value = getJsonDataType(newValue);
+
+          if (oldValueType !== valueType.value) {
+            const currentlySelected =
+              selectedIndex.value !== null && selectedIndex.value !== undefined
+                ? mixedRenderInfos.value[selectedIndex.value]
+                : undefined;
+            if (
+              currentlySelected &&
+              schemaSupportsInputType(
+                currentlySelected.resolvedSchema.type,
+                valueType.value,
+              )
+            ) {
+              return;
+            }
+            selectedIndex.value = matchingSchema.value?.index;
+          }
+        }
+      },
+      { deep: false },
+    );
+
+    watch(
+      treeNodes,
+      (nodes) => {
+        const allNodeIds = flattenTree(nodes).map((node) => node.nodeId);
+        const allNodeIdSet = new Set(allNodeIds);
+        const rootNodeId = toTreeNodeId(input.control.value.path);
+        if (!allNodeIds.includes(activeNodeId.value)) {
+          activeNodeId.value = rootNodeId;
+        }
+        openedNodes.value = Array.from(
+          new Set([rootNodeId, ...openedNodes.value]),
+        ).filter((id) => allNodeIdSet.has(id));
+      },
+      { immediate: true },
+    );
+
+    const getRelativePath = (nodePath: string): string | null => {
+      const rootPath = input.control.value.path;
+      if (nodePath === rootPath) {
+        return null;
+      }
+      return rootPath && nodePath.startsWith(`${rootPath}.`)
+        ? nodePath.slice(rootPath.length + 1)
+        : nodePath;
+    };
+
+    const getParentPath = (nodePath: string): string => {
+      const lastDot = nodePath.lastIndexOf('.');
+      return lastDot > 0
+        ? nodePath.substring(0, lastDot)
+        : input.control.value.path;
+    };
+
+    const getParentSchema = (parentPath: string): JsonSchema | undefined => {
+      const parentRelativePath = getRelativePath(parentPath);
+      if (parentRelativePath === null) {
+        return resolvedSchema.value ?? input.control.value.schema;
+      }
+
+      const segments = parentRelativePath.split('.');
+      let currentSchema: JsonSchema =
+        resolvedSchema.value ?? input.control.value.schema;
+
+      for (const segment of segments) {
+        currentSchema = resolveSchema(
+          currentSchema,
+          input.control.value.rootSchema,
+        );
+        if (currentSchema.type === 'array') {
+          currentSchema = (currentSchema.items as JsonSchema) ?? {};
+        } else {
+          currentSchema =
+            currentSchema.properties?.[segment] ??
+            findPropertySchema(
+              currentSchema,
+              segment,
+              input.control.value.rootSchema,
+            ) ??
+            {};
+        }
+      }
+
+      return currentSchema;
+    };
+
+    const toggleShowPrimitives = () => {
+      showPrimitivesInTree.value = !showPrimitivesInTree.value;
+    };
+
+    const startRename = (node: MixedTreeNode) => {
+      if (!node.canRename) {
+        return;
+      }
+      renamingNodeId.value = node.nodeId;
+      renameValue.value = node.label;
+      renameError.value = null;
+    };
+
+    const cancelRename = () => {
+      renamingNodeId.value = null;
+      renameValue.value = '';
+      renameError.value = null;
+    };
+
+    const commitRename = (node: MixedTreeNode) => {
+      if (renamingNodeId.value !== node.nodeId) {
+        return;
+      }
+
+      const trimmed = renameValue.value.trim();
+      if (!trimmed || trimmed === node.label) {
+        cancelRename();
+        return;
+      }
+
+      const parentPath = getParentPath(node.control.path);
+      const parentRelativePath = getRelativePath(parentPath);
+      const parentData =
+        parentRelativePath === null
+          ? input.control.value.data
+          : get(input.control.value.data, parentRelativePath);
+
+      if (
+        typeof parentData !== 'object' ||
+        parentData === null ||
+        Array.isArray(parentData)
+      ) {
+        cancelRename();
+        return;
+      }
+
+      if (trimmed in parentData) {
+        renameError.value = `Property "${trimmed}" already exists`;
+        return;
+      }
+
+      let parentSchema = getParentSchema(parentPath);
+      if (parentSchema) {
+        parentSchema = resolveSchema(
+          parentSchema,
+          input.control.value.rootSchema,
+        );
+      }
+
+      if (parentSchema?.patternProperties) {
+        const hadMatchingPattern = Object.keys(
+          parentSchema.patternProperties,
+        ).some((pattern) => new RegExp(pattern).test(node.label));
+        const hasMatchingPattern = Object.keys(
+          parentSchema.patternProperties,
+        ).some((pattern) => new RegExp(pattern).test(trimmed));
+        if (hadMatchingPattern && !hasMatchingPattern) {
+          renameError.value = `Property name must match pattern: ${Object.keys(
+            parentSchema.patternProperties,
+          ).join(', ')}`;
+          return;
+        }
+      }
+
+      const propertyNames = (parentSchema as any)?.propertyNames as
+        | JsonSchema
+        | undefined;
+      if (propertyNames?.pattern) {
+        const pattern = new RegExp(propertyNames.pattern);
+        if (!pattern.test(trimmed)) {
+          renameError.value = `Property name must match pattern: ${propertyNames.pattern}`;
+          return;
+        }
+      }
+
+      const updatedData = Object.fromEntries(
+        Object.entries(parentData).map(([key, value]) => [
+          key === node.label ? trimmed : key,
+          value,
+        ]),
+      );
+      vuetifyControl.handleChange(parentPath, updatedData);
+
+      const newPath = compose(parentPath, trimmed);
+      selectPath(newPath);
+      cancelRename();
+    };
+
+    const deleteNode = (node: MixedTreeNode) => {
+      if (!node.canDelete) {
+        return;
+      }
+
+      const parentPath = getParentPath(node.control.path);
+      const parentRelativePath = getRelativePath(parentPath);
+      const parentData =
+        parentRelativePath === null
+          ? input.control.value.data
+          : get(input.control.value.data, parentRelativePath);
+      const key = node.control.path.slice(
+        parentPath.length ? parentPath.length + 1 : 0,
+      );
+
+      if (Array.isArray(parentData)) {
+        const index = Number(key);
+        if (!Number.isInteger(index)) {
+          return;
+        }
+        const updatedData = [...parentData];
+        updatedData.splice(index, 1);
+        vuetifyControl.handleChange(parentPath, updatedData);
+      } else if (typeof parentData === 'object' && parentData !== null) {
+        const updatedData = { ...parentData };
+        delete updatedData[key];
+        vuetifyControl.handleChange(parentPath, updatedData);
+      }
+
+      if (
+        activeNodeId.value === node.nodeId ||
+        activeNodeId.value.startsWith(`${node.nodeId}.`)
+      ) {
+        selectPath(parentPath);
+      }
+    };
+
+    const handleSelectChange = (newIndex: number | null | undefined): void => {
+      const newData =
+        newIndex != null
+          ? createDefaultValue(
+              mixedRenderInfos.value[newIndex].resolvedSchema,
+              input.control.value.rootSchema,
+            )
+          : undefined;
+
+      vuetifyControl.handleChange(input.control.value.path, newData);
+      selectedIndex.value = newIndex;
+
+      const type =
+        newIndex != null
+          ? mixedRenderInfos.value[newIndex]?.resolvedSchema?.type
+          : null;
+      valueType.value = type as JsonDataType | null;
+      activeNodeId.value = toTreeNodeId(input.control.value.path);
+      currentlyExpanded.value = 0;
+    };
+
+    const selectCurrentPath = () => {
+      navigationContext?.selectPath(input.control.value.path);
+    };
+
+    const getTypeIcon = (type: JsonDataType | undefined): IconValue => {
+      switch (type) {
+        case 'array':
+          return icons.current.value.typeArray;
+        case 'object':
+          return icons.current.value.typeObject;
+        case 'boolean':
+          return icons.current.value.typeBoolean;
+        case 'integer':
+        case 'number':
+          return icons.current.value.typeNumber;
+        case 'null':
+          return icons.current.value.typeNull;
+        case 'string':
+          return icons.current.value.typeString;
+        default:
+          return icons.current.value.typeUnknown;
+      }
+    };
+
     provide(IsDynamicPropertyContext, true);
 
     return {
-      ...useCombinatorTranslations(useVuetifyControl(input)),
+      ...vuetifyControl,
       isControlEditable,
       nullable,
       mixedRenderInfos,
@@ -472,44 +1476,49 @@ const controlRenderer = defineComponent({
       path,
       icons,
       currentlyExpanded,
+      showTreeView,
+      isNestedComplexType,
+      treeNodes,
+      selectedNode,
+      activatedTreeNodes,
+      activeNodeId,
+      openedNodes,
+      treeSearch,
+      showPrimitivesInTree,
+      renamingNodeId,
+      renameValue,
+      renameError,
+      navigationContext,
+      toggleShowPrimitives,
+      startRename,
+      cancelRename,
+      commitRename,
+      deleteNode,
+      handleSelectChange,
+      selectCurrentPath,
+      getTypeIcon,
     };
-  },
-  methods: {
-    setToNull(): void {
-      this.handleChange(this.control.path, null);
-    },
-    handleSelectChange(newIndex: number): void {
-      const newData =
-        newIndex != null
-          ? createDefaultValue(
-              this.mixedRenderInfos[newIndex].resolvedSchema,
-              this.control.rootSchema,
-            )
-          : undefined;
-
-      this.handleChange(this.control.path, newData);
-      this.selectedIndex = newIndex;
-
-      const type = newIndex
-        ? this.mixedRenderInfos[newIndex]?.resolvedSchema?.type
-        : null;
-      this.valueType = type as string | null; // we know that this should be either a string or null
-
-      this.currentlyExpanded = 0;
-    },
   },
 });
 
 export default controlRenderer;
 </script>
+
 <style scoped>
-.prefixed-input {
+.mixed-renderer {
+  width: 100%;
+}
+
+.mixed-primitive,
+.mixed-nested-complex {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
+  gap: 8px;
 }
 
 .select {
   flex-shrink: 0;
+  min-width: 160px;
 }
 
 .input {
@@ -517,7 +1526,95 @@ export default controlRenderer;
   width: 100%;
 }
 
+.mixed-tree-container {
+  width: 100%;
+}
+
+.mixed-splitpanes {
+  min-height: 280px;
+}
+
+.mixed-tree-pane {
+  height: 100%;
+  padding: 8px 16px 8px 0;
+}
+
+.mixed-detail-pane {
+  height: 100%;
+  min-width: 0;
+  padding: 8px 0 8px 16px;
+}
+
+.mixed-tree-search {
+  margin-bottom: 8px;
+}
+
+.mixed-tree {
+  max-height: calc(100vh - 300px);
+  overflow: auto;
+}
+
+:deep(.mixed-tree .v-list-item) {
+  align-items: center;
+}
+
+:deep(.mixed-tree .v-list-item__prepend),
+:deep(.mixed-tree .v-list-item__append) {
+  align-self: center;
+  align-items: center;
+}
+
+:deep(.mixed-tree .v-list-item-title) {
+  display: flex;
+  align-items: center;
+  min-height: 32px;
+  line-height: 1.25;
+}
+
+.mixed-navigate-button {
+  margin-top: 4px;
+}
+
+.mixed-tree-title {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mixed-tree-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.mixed-tree-action {
+  opacity: 0.7;
+}
+
+.mixed-hover-action {
+  opacity: 0;
+}
+
+:deep(.v-list-item:hover) .mixed-hover-action,
+:deep(.v-list-item--active) .mixed-hover-action,
+.mixed-hover-action:focus-visible {
+  opacity: 1;
+}
+
+.mixed-rename-input {
+  min-width: 120px;
+}
+
 :deep(.v-expansion-panel-text__wrapper) {
-  padding: 0px;
+  padding: 0;
+}
+
+@media (max-width: 959px) {
+  .mixed-splitpanes {
+    min-height: 520px;
+  }
 }
 </style>

--- a/packages/vue-vuetify/src/complex/ObjectRenderer.vue
+++ b/packages/vue-vuetify/src/complex/ObjectRenderer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="control.visible">
+  <div v-if="control.visible && isRootObject">
     <dispatch-renderer
       :visible="control.visible"
       :enabled="control.enabled"
@@ -15,6 +15,29 @@
       :input="input"
     ></additional-properties>
   </div>
+  <v-card
+    v-else-if="control.visible"
+    :class="objectCardClasses"
+    :outlined="nested.level > 0"
+  >
+    <v-card-title v-if="objectLabel">{{ objectLabel }}</v-card-title>
+    <v-card-text>
+      <dispatch-renderer
+        :visible="control.visible"
+        :enabled="control.enabled"
+        :readonly="control.readonly"
+        :schema="control.schema"
+        :uischema="detailUiSchema"
+        :path="control.path"
+        :renderers="control.renderers"
+        :cells="control.cells"
+      />
+      <additional-properties
+        v-if="showAdditionalProperties"
+        :input="input"
+      ></additional-properties>
+    </v-card-text>
+  </v-card>
 </template>
 
 <script lang="ts">
@@ -24,6 +47,7 @@ import {
   findUISchema,
   type ControlElement,
   type GroupLayout,
+  type Layout,
   type UISchemaElement,
 } from '@jsonforms/core';
 import {
@@ -36,6 +60,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import isEmpty from 'lodash/isEmpty';
 import isObject from 'lodash/isObject';
 import { defineComponent, provide } from 'vue';
+import { VCard, VCardText, VCardTitle } from 'vuetify/components';
 import { useNested, useVuetifyControl } from '../util';
 import { AdditionalProperties } from './components';
 
@@ -44,6 +69,9 @@ const controlRenderer = defineComponent({
   components: {
     DispatchRenderer,
     AdditionalProperties,
+    VCard,
+    VCardText,
+    VCardTitle,
   },
   props: {
     ...rendererProps<ControlElement>(),
@@ -64,6 +92,19 @@ const controlRenderer = defineComponent({
     };
   },
   computed: {
+    isRootObject(): boolean {
+      return isEmpty(this.control.path);
+    },
+    objectLabel(): string | undefined {
+      return this.isRootObject ? undefined : this.control.label;
+    },
+    objectCardClasses(): string {
+      const classes = ['my-1', 'pa-0'];
+      if (this.nested.level > 0) {
+        classes.push('group-bare');
+      }
+      return classes.join(' ');
+    },
     hasAdditionalProperties(): boolean {
       return (
         !isEmpty(this.control.schema.patternProperties) ||
@@ -80,18 +121,12 @@ const controlRenderer = defineComponent({
     },
     detailUiSchema(): UISchemaElement {
       const uiSchemaGenerator = () => {
-        const uiSchema = Generate.uiSchema(
+        return Generate.uiSchema(
           this.control.schema,
-          'Group',
+          'VerticalLayout',
           undefined,
-          this.control.rootSchema,
+          this.control.rootSchema
         );
-        if (isEmpty(this.control.path)) {
-          uiSchema.type = 'VerticalLayout';
-        } else {
-          (uiSchema as GroupLayout).label = this.control.label;
-        }
-        return uiSchema;
       };
 
       let result = findUISchema(
@@ -101,11 +136,18 @@ const controlRenderer = defineComponent({
         this.control.path,
         uiSchemaGenerator,
         this.control.uischema,
-        this.control.rootSchema,
+        this.control.rootSchema
       );
 
       if (this.nested.level > 0) {
         result = cloneDeep(result);
+        if (result.type === 'Group') {
+          result = {
+            ...result,
+            type: 'VerticalLayout',
+            elements: (result as GroupLayout).elements,
+          } as Layout;
+        }
         result.options = {
           ...result.options,
           bare: true,

--- a/packages/vue-vuetify/src/complex/ObjectRenderer.vue
+++ b/packages/vue-vuetify/src/complex/ObjectRenderer.vue
@@ -62,6 +62,7 @@ import isObject from 'lodash/isObject';
 import { defineComponent, provide, type DefineComponent } from 'vue';
 import { useNested, useVuetifyControl } from '../util';
 import { AdditionalProperties } from './components';
+import { VCard, VCardText, VCardTitle } from 'vuetify/components';
 
 const controlRenderer = defineComponent({
   name: 'object-renderer',

--- a/packages/vue-vuetify/src/complex/components/AdditionalProperties.vue
+++ b/packages/vue-vuetify/src/complex/components/AdditionalProperties.vue
@@ -1,11 +1,25 @@
 <template>
-  <v-card v-if="control.visible" v-bind="vuetifyProps('v-card')" flat>
+  <v-card
+    v-if="control.visible"
+    class="additional-properties-card"
+    v-bind="vuetifyProps('v-card')"
+    flat
+  >
     <v-container class="py-0">
-      <v-row no-gutters>
-        <v-col v-if="mdAndUp && additionalPropertiesTitle">
-          {{ additionalPropertiesTitle }}</v-col
+      <div
+        class="additional-properties-add"
+        :class="{
+          'additional-properties-add--with-title':
+            mdAndUp && additionalPropertiesTitle,
+        }"
+      >
+        <div
+          v-if="mdAndUp && additionalPropertiesTitle"
+          class="additional-properties-title"
         >
-        <v-col>
+          {{ additionalPropertiesTitle }}
+        </div>
+        <div class="additional-properties-add-field">
           <json-forms
             :data="newPropertyName"
             :uischema="
@@ -26,8 +40,8 @@
             :ajv="ajv"
             :middleware="middleware"
             @change="propertyNameChange"
-          ></json-forms
-        ></v-col>
+          ></json-forms>
+        </div>
         <v-tooltip location="bottom">
           <template v-slot:activator="{ props }">
             <v-btn
@@ -45,15 +59,18 @@
           </template>
           {{ translations.addTooltip }}
         </v-tooltip>
-      </v-row>
+      </div>
     </v-container>
-    <v-container v-bind="vuetifyProps('v-container')" class="py-0">
-      <v-row
-        no-gutters
+    <v-container
+      v-bind="vuetifyProps('v-container')"
+      class="additional-properties-items py-0"
+    >
+      <div
+        :class="additionalPropertyRowClasses(element)"
         v-for="element in additionalPropertyItems"
         :key="`${element.propertyName}`"
       >
-        <v-col class="flex-shrink-0 flex-grow-1">
+        <div class="additional-property-content">
           <dispatch-renderer
             v-if="element.schema && element.uischema"
             :schema="element.schema"
@@ -63,18 +80,74 @@
             :readonly="control.readonly"
             :renderers="control.renderers"
             :cells="control.cells"
-        /></v-col>
-        <v-col v-if="control.enabled" class="flex-shrink-1 flex-grow-0">
+          />
+        </div>
+        <div v-if="control.enabled" class="additional-property-actions">
+          <v-menu
+            :model-value="renamingPropertyName === element.propertyName"
+            :close-on-content-click="false"
+            location="top end"
+            @update:model-value="
+              (open) =>
+                open ? startRename(element.propertyName) : cancelRename()
+            "
+          >
+            <template v-slot:activator="{ props }">
+              <v-btn
+                v-bind="props"
+                class="additional-property-action-button"
+                icon
+                variant="text"
+                elevation="0"
+                :aria-label="'Rename property ' + element.propertyName"
+                :title="'Rename property ' + element.propertyName"
+              >
+                <v-icon class="notranslate">{{
+                  icons.current.value.itemEdit
+                }}</v-icon>
+              </v-btn>
+            </template>
+            <v-card class="additional-property-rename-menu" elevation="8">
+              <v-text-field
+                v-model="renameValue"
+                density="compact"
+                hide-details="auto"
+                autofocus
+                :label="propertyNameLabel"
+                :error-messages="renameError ? [renameError] : []"
+                v-bind="vuetifyProps('v-text-field')"
+                @update:model-value="updateRenameError(element.propertyName)"
+                @keydown.enter="renameProperty(element.propertyName)"
+                @keydown.esc="cancelRename"
+              />
+              <div class="additional-property-rename-actions">
+                <v-btn
+                  variant="text"
+                  size="small"
+                  :disabled="renamePropertyDisabled(element.propertyName)"
+                  @click="renameProperty(element.propertyName)"
+                >
+                  Rename
+                </v-btn>
+                <v-btn variant="text" size="small" @click="cancelRename">
+                  Cancel
+                </v-btn>
+              </div>
+            </v-card>
+          </v-menu>
           <v-tooltip location="bottom">
             <template v-slot:activator="{ props }">
               <v-btn
                 v-bind="props"
+                class="additional-property-action-button"
                 icon
                 variant="text"
                 elevation="0"
-                small
                 :aria-label="translations.removeAriaLabel"
-                :disabled="removePropertyDisabled"
+                :disabled="
+                  removePropertyDisabled ||
+                  renamingPropertyName === element.propertyName
+                "
                 @click="removeProperty(element.propertyName)"
               >
                 <v-icon class="notranslate">{{
@@ -83,9 +156,9 @@
               </v-btn>
             </template>
             {{ translations.removeTooltip }}
-          </v-tooltip></v-col
-        >
-      </v-row>
+          </v-tooltip>
+        </div>
+      </div>
     </v-container>
   </v-card>
 </template>
@@ -118,7 +191,6 @@ import type { ErrorObject } from 'ajv';
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 import isPlainObject from 'lodash/isPlainObject';
-import omit from 'lodash/omit';
 import startCase from 'lodash/startCase';
 
 import { IsDynamicPropertyContext } from '@/util/inject';
@@ -135,10 +207,10 @@ import { useDisplay } from 'vuetify';
 import {
   VBtn,
   VCard,
-  VCol,
   VContainer,
   VIcon,
-  VRow,
+  VMenu,
+  VTextField,
   VTooltip,
 } from 'vuetify/components';
 import { DisabledIconFocus } from '../../controls/directives';
@@ -165,9 +237,9 @@ export default defineComponent({
     VTooltip,
     VIcon,
     VBtn,
+    VMenu,
     VContainer,
-    VRow,
-    VCol,
+    VTextField,
     JsonForms,
   },
   directives: {
@@ -292,6 +364,9 @@ export default defineComponent({
     const newPropertyName = ref<string | null>('');
     const newPropertyErrors = ref<ErrorObject[] | undefined>(undefined);
     const additionalErrors = ref<ErrorObject[]>([]);
+    const renamingPropertyName = ref<string | null>(null);
+    const renameValue = ref('');
+    const renameError = ref<string | null>(null);
 
     const propertyNameSchema = computed<JsonSchema7>(() => {
       let result: JsonSchema7 = {
@@ -440,6 +515,9 @@ export default defineComponent({
       propertyNameChange,
       newPropertyErrors,
       additionalErrors,
+      renamingPropertyName,
+      renameValue,
+      renameError,
       icons,
       isControlEditable,
       propertyNameSchema,
@@ -494,25 +572,12 @@ export default defineComponent({
   watch: {
     'control.data': {
       handler(newData, oldData) {
-        function isEqualIgnoringKeys(
-          obj1: Record<string, any>,
-          obj2: Record<string, any>,
-          keysToIgnore: string[],
-        ) {
-          // Omit the specified keys from both objects
-          const filteredObj1 = omit(obj1, keysToIgnore);
-          const filteredObj2 = omit(obj2, keysToIgnore);
+        const additionalKeys = (data: Record<string, any> | undefined) =>
+          Object.keys(data || {}).filter(
+            (k) => !this.reservedPropertyNames.includes(k),
+          );
 
-          // Perform a deep comparison
-          // return isEqual(filteredObj1, filteredObj2);
-
-          // compare with property order as well
-          return JSON.stringify(filteredObj1) === JSON.stringify(filteredObj2);
-        }
-
-        if (
-          !isEqualIgnoringKeys(newData, oldData, this.reservedPropertyNames)
-        ) {
+        if (!isEqual(additionalKeys(newData), additionalKeys(oldData))) {
           this.additionalPropertyItems = this.additionalKeys.map((propName) =>
             this.toAdditionalPropertyType(
               propName,
@@ -528,6 +593,116 @@ export default defineComponent({
   },
   methods: {
     composePaths,
+    additionalPropertyRowClasses(element: AdditionalPropertyType): string[] {
+      const schemaType = element.schema?.type;
+      const classes = ['additional-property-row'];
+
+      if (Array.isArray(schemaType)) {
+        classes.push('additional-property-row--mixed');
+      } else if (schemaType === 'object') {
+        classes.push('additional-property-row--object');
+      } else if (schemaType === 'array') {
+        classes.push('additional-property-row--array');
+      } else {
+        classes.push('additional-property-row--primitive');
+      }
+
+      return classes;
+    },
+    validatePropertyName(
+      propertyName: string,
+      currentPropertyName?: string,
+    ): string | null {
+      if (!propertyName) {
+        return null;
+      }
+
+      if (
+        typeof this.control.data === 'object' &&
+        this.control.data &&
+        Object.prototype.hasOwnProperty.call(this.control.data, propertyName)
+      ) {
+        if (propertyName === currentPropertyName) {
+          return null;
+        }
+        return (
+          unref(
+            this.translations[
+              AdditionalPropertiesTranslationEnum.propertyAlreadyDefined
+            ],
+          ) ?? `Property '${propertyName}' already defined`
+        );
+      }
+
+      if (
+        propertyName.includes('[') ||
+        propertyName.includes(']') ||
+        propertyName.includes('.')
+      ) {
+        return (
+          unref(
+            this.translations[
+              AdditionalPropertiesTranslationEnum.propertyNameInvalid
+            ],
+          ) ?? `Property name '${propertyName}' is invalid`
+        );
+      }
+
+      const pattern = this.propertyNameSchema.pattern;
+      if (pattern && !new RegExp(pattern).test(propertyName)) {
+        return `Property name must match pattern: ${pattern}`;
+      }
+
+      return null;
+    },
+    startRename(propName: string): void {
+      this.renamingPropertyName = propName;
+      this.renameValue = propName;
+      this.renameError = null;
+    },
+    cancelRename(): void {
+      this.renamingPropertyName = null;
+      this.renameValue = '';
+      this.renameError = null;
+    },
+    renamePropertyDisabled(propName: string): boolean {
+      const trimmed = this.renameValue.trim();
+      return (
+        !this.isControlEditable(this.control) ||
+        !trimmed ||
+        trimmed === propName ||
+        Boolean(this.validatePropertyName(trimmed, propName))
+      );
+    },
+    updateRenameError(propName: string): void {
+      this.renameError = this.validatePropertyName(
+        this.renameValue.trim(),
+        propName,
+      );
+    },
+    renameProperty(propName: string): void {
+      const trimmed = this.renameValue.trim();
+      this.renameError = this.validatePropertyName(trimmed, propName);
+      if (
+        this.renameError ||
+        !trimmed ||
+        trimmed === propName ||
+        typeof this.control.data !== 'object' ||
+        this.control.data === null ||
+        Array.isArray(this.control.data)
+      ) {
+        return;
+      }
+
+      const updatedData = Object.fromEntries(
+        Object.entries(this.control.data).map(([key, value]) => [
+          key === propName ? trimmed : key,
+          value,
+        ]),
+      );
+      this.input.handleChange(this.control.path, updatedData);
+      this.cancelRename();
+    },
     addProperty() {
       if (this.newPropertyName) {
         const additionalProperty = this.toAdditionalPropertyType(
@@ -573,3 +748,82 @@ export default defineComponent({
   },
 });
 </script>
+
+<style scoped>
+.additional-properties-card {
+  margin-top: 8px;
+}
+
+.additional-properties-items {
+  width: 100%;
+}
+
+.additional-properties-add {
+  align-items: flex-start;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  width: 100%;
+}
+
+.additional-properties-add--with-title {
+  grid-template-columns: minmax(180px, max-content) minmax(0, 1fr) auto;
+}
+
+.additional-properties-title {
+  padding-top: 10px;
+}
+
+.additional-properties-add-field {
+  min-width: 0;
+}
+
+.additional-property-row {
+  align-items: flex-start;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-width: 0;
+  width: 100%;
+}
+
+.additional-property-content {
+  min-width: 0;
+  width: 100%;
+}
+
+.additional-property-actions {
+  align-items: center;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0;
+  opacity: 0.72;
+  transition: opacity 120ms ease;
+}
+
+.additional-property-row:hover .additional-property-actions {
+  opacity: 1;
+}
+
+.additional-property-action-button {
+  height: 24px;
+  width: 24px;
+}
+
+.additional-property-action-button :deep(.v-icon) {
+  font-size: 16px;
+}
+
+.additional-property-rename-menu {
+  min-width: 280px;
+  padding: 12px;
+}
+
+.additional-property-rename-actions {
+  align-items: flex-start;
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+</style>

--- a/packages/vue-vuetify/src/complex/components/AdditionalProperties.vue
+++ b/packages/vue-vuetify/src/complex/components/AdditionalProperties.vue
@@ -88,7 +88,7 @@
             :close-on-content-click="false"
             location="top end"
             @update:model-value="
-              (open) =>
+              (open: boolean) =>
                 open ? startRename(element.propertyName) : cancelRename()
             "
           >
@@ -589,13 +589,14 @@ export default defineComponent({
           );
 
         if (!isEqual(additionalKeys(newData), additionalKeys(oldData))) {
-          this.additionalPropertyItems = this.additionalKeys.map((propName) =>
-            this.toAdditionalPropertyType(
-              propName,
-              newData[propName],
-              this.control.schema,
-              this.control.rootSchema,
-            ),
+          this.additionalPropertyItems = this.additionalKeys.map(
+            (propName: string) =>
+              this.toAdditionalPropertyType(
+                propName,
+                newData[propName],
+                this.control.schema,
+                this.control.rootSchema,
+              ),
           );
         }
       },

--- a/packages/vue-vuetify/src/components/VPane.vue
+++ b/packages/vue-vuetify/src/components/VPane.vue
@@ -1,0 +1,18 @@
+<template>
+  <pane v-bind="$attrs" class="v-pane">
+    <slot />
+  </pane>
+</template>
+
+<script lang="ts">
+import { Pane } from 'splitpanes';
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'VPane',
+  components: {
+    Pane,
+  },
+  inheritAttrs: false,
+});
+</script>

--- a/packages/vue-vuetify/src/components/VSplitpanes.sass
+++ b/packages/vue-vuetify/src/components/VSplitpanes.sass
@@ -1,0 +1,218 @@
+@use 'sass:math'
+@use 'vuetify/tools'
+
+$splitter-thickness: 1px
+$splitter-hover-thickness: 4px
+$splitter-hit-area: 8px
+$splitter-transition: background-color 0.15s ease, width 0.15s ease, height 0.15s ease
+$pane-transition: 0.25s cubic-bezier(0.4, 0, 0.2, 1)
+
+@mixin splitter-base
+  box-sizing: border-box
+  flex-shrink: 0
+  background-color: transparent
+  transition: none
+  position: relative
+
+@mixin splitter-line($width: $splitter-thickness, $height: 100%, $top: 0, $left: 0)
+  content: ''
+  position: absolute
+  top: $top
+  left: $left
+  width: $width
+  height: $height
+  background-color: rgba(var(--v-border-color), var(--v-border-opacity))
+  transition: $splitter-transition
+  z-index: 1
+
+@mixin splitter-hover-state($is-horizontal: false)
+  @if $is-horizontal
+    height: $splitter-hover-thickness
+    width: 100%
+    top: -1.5px
+    left: 0
+  @else
+    width: $splitter-hover-thickness
+    height: 100%
+    left: -1.5px
+    top: 0
+  background-color: rgb(var(--v-theme-primary))
+
+@mixin hit-area($is-horizontal: false)
+  content: ''
+  position: absolute
+  z-index: 0
+  background-color: transparent
+
+  @if $is-horizontal
+    top: -(math.div($splitter-hit-area, 2))
+    bottom: -(math.div($splitter-hit-area, 2))
+    left: 0
+    right: 0
+    cursor: row-resize
+  @else
+    left: -(math.div($splitter-hit-area, 2))
+    right: -(math.div($splitter-hit-area, 2))
+    top: 0
+    bottom: 0
+    cursor: col-resize
+
+@mixin pane-transition($property)
+  transition: none
+
+  .splitpanes:not(.splitpanes--dragging) &
+    transition: #{$property} $pane-transition
+
+@include tools.layer('components')
+  .splitpanes
+    display: flex
+    width: 100%
+    height: 100%
+
+    &--vertical
+      flex-direction: row
+
+    &--horizontal
+      flex-direction: column
+
+    &--dragging
+      -webkit-user-select: none
+      user-select: none
+      pointer-events: auto
+      transform: translateZ(0)
+      will-change: transform
+
+      *, *:before, *:after
+        transition: none !important
+
+      .splitpanes__splitter
+        pointer-events: auto
+
+    &[dir='rtl']
+      &.splitpanes--vertical
+        flex-direction: row-reverse
+
+        > .splitpanes__splitter
+          border-left: none
+          border-right: $splitter-thickness solid rgba(var(--v-border-color), var(--v-border-opacity))
+
+  .splitpanes__pane
+    width: 100%
+    height: 100%
+    overflow: hidden
+    transform: translateZ(0)
+    backface-visibility: hidden
+
+    .splitpanes--vertical &
+      @include pane-transition(width)
+
+    .splitpanes--horizontal &
+      @include pane-transition(height)
+
+  .splitpanes__splitter
+    .splitpanes--vertical > &
+      min-width: $splitter-thickness
+      cursor: col-resize
+
+    .splitpanes--horizontal > &
+      min-height: $splitter-thickness
+      cursor: row-resize
+
+    &:first-child
+      cursor: auto
+
+    &:focus-visible
+      outline: 2px solid rgb(var(--v-theme-primary))
+      outline-offset: -2px
+
+  .splitpanes.v-splitpanes
+    color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity))
+
+    .splitpanes__pane
+      background-color: rgb(var(--v-theme-surface))
+
+    .splitpanes__splitter
+      @include splitter-base
+      transform: translateZ(0)
+      will-change: auto
+
+      &:before
+        @include splitter-line
+
+      &:hover:before
+        @include splitter-hover-state
+
+      .splitpanes--dragging &:before
+        @include splitter-hover-state
+        transition: none !important
+
+      .splitpanes &
+        z-index: 1
+
+    &.splitpanes--vertical > .splitpanes__splitter:after
+      @include hit-area
+
+    &.splitpanes--horizontal > .splitpanes__splitter
+      &:before
+        @include splitter-line(100%, $splitter-thickness)
+
+      &:hover:before
+        @include splitter-hover-state(true)
+
+      .splitpanes--dragging &:before
+        @include splitter-hover-state(true)
+        transition: none !important
+
+      &:after
+        @include hit-area(true)
+
+  .splitpanes.v-splitpanes.splitpanes--dragging
+    .splitpanes__pane
+      transition: none
+
+    .splitpanes__splitter:hover:before,
+    .splitpanes__splitter:focus:before,
+    .splitpanes__splitter:active:before
+      @include splitter-hover-state
+      transition: none
+
+    .splitpanes__pane .splitpanes__splitter:before
+      background-color: rgba(var(--v-border-color), var(--v-border-opacity))
+      width: $splitter-thickness
+      height: 100%
+      top: 0
+      left: 0
+      transition: none
+
+    .splitpanes__pane .splitpanes__splitter:hover:before,
+    .splitpanes__pane .splitpanes__splitter:focus:before,
+    .splitpanes__pane .splitpanes__splitter:active:before
+      @include splitter-hover-state
+      transition: none
+
+    &.splitpanes--horizontal .splitpanes__splitter:before,
+    .splitpanes__pane .splitpanes--horizontal .splitpanes__splitter:before
+      background-color: rgba(var(--v-border-color), var(--v-border-opacity))
+      width: 100%
+      height: $splitter-thickness
+      top: 0
+      left: 0
+      transition: none
+
+    &.splitpanes--horizontal .splitpanes__splitter:hover:before,
+    &.splitpanes--horizontal .splitpanes__splitter:focus:before,
+    &.splitpanes--horizontal .splitpanes__splitter:active:before,
+    .splitpanes__pane .splitpanes--horizontal .splitpanes__splitter:hover:before,
+    .splitpanes__pane .splitpanes--horizontal .splitpanes__splitter:focus:before,
+    .splitpanes__pane .splitpanes--horizontal .splitpanes__splitter:active:before
+      @include splitter-hover-state(true)
+      transition: none
+
+  @media (prefers-contrast: high)
+    .splitpanes.v-splitpanes .splitpanes__splitter
+      opacity: 1 !important
+      background-color: rgba(var(--v-border-color), 0.87) !important
+
+  @media (prefers-reduced-motion: reduce)
+    .splitpanes__pane
+      transition: none

--- a/packages/vue-vuetify/src/components/VSplitpanes.vue
+++ b/packages/vue-vuetify/src/components/VSplitpanes.vue
@@ -1,0 +1,27 @@
+<template>
+  <splitpanes v-bind="$attrs" class="v-splitpanes" :rtl="rtl.isRtl.value">
+    <slot />
+  </splitpanes>
+</template>
+
+<script lang="ts">
+import { Splitpanes } from 'splitpanes';
+import { defineComponent } from 'vue';
+import { useRtl } from 'vuetify';
+import './VSplitpanes.sass';
+
+export default defineComponent({
+  name: 'VSplitpanes',
+  components: {
+    Splitpanes,
+  },
+  inheritAttrs: false,
+  setup() {
+    const rtl = useRtl();
+
+    return {
+      rtl,
+    };
+  },
+});
+</script>

--- a/packages/vue-vuetify/src/components/index.ts
+++ b/packages/vue-vuetify/src/components/index.ts
@@ -1,0 +1,2 @@
+export { default as VPane } from './VPane.vue';
+export { default as VSplitpanes } from './VSplitpanes.vue';

--- a/packages/vue-vuetify/src/icons/fa.ts
+++ b/packages/vue-vuetify/src/icons/fa.ts
@@ -2,13 +2,28 @@ import type { IconAliases } from './icons';
 
 const aliases: IconAliases = {
   itemAdd: 'fas fa-plus',
+  itemCancel: 'fas fa-xmark',
+  itemConfirm: 'fas fa-check',
+  itemEdit: 'far fa-pen-to-square',
   itemMoveUp: 'fas fa-arrow-up',
   itemMoveDown: 'fas fa-arrow-down',
   itemDelete: 'fas fa-trash',
+  search: 'fas fa-magnifying-glass',
+  treeExpand: 'fas fa-chevron-right',
+  treeCollapse: 'fas fa-chevron-down',
+  visibilityOff: 'far fa-eye-slash',
+  visibilityOn: 'far fa-eye',
   calendarClock: 'fas fa-calendar',
   clock: 'far fa-clock',
   passwordHide: 'far fa-eye-slash',
   passwordShow: 'far fa-eye',
+  typeArray: 'fas fa-list',
+  typeBoolean: 'fas fa-toggle-on',
+  typeNull: 'fas fa-ban',
+  typeNumber: 'fas fa-hashtag',
+  typeObject: 'far fa-folder',
+  typeString: 'fas fa-font',
+  typeUnknown: 'fas fa-circle',
   validationError: 'fas fa-circle-exclamation',
 };
 

--- a/packages/vue-vuetify/src/icons/icons.ts
+++ b/packages/vue-vuetify/src/icons/icons.ts
@@ -10,12 +10,27 @@ export type IconValue =
 
 export interface IconAliases {
   itemAdd: IconValue;
+  itemCancel: IconValue;
+  itemConfirm: IconValue;
+  itemEdit: IconValue;
   itemMoveUp: IconValue;
   itemMoveDown: IconValue;
   itemDelete: IconValue;
+  search: IconValue;
+  treeExpand: IconValue;
+  treeCollapse: IconValue;
+  visibilityOff: IconValue;
+  visibilityOn: IconValue;
   calendarClock: IconValue;
   clock: IconValue;
   passwordHide: IconValue;
   passwordShow: IconValue;
+  typeArray: IconValue;
+  typeBoolean: IconValue;
+  typeNull: IconValue;
+  typeNumber: IconValue;
+  typeObject: IconValue;
+  typeString: IconValue;
+  typeUnknown: IconValue;
   validationError: IconValue;
 }

--- a/packages/vue-vuetify/src/icons/mdi.ts
+++ b/packages/vue-vuetify/src/icons/mdi.ts
@@ -2,13 +2,28 @@ import type { IconAliases } from './icons';
 
 const aliases: IconAliases = {
   itemAdd: 'mdi-plus',
+  itemCancel: 'mdi-close',
+  itemConfirm: 'mdi-check',
+  itemEdit: 'mdi-pencil-outline',
   itemMoveUp: 'mdi-arrow-up',
   itemMoveDown: 'mdi-arrow-down',
   itemDelete: 'mdi-delete',
+  search: 'mdi-magnify',
+  treeExpand: 'mdi-chevron-right',
+  treeCollapse: 'mdi-chevron-down',
+  visibilityOff: 'mdi-eye-off',
+  visibilityOn: 'mdi-eye',
   calendarClock: 'mdi-calendar-clock',
   clock: 'mdi-clock-outline',
   passwordHide: 'mdi-eye-off',
   passwordShow: 'mdi-eye',
+  typeArray: 'mdi-format-list-bulleted',
+  typeBoolean: 'mdi-toggle-switch-outline',
+  typeNull: 'mdi-null',
+  typeNumber: 'mdi-numeric',
+  typeObject: 'mdi-folder-outline',
+  typeString: 'mdi-format-text',
+  typeUnknown: 'mdi-circle-small',
   validationError: 'mdi-alert-circle-outline',
 };
 

--- a/packages/vue-vuetify/src/index.ts
+++ b/packages/vue-vuetify/src/index.ts
@@ -1,6 +1,7 @@
 export * from './additional';
 export * from './array';
 export * from './complex';
+export * from './components';
 export * from './controls';
 export * from './extended';
 export * from './i18n';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -629,6 +629,9 @@ importers:
       '@mui/x-date-pickers':
         specifier: ^8.11.3
         version: 8.11.3(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2))(@mui/material@7.3.0(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@mui/system@7.3.0(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(dayjs@1.10.7)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@mui/x-tree-view':
+        specifier: ^8.29.0
+        version: 8.29.0(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2))(@mui/material@7.3.0(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@mui/system@7.3.0(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@rollup/plugin-commonjs':
         specifier: ^23.0.3
         version: 23.0.7(rollup@2.80.0)
@@ -1351,8 +1354,8 @@ importers:
         specifier: ^4.0.2
         version: 4.0.2(postcss@8.5.12)(ts-node@10.9.2(@types/node@24.12.2)(typescript@5.8.3))
       splitpanes:
-        specifier: ^3.1.5
-        version: 3.1.5
+        specifier: ^3.2.0
+        version: 3.2.0(vue@3.5.17(typescript@5.8.3))
       typedoc:
         specifier: ~0.25.3
         version: 0.25.13(typescript@5.8.3)
@@ -1373,7 +1376,7 @@ importers:
         version: 2.3.2(vite@5.4.21(@types/node@24.12.2)(less@4.4.0)(sass@1.93.2)(stylus@0.57.0)(terser@5.48.0))
       vite-plugin-vuetify:
         specifier: ^2.1.1
-        version: 2.1.1(vite@5.4.21(@types/node@24.12.2)(less@4.4.0)(sass@1.93.2)(stylus@0.57.0)(terser@5.48.0))(vue@3.5.17(typescript@5.8.3))(vuetify@3.12.8)
+        version: 2.1.1(vite@5.4.21(@types/node@24.12.2)(less@4.4.0)(sass@1.93.2)(stylus@0.57.0)(terser@5.48.0))(vue@3.5.17(typescript@5.8.3))(vuetify@3.11.9)
       vitest:
         specifier: ^1.4.0
         version: 1.6.0(@types/node@24.12.2)(jsdom@27.2.0)(less@4.4.0)(sass@1.93.2)(stylus@0.57.0)(terser@5.48.0)
@@ -1388,7 +1391,7 @@ importers:
         version: 2.2.12(typescript@5.8.3)
       vuetify:
         specifier: ^3.11.0
-        version: 3.12.8(typescript@5.8.3)(vite-plugin-vuetify@2.1.1)(vue@3.5.17(typescript@5.8.3))
+        version: 3.11.9(typescript@5.8.3)(vite-plugin-vuetify@2.1.1)(vue@3.5.17(typescript@5.8.3))
 
 packages:
 
@@ -1588,6 +1591,7 @@ packages:
   '@angular/animations@20.3.24':
     resolution: {integrity: sha512-lc6OjwBTEITVqFYTwqEuq/UyCutwJ6NQid4U5gOmwSl1GYbnUUV2X/DRN1sz/JRHnXkC4QCGTWqebnm2SLVRiA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    deprecated: '@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.'
     peerDependencies:
       '@angular/core': 20.3.24
 
@@ -2955,6 +2959,10 @@ packages:
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.24.0':
     resolution: {integrity: sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==}
     engines: {node: '>=6.9.0'}
@@ -2998,6 +3006,16 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/utils@0.2.9':
+    resolution: {integrity: sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -3775,6 +3793,9 @@ packages:
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@fortawesome/fontawesome-free@6.6.0':
     resolution: {integrity: sha512-60G28ke/sXdtS9KZCpZSHHkCbdsOGEhIUGlwq6yhY74UpTiToIh8np7A8yphhM4BWsvNFtIvLpi4co+h9Mr9Ow==}
     engines: {node: '>=6'}
@@ -4340,6 +4361,14 @@ packages:
       '@types/react':
         optional: true
 
+  '@mui/types@7.4.12':
+    resolution: {integrity: sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@mui/types@7.4.5':
     resolution: {integrity: sha512-ZPwlAOE3e8C0piCKbaabwrqZbW4QvWz0uapVPWya7fYj6PeDkl5sSJmomT7wjOcZGPB48G/a6Ubidqreptxz4g==}
     peerDependencies:
@@ -4358,6 +4387,16 @@ packages:
 
   '@mui/utils@7.3.0':
     resolution: {integrity: sha512-YdL6ebwFV7PIOidIsees3HxkZ8hZjj+/atKLuI1ENwvJJ1puiEoLEmuDU72qSbKu911/GeFa7pc7Cn/ZmAj6yQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/utils@7.3.11':
+    resolution: {integrity: sha512-XTjGnifwteg71/ij+0e7Y7d+hwyntMYP5wPoA/g2drdGH+Flkvjwy0OfrVpKBbaOvofq4zU/LIyUZyKgmWu18g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -4418,6 +4457,28 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@mui/x-internals@8.29.0':
+    resolution: {integrity: sha512-xlqq765k39g6vkVGIypOBlsdYGawIP0JdSh+qqrkUCIIN39AUZRNMA/nGH0nSkhVHMHcCSDWBM5/6+6BLfc7Mg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@mui/x-tree-view@8.29.0':
+    resolution: {integrity: sha512-y7QkvKEnQOEvM4yLRiOwWhTAsE86coanRJl++P/vBM6AjROZwjXSIAm3NXrQaUSocQOSLAqotIFivewh88xEUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^5.15.14 || ^6.0.0 || ^7.0.0
+      '@mui/system': ^5.15.14 || ^6.0.0 || ^7.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
 
   '@napi-rs/nice-android-arm-eabi@1.1.1':
     resolution: {integrity: sha512-kjirL3N6TnRPv5iuHw36wnucNqXAO46dzK9oPb0wj076R5Xm8PfUVA9nAFB5ZNMmfJQJVKACAPd/Z2KYMppthw==}
@@ -12342,6 +12403,9 @@ packages:
   react-is@19.1.1:
     resolution: {integrity: sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==}
 
+  react-is@19.2.7:
+    resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
+
   react-redux@7.2.9:
     resolution: {integrity: sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==}
     peerDependencies:
@@ -13193,8 +13257,10 @@ packages:
   split@1.0.1:
     resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
 
-  splitpanes@3.1.5:
-    resolution: {integrity: sha512-r3Mq2ITFQ5a2VXLOy4/Sb2Ptp7OfEO8YIbhVJqJXoFc9hc5nTXXkCvtVDjIGbvC0vdE7tse+xTM9BMjsszP6bw==}
+  splitpanes@3.2.0:
+    resolution: {integrity: sha512-K+WKxWdqtKShV33gPjQl769wHxB3glypTOReCvYu/AJd38J+abHlpiF8rK6uBNPMrgw5thHZCI5JkEwsAqa9XA==}
+    peerDependencies:
+      vue: ^3.2.0
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -14075,6 +14141,11 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -14365,8 +14436,8 @@ packages:
       typescript:
         optional: true
 
-  vuetify@3.12.8:
-    resolution: {integrity: sha512-gvmOWeLd6CG7LVh2Qonft5YrIb7MpbKZglRjg0ItEloSbu6hfUII2RZmRSVxGKYdiXTf7J1hI3BRSHr8J9LkxA==}
+  vuetify@3.11.9:
+    resolution: {integrity: sha512-XKcaQU+y/ZURLWII4rOX26LgU/wYRjskDVQFQ35OQuTt81wkruyle9sM9RDkFXCYI5zFApaRpBnTzS8uIN6Yog==}
     peerDependencies:
       typescript: '>=4.7'
       vite-plugin-vuetify: '>=2.1.0'
@@ -17145,6 +17216,8 @@ snapshots:
 
   '@babel/runtime@7.28.4': {}
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.24.0':
     dependencies:
       '@babel/code-frame': 7.24.2
@@ -17227,6 +17300,17 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@base-ui/utils@0.2.9(@types/react@17.0.80)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.11
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@17.0.2)
+    optionalDependencies:
+      '@types/react': 17.0.80
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -17715,6 +17799,8 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.0': {}
+
+  '@floating-ui/utils@0.2.11': {}
 
   '@fortawesome/fontawesome-free@6.6.0': {}
 
@@ -18421,8 +18507,8 @@ snapshots:
 
   '@mui/private-theming@7.3.0(@types/react@17.0.80)(react@17.0.2)':
     dependencies:
-      '@babel/runtime': 7.28.2
-      '@mui/utils': 7.3.0(@types/react@17.0.80)(react@17.0.2)
+      '@babel/runtime': 7.28.4
+      '@mui/utils': 7.3.2(@types/react@17.0.80)(react@17.0.2)
       prop-types: 15.8.1
       react: 17.0.2
     optionalDependencies:
@@ -18430,7 +18516,7 @@ snapshots:
 
   '@mui/styled-engine@7.3.0(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2))(react@17.0.2)':
     dependencies:
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.28.4
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       '@emotion/sheet': 1.4.0
@@ -18457,6 +18543,12 @@ snapshots:
       '@emotion/styled': 11.11.5(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2)
       '@types/react': 17.0.80
 
+  '@mui/types@7.4.12(@types/react@17.0.80)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+    optionalDependencies:
+      '@types/react': 17.0.80
+
   '@mui/types@7.4.5(@types/react@17.0.80)':
     dependencies:
       '@babel/runtime': 7.28.2
@@ -18478,6 +18570,18 @@ snapshots:
       prop-types: 15.8.1
       react: 17.0.2
       react-is: 19.1.1
+    optionalDependencies:
+      '@types/react': 17.0.80
+
+  '@mui/utils@7.3.11(@types/react@17.0.80)(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/types': 7.4.12(@types/react@17.0.80)
+      '@types/prop-types': 15.7.15
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 17.0.2
+      react-is: 19.2.7
     optionalDependencies:
       '@types/react': 17.0.80
 
@@ -18520,6 +18624,36 @@ snapshots:
       react: 17.0.2
       reselect: 5.1.1
       use-sync-external-store: 1.5.0(react@17.0.2)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-internals@8.29.0(@types/react@17.0.80)(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@mui/utils': 7.3.11(@types/react@17.0.80)(react@17.0.2)
+      react: 17.0.2
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@17.0.2)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-tree-view@8.29.0(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2))(@mui/material@7.3.0(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@mui/system@7.3.0(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@base-ui/utils': 0.2.9(@types/react@17.0.80)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@mui/material': 7.3.0(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@mui/system': 7.3.0(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2)
+      '@mui/utils': 7.3.11(@types/react@17.0.80)(react@17.0.2)
+      '@mui/x-internals': 8.29.0(@types/react@17.0.80)(react@17.0.2)
+      '@types/react-transition-group': 4.4.12(@types/react@17.0.80)
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      react-transition-group: 4.4.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+    optionalDependencies:
+      '@emotion/react': 11.11.4(@types/react@17.0.80)(react@17.0.2)
+      '@emotion/styled': 11.11.5(@emotion/react@11.11.4(@types/react@17.0.80)(react@17.0.2))(@types/react@17.0.80)(react@17.0.2)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -19860,7 +19994,7 @@ snapshots:
       '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.24.5)
       '@babel/plugin-transform-runtime': 7.24.3(@babel/core@7.24.5)
       '@babel/preset-env': 7.24.5(@babel/core@7.24.5)
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.28.4
       '@vue/babel-plugin-jsx': 1.2.2(@babel/core@7.24.5)
       '@vue/babel-preset-jsx': 1.4.0(@babel/core@7.24.5)(vue@3.5.17(typescript@5.8.3))
       babel-plugin-dynamic-import-node: 2.3.3
@@ -20395,11 +20529,11 @@ snapshots:
 
   '@vue/web-component-wrapper@1.3.0': {}
 
-  '@vuetify/loader-shared@2.1.0(vue@3.5.17(typescript@5.8.3))(vuetify@3.12.8)':
+  '@vuetify/loader-shared@2.1.0(vue@3.5.17(typescript@5.8.3))(vuetify@3.11.9)':
     dependencies:
       upath: 2.0.1
       vue: 3.5.17(typescript@5.8.3)
-      vuetify: 3.12.8(typescript@5.8.3)(vite-plugin-vuetify@2.1.1)(vue@3.5.17(typescript@5.8.3))
+      vuetify: 3.11.9(typescript@5.8.3)(vite-plugin-vuetify@2.1.1)(vue@3.5.17(typescript@5.8.3))
 
   '@webassemblyjs/ast@1.12.1':
     dependencies:
@@ -21161,7 +21295,7 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.28.4
       cosmiconfig: 7.1.0
       resolve: 1.22.8
 
@@ -22829,7 +22963,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.28.4
       csstype: 3.1.3
 
   dom-serialize@2.2.1:
@@ -28618,6 +28752,8 @@ snapshots:
 
   react-is@19.1.1: {}
 
+  react-is@19.2.7: {}
+
   react-redux@7.2.9(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
     dependencies:
       '@babel/runtime': 7.24.5
@@ -28781,7 +28917,7 @@ snapshots:
 
   regenerator-transform@0.15.2:
     dependencies:
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.28.4
 
   regex-parser@2.3.0: {}
 
@@ -29700,7 +29836,9 @@ snapshots:
     dependencies:
       through: 2.3.8
 
-  splitpanes@3.1.5: {}
+  splitpanes@3.2.0(vue@3.5.17(typescript@5.8.3)):
+    dependencies:
+      vue: 3.5.17(typescript@5.8.3)
 
   sprintf-js@1.0.3: {}
 
@@ -30583,6 +30721,10 @@ snapshots:
     dependencies:
       react: 17.0.2
 
+  use-sync-external-store@1.6.0(react@17.0.2):
+    dependencies:
+      react: 17.0.2
+
   util-deprecate@1.0.2: {}
 
   util@0.12.5:
@@ -30721,14 +30863,14 @@ snapshots:
       picocolors: 1.1.1
       vite: 5.4.21(@types/node@24.12.2)(less@4.4.0)(sass@1.93.2)(stylus@0.57.0)(terser@5.48.0)
 
-  vite-plugin-vuetify@2.1.1(vite@5.4.21(@types/node@24.12.2)(less@4.4.0)(sass@1.93.2)(stylus@0.57.0)(terser@5.48.0))(vue@3.5.17(typescript@5.8.3))(vuetify@3.12.8):
+  vite-plugin-vuetify@2.1.1(vite@5.4.21(@types/node@24.12.2)(less@4.4.0)(sass@1.93.2)(stylus@0.57.0)(terser@5.48.0))(vue@3.5.17(typescript@5.8.3))(vuetify@3.11.9):
     dependencies:
-      '@vuetify/loader-shared': 2.1.0(vue@3.5.17(typescript@5.8.3))(vuetify@3.12.8)
+      '@vuetify/loader-shared': 2.1.0(vue@3.5.17(typescript@5.8.3))(vuetify@3.11.9)
       debug: 4.3.7
       upath: 2.0.1
       vite: 5.4.21(@types/node@24.12.2)(less@4.4.0)(sass@1.93.2)(stylus@0.57.0)(terser@5.48.0)
       vue: 3.5.17(typescript@5.8.3)
-      vuetify: 3.12.8(typescript@5.8.3)(vite-plugin-vuetify@2.1.1)(vue@3.5.17(typescript@5.8.3))
+      vuetify: 3.11.9(typescript@5.8.3)(vite-plugin-vuetify@2.1.1)(vue@3.5.17(typescript@5.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -30943,12 +31085,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  vuetify@3.12.8(typescript@5.8.3)(vite-plugin-vuetify@2.1.1)(vue@3.5.17(typescript@5.8.3)):
+  vuetify@3.11.9(typescript@5.8.3)(vite-plugin-vuetify@2.1.1)(vue@3.5.17(typescript@5.8.3)):
     dependencies:
       vue: 3.5.17(typescript@5.8.3)
     optionalDependencies:
       typescript: 5.8.3
-      vite-plugin-vuetify: 2.1.1(vite@5.4.21(@types/node@24.12.2)(less@4.4.0)(sass@1.93.2)(stylus@0.57.0)(terser@5.48.0))(vue@3.5.17(typescript@5.8.3))(vuetify@3.12.8)
+      vite-plugin-vuetify: 2.1.1(vite@5.4.21(@types/node@24.12.2)(less@4.4.0)(sass@1.93.2)(stylus@0.57.0)(terser@5.48.0))(vue@3.5.17(typescript@5.8.3))(vuetify@3.11.9)
 
   w3c-hr-time@1.0.2:
     dependencies:


### PR DESCRIPTION
Add MixedRenderer and AdditionalProperties support across Material renderers.

- add React Material mixed/additional property renderers with tree navigation
- add Angular Material mixed/additional property renderers with Material tree support
- update Vue Vuetify mixed/additional property UX with v-treeview and Vuetify-styled split panes
- support nested object/array navigation, rename/delete actions, and dynamic property editing
- add shared Vuetify splitpane components and renderer icon mappings