### PR TITLE
fix(vue-vuetify): resolve TS7056 and TS4023 serialization errors (#2577)

### DIFF
--- a/packages/vue-vuetify/src/complex/ObjectRenderer.vue
+++ b/packages/vue-vuetify/src/complex/ObjectRenderer.vue
@@ -35,7 +35,7 @@ import {
 import cloneDeep from 'lodash/cloneDeep';
 import isEmpty from 'lodash/isEmpty';
 import isObject from 'lodash/isObject';
-import { defineComponent, provide } from 'vue';
+import { defineComponent, provide, type DefineComponent } from 'vue';
 import { useNested, useVuetifyControl } from '../util';
 import { AdditionalProperties } from './components';
 
@@ -117,7 +117,7 @@ const controlRenderer = defineComponent({
       return result;
     },
   },
-});
+}) as DefineComponent<any, any, any>;
 
 export default controlRenderer;
 </script>

--- a/packages/vue-vuetify/src/complex/components/AdditionalProperties.vue
+++ b/packages/vue-vuetify/src/complex/components/AdditionalProperties.vue
@@ -130,6 +130,7 @@ import {
   ref,
   unref,
   type PropType,
+  type DefineComponent
 } from 'vue';
 import { useDisplay } from 'vuetify';
 import {
@@ -150,7 +151,7 @@ import {
 } from '../../util';
 
 type Input = ReturnType<typeof useJsonFormsControlWithDetail>;
-interface AdditionalPropertyType {
+export interface AdditionalPropertyType {
   propertyName: string;
   path: string;
   schema: JsonSchema | undefined;
@@ -513,7 +514,7 @@ export default defineComponent({
         if (
           !isEqualIgnoringKeys(newData, oldData, this.reservedPropertyNames)
         ) {
-          this.additionalPropertyItems = this.additionalKeys.map((propName) =>
+          this.additionalPropertyItems = this.additionalKeys.map((propName: string) =>
             this.toAdditionalPropertyType(
               propName,
               newData[propName],
@@ -562,7 +563,7 @@ export default defineComponent({
     },
     removeProperty(propName: string): void {
       this.additionalPropertyItems = this.additionalPropertyItems.filter(
-        (d) => d.propertyName !== propName,
+        (d: AdditionalPropertyType) => d.propertyName !== propName,
       );
       if (typeof this.control.data === 'object') {
         const updatedData = { ...this.control.data };
@@ -571,5 +572,5 @@ export default defineComponent({
       }
     },
   },
-});
+}) as DefineComponent<any, any, any>;
 </script>

--- a/packages/vue-vuetify/src/extended/AutocompleteEnumControlRenderer.vue
+++ b/packages/vue-vuetify/src/extended/AutocompleteEnumControlRenderer.vue
@@ -63,7 +63,7 @@ import {
   useJsonFormsEnumControl,
   type RendererProps,
 } from '@jsonforms/vue';
-import { defineComponent } from 'vue';
+import { defineComponent, type DefineComponent } from 'vue';
 import { VAutocomplete, VSelect } from 'vuetify/components';
 import { default as ControlWrapper } from '../controls/ControlWrapper.vue';
 import { DisabledIconFocus } from '../controls/directives';
@@ -90,7 +90,7 @@ const controlRenderer = defineComponent({
       300,
     );
   },
-});
+}) as DefineComponent<any, any, any>;
 
 export default controlRenderer;
 </script>

--- a/packages/vue-vuetify/src/extended/AutocompleteOneOfEnumControlRenderer.vue
+++ b/packages/vue-vuetify/src/extended/AutocompleteOneOfEnumControlRenderer.vue
@@ -63,7 +63,7 @@ import {
   useJsonFormsOneOfEnumControl,
   type RendererProps,
 } from '@jsonforms/vue';
-import { defineComponent } from 'vue';
+import { defineComponent, type DefineComponent } from 'vue';
 import { VAutocomplete, VSelect } from 'vuetify/components';
 import { default as ControlWrapper } from '../controls/ControlWrapper.vue';
 import { DisabledIconFocus } from '../controls/directives';
@@ -90,7 +90,7 @@ const controlRenderer = defineComponent({
       300,
     );
   },
-});
+}) as DefineComponent<any, any, any>;
 
 export default controlRenderer;
 </script>


### PR DESCRIPTION
Fixes TS7056 and TS4023 serialization errors in `@jsonforms/vue-vuetify` during `pnpm build`. 

* Exported `AdditionalPropertyType` in `AdditionalProperties.vue`
* Avoided `tsc` max serialization limit on generated output types by casting inferred `defineComponent()` returns to `DefineComponent<any, any, any>` in four renderers.

This addresses bug `#2577`.