### PR TITLE
fix(vue-vuetify): resolve a `$ref` on propertyNames in the additional-properties nested form

### DIFF
--- a/packages/vue-vuetify/src/complex/components/AdditionalProperties.vue
+++ b/packages/vue-vuetify/src/complex/components/AdditionalProperties.vue
@@ -301,8 +301,17 @@ export default defineComponent({
       // TODO: create issue against jsonforms to add propertyNames into the JsonSchema interface
       // propertyNames exist in draft-6 but not defined in the JsonSchema
       if (typeof (control.value.schema as any).propertyNames === 'object') {
+        let propertyNames = (control.value.schema as any).propertyNames;
+        if (typeof propertyNames.$ref === 'string') {
+          propertyNames =
+            Resolve.schema(
+              control.value.rootSchema,
+              propertyNames.$ref,
+              control.value.rootSchema,
+            ) ?? propertyNames;
+        }
         result = {
-          ...(control.value.schema as any).propertyNames,
+          ...propertyNames,
           ...result,
         };
       } else if (

--- a/packages/vue-vuetify/tests/unit/additional/AdditionalPropertiesRef.spec.ts
+++ b/packages/vue-vuetify/tests/unit/additional/AdditionalPropertiesRef.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { clearAllIds } from '@jsonforms/core';
+import { extendedVuetifyRenderers } from '../../../src';
+import { mountJsonForms } from '../util';
+
+// Test use of `$ref` in additional-properties `propertyNames`
+describe('AdditionalProperties nested $ref propertyNames', () => {
+  const schema = {
+    type: 'object' as const,
+    $defs: {
+      attrName: {
+        type: 'string' as const,
+        pattern: '^[A-Za-z_][A-Za-z0-9_]*$',
+      },
+    },
+    properties: {
+      secretFiles: {
+        type: 'object' as const,
+        additionalProperties: { type: 'string' as const },
+        propertyNames: { $ref: '#/$defs/attrName' },
+      },
+    },
+  };
+  const uischema = { type: 'Control' as const, scope: '#' };
+
+  beforeEach(() => {
+    clearAllIds();
+  });
+
+  it('mounts a map whose key type is a `$ref` into the root `$defs`', () => {
+    expect(() =>
+      mountJsonForms({ secretFiles: {} }, schema, extendedVuetifyRenderers, uischema),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Resolve a `$ref` on @vue-vuetify `additionalProperties`' `propertyNames` against the root schema (`control.value.rootSchema`, via `Resolve.schema`) before spreading it into the nested form's schema.
Further add a test verifying these are resolved with this change.

The `additional-properties` (map) renderer builds the nested new-key form's schema by spreading `control.value.schema.propertyNames`. When `propertyNames` is a `$ref` into the root's `$defs` (the shape a schema that shares a named key type across many maps emits), the nested `<json-forms>` mounts it as its _own_ root, where `#/$defs/...` does not exist. AJV then throws `can't resolve reference #/$defs/... from id #` and the map fails to render.

Disclaimer: I used a coding agent in the creation of this patch.
