### PR TITLE
Pass explicit undefined defaults to optional jsonforms

### DIFF
--- a/packages/vue/src/jsonFormsCompositions.ts
+++ b/packages/vue/src/jsonFormsCompositions.ts
@@ -531,7 +531,10 @@ export const useJsonFormsCategorization = (props: LayoutProps) => {
 export function useJsonForms(): JsonFormsSubStates;
 export function useJsonForms(optional: true): JsonFormsSubStates | undefined;
 export function useJsonForms(optional?: true) {
-  const jsonforms = inject<JsonFormsSubStates>('jsonforms');
+  const jsonforms = inject<JsonFormsSubStates | undefined>(
+    'jsonforms',
+    undefined
+  );
 
   if (!jsonforms && !optional) {
     throw new Error(
@@ -550,7 +553,10 @@ export function useJsonForms(optional?: true) {
 export function useDispatch(): Dispatch<CoreActions>;
 export function useDispatch(optional: true): Dispatch<CoreActions> | undefined;
 export function useDispatch(optional?: true) {
-  const dispatch = inject<Dispatch<CoreActions>>('dispatch');
+  const dispatch = inject<Dispatch<CoreActions> | undefined>(
+    'dispatch',
+    undefined
+  );
 
   if (!dispatch && !optional) {
     throw new Error(


### PR DESCRIPTION
Pass explicit undefined defaults to optional jsonforms and dispatch injections so Vue does not warn when helper components are rendered outside a JsonForms provider.