### PR TITLE
fix(vue-vuetify): decouple NumberControl precision from step (fixes #2523)

### DIFF
--- a/packages/vue-vuetify/src/controls/NumberControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/NumberControlRenderer.vue
@@ -78,7 +78,6 @@ const controlRenderer = defineComponent({
     precision(): number | null {
       const options: any = this.appliedOptions;
 
-      // If precision is explicitly configured in the UI Schema options, respect it
       if (options.precision !== undefined && options.precision !== null) {
         return Number(options.precision);
       }

--- a/packages/vue-vuetify/src/controls/NumberControlRenderer.vue
+++ b/packages/vue-vuetify/src/controls/NumberControlRenderer.vue
@@ -75,16 +75,16 @@ const controlRenderer = defineComponent({
       const options: any = this.appliedOptions;
       return options.step ?? 0.1;
     },
-    precision(): number | undefined {
-      if (!this.step || Number.isInteger(this.step)) return undefined;
-      // Handle scientific notation and float imprecision
-      const stepStr = this.step.toString();
-      if (stepStr.indexOf('e-') > -1) {
-        // Handle cases like 1e-3
-        return parseInt(stepStr.split('e-')[1], 10);
+    precision(): number | null {
+      const options: any = this.appliedOptions;
+
+      // If precision is explicitly configured in the UI Schema options, respect it
+      if (options.precision !== undefined && options.precision !== null) {
+        return Number(options.precision);
       }
-      const fraction = stepStr.split('.')[1];
-      return fraction ? fraction.length : undefined;
+
+      // Return null (not undefined) to allow Vuetify to accept any precision by default
+      return null;
     },
     value(): number | null | undefined {
       if (

--- a/packages/vue-vuetify/tests/unit/controls/NumberControlRenderer.spec.ts
+++ b/packages/vue-vuetify/tests/unit/controls/NumberControlRenderer.spec.ts
@@ -4,6 +4,7 @@ import NumberControlRenderer from '../../../src/controls/NumberControlRenderer.v
 import { entry as numberControlRendererEntry } from '../../../src/controls/NumberControlRenderer.entry';
 import { wait } from '../../../tests';
 import { mountJsonForms } from '../util';
+import { VNumberInput } from 'vuetify/components';
 
 describe('NumberControlRenderer.vue', () => {
   const renderers = [numberControlRendererEntry];
@@ -57,8 +58,6 @@ describe('NumberControlRenderer.vue', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 });
-
-import { VNumberInput } from 'vuetify/components';
 
 describe('NumberControlRenderer precision logic', () => {
   const renderers = [numberControlRendererEntry];

--- a/packages/vue-vuetify/tests/unit/controls/NumberControlRenderer.spec.ts
+++ b/packages/vue-vuetify/tests/unit/controls/NumberControlRenderer.spec.ts
@@ -57,3 +57,35 @@ describe('NumberControlRenderer.vue', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 });
+
+import { VNumberInput } from 'vuetify/components';
+
+describe('NumberControlRenderer precision logic', () => {
+  const renderers = [numberControlRendererEntry];
+  const schema = { type: 'number' };
+
+  beforeEach(() => {
+    clearAllIds();
+  });
+
+  it('allows unlimited precision by default (passes null to v-number-input)', () => {
+    const uischema = { type: 'Control', scope: '#' };
+    const wrapper = mountJsonForms(1.23456, schema, renderers, uischema);
+
+    const numberInput = wrapper.findComponent(VNumberInput);
+    // Vuetify requires null to remove precision limits
+    expect(numberInput.props('precision')).toBeNull();
+  });
+
+  it('respects explicitly configured precision via UI schema options', () => {
+    const uischema = {
+      type: 'Control',
+      scope: '#',
+      options: { precision: 3 }
+    };
+    const wrapper = mountJsonForms(1.23456, schema, renderers, uischema);
+
+    const numberInput = wrapper.findComponent(VNumberInput);
+    expect(numberInput.props('precision')).toBe(3);
+  });
+});

--- a/packages/vue-vuetify/tests/unit/controls/__snapshots__/NumberControlRenderer.spec.ts.snap
+++ b/packages/vue-vuetify/tests/unit/controls/__snapshots__/NumberControlRenderer.spec.ts.snap
@@ -29,7 +29,7 @@ exports[`NumberControlRenderer.vue > should render component and match snapshot 
               </label><label class="v-label v-field-label" id="#6-input-label" aria-hidden="true">
                 <!---->My Number
               </label>
-              <!----><input placeholder="number placeholder" size="1" type="text" aria-labelledby="#6-input-label" id="#6-input" aria-describedby="#6-input-messages" inputmode="decimal" class="v-field__input" value="1.0">
+              <!----><input placeholder="number placeholder" size="1" type="text" aria-labelledby="#6-input-label" id="#6-input" aria-describedby="#6-input-messages" inputmode="decimal" class="v-field__input" value="1">
               <!---->
             </div>
             <transition-stub name="expand-x-transition" appear="false" persisted="false" css="true">


### PR DESCRIPTION
### Description
This PR resolves [#2523](https://github.com/eclipsesource/jsonforms/issues/2523) regarding the default precision limitation in the Vue-Vuetify `NumberControlRenderer`.

**The Problem:**
Previously, the `precision` computed property artificially restricted decimal places by tying them to the length of the `step` property (which defaults to `0.1`). Furthermore, when `step` was an integer, it returned `undefined`, which did not lift the restriction in Vuetify (Vuetify's `VNumberInput` requires `null` to allow infinite precision). This prevented users from typing standard decimal values.

**The Solution:**
* Decoupled `precision` from `step`.
* The control now returns `null` by default, allowing the native Vuetify input to accept unlimited decimal places.
* If a developer explicitly provides an `options.precision` property via the UI Schema, that specific configuration is now respected and passed to the input.

### Motivation and Context
Allows the `NumberControl` to behave naturally like a standard numeric input without abruptly truncating user data, while still allowing developers to restrict precision if they explicitly configure it in the UI Schema. 

### How Has This Been Tested?
* Added unit test asserting that `precision` resolves to `null` by default.
* Added unit test asserting that `options.precision` is correctly passed through to the `VNumberInput`.
* Updated the existing snapshot (the default value `1.0` correctly reverted to `1` as artificial precision formatting was removed).
* Tested manually in a downstream Vue 3 + Vite application.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)